### PR TITLE
[P4-606] Trigger alerts import when importing a move from NOMIS

### DIFF
--- a/app/lib/nomis_client/moves.rb
+++ b/app/lib/nomis_client/moves.rb
@@ -3,17 +3,17 @@
 module NomisClient
   class Moves
     class << self
-      def get(nomis_agency_id, date, event_type = :courtEvents)
+      def get(nomis_agency_ids, date, event_type = :courtEvents)
         attributes_for(
-          get_response(nomis_agency_id: nomis_agency_id, date: date, event_type: event_type),
+          get_response(nomis_agency_ids: nomis_agency_ids, date: date, event_type: event_type),
           event_type
         )
       end
 
-      def get_response(nomis_agency_id:, date:, event_type: :courtEvents)
+      def get_response(nomis_agency_ids:, date:, event_type: :courtEvents)
         NomisClient::Base.get(
           '/movements/transfers',
-          params: { agencyId: nomis_agency_id, **date_params(date), **event_params(event_type) },
+          params: { agencyId: nomis_agency_ids, **date_params(date), **event_params(event_type) },
           headers: { 'Page-Limit' => '500' }
         ).parsed
       end

--- a/app/lib/nomis_client/moves.rb
+++ b/app/lib/nomis_client/moves.rb
@@ -3,17 +3,17 @@
 module NomisClient
   class Moves
     class << self
-      def get(nomis_agency_ids, date, event_type = :courtEvents)
+      def get(nomis_agency_id, date, event_type = :courtEvents)
         attributes_for(
-          get_response(nomis_agency_ids: nomis_agency_ids, date: date, event_type: event_type),
+          get_response(nomis_agency_id: nomis_agency_id, date: date, event_type: event_type),
           event_type
         )
       end
 
-      def get_response(nomis_agency_ids:, date:, event_type: :courtEvents)
+      def get_response(nomis_agency_id:, date:, event_type: :courtEvents)
         NomisClient::Base.get(
           '/movements/transfers',
-          params: { agencyId: nomis_agency_ids, **date_params(date), **event_params(event_type) },
+          params: { agencyId: nomis_agency_id, **date_params(date), **event_params(event_type) },
           headers: { 'Page-Limit' => '500' }
         ).parsed
       end

--- a/app/services/moves/importer.rb
+++ b/app/services/moves/importer.rb
@@ -11,6 +11,7 @@ module Moves
     def call
       items.each do |move|
         import_person(move[:person_nomis_prison_number])
+        import_alerts(move[:person_nomis_prison_number])
         import_move(move)
       end
     end
@@ -20,6 +21,12 @@ module Moves
     def import_person(prison_number)
       person_attributes = NomisClient::People.get(prison_number)
       People::Importer.new(person_attributes).call
+    end
+
+    def import_alerts(prison_number)
+      person = Person.find_by(nomis_prison_number: prison_number)
+      alerts = NomisClient::Alerts.get(prison_number)
+      Alerts::Importer.new(profile: person.latest_profile, alerts: alerts).call
     end
 
     def import_move(move)

--- a/spec/services/moves/importer_spec.rb
+++ b/spec/services/moves/importer_spec.rb
@@ -32,15 +32,23 @@ RSpec.describe Moves::Importer do
   let!(:prisoner_two) { create(:person, nomis_prison_number: 'G7157AB') }
 
   let(:people_importer) { instance_double('People::Importer', call: true) }
+  let(:alerts_importer) { instance_double('Alerts::Importer', call: true) }
 
   before do
     allow(NomisClient::People).to receive(:get)
+    allow(NomisClient::Alerts).to receive(:get)
     allow(People::Importer).to receive(:new).and_return(people_importer)
+    allow(Alerts::Importer).to receive(:new).and_return(alerts_importer)
   end
 
   it 'calls the People::Importer service twice' do
     importer.call
     expect(people_importer).to have_received(:call).twice
+  end
+
+  it 'calls the Alerts::Importer service twice' do
+    importer.call
+    expect(alerts_importer).to have_received(:call).twice
   end
 
   context 'with no existing records' do


### PR DESCRIPTION
This PR just invokes `Alerts::Importer` from `Moves::Importer` so alerts are imported at the same time as moves and profiles.