### PR TITLE
[P4-183] CircleCI config for production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,9 @@ workflows:
           type: approval
           requires:
             - test
+          filters:
+            branches:
+              only: master
       - build_production:
           requires:
             - hold_production


### PR DESCRIPTION
The `build_production` step needs to be manually approved - after the build runs automatically this step is left _On Hold_ until one of us manually approves it to kick off the deployment to production.

I've attempted to factor the common parts of the build and deploy jobs to commands that are currently used for two new `build_production` and `deploy_production` jobs. The intention would be to use these on the `build_staging` and `deploy_staging` jobs too.

I've tested as far as a I can on the feature branch (by temporarily dropping the master branch filter on the `build_production` job (lots of syntax problems have been fixed!) but we will need to get this merged before we can properly validate it.