### PR TITLE
[P4-664] Only synchronise move data from NOMIS for prisons

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class Location < ApplicationRecord
+  LOCATION_TYPE_COURT = 'court'
+  LOCATION_TYPE_POLICE = 'police'
+  LOCATION_TYPE_PRISON = 'prison'
+
   NOMIS_AGENCY_TYPES = {
-    'INST' => :prison,
-    'CRT' => :court
+    'INST' => LOCATION_TYPE_PRISON,
+    'CRT' => LOCATION_TYPE_COURT
   }.freeze
 
   has_many :moves_from, class_name: 'Move', foreign_key: :from_location_id
@@ -12,4 +16,16 @@ class Location < ApplicationRecord
   validates :key, presence: true
   validates :title, presence: true
   validates :location_type, presence: true
+
+  def prison?
+    location_type.to_s == LOCATION_TYPE_PRISON
+  end
+
+  def police?
+    location_type.to_s == LOCATION_TYPE_POLICE
+  end
+
+  def court?
+    location_type.to_s == LOCATION_TYPE_COURT
+  end
 end

--- a/app/services/moves/nomis_synchroniser.rb
+++ b/app/services/moves/nomis_synchroniser.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Moves
+  class NomisSynchroniser
+    attr_accessor :location, :date
+
+    def initialize(location:, date:)
+      self.location = location
+      self.date = date
+    end
+
+    def call
+      return unless nomis_agency_id && date && prison?
+
+      moves = NomisClient::Moves.get(nomis_agency_id, date)
+      Moves::Importer.new(moves).call
+    end
+
+    private
+
+    def nomis_agency_id
+      location&.nomis_agency_id
+    end
+
+    def prison?
+      location&.prison?
+    end
+  end
+end

--- a/app/services/people/anonymiser.rb
+++ b/app/services/people/anonymiser.rb
@@ -45,7 +45,7 @@ module People
     private
 
     def prisons
-      Location.where(location_type: 'prison').all
+      Location.where(location_type: Location::LOCATION_TYPE_PRISON).all
     end
   end
 end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -4,20 +4,20 @@ FactoryBot.define do
   factory :location do
     key { 'hmp_pentonville' }
     title { 'HMP Pentonville' }
-    location_type { 'prison' }
+    location_type { Location::LOCATION_TYPE_PRISON }
     nomis_agency_id { 'PEI' }
 
     trait :court do
       key { 'guildford_crown_court' }
       title { 'Guildford Crown Court' }
-      location_type { 'court' }
+      location_type { Location::LOCATION_TYPE_COURT }
       nomis_agency_id { 'GUICCT' }
     end
 
     trait :police do
       key { 'guildford_police_station' }
       title { 'Guildford Police Station' }
-      location_type { 'police' }
+      location_type { Location::LOCATION_TYPE_POLICE }
       nomis_agency_id { 'GUIPS' }
     end
   end

--- a/spec/lib/nomis_client/locations_spec.rb
+++ b/spec/lib/nomis_client/locations_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NomisClient::Locations, with_nomis_client_authentication: true do
 
     it 'returns the correct data for the first match' do
       expect(response.first)
-        .to eq(key: 'abdrct', nomis_agency_id: 'ABDRCT', title: 'Aberdare County Court', location_type: :court)
+        .to eq(key: 'abdrct', nomis_agency_id: 'ABDRCT', title: 'Aberdare County Court', location_type: 'court')
     end
 
     it 'does not return locations different from prisons and courts' do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -8,4 +8,28 @@ RSpec.describe Location do
 
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_presence_of(:location_type) }
+
+  context 'when location is a prison' do
+    subject(:location) { build :location }
+
+    it { expect(location.prison?).to be true }
+    it { expect(location.police?).to be false }
+    it { expect(location.court?).to be false }
+  end
+
+  context 'when location is a police custody unit' do
+    subject(:location) { build :location, :police }
+
+    it { expect(location.prison?).to be false }
+    it { expect(location.police?).to be true }
+    it { expect(location.court?).to be false }
+  end
+
+  context 'when location is a court' do
+    subject(:location) { build :location, :court }
+
+    it { expect(location.prison?).to be false }
+    it { expect(location.police?).to be false }
+    it { expect(location.court?).to be true }
+  end
 end

--- a/spec/services/moves/nomis_synchroniser_spec.rb
+++ b/spec/services/moves/nomis_synchroniser_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moves::NomisSynchroniser do
+  subject(:synchroniser) do
+    described_class.new(
+      location: location,
+      date: date
+    )
+  end
+
+  let(:date) { Date.today }
+
+  describe '.call' do
+    let(:importer) { instance_double(Moves::Importer, call: nil) }
+
+    before do
+      allow(Moves::Importer).to receive(:new).and_return(importer)
+      allow(NomisClient::Moves).to receive(:get).and_return([])
+      synchroniser.call
+    end
+
+    context 'when the location is a police custody unit' do
+      let(:location) { build :location, :police }
+
+      it 'does NOT call importer' do
+        expect(Moves::Importer).not_to have_received(:new)
+      end
+
+      it 'does NOT call the NOMIS API' do
+        expect(NomisClient::Moves).not_to have_received(:get)
+      end
+    end
+
+    context 'when the location is a prison' do
+      let(:location) { build :location }
+
+      it 'calls importer' do
+        expect(Moves::Importer).to have_received(:new).with([])
+      end
+
+      it 'calls the NOMIS API' do
+        expect(NomisClient::Moves).to have_received(:get)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have been doing the call to NOMIS on all requests up to now. They are redundant for Police so we will skip for now.

Have also refactored some business logic out of the controller into a new `Moves::NomisSynchroniser` service class (if anybody can think of a better name let me know).