### PR TITLE
[P4-561] Bugfix for persistence of `Move#move_type`

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -33,7 +33,7 @@ module Api
       private
 
       PERMITTED_FILTER_PARAMS = %i[date_from date_to from_location_id location_type status].freeze
-      PERMITTED_MOVE_PARAMS = [:type, attributes: %i[date time_due status], relationships: {}].freeze
+      PERMITTED_MOVE_PARAMS = [:type, attributes: %i[date time_due status move_type], relationships: {}].freeze
       PERMITTED_PATCH_MOVE_PARAMS = [attributes: %i[date time_due status]].freeze
 
       def filter_params
@@ -52,7 +52,7 @@ module Api
         move_params[:attributes].merge(
           person: Person.find(move_params.dig(:relationships, :person, :data, :id)),
           from_location: Location.find(move_params.dig(:relationships, :from_location, :data, :id)),
-          to_location: Location.find(move_params.dig(:relationships, :to_location, :data, :id))
+          to_location: Location.find_by(id: move_params.dig(:relationships, :to_location, :data, :id))
         )
       end
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -13,7 +13,7 @@ class Move < ApplicationRecord
   }
 
   belongs_to :from_location, class_name: 'Location'
-  belongs_to :to_location, class_name: 'Location'
+  belongs_to :to_location, class_name: 'Location', optional: true
   belongs_to :person
 
   validates :from_location, presence: true

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -29,10 +29,10 @@ module Moves
     end
 
     def apply_location_type_filters(scope)
-      scope = scope.joins(:to_location)
       return scope unless filter_params.key?(:location_type)
 
       scope
+        .joins(:to_location)
         .where(locations: { location_type: filter_params[:location_type] })
     end
   end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Move do
   it { is_expected.to belong_to(:from_location) }
-  it { is_expected.to belong_to(:to_location) }
+  it { is_expected.to belong_to(:to_location).optional }
   it { is_expected.to belong_to(:person) }
 
   it { is_expected.to validate_presence_of(:from_location) }

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
         relationships: {
           person: { data: { type: 'people', id: person.id } },
           from_location: { data: { type: 'locations', id: from_location.id } },
-          to_location: { data: { type: 'locations', id: to_location.id } }
+          to_location: to_location ? { data: { type: 'locations', id: to_location.id } } : nil
         }
       }
     end
@@ -50,6 +50,46 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
 
       it 'returns the correct data' do
         expect(response_json).to eq resource_to_json
+      end
+
+      context 'without a `to_location`' do
+        let(:to_location) { nil }
+        let(:data) do
+          {
+            type: 'moves',
+            attributes: move_attributes.merge(move_type: nil),
+            relationships: {
+              person: { data: { type: 'people', id: person.id } },
+              from_location: { data: { type: 'locations', id: from_location.id } }
+            }
+          }
+        end
+
+        it_behaves_like 'an endpoint that responds with success 201'
+
+        it 'creates a move', skip_before: true do
+          expect { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
+            .to change(Move, :count).by(1)
+        end
+
+        it 'sets the move_type to `prison_recall`' do
+          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'prison_recall'
+        end
+      end
+
+      context 'with explicit `move_type`' do
+        let(:move_attributes) { attributes_for(:move, move_type: 'prison_recall') }
+
+        it_behaves_like 'an endpoint that responds with success 201'
+
+        it 'creates a move', skip_before: true do
+          expect { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
+            .to change(Move, :count).by(1)
+        end
+
+        it 'sets the move_type to `prison_recall`' do
+          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'prison_recall'
+        end
       end
     end
 

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe Moves::Finder do
       end
     end
 
+    context 'with no location type and no location' do
+      let!(:move) { create :move, move_type: 'prison_recall', to_location: nil }
+      let(:filter_params) { {} }
+
+      it 'returns all moves' do
+        expect(move_finder.call.pluck(:id)).to eql [move.id]
+      end
+    end
+
     context 'with mis-matching location filter' do
       let(:filter_params) { { location_type: 'hospital' } }
 

--- a/swagger/v1/location_reference.json
+++ b/swagger/v1/location_reference.json
@@ -6,24 +6,29 @@
     ],
     "properties": {
       "data": {
-        "type": "object",
-        "required": [
-          "id",
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "example": "locations",
-            "description": "The type of this object - always `locations`"
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "id",
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "example": "locations",
+                "description": "The type of this object - always `locations`"
+              },
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "example": "3561f372-9f1c-4e13-997e-b11e1647cce1",
+                "description": "The unique identifier (UUID) of object that this reference points to"
+              }
+            }
           },
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "example": "3561f372-9f1c-4e13-997e-b11e1647cce1",
-            "description": "The unique identifier (UUID) of object that this reference points to"
-          }
-        }
+          { "type": "null" }
+        ]
       }
     }
   }


### PR DESCRIPTION
Adds some further more specific request specs to cover the rules around `move_type` and `to_location`.

Also need to relax the implicit validation on `belongs_to :to_location`.