### PR TITLE
Remove id attribute from errors

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -23,7 +23,6 @@ class ApiController < ApplicationController
   def render_resource_not_found_error
     render(
       json: { errors: [{
-        id: 404,
         title: 'Resource not found',
         detail: 'The requested resource was not found'
       }] },
@@ -34,7 +33,6 @@ class ApiController < ApplicationController
   def render_invalid_media_type_error
     render(
       json: { errors: [{
-        id: 415,
         title: 'Invalid Media Type',
         detail: "Content-Type must be #{JSON_API_CONTENT_TYPE}"
       }] },

--- a/swagger/v1/errors.json
+++ b/swagger/v1/errors.json
@@ -2,10 +2,6 @@
   "BadRequest": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "integer",
-        "example": 12345
-      },
       "title": {
         "type": "string",
         "example": "Bad request"
@@ -19,10 +15,6 @@
   "NotAuthorisedError": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "integer",
-        "example": 12345
-      },
       "title": {
         "type": "string",
         "example": "Not authorized"
@@ -36,10 +28,6 @@
   "ResourceNotFound": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "integer",
-        "example": 12345
-      },
       "title": {
         "type": "string",
         "example": "Resource not found"
@@ -53,10 +41,6 @@
   "UnsupportedMediaType": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "integer",
-        "example": 12345
-      },
       "title": {
         "type": "string",
         "example": "Invalid Media Type"
@@ -70,10 +54,6 @@
   "UnprocessableEntity": {
     "type": "object",
     "properties": {
-      "status": {
-        "type": "integer",
-        "example": 422
-      },
       "title": {
         "type": "string",
         "example": "Unprocessable entity"


### PR DESCRIPTION
Following the json:api specification for errors:

[https://jsonapi.org/format/#errors](https://jsonapi.org/format/#errors)

id attribute should be a unique identifier for the particular occurrence of the problem. In our case was just a repetition of the status code