### PR TITLE
Allow filtering of location by NOMIS agency ID

### DIFF
--- a/app/controllers/api/v1/reference/locations_controller.rb
+++ b/app/controllers/api/v1/reference/locations_controller.rb
@@ -24,7 +24,7 @@ module Api
           render json: location, status: status
         end
 
-        PERMITTED_FILTER_PARAMS = %i[location_type].freeze
+        PERMITTED_FILTER_PARAMS = %i[location_type nomis_agency_id].freeze
 
         def filter_params
           params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h

--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -9,7 +9,7 @@ module Locations
     end
 
     def call
-      Location.where(filter_params.slice(:location_type))
+      Location.where(filter_params.slice(:location_type, :nomis_agency_id))
     end
   end
 end

--- a/spec/requests/api/v1/reference/locations_controller_spec.rb
+++ b/spec/requests/api/v1/reference/locations_controller_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Api::V1::Reference::LocationsController, with_client_authenticati
 
     describe 'filters' do
       let!(:location) { create :location }
-      let(:filters) { { location_type: 'prison' } }
+      let(:filters) { { location_type: 'prison', nomis_agency_id: 'PEI' } }
       let(:params) { { filter: filters } }
 
       before do
@@ -121,7 +121,10 @@ RSpec.describe Api::V1::Reference::LocationsController, with_client_authenticati
       end
 
       it 'delegates the query execution to Locations::Finder with the correct filters' do
-        expect(Locations::Finder).to have_received(:new).with(location_type: location.location_type)
+        expect(Locations::Finder).to have_received(:new).with(
+          location_type: location.location_type,
+          nomis_agency_id: location.nomis_agency_id
+        )
       end
 
       it 'returns results from Locations::Finder' do

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -905,7 +905,7 @@
     },
     "/reference/locations": {
       "get": {
-        "summary": "Returns a list of locations optionally filtered by type",
+        "summary": "Returns a list of locations, optionally filtered by type or NOMIS agency ID",
         "tags": [
           "Locations"
         ],
@@ -930,6 +930,14 @@
             "schema": {
               "type": "string",
               "enum": ["court", "police", "prison"]
+            }
+          },
+          {
+            "name": "filter[nomis_agency_id]",
+            "in": "query",
+            "description": "Filters results by NOMIS agency ID",
+            "schema": {
+              "type": "string"
             }
           }
         ],


### PR DESCRIPTION
HMPPS SSO provides the frontend application with a list of locations for the user in the form of their NOMIS agency ID(s). The frontend application therefore needs a way to look those up and resolve them to the IDs used in the API.

This provides an additional filter to find locations by their NOMIS agency ID. It is theoretically possible for there to be more than one with the same ID, but I haven't tried to resolve this here. For now the frontend will just use the first one that isn't disabled.