### PR TITLE
[P4-297] Switch to serve API docs on production/staging

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  unless Rails.env.production?
+  if !Rails.env.production? || ENV['SERVE_API_DOCS']
     mount Rswag::Ui::Engine => '/api-docs'
     mount Rswag::Api::Engine => '/api-docs'
   end

--- a/kubernetes_deploy/staging/config_map.yml
+++ b/kubernetes_deploy/staging/config_map.yml
@@ -8,3 +8,4 @@ data:
   RACK_ENV: production
   # OK for staging but for production move this to a git-crypt secret
   SECRET_KEY_BASE: ce77c24e3567b1dfa18c0f6e3b257b3e6c68234d6572bc3ba79e95ed7933fe8aa7d38dfc87566821301b156605194460e5f2ecd36170f9f6927cdcba1b2b66e8
+  SERVE_API_DOCS: true


### PR DESCRIPTION
Just need to set the `SERVE_API_DOCS` environment variable to override the rule that hides docs in `production` environments.