### PR TITLE
Fix `Location#nomis_agency_id` for Guildford Police

### DIFF
--- a/db/migrate/20190819104500_fix_guildford_police_station_nomis_id.rb
+++ b/db/migrate/20190819104500_fix_guildford_police_station_nomis_id.rb
@@ -1,0 +1,9 @@
+class FixGuildfordPoliceStationNomisId < ActiveRecord::Migration[5.2]
+  def up
+    guildford_police = Location.find_by(location_type: 'police', nomis_agency_id: 'GLFD')
+    guildford_police&.update!(nomis_agency_id: 'SRY016', key: 'sry016')
+  end
+
+  # We don't want to ever revert back to the original value
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_08_151619) do
+ActiveRecord::Schema.define(version: 2019_08_19_104500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
Was causing issues on staging now that we have capability for multiple locations because the original agency id did not match what was (later) added to NOMIS itself. Should be `SRY016` rather than `GLFD`.