### PR TITLE
[P4-606] Ensure that title and comments are set when importing alerts

### DIFF
--- a/app/services/alerts/importer.rb
+++ b/app/services/alerts/importer.rb
@@ -23,8 +23,8 @@ module Alerts
       assessment_question = find_assessment_question(alert)
 
       Profile::AssessmentAnswer.new(
-        title: alert[:description],
-        comments: alert[:comments],
+        title: alert_title(alert),
+        comments: alert[:comment],
         assessment_question_id: assessment_question&.id,
         created_at: alert[:created_at],
         expires_at: alert[:expires_at],
@@ -36,6 +36,10 @@ module Alerts
       ).tap(&:set_timestamps)
     end
     # rubocop:enable Metrics/MethodLength
+
+    def alert_title(alert)
+      [alert[:alert_type_description], alert[:alert_code_description]].reject(&:blank?).join(' - ')
+    end
 
     def find_assessment_question(alert)
       nomis_alert = NomisAlert.includes(:assessment_question).find_by(

--- a/spec/services/alerts/importer_spec.rb
+++ b/spec/services/alerts/importer_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe Alerts::Importer do
       importer.call
       expect(profile.reload.assessment_answers&.first&.imported_from_nomis).to be true
     end
+
+    it 'sets the title' do
+      importer.call
+      expect(profile.reload.assessment_answers&.first&.title).to eq 'Security - Violent'
+    end
+
+    it 'sets the comments' do
+      importer.call
+      expect(profile.reload.assessment_answers&.first&.comments).to eq 'Threatening to take staff hostage'
+    end
   end
 
   context 'with a relevant nomis alert mapping' do


### PR DESCRIPTION
When tested against real data this wasn't working the way I expected so have made a few tweaks to the mappings.

- `AssessmentAnswer#title` is derived from the alert type description and alert code description (concatenated with a ' - ').
- `AssessmentAnswer#comments` is fixed.

We still need to work out whether what we are getting back from NOMIS is right for display or whether there is further work to do back or front end.

This is an example of what I see now when running the front end:

![image](https://user-images.githubusercontent.com/450843/64524724-1144fe00-d2f7-11e9-8683-41aa82d099d6.png)

In this example most of the alerts from NOMIS don't map to our own assessment questions, e.g. 'OTHER - NO CONTACT REQUEST'. There are 3 that do map including two for the same question 'Violent'.
