### PR TITLE
Add NOMIS client library

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,7 @@
-DATABASE_URL=postgresql://postgres@db/pecs-move-platform-backend
+DATABASE_URL=postgresql://postgres@localhost/pecs-move-platform-backend
+NOMIS_SITE='https://nomis-api.example.com'
+NOMIS_CLIENT_ID='client_id'
+NOMIS_CLIENT_SECRET='client_secret'
+NOMIS_AUTH_SCHEME='auth_scheme'
+NOMIS_API_PATH_PREFIX='/api_prefix'
+NOMIS_AUTH_PATH_PREFIX='/auth_prefix'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,3 +22,6 @@ Metrics/LineLength:
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
+
+RSpec/NestedGroups:
+  Max: 4

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby '2.6.2'
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'kaminari'
+gem 'oauth2'
 gem 'pager_api'
 gem 'pg', '~> 1.0.0'
 gem 'puma', '~> 3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       activesupport (>= 4.2.0)
     faker (1.9.3)
       i18n (>= 0.7)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -72,6 +74,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
     jsonapi-renderer (0.2.0)
+    jwt (2.1.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -101,9 +104,18 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.10)
+    multi_json (1.13.1)
+    multi_xml (0.6.0)
+    multipart-post (2.0.0)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.1)
+      faraday (>= 0.8, < 0.16.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
     pager_api (0.2.4)
     parallel (1.17.0)
     parser (2.6.2.1)
@@ -215,6 +227,7 @@ DEPENDENCIES
   faker
   kaminari
   listen (>= 3.0.5, < 3.2)
+  oauth2
   pager_api
   pg (~> 1.0.0)
   pry-byebug

--- a/app/lib/nomis_client.rb
+++ b/app/lib/nomis_client.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class NomisClient
+  class << self
+    def get(path, params = {})
+      token.get("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params: params)
+    end
+
+    private
+
+    REFRESH_TOKEN_TIMEFRAME_IN_SECONDS = 5
+
+    def client
+      @client ||= OAuth2::Client.new(
+        ENV['NOMIS_CLIENT_ID'],
+        ENV['NOMIS_CLIENT_SECRET'],
+        site: ENV['NOMIS_SITE'],
+        auth_scheme: ENV['NOMIS_AUTH_SCHEME'],
+        token_url: "#{ENV['NOMIS_AUTH_PATH_PREFIX']}/oauth/token",
+        raise_errors: false
+      )
+    end
+
+    def token
+      @token ||= client.client_credentials.get_token
+      @token.refresh! if token_expired_or_to_expire?
+      @token
+    end
+
+    def token_expired_or_to_expire?
+      @token.expires? &&
+        (@token.expires_at - REFRESH_TOKEN_TIMEFRAME_IN_SECONDS < Time.now.to_i)
+    end
+  end
+end

--- a/spec/fixtures/files/nomis_get_prisoner_200.json
+++ b/spec/fixtures/files/nomis_get_prisoner_200.json
@@ -1,0 +1,26 @@
+[
+  {
+    "offenderNo": "G3239GV",
+    "firstName": "AVEILKE",
+    "middleNames": "EMMANDA",
+    "lastName": "ABBELLA",
+    "dateOfBirth": "1965-10-15",
+    "gender": "Male",
+    "sexCode": "M",
+    "nationalities": "sxiVsxi",
+    "currentlyInPrison": "Y",
+    "latestBookingId": 20305,
+    "latestLocationId": "FNI",
+    "latestLocation": "Full Sutton (HMP)",
+    "internalLocation": "FNI-D-2-044",
+    "pncNumber": "82/18053V",
+    "croNumber": "018053/82G",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "birthCountry": "England",
+    "religion": "sEKnmTzRNPADrQsEKnmTzRNPADrQ",
+    "convictedStatus": "Convicted",
+    "imprisonmentStatus": "LIFE",
+    "receptionDate": "2000-02-18",
+    "maritalStatus": "sjedbztIaJRRzRZVIYadsjedbztIaJRRzRZVIYa"
+  }
+]

--- a/spec/fixtures/files/nomis_get_prisoner_404.json
+++ b/spec/fixtures/files/nomis_get_prisoner_404.json
@@ -1,0 +1,5 @@
+{
+  "status": 404,
+  "userMessage": "Resource not found.",
+  "developerMessage": "Resource not found."
+}

--- a/spec/fixtures/files/nomis_get_prisoner_500.json
+++ b/spec/fixtures/files/nomis_get_prisoner_500.json
@@ -1,0 +1,5 @@
+{
+  "status": 500,
+  "userMessage": "Unrecoverable error occurred whilst processing request.",
+  "developerMessage": "Unrecoverable error occurred whilst processing request."
+}

--- a/spec/lib/nomis_client_spec.rb
+++ b/spec/lib/nomis_client_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NomisClient do
+  let(:oauth2_client) { instance_double('OAuth2::Client', client_credentials: client_credentials) }
+  let(:client_credentials) { instance_double('OAuth2::Strategy::ClientCredentials', get_token: token) }
+  let(:token) do
+    instance_double('OAuth2::AccessToken',
+      get: oauth2_response,
+      expires?: true,
+      refresh!: true,
+      expires_at: token_expires_at)
+  end
+  let(:oauth2_response) { instance_double('OAuth2::Response', body: response_body, status: response_status) }
+
+  before { allow(OAuth2::Client).to receive(:new).and_return(oauth2_client) }
+
+  after do
+    described_class.instance_variable_set(:@client, nil)
+    described_class.instance_variable_set(:@token, nil)
+  end
+
+  describe '.get' do
+    let(:response) { described_class.get(api_endpoint) }
+    let(:api_endpoint) { '/prisoners/A1234BC' }
+
+    context 'with a valid token' do
+      let(:token_expires_at) { 1.hour.from_now.to_i }
+
+      context 'when a resource is found' do
+        let(:response_body) { file_fixture('nomis_get_prisoner_200.json').read }
+        let(:response_status) { 200 }
+
+        it 'returns a response object with JSON data in the body' do
+          expect(response.body).to eq response_body
+        end
+
+        it 'returns a response object with status 200' do
+          expect(response.status).to eq 200
+        end
+      end
+
+      context 'when a resource is not found' do
+        let(:response_body) { file_fixture('nomis_get_prisoner_404.json').read }
+        let(:response_status) { 404 }
+
+        it 'returns a response object with error message in the body' do
+          expect(response.body).to eq response_body
+        end
+
+        it 'returns a response object with status 404' do
+          expect(response.status).to eq 404
+        end
+      end
+
+      context 'when an unrecoverable error occurrs' do
+        let(:response_body) { file_fixture('nomis_get_prisoner_500.json').read }
+        let(:response_status) { 500 }
+
+        it 'returns a response object with error message in the body' do
+          expect(response.body).to eq response_body
+        end
+
+        it 'returns a response object with status 500' do
+          expect(response.status).to eq 500
+        end
+      end
+    end
+
+    context 'with an expired token' do
+      let(:token_expires_at) { 2.hours.ago.to_i }
+      let(:response_body) { '' }
+      let(:response_status) { 200 }
+
+      it 'refreshes the token' do
+        response
+
+        expect(token).to have_received(:refresh!)
+      end
+    end
+
+    context 'with a token about to expire' do
+      let(:token_expires_at) { 3.seconds.from_now.to_i }
+      let(:response_body) { '' }
+      let(:response_status) { 200 }
+
+      it 'refreshes the token' do
+        response
+
+        expect(token).to have_received(:refresh!)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I tried to make this library as generic as possible, but there is the assumption that the authentication grant type is 'Clients Credentials'.

Also I set the option `raise_errors: false` so that an error is not raised when a resource is not found so that we can deal with the error code and message in the body of the response, not sure if it's the right approach.