### PR TITLE
[P4-564] Alerts data fixtures

### DIFF
--- a/app/lib/nomis_client/alerts.rb
+++ b/app/lib/nomis_client/alerts.rb
@@ -4,9 +4,13 @@ module NomisClient
   class Alerts < NomisClient::Base
     class << self
       def get(prison_number)
-        NomisClient::Base.get("/bookings/offenderNo/#{prison_number}/alerts").parsed.map do |alert|
+        get_response(prison_number).parsed.map do |alert|
           attributes_for(alert)
         end
+      end
+
+      def get_response(nomis_offender_number:)
+        NomisClient::Base.get("/bookings/offenderNo/#{nomis_offender_number}/alerts")
       end
 
       # rubocop:disable Metrics/MethodLength

--- a/app/lib/nomis_client/alerts.rb
+++ b/app/lib/nomis_client/alerts.rb
@@ -4,7 +4,7 @@ module NomisClient
   class Alerts < NomisClient::Base
     class << self
       def get(prison_number)
-        get_response(prison_number).parsed.map do |alert|
+        get_response(nomis_offender_number: prison_number).parsed.map do |alert|
           attributes_for(alert)
         end
       end

--- a/app/services/alerts/anonymiser.rb
+++ b/app/services/alerts/anonymiser.rb
@@ -10,17 +10,29 @@ module Alerts
     end
 
     def call
-      alerts.map do |alert|
-        alert.merge(
-          addedByFirstName: Faker::Name.first_name.upcase,
-          addedByLastName: Faker::Name.last_name.upcase,
-          expiredByFirstName: Faker::Name.first_name.upcase,
-          expiredByLastName: Faker::Name.last_name.upcase,
-          dateCreated: Faker::Date.between(10.years.ago, 6.years.ago).iso8601,
-          dateExpires: Faker::Date.between(5.years.ago, 1.years.ago).iso8601,
-          comment: ''
-        ).with_indifferent_access
-      end
+      alerts.map { |alert| anonymise_alert(alert) }
+    end
+
+    private
+
+    def anonymise_alert(alert)
+      alert.merge(
+        addedByFirstName: Faker::Name.first_name.upcase,
+        addedByLastName: Faker::Name.last_name.upcase,
+        expiredByFirstName: Faker::Name.first_name.upcase,
+        expiredByLastName: Faker::Name.last_name.upcase,
+        dateCreated: fake_date_created,
+        dateExpires: fake_date_expires,
+        comment: ''
+      ).with_indifferent_access
+    end
+
+    def fake_date_created
+      Faker::Date.between(10.years.ago, 6.years.ago).iso8601
+    end
+
+    def fake_date_expires
+      Faker::Date.between(5.years.ago, 1.years.ago).iso8601
     end
   end
 end

--- a/app/services/alerts/anonymiser.rb
+++ b/app/services/alerts/anonymiser.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Alerts
+  class Anonymiser
+    attr_accessor :nomis_offender_number, :alerts
+
+    def initialize(nomis_offender_number:, alerts:)
+      self.nomis_offender_number = nomis_offender_number
+      self.alerts = alerts
+    end
+
+    def call
+      alerts.map do |alert|
+        alert.merge(
+          addedByFirstName: Faker::Name.first_name.upcase,
+          addedByLastName: Faker::Name.last_name.upcase,
+          expiredByFirstName: Faker::Name.first_name.upcase,
+          expiredByLastName: Faker::Name.last_name.upcase,
+          dateCreated: Faker::Date.between(10.years.ago, 6.years.ago).iso8601,
+          dateExpires: Faker::Date.between(5.years.ago, 1.years.ago).iso8601,
+          comment: ''
+        ).with_indifferent_access
+      end
+    end
+  end
+end

--- a/app/services/alerts/anonymiser.rb
+++ b/app/services/alerts/anonymiser.rb
@@ -23,7 +23,7 @@ module Alerts
         expiredByLastName: Faker::Name.last_name.upcase,
         dateCreated: fake_date_created,
         dateExpires: fake_date_expires,
-        comment: ''
+        comment: nil
       ).with_indifferent_access
     end
 

--- a/lib/tasks/nomis_fixtures.rake
+++ b/lib/tasks/nomis_fixtures.rake
@@ -14,7 +14,7 @@ namespace :nomis_fixtures do
     create_fixture_directory
     file_name = "#{NomisClient::Base::FIXTURE_DIRECTORY}/alerts-#{nomis_offender_number}.json"
     File.open(file_name, 'w+') do |file|
-      file.write(JSON.pretty_generate([anonymised_alerts_response], indent: '  '))
+      file.write(JSON.pretty_generate(anonymised_alerts_response, indent: '  '))
     end
   end
 

--- a/lib/tasks/nomis_fixtures.rake
+++ b/lib/tasks/nomis_fixtures.rake
@@ -10,6 +10,14 @@ namespace :nomis_fixtures do
     FileUtils.mkdir_p(NomisClient::Base::FIXTURE_DIRECTORY) unless File.directory?(NomisClient::Base::FIXTURE_DIRECTORY)
   end
 
+  def save_alerts_response(anonymised_alerts_response, nomis_offender_number)
+    create_fixture_directory
+    file_name = "#{NomisClient::Base::FIXTURE_DIRECTORY}/alerts-#{nomis_offender_number}.json"
+    File.open(file_name, 'w+') do |file|
+      file.write(JSON.pretty_generate([anonymised_alerts_response], indent: '  '))
+    end
+  end
+
   def save_person_response(anonymised_person_response, nomis_offender_number)
     create_fixture_directory
     file_name = "#{NomisClient::Base::FIXTURE_DIRECTORY}/person-#{nomis_offender_number}.json"
@@ -64,6 +72,16 @@ namespace :nomis_fixtures do
               anonymised_person_response = People::Anonymiser.new(nomis_offender_number: nomis_offender_number).call
               save_person_response(anonymised_person_response, nomis_offender_number)
               puts "Anonymising #{nomis_offender_number}..."
+
+              alerts_response = NomisClient::Alerts.get_response(
+                nomis_offender_number: real_offender_number
+              ).parsed
+              anonymised_alerts_response = Alerts::Anonymiser.new(
+                nomis_offender_number: nomis_offender_number,
+                alerts: alerts_response
+              ).call
+              save_alerts_response(anonymised_alerts_response, nomis_offender_number)
+
               Moves::Anonymiser.new(
                 nomis_offender_number: nomis_offender_number,
                 day_offset: day_offset,

--- a/spec/services/alerts/anonymiser_spec.rb
+++ b/spec/services/alerts/anonymiser_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe Alerts::Anonymiser do
         alertCode: 'XER',
         alertCodeDescription: 'Escape Risk',
         comment: 'some personal details',
-        dateCreated: '2011-09-28',
+        dateCreated: '2001-09-28',
         expired: false,
         active: true,
-        addedByFirstName: 'REFUGIO',
-        addedByLastName: 'ROGAHN',
+        addedByFirstName: 'PAMMY-BARBARA',
+        addedByLastName: 'SUMMERBURGER',
         expiredByFirstName: 'GLENNA',
         expiredByLastName: 'FLATLEY',
-        dateExpires: '2016-12-26'
+        dateExpires: '2006-12-26'
       },
       {
         alertId: 2,
@@ -37,14 +37,14 @@ RSpec.describe Alerts::Anonymiser do
         alertCode: 'XEL',
         alertCodeDescription: 'Escape List',
         comment: 'some more personal details',
-        dateCreated: '2011-11-14',
+        dateCreated: '2001-11-14',
         expired: false,
         active: true,
-        addedByFirstName: 'AUGUSTUS',
-        addedByLastName: 'WILLIAMSON',
+        addedByFirstName: 'BILLY-BOB',
+        addedByLastName: 'GREYGARDINER',
         expiredByFirstName: 'TOMMY',
         expiredByLastName: 'POLLICH',
-        dateExpires: '2018-02-06'
+        dateExpires: '2008-02-06'
       }
     ]
   end
@@ -58,8 +58,20 @@ RSpec.describe Alerts::Anonymiser do
       expect(anonymised[:comment]).to be_nil
     end
 
-    it 'resets names' do
-      expect(anonymised[:addedByFirstName]).not_to eql 'AUGUSTUS'
+    it 'resets first name' do
+      expect(anonymised[:addedByFirstName]).not_to eql 'PAMMY-BARBARA'
+    end
+
+    it 'resets last name' do
+      expect(anonymised[:addedByLastName]).not_to eql 'SUMMERBURGER'
+    end
+
+    it 'resets created date' do
+      expect(anonymised[:dateCreated]).not_to eql '2001-11-14'
+    end
+
+    it 'resets expires date' do
+      expect(anonymised[:dateCreated]).not_to eql '2008-02-06'
     end
   end
 end

--- a/spec/services/alerts/anonymiser_spec.rb
+++ b/spec/services/alerts/anonymiser_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'dotenv/load'
 
 RSpec.describe Alerts::Anonymiser do
   subject(:anonymiser) do

--- a/spec/services/alerts/anonymiser_spec.rb
+++ b/spec/services/alerts/anonymiser_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'dotenv/load'
+
+RSpec.describe Alerts::Anonymiser do
+  subject(:anonymiser) do
+    described_class.new(
+      nomis_offender_number: nomis_offender_number,
+      alerts: alerts
+    )
+  end
+
+  let(:nomis_offender_number) { 'D1234VG' }
+  let(:alerts) do
+    [
+      {
+        alertId: 1,
+        alertType: 'X',
+        alertTypeDescription: 'Security',
+        alertCode: 'XER',
+        alertCodeDescription: 'Escape Risk',
+        comment: 'some personal details',
+        dateCreated: '2011-09-28',
+        expired: false,
+        active: true,
+        addedByFirstName: 'REFUGIO',
+        addedByLastName: 'ROGAHN',
+        expiredByFirstName: 'GLENNA',
+        expiredByLastName: 'FLATLEY',
+        dateExpires: '2016-12-26'
+      },
+      {
+        alertId: 2,
+        alertType: 'X',
+        alertTypeDescription: 'Security',
+        alertCode: 'XEL',
+        alertCodeDescription: 'Escape List',
+        comment: 'some more personal details',
+        dateCreated: '2011-11-14',
+        expired: false,
+        active: true,
+        addedByFirstName: 'AUGUSTUS',
+        addedByLastName: 'WILLIAMSON',
+        expiredByFirstName: 'TOMMY',
+        expiredByLastName: 'POLLICH',
+        dateExpires: '2018-02-06'
+      }
+    ]
+  end
+
+  describe '.call' do
+    let(:anonymised) do
+      anonymiser.call.first
+    end
+
+    it 'resets comment' do
+      expect(anonymised[:comment]).to be_nil
+    end
+
+    it 'resets names' do
+      expect(anonymised[:addedByFirstName]).not_to eql 'AUGUSTUS'
+    end
+  end
+end


### PR DESCRIPTION
Include alerts in the data fixture files exported to `db/fixtures/nomis`. These are used in https://github.com/ministryofjustice/elite2-api-mock (separate PR to follow).