### PR TITLE
Logstash formatting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,3 +43,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
+
+gem "lograge", "~> 0.11.2"
+gem "logstash-event", "~> 1.2"
+gem "logstash-logger", "~> 0.26.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,14 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
+    logstash-event (1.2.02)
+    logstash-logger (0.26.1)
+      logstash-event (~> 1.2)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -177,6 +185,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    request_store (1.4.1)
+      rack (>= 1.4)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -259,6 +269,9 @@ DEPENDENCIES
   json-schema
   kaminari
   listen (>= 3.0.5, < 3.2)
+  lograge (~> 0.11.2)
+  logstash-event (~> 1.2)
+  logstash-logger (~> 0.26.1)
   nokogiri (>= 1.10.4)
   oauth2
   pager_api

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,4 +82,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # We only want lograge enabled in production
+  config.lograge.enabled = true
 end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  config.lograge.base_controller_class = 'ActionController::API'
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
+end


### PR DESCRIPTION
This PR introduces the `lograge` gem to output JSON-formatted logs to `stdout`, which are then consumed by fluentd and pushed into the Cloud Platform Kibana instance.

Switching from plain-text to JSON logs should allow us to graph (for example) request/response times, filter and query by status, action, controller, etc.