### PR TITLE
[P4-670] Remove redundant AssessmentQuestion attributes

### DIFF
--- a/app/serializers/assessment_question_serializer.rb
+++ b/app/serializers/assessment_question_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class AssessmentQuestionSerializer < ActiveModel::Serializer
-  attributes :id, :key, :category, :title, :nomis_alert_type, :nomis_alert_code, :disabled_at
+  attributes :id, :key, :category, :title, :disabled_at
 end

--- a/db/migrate/20190916113440_remove_assessment_questions_nomis_code.rb
+++ b/db/migrate/20190916113440_remove_assessment_questions_nomis_code.rb
@@ -1,0 +1,6 @@
+class RemoveAssessmentQuestionsNomisCode < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :assessment_questions, :nomis_alert_code
+    remove_column :assessment_questions, :nomis_alert_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_28_103544) do
+ActiveRecord::Schema.define(version: 2019_09_16_113440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -19,8 +19,6 @@ ActiveRecord::Schema.define(version: 2019_08_28_103544) do
   create_table "assessment_questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.string "category", null: false
-    t.string "nomis_alert_type"
-    t.string "nomis_alert_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "key", null: false

--- a/spec/factories/assessment_question.rb
+++ b/spec/factories/assessment_question.rb
@@ -3,8 +3,6 @@
 FactoryBot.define do
   factory :assessment_question do
     category { 'health' }
-    nomis_alert_type { 'M' }
-    nomis_alert_code { 'MSI' }
     key { 'sight_impaired' }
     title { 'Sight Impaired' }
 

--- a/spec/requests/api/v1/reference/assessment_questions_controller_spec.rb
+++ b/spec/requests/api/v1/reference/assessment_questions_controller_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe Api::V1::Reference::AssessmentQuestionsController, with_client_au
           type: 'assessment_questions',
           attributes: {
             category: 'health',
-            nomis_alert_type: 'M',
-            nomis_alert_code: 'MSI',
             title: 'Sight Impaired'
           }
         }

--- a/spec/serializers/assessment_question_serializer_spec.rb
+++ b/spec/serializers/assessment_question_serializer_spec.rb
@@ -29,14 +29,6 @@ RSpec.describe AssessmentQuestionSerializer do
     expect(result[:data][:attributes][:key]).to eql 'sight_impaired'
   end
 
-  it 'contains a nomis_alert_code attribute' do
-    expect(result[:data][:attributes][:nomis_alert_code]).to eql 'MSI'
-  end
-
-  it 'contains a nomis_alert_type attribute' do
-    expect(result[:data][:attributes][:nomis_alert_type]).to eql 'M'
-  end
-
   it 'contains a disabled_at attribute' do
     expect(Time.parse(result[:data][:attributes][:disabled_at])).to eql disabled_at
   end

--- a/swagger/v1/assessment_question.json
+++ b/swagger/v1/assessment_question.json
@@ -21,16 +21,6 @@
             "enum": ["health", "risk", "court"],
             "description": "Category is the section in the Create Move form that an assessment question appears in, e.g. Health or Risks"
           },
-          "nomis_alert_type": {
-            "type": "String",
-            "example": "M",
-            "description": "The NOMIS alert type for this assessment question"
-          },
-          "nomis_alert_code": {
-            "type": "String",
-            "example": "MSI",
-            "description": "The NOMIS alert code for this assessment question"
-          },
           "key": {
             "type": "String",
             "example": "sight_impaired",


### PR DESCRIPTION
This PR removes the following attributes from `AssessmentQuestion` (they were never used):

* `nomis_alert_code`
* `nomis_alert_type`

Mappings to NOMIS alerts are now declared in the `NomisAlerts` model.