### PR TITLE
use updated GH team for CP deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ references:
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
         environment:
-          GITHUB_TEAM_NAME_SLUG: pecs
+          GITHUB_TEAM_NAME_SLUG: book-a-secure-move
 
 commands:
   build_for_k8s:


### PR DESCRIPTION
This PR should resolve the failed Cloud Platform deployments by using the updates RBAC team `book-a-secure-move`.