### PR TITLE
Set default sort order to ID on moves

### DIFF
--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -9,7 +9,7 @@ module Moves
     end
 
     def call
-      apply_filters(Move).order('locations.title')
+      apply_filters(Move).order('moves.id')
     end
 
     private


### PR DESCRIPTION
We were previously sorting moves by location title to help with
the frontend. This currently causing issues with pagination where
results may be returned across multiple pages as location is not
always guaranteed.

This change amends the sort to be by ID so the order returned during
pagination will always be the same.