### PR TITLE
[P4-707] Support for multiple location downloads

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -94,6 +94,8 @@ module Api
         @from_locations ||=
           if filter_params[:from_location_id]
             [Location.find(filter_params[:from_location_id])]
+          elsif ENV['NOMIS_AGENCY_IDS']
+            Location.where('nomis_agency_id IN (?)', ENV['NOMIS_AGENCY_IDS'].split(',').map(&:strip))
           else
             []
           end

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -82,18 +82,21 @@ module Api
 
       def import_moves_from_nomis(move: nil)
         if move.present?
-          Moves::NomisSynchroniser.new(location: move.from_location, date: move.date).call
+          Moves::NomisSynchroniser.new(locations: [move.from_location], date: move.date).call
         else
-          Moves::NomisSynchroniser.new(location: from_location, date: date).call
+          Moves::NomisSynchroniser.new(locations: from_locations, date: date).call
         end
       rescue StandardError => e
         Raven.capture_exception(e)
       end
 
-      def from_location
-        return unless filter_params[:from_location_id]
-
-        @from_location ||= Location.find(filter_params[:from_location_id])
+      def from_locations
+        @from_locations ||=
+          if filter_params[:from_location_id]
+            [Location.find(filter_params[:from_location_id])]
+          else
+            []
+          end
       end
 
       def date

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -94,8 +94,8 @@ module Api
         @from_locations ||=
           if filter_params[:from_location_id]
             [Location.find(filter_params[:from_location_id])]
-          elsif ENV['NOMIS_AGENCY_IDS']
-            Location.where('nomis_agency_id IN (?)', ENV['NOMIS_AGENCY_IDS'].split(',').map(&:strip))
+          elsif ENV['DEFAULT_NOMIS_AGENCY_IDS']
+            Location.where('nomis_agency_id IN (?)', ENV['DEFAULT_NOMIS_AGENCY_IDS'].split(',').map(&:strip))
           else
             []
           end

--- a/app/lib/nomis_client/moves.rb
+++ b/app/lib/nomis_client/moves.rb
@@ -3,19 +3,19 @@
 module NomisClient
   class Moves
     class << self
-      def get(nomis_agency_id, date, event_type = :courtEvents)
+      def get(nomis_agency_ids, date, event_type = :courtEvents)
         attributes_for(
-          get_response(nomis_agency_id: nomis_agency_id, date: date, event_type: event_type),
+          get_response(nomis_agency_ids: nomis_agency_ids, date: date, event_type: event_type),
           event_type
         ).map do |move|
           response(move)
         end
       end
 
-      def get_response(nomis_agency_id:, date:, event_type: :courtEvents)
+      def get_response(nomis_agency_ids:, date:, event_type: :courtEvents)
         NomisClient::Base.get(
           '/movements/transfers',
-          params: { agencyId: nomis_agency_id, **date_params(date), **event_params(event_type) },
+          params: { agencyId: nomis_agency_ids, **date_params(date), **event_params(event_type) },
           headers: { 'Page-Limit' => '500' }
         ).parsed
       end

--- a/app/lib/nomis_client/moves.rb
+++ b/app/lib/nomis_client/moves.rb
@@ -14,13 +14,17 @@ module NomisClient
 
       def get_response(nomis_agency_ids:, date:, event_type: :courtEvents)
         NomisClient::Base.get(
-          '/movements/transfers',
-          params: { agencyId: nomis_agency_ids, **date_params(date), **event_params(event_type) },
+          "/movements/transfers?#{agency_id_params(nomis_agency_ids)}",
+          params: { **date_params(date), **event_params(event_type) },
           headers: { 'Page-Limit' => '500' }
         ).parsed
       end
 
       private
+
+      def agency_id_params(nomis_agency_ids)
+        nomis_agency_ids.map { |id| "agencyId=#{CGI.escape(id)}" }.join('&')
+      end
 
       # rubocop:disable Metrics/MethodLength
       def attributes_for(nomis_data, event_type)

--- a/app/services/moves/nomis_synchroniser.rb
+++ b/app/services/moves/nomis_synchroniser.rb
@@ -14,7 +14,7 @@ module Moves
 
       moves = NomisClient::Moves.get(nomis_agency_ids, date)
       Moves::Importer.new(moves).call
-      Moves::Sweeper.new(location, date, moves).call
+      Moves::Sweeper.new(locations, date, moves).call
     end
 
     private

--- a/app/services/moves/nomis_synchroniser.rb
+++ b/app/services/moves/nomis_synchroniser.rb
@@ -2,28 +2,28 @@
 
 module Moves
   class NomisSynchroniser
-    attr_accessor :location, :date
+    attr_accessor :locations, :date
 
-    def initialize(location:, date:)
-      self.location = location
+    def initialize(locations:, date:)
+      self.locations = locations || []
       self.date = date
     end
 
     def call
-      return unless nomis_agency_id && date && prison?
+      return unless nomis_agency_ids.present? && date && prison?
 
-      moves = NomisClient::Moves.get(nomis_agency_id, date)
+      moves = NomisClient::Moves.get(nomis_agency_ids, date)
       Moves::Importer.new(moves).call
     end
 
     private
 
-    def nomis_agency_id
-      location&.nomis_agency_id
+    def nomis_agency_ids
+      locations.map(&:nomis_agency_id)
     end
 
     def prison?
-      location&.prison?
+      locations.any?(&:prison?)
     end
   end
 end

--- a/app/services/moves/sweeper.rb
+++ b/app/services/moves/sweeper.rb
@@ -2,10 +2,10 @@
 
 module Moves
   class Sweeper
-    attr_accessor :items, :date, :location
+    attr_accessor :items, :date, :locations
 
-    def initialize(location, date, items)
-      self.location = location
+    def initialize(locations, date, items)
+      self.locations = locations
       self.date = date
       self.items = items
     end
@@ -19,7 +19,7 @@ module Moves
     def cancel_outdated_moves!
       outdated_moves = Move.where(
         date: date,
-        from_location_id: location.id
+        from_location_id: locations.map(&:id)
       ).where.not(
         nomis_event_id: current_nomis_event_ids
       )

--- a/spec/lib/nomis_client/moves_spec.rb
+++ b/spec/lib/nomis_client/moves_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe NomisClient::Moves do
       allow(NomisClient::Base).to(
         receive(:get)
         .with(
-          '/movements/transfers',
-          params: params,
+          '/movements/transfers?agencyId=LEI',
+          params: params.except(:agencyId),
           headers: { 'Page-Limit' => '500' }
         )
         .and_return(nomis_response)
@@ -93,7 +93,7 @@ RSpec.describe NomisClient::Moves do
   describe '.get', with_nomis_client_authentication: true do
     let(:nomis_agency_id) { 'BXI' }
     let(:date) { Date.parse('2019-08-19') }
-    let(:response) { described_class.get(nomis_agency_id, date) }
+    let(:response) { described_class.get([nomis_agency_id], date) }
     let(:client_response) do
       [
         {

--- a/spec/lib/nomis_client/moves_spec.rb
+++ b/spec/lib/nomis_client/moves_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe NomisClient::Moves do
       JSON
     end
     let(:nomis_response) { instance_double('response', parsed: JSON.parse(json_response)) }
-    let(:response) { described_class.get_response(nomis_agency_id: nomis_agency_id, date: date) }
+    let(:response) { described_class.get_response(nomis_agency_ids: [nomis_agency_id], date: date) }
     let(:params) do
       {
-        agencyId: 'LEI',
+        agencyId: ['LEI'],
         courtEvents: true,
         fromDateTime: '2019-07-08T00:00:00',
         toDateTime: '2019-07-09T00:00:00',

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
         end
 
         it 'invokes the client library to fetch moves from NOMIS', skip_before: true do
-          expect(NomisClient::Moves).to have_received(:get).with(from_location.nomis_agency_id, date)
+          expect(NomisClient::Moves).to have_received(:get).with([from_location.nomis_agency_id], date)
         end
 
         it 'invokes the service to create moves into the database', skip_before: true do

--- a/spec/requests/api/v1/moves_controller_show_spec.rb
+++ b/spec/requests/api/v1/moves_controller_show_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
       end
 
       it 'syncs data' do
-        expect(Moves::NomisSynchroniser).to have_received(:new).with(location: move.from_location, date: move.date)
+        expect(Moves::NomisSynchroniser).to have_received(:new).with(locations: [move.from_location], date: move.date)
       end
     end
 

--- a/spec/services/moves/nomis_synchroniser_spec.rb
+++ b/spec/services/moves/nomis_synchroniser_spec.rb
@@ -5,11 +5,12 @@ require 'rails_helper'
 RSpec.describe Moves::NomisSynchroniser do
   subject(:synchroniser) do
     described_class.new(
-      locations: [location],
+      locations: locations,
       date: date
     )
   end
 
+  let(:locations) { [location] }
   let(:date) { Date.today }
 
   describe '.call' do
@@ -47,11 +48,30 @@ RSpec.describe Moves::NomisSynchroniser do
       end
 
       it 'calls sweeper' do
-        expect(Moves::Sweeper).to have_received(:new).with(location, date, [])
+        expect(Moves::Sweeper).to have_received(:new).with([location], date, [])
       end
 
       it 'calls the NOMIS API' do
         expect(NomisClient::Moves).to have_received(:get)
+      end
+    end
+
+    context 'with multiple locations' do
+      let(:locations) { build_list :location, 2 }
+
+      it 'calls importer' do
+        expect(Moves::Importer).to have_received(:new).with([])
+      end
+
+      it 'calls sweeper' do
+        expect(Moves::Sweeper).to have_received(:new).with(locations, date, [])
+      end
+
+      it 'calls the NOMIS API' do
+        expect(NomisClient::Moves).to have_received(:get).with(
+          locations.map(&:nomis_agency_id),
+          Date.today
+        )
       end
     end
   end

--- a/spec/services/moves/nomis_synchroniser_spec.rb
+++ b/spec/services/moves/nomis_synchroniser_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Moves::NomisSynchroniser do
   subject(:synchroniser) do
     described_class.new(
-      location: location,
+      locations: [location],
       date: date
     )
   end

--- a/spec/services/moves/sweeper_spec.rb
+++ b/spec/services/moves/sweeper_spec.rb
@@ -119,23 +119,33 @@ RSpec.describe Moves::Sweeper do
           sweeper.call
           expect(court_move.reload.status).to eq 'requested'
         end
+      end
 
-        context 'with multiple locations' do
-          let(:locations) { [brixton_prison, wood_green_court] }
+      context 'with multiple locations' do
+        let(:locations) { [brixton_prison, wood_green_court] }
+        let!(:court_move) do
+          Move.create!(
+            date: attributes[:date],
+            time_due: attributes[:time_due],
+            nomis_event_id: 487_463_208,
+            person: Person.find_by(nomis_prison_number: attributes[:person_nomis_prison_number]),
+            from_location: wood_green_court,
+            to_location: Location.find_by(nomis_agency_id: attributes[:to_location_nomis_agency_id])
+          )
+        end
 
-          it 'cancels two moves' do
-            expect { sweeper.call }.to change { Move.where(status: :cancelled).count }.by(2)
-          end
+        it 'cancels two moves' do
+          expect { sweeper.call }.to change { Move.where(status: :cancelled).count }.by(2)
+        end
 
-          it 'cancels the move that matched the first location' do
-            sweeper.call
-            expect(outdated_move.reload.status).to eq 'cancelled'
-          end
+        it 'cancels the move that matched the first location' do
+          sweeper.call
+          expect(outdated_move.reload.status).to eq 'cancelled'
+        end
 
-          it 'cancels the move that matched the second location' do
-            sweeper.call
-            expect(court_move.reload.status).to eq 'cancelled'
-          end
+        it 'cancels the move that matched the second location' do
+          sweeper.call
+          expect(court_move.reload.status).to eq 'cancelled'
         end
       end
     end


### PR DESCRIPTION
We can now use the environment variable `NOMIS_AGENCY_IDS` to specify a comma-separated list of NOMIS ids for the prisons that form part of the pilot program. This value will be used for requests to `GET /moves` that do not specify a `from_location_id`, e.g.

```
NOMIS_AGENCY_IDS=HLI,PVI
```