### PR TITLE
Allow passing headers and params to token

### DIFF
--- a/app/lib/nomis_client.rb
+++ b/app/lib/nomis_client.rb
@@ -3,7 +3,7 @@
 class NomisClient
   class << self
     def get(path, params = {})
-      token.get("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params: params)
+      token.get("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
     end
 
     private


### PR DESCRIPTION
Before you could only pass params to get requests, now the hash can
contain headers too.