### PR TITLE
[P4-606] Alerts importer

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -20,10 +20,14 @@ class Profile < ApplicationRecord
   ].freeze
 
   def merge_assessment_answers!(assessment_answers)
-    self.assessment_answers = assessment_answers
+    self.assessment_answers = manually_created_assessment_answers + assessment_answers
   end
 
   private
+
+  def manually_created_assessment_answers
+    assessment_answers.reject(&:imported_from_nomis)
+  end
 
   def set_assessment_answers
     assessment_answers.each(&:set_timestamps)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -19,6 +19,10 @@ class Profile < ApplicationRecord
     police_national_computer criminal_records_office prison_number niche_reference athena_reference
   ].freeze
 
+  def merge_assessment_answers!(assessment_answers)
+    self.assessment_answers = assessment_answers
+  end
+
   private
 
   def set_assessment_answers

--- a/app/models/profile/assessment_answer.rb
+++ b/app/models/profile/assessment_answer.rb
@@ -9,13 +9,15 @@ class Profile
       :created_at,
       :expires_at,
       :category,
-      :key
+      :key,
+      :nomis_alert_code,
+      :nomis_alert_type
     )
 
     attr_accessor :title, :comments, :assessment_question_id, :category, :key
     attr_reader :created_at, :expires_at
 
-    validates :assessment_question_id, presence: true
+    # validates :assessment_question_id, presence: true
 
     def initialize(attributes = {})
       attributes.symbolize_keys! if attributes.respond_to?(:symbolize_keys!)

--- a/app/models/profile/assessment_answer.rb
+++ b/app/models/profile/assessment_answer.rb
@@ -14,11 +14,12 @@ class Profile
       :nomis_alert_type
     )
 
-    attr_accessor :title, :comments, :assessment_question_id, :category, :key
+    attr_accessor :title, :comments, :assessment_question_id, :category, :key, :nomis_alert_code, :nomis_alert_type
     attr_reader :created_at, :expires_at
 
     validate :assessment_question_or_nomis_code_present
 
+    # rubocop:disable Metrics/MethodLength
     def initialize(attributes = {})
       attributes.symbolize_keys! if attributes.respond_to?(:symbolize_keys!)
 
@@ -29,8 +30,11 @@ class Profile
       self.assessment_question_id = attributes[:assessment_question_id]
       self.category = attributes[:category]
       self.key = attributes[:key]
+      self.nomis_alert_code = attributes[:nomis_alert_code]
+      self.nomis_alert_type = attributes[:nomis_alert_type]
       super
     end
+    # rubocop:enable Metrics/MethodLength
 
     def created_at=(value)
       @created_at = value.is_a?(String) ? Date.parse(value) : value
@@ -44,6 +48,7 @@ class Profile
       assessment_question_id.blank?
     end
 
+    # rubocop:disable Metrics/MethodLength
     def as_json
       {
         title: title,
@@ -52,9 +57,12 @@ class Profile
         expires_at: expires_at,
         assessment_question_id: assessment_question_id,
         category: category,
-        key: key
+        key: key,
+        nomis_alert_type: nomis_alert_type,
+        nomis_alert_code: nomis_alert_code
       }
     end
+    # rubocop:enable Metrics/MethodLength
 
     def risk?
       category == 'risk'

--- a/app/models/profile/assessment_answer.rb
+++ b/app/models/profile/assessment_answer.rb
@@ -11,30 +11,29 @@ class Profile
       :category,
       :key,
       :nomis_alert_code,
-      :nomis_alert_type
+      :nomis_alert_type,
+      :imported_from_nomis
     )
 
-    attr_accessor :title, :comments, :assessment_question_id, :category, :key, :nomis_alert_code, :nomis_alert_type
+    attr_accessor(
+      :title,
+      :comments,
+      :assessment_question_id,
+      :category,
+      :key,
+      :nomis_alert_code,
+      :nomis_alert_type,
+      :imported_from_nomis
+    )
     attr_reader :created_at, :expires_at
 
     validate :assessment_question_or_nomis_code_present
 
-    # rubocop:disable Metrics/MethodLength
     def initialize(attributes = {})
       attributes.symbolize_keys! if attributes.respond_to?(:symbolize_keys!)
-
-      self.title = attributes[:title]
-      self.comments = attributes[:comments]
-      self.created_at = attributes[:created_at]
-      self.expires_at = attributes[:expires_at]
-      self.assessment_question_id = attributes[:assessment_question_id]
-      self.category = attributes[:category]
-      self.key = attributes[:key]
-      self.nomis_alert_code = attributes[:nomis_alert_code]
-      self.nomis_alert_type = attributes[:nomis_alert_type]
+      assign_attributes(attributes)
       super
     end
-    # rubocop:enable Metrics/MethodLength
 
     def created_at=(value)
       @created_at = value.is_a?(String) ? Date.parse(value) : value
@@ -59,7 +58,8 @@ class Profile
         category: category,
         key: key,
         nomis_alert_type: nomis_alert_type,
-        nomis_alert_code: nomis_alert_code
+        nomis_alert_code: nomis_alert_code,
+        imported_from_nomis: imported_from_nomis
       }
     end
     # rubocop:enable Metrics/MethodLength
@@ -89,10 +89,25 @@ class Profile
       self.created_at ||= Time.zone.now
     end
 
+    private
+
     def assessment_question_or_nomis_code_present
       return if assessment_question_id.present? || (nomis_alert_type.present? && nomis_alert_code.present?)
 
       errors.add(:assessment_question_id, "can't be blank unless nomis_alert_type and nomis_alert_code are present")
+    end
+
+    def assign_attributes(attributes)
+      self.title = attributes[:title]
+      self.comments = attributes[:comments]
+      self.created_at = attributes[:created_at]
+      self.expires_at = attributes[:expires_at]
+      self.assessment_question_id = attributes[:assessment_question_id]
+      self.category = attributes[:category]
+      self.key = attributes[:key]
+      self.nomis_alert_code = attributes[:nomis_alert_code]
+      self.nomis_alert_type = attributes[:nomis_alert_type]
+      self.imported_from_nomis = attributes[:imported_from_nomis]
     end
   end
 end

--- a/app/models/profile/assessment_answer.rb
+++ b/app/models/profile/assessment_answer.rb
@@ -17,7 +17,7 @@ class Profile
     attr_accessor :title, :comments, :assessment_question_id, :category, :key
     attr_reader :created_at, :expires_at
 
-    # validates :assessment_question_id, presence: true
+    validate :assessment_question_or_nomis_code_present
 
     def initialize(attributes = {})
       attributes.symbolize_keys! if attributes.respond_to?(:symbolize_keys!)
@@ -79,6 +79,12 @@ class Profile
 
     def set_timestamps
       self.created_at ||= Time.zone.now
+    end
+
+    def assessment_question_or_nomis_code_present
+      return if assessment_question_id.present? || (nomis_alert_type.present? && nomis_alert_code.present?)
+
+      errors.add(:assessment_question_id, "can't be blank unless nomis_alert_type and nomis_alert_code are present")
     end
   end
 end

--- a/app/services/alerts/importer.rb
+++ b/app/services/alerts/importer.rb
@@ -10,15 +10,40 @@ module Alerts
     end
 
     def call
-      alerts.each do |alert|
-        import_alert(alert)
-      end
+      profile.merge_assessment_answers!(
+        alerts.map { |alert| build_alert(alert) }
+      )
+      profile.save!
     end
 
     private
 
-    def import_alert(alert)
-      # TODO:
+    # alert_id: alert['alertId'],
+    # alert_type: alert['alertType'],
+    # alert_type_description: alert['alertTypeDescription'],
+    # alert_code: alert['alertCode'],
+    # alert_code_description: alert['alertCodeDescription'],
+    # comment: alert['comment'],
+    # created_at: alert['dateCreated'],
+    # expires_at: alert['dateExpires'],
+    # expired: alert['expired'],
+    # active: alert['active'],
+    # rnum: alert['rnum']
+    def build_alert(alert)
+      #TODO: Look up assessment question mapping (NomisAlerts)
+      assessment_question = nil
+
+      Profile::AssessmentAnswer.new(
+        title: alert[:description],
+        comments: alert[:comments],
+        assessment_question_id: assessment_question&.id,
+        created_at: alert[:created_at],
+        expires_at: alert[:expires_at],
+        category: assessment_question&.category || :risk,
+        key: assessment_question&.key || alert[:alert_code],
+        nomis_alert_code: alert[:alert_code],
+        nomis_alert_type: alert[:alert_type]
+      ).tap(&:set_timestamps)
     end
   end
 end

--- a/app/services/alerts/importer.rb
+++ b/app/services/alerts/importer.rb
@@ -18,20 +18,9 @@ module Alerts
 
     private
 
-    # alert_id: alert['alertId'],
-    # alert_type: alert['alertType'],
-    # alert_type_description: alert['alertTypeDescription'],
-    # alert_code: alert['alertCode'],
-    # alert_code_description: alert['alertCodeDescription'],
-    # comment: alert['comment'],
-    # created_at: alert['dateCreated'],
-    # expires_at: alert['dateExpires'],
-    # expired: alert['expired'],
-    # active: alert['active'],
-    # rnum: alert['rnum']
+    # rubocop:disable Metrics/MethodLength
     def build_alert(alert)
-      #TODO: Look up assessment question mapping (NomisAlerts)
-      assessment_question = nil
+      assessment_question = find_assessment_question(alert)
 
       Profile::AssessmentAnswer.new(
         title: alert[:description],
@@ -44,6 +33,15 @@ module Alerts
         nomis_alert_code: alert[:alert_code],
         nomis_alert_type: alert[:alert_type]
       ).tap(&:set_timestamps)
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def find_assessment_question(alert)
+      nomis_alert = NomisAlert.includes(:assessment_question).find_by(
+        code: alert[:alert_code],
+        type_code: alert[:alert_type]
+      )
+      nomis_alert&.assessment_question
     end
   end
 end

--- a/app/services/alerts/importer.rb
+++ b/app/services/alerts/importer.rb
@@ -31,7 +31,8 @@ module Alerts
         category: assessment_question&.category || :risk,
         key: assessment_question&.key || alert[:alert_code],
         nomis_alert_code: alert[:alert_code],
-        nomis_alert_type: alert[:alert_type]
+        nomis_alert_type: alert[:alert_type],
+        imported_from_nomis: true
       ).tap(&:set_timestamps)
     end
     # rubocop:enable Metrics/MethodLength

--- a/app/services/alerts/importer.rb
+++ b/app/services/alerts/importer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Alerts
+  class Importer
+    attr_accessor :profile, :alerts
+
+    def initialize(profile:, alerts:)
+      self.profile = profile
+      self.alerts = alerts
+    end
+
+    def call
+      alerts.each do |alert|
+        import_alert(alert)
+      end
+    end
+
+    private
+
+    def import_alert(alert)
+      # TODO:
+    end
+  end
+end

--- a/spec/factories/nomis_alert.rb
+++ b/spec/factories/nomis_alert.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :nomis_alert do
+    description { 'Risk to people' }
+    type_description { 'Risk' }
+    code { 'RTP' }
+    type_code { 'R' }
+  end
+end

--- a/spec/models/profile/assessment_answer_spec.rb
+++ b/spec/models/profile/assessment_answer_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe Profile::AssessmentAnswer, type: :model do
       created_at: Date.civil(2019, 5, 30),
       expires_at: Date.civil(2019, 6, 30),
       category: 'risk',
-      key: 'just_a_test'
+      key: 'just_a_test',
+      nomis_alert_code: nil,
+      nomis_alert_type: nil,
+      imported_from_nomis: false
     }
   end
 
@@ -114,7 +117,10 @@ RSpec.describe Profile::AssessmentAnswer, type: :model do
         created_at: Date.civil(2019, 5, 30),
         expires_at: Date.civil(2019, 6, 30),
         category: 'foo',
-        title: 'foo'
+        title: 'foo',
+        nomis_alert_code: nil,
+        nomis_alert_type: nil,
+        imported_from_nomis: false
       }
     end
 

--- a/spec/models/profile/assessment_answer_spec.rb
+++ b/spec/models/profile/assessment_answer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Profile::AssessmentAnswer, type: :model do
   end
 
   describe 'validations' do
-    context 'without an assessment_question_id' do
+    context 'without an assessment_question_id or nomis_alert_type and nomis_alert_code' do
       let(:attribute_values) do
         {
           title: title,
@@ -37,6 +37,19 @@ RSpec.describe Profile::AssessmentAnswer, type: :model do
       let(:attribute_values) do
         {
           assessment_question_id: 123
+        }
+      end
+
+      it 'is valid' do
+        expect(assessment_answer.valid?).to be true
+      end
+    end
+
+    context 'with a nomis_alert_code and nomis_alert_type' do
+      let(:attribute_values) do
+        {
+          nomis_alert_type: 'A',
+          nomis_alert_code: 'ABC'
         }
       end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -92,7 +92,8 @@ RSpec.describe Profile, type: :model do
           created_at: Date.civil(2019, 5, 30),
           expires_at: Date.civil(2019, 6, 30),
           nomis_alert_code: nil,
-          nomis_alert_type: nil
+          nomis_alert_type: nil,
+          imported_from_nomis: false
         }
       ]
     end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -90,7 +90,9 @@ RSpec.describe Profile, type: :model do
           comments: 'just a test',
           assessment_question_id: assessment_question.id,
           created_at: Date.civil(2019, 5, 30),
-          expires_at: Date.civil(2019, 6, 30)
+          expires_at: Date.civil(2019, 6, 30),
+          nomis_alert_code: nil,
+          nomis_alert_type: nil
         }
       ]
     end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -118,4 +118,57 @@ RSpec.describe Profile, type: :model do
       expect(profile.assessment_answers.first).to be_a(Profile::AssessmentAnswer)
     end
   end
+
+  describe '#merge_assessment_answers!' do
+    subject(:profile) { build :profile, assessment_answers: assessment_answers }
+
+    let(:assessment_answers) do
+      [
+        Profile::AssessmentAnswer.new(
+          key: 'hold_separately',
+          imported_from_nomis: false
+        ),
+        Profile::AssessmentAnswer.new(
+          key: 'ABC',
+          imported_from_nomis: true,
+          nomis_alert_type: 'A',
+          nomis_alert_code: 'ABC',
+          description: 'NOMIS imported item'
+        ),
+        Profile::AssessmentAnswer.new(
+          key: 'not_for_release',
+          imported_from_nomis: false
+        )
+      ]
+    end
+
+    let(:imported_assessment_answers) do
+      [
+        Profile::AssessmentAnswer.new(
+          key: 'DEF',
+          imported_from_nomis: true,
+          nomis_alert_type: 'D',
+          nomis_alert_code: 'DEF',
+          description: 'NOMIS imported item #2'
+        ),
+        Profile::AssessmentAnswer.new(
+          key: 'HIJ',
+          imported_from_nomis: true,
+          nomis_alert_type: 'H',
+          nomis_alert_code: 'HIJ',
+          description: 'NOMIS imported item #3'
+        )
+      ]
+    end
+
+    before do
+      profile.merge_assessment_answers!(imported_assessment_answers)
+    end
+
+    it 'overwrites previously imported answers and leaves other as they were' do
+      expect(profile.assessment_answers.map(&:key)).to match_array(
+        %w[not_for_release hold_separately DEF HIJ]
+      )
+    end
+  end
 end

--- a/spec/services/alerts/importer_spec.rb
+++ b/spec/services/alerts/importer_spec.rb
@@ -62,6 +62,11 @@ RSpec.describe Alerts::Importer do
       importer.call
       expect(profile.reload.assessment_answers&.first&.assessment_question_id).to be_nil
     end
+
+    it 'sets imported_from_nomis' do
+      importer.call
+      expect(profile.reload.assessment_answers&.first&.imported_from_nomis).to be true
+    end
   end
 
   context 'with a relevant nomis alert mapping' do

--- a/spec/services/alerts/importer_spec.rb
+++ b/spec/services/alerts/importer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Alerts::Importer do
+  subject(:importer) do
+    described_class.new(
+      profile: profile,
+      alerts: alerts
+    )
+  end
+
+  let(:person) { create :person }
+  let(:profile) { person.latest_profile }
+  let(:alerts) do
+    [
+      {
+        alert_id: 1,
+        alert_type: 'X',
+        alert_type_description: 'Security',
+        alert_code: 'XVL',
+        alert_code_description: 'Violent',
+        comment: 'Threatening to take staff hostage',
+        created_at: '2018-07-29',
+        expires_at: nil,
+        expired: false,
+        active: true,
+        rnum: 1
+      },
+      {
+        alert_id: 2,
+        alert_type: 'X',
+        alert_type_description: 'Security',
+        alert_code: 'XEL',
+        alert_code_description: 'Escape List',
+        comment: 'Caught in possession of a rock hammer',
+        created_at: '2017-06-15',
+        expires_at: nil,
+        expired: false,
+        active: true,
+        rnum: 2
+      }
+    ]
+  end
+
+  it 'works' do
+    importer.call
+    expect(profile.assessment_answers.count).to be 2
+  end
+end

--- a/spec/services/alerts/importer_spec.rb
+++ b/spec/services/alerts/importer_spec.rb
@@ -43,8 +43,9 @@ RSpec.describe Alerts::Importer do
     ]
   end
 
-  it 'works' do
-    importer.call
-    expect(profile.assessment_answers.count).to be 2
+  context 'when there are no relevant nomis alert mappings' do
+    it 'creates new assessment answers with nomis alert code and type' do
+      expect { importer.call }.to change { profile.reload.assessment_answers.count }.by(2)
+    end
   end
 end


### PR DESCRIPTION
This PR adds an `Alerts::Importer` class to import alerts for moves (via profiles).

Alerts from NOMIS are merged into our `AssessmentAnswer`s by overwriting all existing NOMIS imported assessment answers but leaving any that were manually created. To facilitate this we have included an `AssessmentAnswer#imported_from_nomis` attribute that is `true` iff the assessment answer came from NOMIS direct.