### PR TITLE
Update swagger docs

### DIFF
--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -4,6 +4,12 @@
     "title": "PECS frontend API",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "https://pecs-move-platform-backend-staging.apps.live-1.cloud-platform.service.justice.gov.uk/api/v1",
+      "description": "Staging server"
+    }
+  ],
   "components": {
     "schemas": {
       "Move": {


### PR DESCRIPTION
This includes some updates to the Swagger API docs so that they can be imported
into a third party API client, like [Postman](https://www.getpostman.com/).

See commits for more details around each change.