### PR TITLE
Change moves time_due to be a datetime

### DIFF
--- a/app/lib/nomis_client/moves.rb
+++ b/app/lib/nomis_client/moves.rb
@@ -27,7 +27,7 @@ class NomisClient
             from_location_nomis_agency_id: item['fromAgency'],
             to_location_nomis_agency_id: item['toAgency'],
             date: item['eventDate'],
-            time_due: item['startTime'] ? item['startTime'].split('T').last : nil,
+            time_due: item['startTime'],
             nomis_event_id: item['eventId']
           }
         end

--- a/db/migrate/20190821095338_change_time_due_to_datetime.rb
+++ b/db/migrate/20190821095338_change_time_due_to_datetime.rb
@@ -1,0 +1,6 @@
+class ChangeTimeDueToDatetime < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :moves, :time_due
+    add_column :moves, :time_due, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_08_151619) do
+ActiveRecord::Schema.define(version: 2019_08_21_095338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -69,12 +69,12 @@ ActiveRecord::Schema.define(version: 2019_08_08_151619) do
     t.uuid "to_location_id"
     t.uuid "person_id", null: false
     t.string "status", default: "requested", null: false
-    t.time "time_due"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "reference", null: false
     t.string "move_type"
     t.string "additional_information"
+    t.datetime "time_due"
     t.index ["reference"], name: "index_moves_on_reference", unique: true
   end
 

--- a/spec/lib/nomis_client/moves_spec.rb
+++ b/spec/lib/nomis_client/moves_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe NomisClient::Moves, with_nomis_client_authentication: true do
           from_location_nomis_agency_id: 'BXI',
           to_location_nomis_agency_id: 'BXI',
           date: '2019-08-19',
-          time_due: '17:00:00',
+          time_due: '2019-08-19T17:00:00',
           nomis_event_id: 468_536_961
         },
         {
@@ -22,7 +22,7 @@ RSpec.describe NomisClient::Moves, with_nomis_client_authentication: true do
           from_location_nomis_agency_id: 'BXI',
           to_location_nomis_agency_id: 'WDGRCC',
           date: '2019-08-19',
-          time_due: '09:00:00',
+          time_due: '2019-08-19T09:00:00',
           nomis_event_id: 487_463_210
         }
       ]


### PR DESCRIPTION
All the moves in production have a time_due that is null, so dropping and recreating the column in the database is safe