### PR TITLE
[P4-561] Backend work to support prison recalls

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -17,7 +17,11 @@ class Move < ApplicationRecord
   belongs_to :person
 
   validates :from_location, presence: true
-  validates :to_location, presence: true
+  validates(
+    :to_location,
+    presence: true,
+    unless: ->(move) { move.move_type == 'prison_recall' }
+  )
   validates :date, presence: true
   validates :move_type, inclusion: { in: move_types }
   validates :person, presence: true

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -29,10 +29,28 @@ class Move < ApplicationRecord
   validates :status, inclusion: { in: statuses }
 
   before_validation :set_reference
+  before_validation :set_move_type
 
   private
 
   def set_reference
     self.reference ||= Moves::ReferenceGenerator.new.call
+  end
+
+  def set_move_type
+    return if move_type.present?
+
+    self.move_type =
+      if to_location.nil?
+        'prison_recall'
+      elsif to_location_is_court?
+        'court_appearance'
+      else
+        'prison_transfer'
+      end
+  end
+
+  def to_location_is_court?
+    to_location&.location_type == 'court'
   end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -6,6 +6,12 @@ class Move < ApplicationRecord
     cancelled: 'cancelled'
   }
 
+  enum move_type: {
+    court_appearance: 'court_appearance',
+    prison_recall: 'prison_recall',
+    prison_transfer: 'prison_transfer'
+  }
+
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location'
   belongs_to :person
@@ -13,9 +19,10 @@ class Move < ApplicationRecord
   validates :from_location, presence: true
   validates :to_location, presence: true
   validates :date, presence: true
+  validates :move_type, inclusion: { in: move_types }
   validates :person, presence: true
-  validates :status, inclusion: { in: statuses }
   validates :reference, presence: true
+  validates :status, inclusion: { in: statuses }
 
   before_validation :set_reference
 

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MoveSerializer < ActiveModel::Serializer
-  attributes :id, :reference, :status, :updated_at, :time_due, :date, :move_type
+  attributes :id, :reference, :status, :updated_at, :time_due, :date, :move_type, :additional_information
 
   has_one :person, serializer: PersonSerializer
   has_one :from_location, serializer: LocationSerializer

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MoveSerializer < ActiveModel::Serializer
-  attributes :id, :reference, :status, :updated_at, :time_due, :date
+  attributes :id, :reference, :status, :updated_at, :time_due, :date, :move_type
 
   has_one :person, serializer: PersonSerializer
   has_one :from_location, serializer: LocationSerializer

--- a/db/migrate/20190808113402_add_moves_move_type.rb
+++ b/db/migrate/20190808113402_add_moves_move_type.rb
@@ -1,0 +1,5 @@
+class AddMovesMoveType < ActiveRecord::Migration[5.2]
+  def change
+    add_column :moves, :move_type, :string, null: true
+  end
+end

--- a/db/migrate/20190808142502_add_moves_additional_information.rb
+++ b/db/migrate/20190808142502_add_moves_additional_information.rb
@@ -1,0 +1,5 @@
+class AddMovesAdditionalInformation < ActiveRecord::Migration[5.2]
+  def change
+    add_column :moves, :additional_information, :string
+  end
+end

--- a/db/migrate/20190808151619_make_moves_to_location_nullable.rb
+++ b/db/migrate/20190808151619_make_moves_to_location_nullable.rb
@@ -1,0 +1,5 @@
+class MakeMovesToLocationNullable < ActiveRecord::Migration[5.2]
+  def change
+    change_column :moves, :to_location_id, :uuid, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_02_142638) do
+ActiveRecord::Schema.define(version: 2019_08_08_113402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2019_08_02_142638) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "reference", null: false
+    t.string "move_type"
     t.index ["reference"], name: "index_moves_on_reference", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_08_113402) do
+ActiveRecord::Schema.define(version: 2019_08_08_142502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2019_08_08_113402) do
     t.datetime "updated_at", null: false
     t.string "reference", null: false
     t.string "move_type"
+    t.string "additional_information"
     t.index ["reference"], name: "index_moves_on_reference", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_08_142502) do
+ActiveRecord::Schema.define(version: 2019_08_08_151619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2019_08_08_142502) do
   create_table "moves", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.date "date", null: false
     t.uuid "from_location_id", null: false
-    t.uuid "to_location_id", null: false
+    t.uuid "to_location_id"
     t.uuid "person_id", null: false
     t.string "status", default: "requested", null: false
     t.time "time_due"

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -13,5 +13,12 @@ FactoryBot.define do
       location_type { 'court' }
       nomis_agency_id { 'GUICCT' }
     end
+
+    trait :police do
+      key { 'guildford_police_station' }
+      title { 'Guildford Police Station' }
+      location_type { 'police' }
+      nomis_agency_id { 'GUIPS' }
+    end
   end
 end

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     date { Date.today }
     time_due { Time.now }
     status { 'requested' }
+    additional_information { 'some more info about the move that the supplier might need to know' }
     move_type { 'court_appearance' }
   end
 end

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     date { Date.today }
     time_due { Time.now }
     status { 'requested' }
+    move_type { 'court_appearance' }
   end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -8,11 +8,22 @@ RSpec.describe Move do
   it { is_expected.to belong_to(:person) }
 
   it { is_expected.to validate_presence_of(:from_location) }
-  it { is_expected.to validate_presence_of(:to_location) }
   it { is_expected.to validate_presence_of(:person) }
   it { is_expected.to validate_presence_of(:date) }
   it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.values) }
   it { is_expected.to validate_inclusion_of(:move_type).in_array(described_class.move_types.values) }
+
+  it 'validates presence of `to_location` if `move_type` is NOT prision_recall' do
+    expect(described_class.new(move_type: 'prison_transfer')).to(
+      validate_presence_of(:to_location)
+    )
+  end
+
+  it 'does NOT validate presence of `to_location` if `move_type` is prision_recall' do
+    expect(described_class.new(move_type: 'prison_recall')).not_to(
+      validate_presence_of(:to_location)
+    )
+  end
 
   context 'without automatic reference generation' do
     # rubocop:disable RSpec/AnyInstance

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Move do
   it { is_expected.to validate_presence_of(:person) }
   it { is_expected.to validate_presence_of(:date) }
   it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.values) }
+  it { is_expected.to validate_inclusion_of(:move_type).in_array(described_class.move_types.values) }
 
   context 'without automatic reference generation' do
     # rubocop:disable RSpec/AnyInstance

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -11,16 +11,15 @@ RSpec.describe Move do
   it { is_expected.to validate_presence_of(:person) }
   it { is_expected.to validate_presence_of(:date) }
   it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.values) }
-  it { is_expected.to validate_inclusion_of(:move_type).in_array(described_class.move_types.values) }
 
-  it 'validates presence of `to_location` if `move_type` is NOT prision_recall' do
-    expect(described_class.new(move_type: 'prison_transfer')).to(
+  it 'validates presence of `to_location` if `move_type` is NOT prison_recall' do
+    expect(build(:move, move_type: 'prison_transfer')).to(
       validate_presence_of(:to_location)
     )
   end
 
-  it 'does NOT validate presence of `to_location` if `move_type` is prision_recall' do
-    expect(described_class.new(move_type: 'prison_recall')).not_to(
+  it 'does NOT validate presence of `to_location` if `move_type` is prison_recall' do
+    expect(build(:move, move_type: 'prison_recall')).not_to(
       validate_presence_of(:to_location)
     )
   end
@@ -44,6 +43,38 @@ RSpec.describe Move do
     it 'does not overwrite an existing reference on validation' do
       move = described_class.new(reference: '12345678')
       expect(move.reference).to eq '12345678'
+    end
+  end
+
+  describe '#move_type' do
+    subject(:move) { build :move, from_location: from_location, to_location: to_location, move_type: nil }
+
+    let(:from_location) { build :location, :police }
+
+    before { move.valid? }
+
+    context 'with no `to_location`' do
+      let(:to_location) { nil }
+
+      it 'sets the move type to `prison_recall` at validation time' do
+        expect(move.move_type).to eq 'prison_recall'
+      end
+    end
+
+    context 'with a court for it\'s `to_location`' do
+      let(:to_location) { build :location, :court }
+
+      it 'sets the move type to `court_appearance` at validation time' do
+        expect(move.move_type).to eq 'court_appearance'
+      end
+    end
+
+    context 'with a prison for it\'s `to_location`' do
+      let(:to_location) { build :location }
+
+      it 'sets the move type to `prison_transfer` at validation time' do
+        expect(move.move_type).to eq 'prison_transfer'
+      end
     end
   end
 end

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe MoveSerializer do
     expect(result[:data][:attributes][:updated_at]).to eql move.updated_at.iso8601
   end
 
+  it 'contains an additional_information attribute' do
+    expect(result[:data][:attributes][:additional_information]).to eql move.additional_information
+  end
+
   describe 'person' do
     let(:adapter_options) { { include: { person: %I[first_names last_name] } } }
     let(:expected_json) do

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe MoveSerializer do
     expect(result[:data][:attributes][:status]).to eql move.status
   end
 
+  it 'contains a move_type attribute' do
+    expect(result[:data][:attributes][:move_type]).to eql move.move_type
+  end
+
   it 'contains a date attribute' do
     expect(result[:data][:attributes][:date]).to eql move.date.iso8601
   end

--- a/swagger/v1/move.json
+++ b/swagger/v1/move.json
@@ -58,7 +58,10 @@
             "description": "Date on which the move is scheduled"
           },
           "additional_information": {
-            "type": "string",
+            "oneOf": [
+              { "type": "string" },
+              { "type": "null" }
+            ],
             "description": "Additional information about the move that the supplier should be made aware of"
           }
         }

--- a/swagger/v1/move.json
+++ b/swagger/v1/move.json
@@ -36,6 +36,11 @@
             "enum": ["requested", "cancelled"],
             "description": "Indicates the stage in it's lifecycle that this move is at"
           },
+          "move_type": {
+            "type": "string",
+            "enum": ["court_appearance", "prison_recall", "prison_transfer"],
+            "description": "Indicates the type of move, e.g. prison transfer or court appearance"
+          },
           "time_due": {
             "type": "string",
             "format": "date-time",

--- a/swagger/v1/move.json
+++ b/swagger/v1/move.json
@@ -56,6 +56,10 @@
             "format": "date",
             "example": "2019-05-24",
             "description": "Date on which the move is scheduled"
+          },
+          "additional_information": {
+            "type": "string",
+            "description": "Additional information about the move that the supplier should be made aware of"
           }
         }
       },


### PR DESCRIPTION
- [x] Reinstate `Move#move_type` with possible values _prison_transfer_, _court_appearance_ and _prison_recall_
- [x] Populate `Move#move_type` in existing move records
- [x] Add a `Move#additional_information` attribute
- [x] Relax the required attribute validation on `to_location` for _prison_recall_ move type only

In future we would probably want to make `Move#move_type` `NOT NULL` but we will make that part of a follow up PR (and deploy) to avoid potential upgrade issues.