### PR TITLE
Upgrade nokogiri following recommendation from Github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'doorkeeper'
 gem 'json-schema'
 gem 'kaminari'
+gem 'nokogiri', '>= 1.10.4'
 gem 'oauth2'
 gem 'pager_api'
 gem 'pg', '~> 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.3.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
@@ -254,6 +254,7 @@ DEPENDENCIES
   json-schema
   kaminari
   listen (>= 3.0.5, < 3.2)
+  nokogiri (>= 1.10.4)
   oauth2
   pager_api
   pg (~> 1.0.0)


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-5477