### PR TITLE
Attempt to fix to_location_id and fetch multiple from_location_id

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -41,7 +41,8 @@ module Api
 
       private
 
-      PERMITTED_FILTER_PARAMS = %i[date_from date_to from_location_id location_type status].freeze
+      PERMITTED_FILTER_PARAMS = [:date_from, :date_to, :location_type, :status,
+                                 from_location_id: [], to_location_id: []].freeze
       PERMITTED_MOVE_PARAMS = [
         :type,
         attributes: %i[date time_due status move_type additional_information
@@ -98,7 +99,7 @@ module Api
       def from_locations
         @from_locations ||=
           if filter_params[:from_location_id]
-            [Location.find(filter_params[:from_location_id])]
+            filter_params[:from_location_id].collect { |id| Location.find(id) }
           elsif ENV['DEFAULT_NOMIS_AGENCY_IDS']
             Location.where('nomis_agency_id IN (?)', ENV['DEFAULT_NOMIS_AGENCY_IDS'].split(',').map(&:strip))
           else

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -99,7 +99,7 @@ module Api
       def from_locations
         @from_locations ||=
           if filter_params[:from_location_id]
-            filter_params[:from_location_id].collect { |id| Location.find(id) }
+            Location.where(id: filter_params[:from_location_id])
           elsif ENV['DEFAULT_NOMIS_AGENCY_IDS']
             Location.where('nomis_agency_id IN (?)', ENV['DEFAULT_NOMIS_AGENCY_IDS'].split(',').map(&:strip))
           else

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -17,4 +17,15 @@ FactoryBot.define do
       cancellation_reason_comment { 'some other reason' }
     end
   end
+
+  factory :from_court_to_prison, class: Move do
+    association(:person)
+    association(:from_location, :court, factory: :location)
+    association(:to_location, factory: :location)
+    date { Date.today }
+    time_due { Time.now }
+    status { 'requested' }
+    additional_information { 'some more info about the move that the supplier might need to know' }
+    move_type { 'court_appearance' }
+  end
 end

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
       it_behaves_like 'an endpoint that responds with success 200'
 
       describe 'filtering results' do
-        let(:from_location_id) { moves.first.from_location_id }
+        let(:from_location_id) { [moves.first.from_location_id] }
         let(:filters) do
           {
             bar: 'bar',
@@ -54,7 +54,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
       context 'with a cancelled move' do
         let(:move) { create(:move, :cancelled) }
         let!(:moves) { [move] }
-        let(:from_location_id) { move.from_location_id }
+        let(:from_location_id) { [move.from_location_id] }
         let(:filters) do
           {
             from_location_id: from_location_id
@@ -119,7 +119,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
         let(:date) { Date.today }
         let(:filters) do
           {
-            from_location_id: from_location.id,
+            from_location_id: [from_location.id],
             date_from: date.to_s
           }
         end
@@ -147,7 +147,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
         let(:from_location) { moves.first.from_location }
         let(:filters) do
           {
-            from_location_id: from_location.id,
+            from_location_id: [from_location.id],
             date_from: 'yyyy-09-Tu'
           }
         end
@@ -170,7 +170,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
         let(:from_location) { moves.first.from_location }
         let(:filters) do
           {
-            from_location_id: from_location.id
+            from_location_id: [from_location.id]
           }
         end
         let(:params) { { filter: filters } }
@@ -198,7 +198,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
         let(:date) { Date.today }
         let(:filters) do
           {
-            from_location_id: from_location.id,
+            from_location_id: [from_location.id],
             date_from: date.to_s
           }
         end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -11,10 +11,19 @@ RSpec.describe Moves::Finder do
 
   describe 'filtering' do
     context 'with matching location filter' do
-      let(:filter_params) { { from_location_id: move.from_location_id } }
+      let(:filter_params) { { from_location_id: [move.from_location_id] } }
 
       it 'returns moves matching from location' do
         expect(move_finder.call.pluck(:id)).to eql [move.id]
+      end
+    end
+
+    context 'with two location filters' do
+      let!(:second_move) { create :from_court_to_prison }
+      let(:filter_params) { { from_location_id: [move.from_location_id, second_move.from_location_id] } }
+
+      it 'returns moves matching multiple locations' do
+        expect(move_finder.call.pluck(:id)).to eql [move.id, second_move.id]
       end
     end
 

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Moves::Finder do
       let(:filter_params) { { from_location_id: [move.from_location_id, second_move.from_location_id] } }
 
       it 'returns moves matching multiple locations' do
-        expect(move_finder.call.pluck(:id)).to eql [move.id, second_move.id]
+        expect(move_finder.call.pluck(:id).sort).to eql [move.id, second_move.id].sort
       end
     end
 

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -109,10 +109,13 @@
           {
             "name": "filter[from_location_id]",
             "in": "query",
-            "type": "string",
-            "description": "Filters results to only include moves from the given location",
-            "schema": {
+            "type": "array",
+            "items": {
               "type": "string"
+            },
+            "description": "Filters results to only include moves from the given locations",
+            "schema": {
+              "type": "array"
             },
             "format": "uuid",
             "example": "950ef512-a25f-46d7-8ced-7ad09510659b"
@@ -120,9 +123,13 @@
           {
             "name": "filter[to_location_id]",
             "in": "query",
-            "description": "Filters results to only include moves to the given location",
-            "schema": {
+            "type": "array",
+            "items": {
               "type": "string"
+            },
+            "description": "Filters results to only include moves to the given locations",
+            "schema": {
+              "type": "array"
             },
             "format": "uuid",
             "example": "92fb1419-04e2-4bda-94e7-e62abaa2f098"


### PR DESCRIPTION
The new `from_location_id` and `to_location_id` (which wasn't working previously) are now accepting arrays.
The goal is to follow json api recommendations (https://jsonapi.org/recommendations/#filtering) without breaking HTTP query strings (which require array parameters to be like "from_location_id[]=foo&from_location_id[]=bar")
