### PR TITLE
Change Prometheus collection condition

### DIFF
--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-unless Rails.env == 'test'
+if Rails.env.production?
   require 'prometheus_exporter/middleware'
   require 'prometheus_exporter/instrumentation'
 


### PR DESCRIPTION
Prometheus will currently attempt to collect stats for all environments
apart from `test`. This causes regular warnings when running the app
locally without Prometheus correctly configured.

This change makes the check look for `production` before setting up
Prometheus.