### PR TITLE
Add rudimentary timing for NOMIS client requests

### DIFF
--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -12,7 +12,7 @@ module NomisClient
         response = token.get("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
 
         total_request_seconds = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start_time)
-        Rails.logger.info "NomisClient request completed (#{total_request_seconds}s): #{ENV['NOMIS_API_PATH_PREFIX']}#{path}"
+        Rails.logger.info "NomisClient request took (#{total_request_seconds}s): #{ENV['NOMIS_API_PATH_PREFIX']}#{path}"
 
         response
       end

--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -7,7 +7,12 @@ module NomisClient
 
     class << self
       def get(path, params = {})
+        request_start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
         token.get("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
+
+        total_request_seconds = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start_time)
+        Rails.logger.info "NomisClient request completed (#{total_request_seconds}s): #{ENV['NOMIS_API_PATH_PREFIX']}#{path}"
       end
 
       def test_mode?

--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -9,10 +9,12 @@ module NomisClient
       def get(path, params = {})
         request_start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-        token.get("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
+        response = token.get("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
 
         total_request_seconds = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start_time)
         Rails.logger.info "NomisClient request completed (#{total_request_seconds}s): #{ENV['NOMIS_API_PATH_PREFIX']}#{path}"
+
+        response
       end
 
       def test_mode?


### PR DESCRIPTION
This PR wraps all `NomisClient`requests so we can log their response times to help understand the `/moves/` performance issue.