### PR TITLE
[P4-551] Change move reference format to ABC1234D

### DIFF
--- a/app/services/moves/reference_generator.rb
+++ b/app/services/moves/reference_generator.rb
@@ -4,12 +4,18 @@ module Moves
   class ReferenceGenerator
     def call
       loop do
-        reference = PERMISSIBLE_CHARACTERS.sample(REFERENCE_LENGTH).join
+        reference =
+          PERMISSIBLE_CHARACTERS.sample(REFERENCE_PART1_LENGTH).join +
+          PERMISSIBLE_NUMBERS.sample(REFERENCE_PART2_LENGTH).join +
+          PERMISSIBLE_CHARACTERS.sample(REFERENCE_PART3_LENGTH).join
         break reference unless Move.where(reference: reference).exists?
       end
     end
 
-    REFERENCE_LENGTH = 8
-    PERMISSIBLE_CHARACTERS = %i[A C E F H J K M N P R T U V W X Y 1 2 3 4 5 6 7 8 9].freeze
+    REFERENCE_PART1_LENGTH = 3
+    REFERENCE_PART2_LENGTH = 4
+    REFERENCE_PART3_LENGTH = 1
+    PERMISSIBLE_CHARACTERS = %i[A C E F H J K M N P R T U V W X Y].freeze
+    PERMISSIBLE_NUMBERS = %i[1 2 3 4 5 6 7 8 9].freeze
   end
 end

--- a/spec/services/moves/reference_generator_spec.rb
+++ b/spec/services/moves/reference_generator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Moves::ReferenceGenerator do
   let!(:move) { create :move, reference: existing_reference }
 
   it 'generates a new reference' do
-    expect(generator.call).to eql 'JUWPTYK6'
+    expect(generator.call).to eql 'JUW9825J'
   end
 
   it 'generates a different reference on each call' do
@@ -20,10 +20,10 @@ RSpec.describe Moves::ReferenceGenerator do
   end
 
   context 'when there is a clash with an existing reference' do
-    let(:existing_reference) { 'JUWPTYK6' }
+    let(:existing_reference) { 'JUW9825J' }
 
     it 'generates a different reference' do
-      expect(generator.call).not_to eql 'JUWPTYK6'
+      expect(generator.call).not_to eql 'JUW9825J'
     end
   end
 end


### PR DESCRIPTION
This change just fixes the position of the characters and numbers, it's still basically random and still 8 characters long. But you get something like `ABC1234D` rather than `1AB2C34D`