### PR TITLE
[P4-297] [Bugfix] Remove dependency on `rspec` in production/staging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,8 @@ gem 'pager_api'
 gem 'pg', '~> 1.0.0'
 gem 'puma', '~> 3.11'
 gem 'rails', '~> 5.2.3'
-gem 'rswag'
+gem 'rswag-api'
+gem 'rswag-ui'
 
 group :development, :test do
   gem 'factory_bot'
@@ -23,6 +24,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rspec-json_expectations'
   gem 'rspec-rails'
+  gem 'rswag-specs'
   gem 'shoulda-matchers'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,10 +186,6 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rswag (2.0.5)
-      rswag-api (= 2.0.5)
-      rswag-specs (= 2.0.5)
-      rswag-ui (= 2.0.5)
     rswag-api (2.0.5)
       railties (>= 3.1, < 6.0)
     rswag-specs (2.0.5)
@@ -255,7 +251,9 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rspec-json_expectations
   rspec-rails
-  rswag
+  rswag-api
+  rswag-specs
+  rswag-ui
   rubocop
   rubocop-rspec
   shoulda-matchers


### PR DESCRIPTION
This crept in when we added Swagger docs in production because the 'include everything' `rswag` gem includes the rspec integration which we don't want on `production`. Caused a crash on startup after I mounted the route in https://github.com/ministryofjustice/pecs-move-platform-backend/pull/56.