### PR TITLE
Hotfix duplicate moves

### DIFF
--- a/app/services/moves/sweeper.rb
+++ b/app/services/moves/sweeper.rb
@@ -5,7 +5,7 @@ module Moves
     attr_accessor :items, :date, :locations
 
     def initialize(locations, date, items)
-      self.locations = locations
+      self.locations = locations.select(&:prison?)
       self.date = date
       self.items = items
     end

--- a/app/services/moves/sweeper.rb
+++ b/app/services/moves/sweeper.rb
@@ -36,6 +36,8 @@ module Moves
         date: date,
         from_location_id: locations.map(&:id)
       )
+
+      update_nomis_event_ids_when_duplicate(scope)
       update_nomis_event_ids_containing_currents(scope)
       update_nomis_event_ids_not_containing_currents(scope)
     end
@@ -45,6 +47,15 @@ module Moves
         'ARRAY[?] && nomis_event_ids', current_nomis_event_ids
       ).each do |move|
         move.update(nomis_event_ids: move.nomis_event_ids & current_nomis_event_ids)
+      end
+    end
+
+    def update_nomis_event_ids_when_duplicate(scope)
+      items.map do |item|
+        move = scope.find_by(
+          person: Person.where(nomis_prison_number: item[:person_nomis_prison_number])
+        )
+        move.update(nomis_event_ids: move.nomis_event_ids << item[:nomis_event_id])
       end
     end
 

--- a/app/services/moves/sweeper.rb
+++ b/app/services/moves/sweeper.rb
@@ -18,7 +18,11 @@ module Moves
 
     def cancel_outdated_moves!
       update_nomis_event_ids!
-      Move.where(nomis_event_ids: []).update(status: Move::MOVE_STATUS_CANCELLED)
+      Move.where(
+        date: date,
+        from_location_id: locations.map(&:id),
+        nomis_event_ids: []
+      ).update(status: Move::MOVE_STATUS_CANCELLED)
     end
 
     def current_nomis_event_ids

--- a/app/services/moves/sweeper.rb
+++ b/app/services/moves/sweeper.rb
@@ -42,20 +42,21 @@ module Moves
       update_nomis_event_ids_not_containing_currents(scope)
     end
 
+    def update_nomis_event_ids_when_duplicate(scope)
+      items.map do |item|
+        move = scope.find_by(
+          person: Person.where(nomis_prison_number: item[:person_nomis_prison_number]),
+          to_location: Location.where(nomis_agency_id: item[:to_location_nomis_agency_id])
+        )
+        move.update(nomis_event_ids: move.nomis_event_ids << item[:nomis_event_id])
+      end
+    end
+
     def update_nomis_event_ids_containing_currents(scope)
       scope.where(
         'ARRAY[?] && nomis_event_ids', current_nomis_event_ids
       ).each do |move|
         move.update(nomis_event_ids: move.nomis_event_ids & current_nomis_event_ids)
-      end
-    end
-
-    def update_nomis_event_ids_when_duplicate(scope)
-      items.map do |item|
-        move = scope.find_by(
-          person: Person.where(nomis_prison_number: item[:person_nomis_prison_number])
-        )
-        move.update(nomis_event_ids: move.nomis_event_ids << item[:nomis_event_id])
       end
     end
 

--- a/db/migrate/20191106121438_unique_index_on_moves.rb
+++ b/db/migrate/20191106121438_unique_index_on_moves.rb
@@ -1,0 +1,5 @@
+class UniqueIndexOnMoves < ActiveRecord::Migration[5.2]
+  def change
+    add_index :moves, [:from_location_id, :to_location_id, :person_id, :date, :time_due], name: 'index_on_move_uniqueness', unique: true
+  end
+end

--- a/db/migrate/20191106121438_unique_index_on_moves.rb
+++ b/db/migrate/20191106121438_unique_index_on_moves.rb
@@ -1,5 +1,5 @@
 class UniqueIndexOnMoves < ActiveRecord::Migration[5.2]
   def change
-    add_index :moves, [:from_location_id, :to_location_id, :person_id, :date, :time_due], name: 'index_on_move_uniqueness', unique: true
+    add_index :moves, [:from_location_id, :to_location_id, :person_id, :date], name: 'index_on_move_uniqueness', unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -88,7 +88,7 @@ ActiveRecord::Schema.define(version: 2019_11_06_121438) do
     t.string "cancellation_reason"
     t.text "cancellation_reason_comment"
     t.integer "nomis_event_ids", default: [], null: false, array: true
-    t.index ["from_location_id", "to_location_id", "person_id", "date", "time_due"], name: "index_on_move_uniqueness", unique: true
+    t.index ["from_location_id", "to_location_id", "person_id", "date"], name: "index_on_move_uniqueness", unique: true
     t.index ["reference"], name: "index_moves_on_reference", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_23_104425) do
+ActiveRecord::Schema.define(version: 2019_11_06_121438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 2019_10_23_104425) do
     t.string "cancellation_reason"
     t.text "cancellation_reason_comment"
     t.integer "nomis_event_ids", default: [], null: false, array: true
+    t.index ["from_location_id", "to_location_id", "person_id", "date", "time_due"], name: "index_on_move_uniqueness", unique: true
     t.index ["reference"], name: "index_moves_on_reference", unique: true
   end
 

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
 namespace :data_maintenance do
+  desc 'remove duplicated moves'
+  task remove_duplicate_moves: :environment do
+    duplicates = Move.select(:nomis_event_ids).group(:nomis_event_ids).having('COUNT(*) > 1').size
+    duplicates.each_pair do |k, _|
+      next if k.nil?
+
+      moves = Move.order(:created_at).where(nomis_event_ids: k).offset(1)
+      moves.destroy_all
+    end
+  end
+
   desc 'move old nomis_event_id to nomis_event_ids'
   task move_event_id_to_event_ids: :environment do
     Move.where.not(nomis_event_id: nil).each do |move|

--- a/spec/services/moves/sweeper_spec.rb
+++ b/spec/services/moves/sweeper_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Moves::Sweeper do
           Move.create!(
             date: attributes[:date],
             time_due: attributes[:time_due],
-            nomis_event_ids: [487_463_208],
+            nomis_event_ids: [],
             person: Person.find_by(nomis_prison_number: attributes[:person_nomis_prison_number]),
             from_location: wood_green_court,
             to_location: Location.find_by(nomis_agency_id: attributes[:to_location_nomis_agency_id])

--- a/spec/services/moves/sweeper_spec.rb
+++ b/spec/services/moves/sweeper_spec.rb
@@ -37,8 +37,10 @@ RSpec.describe Moves::Sweeper do
   end
 
   context 'with records for newly imported moves' do
+    let(:attributes) { input_data.first }
+
     before do
-      input_data.each do |attributes|
+      input_data.first(2).each do |attributes|
         Move.create!(
           date: attributes[:date],
           time_due: attributes[:time_due],
@@ -54,117 +56,105 @@ RSpec.describe Moves::Sweeper do
       expect { sweeper.call }.to change { Move.where(status: :cancelled).count }.by(0)
     end
 
+    context 'with a move with multiple nomis_event_ids' do
+      let(:multiple_nomis_ids_move) { Move.find_by(nomis_event_ids: [attributes[:nomis_event_id]]) }
+
+      before do
+        multiple_nomis_ids_move.update_attribute(:nomis_event_ids, [attributes[:nomis_event_id], 123_456_789])
+      end
+
+      it 'removes the outdated nomis_event_id' do
+        sweeper.call
+        expect(multiple_nomis_ids_move.reload.nomis_event_ids).to eq([attributes[:nomis_event_id]])
+      end
+    end
+
+    context 'with a duplicate move and different nomis_event_id' do
+      let(:input_data) do
+        [
+          {
+            person_nomis_prison_number: 'G3239GV',
+            from_location_nomis_agency_id: 'BXI',
+            to_location_nomis_agency_id: 'WDGRCC',
+            date: '2019-09-15',
+            time_due: '2019-08-19T17:00:00',
+            status: 'requested',
+            nomis_event_id: 468_536_961
+          },
+          {
+            person_nomis_prison_number: 'G7157AB',
+            from_location_nomis_agency_id: 'BXI',
+            to_location_nomis_agency_id: 'BXI',
+            date: '2019-09-15',
+            time_due: '2019-08-19T09:00:00',
+            status: 'completed',
+            nomis_event_id: 487_463_210
+          },
+          {
+            person_nomis_prison_number: 'G3239GV',
+            from_location_nomis_agency_id: 'BXI',
+            to_location_nomis_agency_id: 'WDGRCC',
+            date: '2019-09-15',
+            time_due: '2019-08-19T17:00:00',
+            status: 'requested',
+            nomis_event_id: 468_536_962
+          }
+        ]
+      end
+
+      let(:move) { Move.find_by('? = ANY(nomis_event_ids)', attributes[:nomis_event_id]) }
+
+      it 'merges two moves together' do
+        sweeper.call
+        expect(move.reload.nomis_event_ids.count).to eq(2)
+      end
+
+      it 'adds the new nomis_event_id to nomis_event_ids' do
+        sweeper.call
+        expect(move.reload.nomis_event_ids).to include(
+          input_data.first[:nomis_event_id], input_data.last[:nomis_event_id]
+        )
+      end
+    end
+
     context 'with an outdated move' do
-      let(:attributes) { input_data.first }
-      let!(:outdated_move) do
+      let(:input_data) do
+        [
+          {
+            person_nomis_prison_number: 'G3239GV',
+            from_location_nomis_agency_id: 'BXI',
+            to_location_nomis_agency_id: 'WDGRCC',
+            date: '2019-09-15',
+            time_due: '2019-08-19T17:00:00',
+            status: 'requested',
+            nomis_event_id: 468_536_961
+          }
+        ]
+      end
+      let(:outdated_move) do
+        Move.find_by(from_location: brixton_prison, to_location: brixton_prison, person: prisoner_two)
+      end
+
+      before do
         Move.create!(
-          date: attributes[:date],
-          time_due: attributes[:time_due],
-          nomis_event_ids: [487_463_209],
-          person: Person.find_by(nomis_prison_number: attributes[:person_nomis_prison_number]),
-          from_location: Location.find_by(nomis_agency_id: attributes[:from_location_nomis_agency_id]),
-          to_location: Location.find_by(nomis_agency_id: attributes[:to_location_nomis_agency_id])
+          date: '2019-09-15',
+          from_location: brixton_prison,
+          to_location: brixton_prison,
+          person: prisoner_two,
+          status: 'requested',
+          time_due: '2019-08-19 08:00:00',
+          nomis_event_ids: [487_463_210]
         )
       end
 
-      context 'with an additional move on a different date' do
-        let!(:move_yesterday) do
-          Move.create!(
-            date: yesterday,
-            time_due: attributes[:time_due],
-            nomis_event_ids: [487_463_208],
-            person: Person.find_by(nomis_prison_number: attributes[:person_nomis_prison_number]),
-            from_location: Location.find_by(nomis_agency_id: attributes[:from_location_nomis_agency_id]),
-            to_location: Location.find_by(nomis_agency_id: attributes[:to_location_nomis_agency_id])
-          )
-        end
-
-        it 'cancels one move' do
-          expect { sweeper.call }.to change { Move.where(status: :cancelled).count }.by(1)
-        end
-
-        it 'cancels the move that did match by date' do
-          sweeper.call
-          expect(outdated_move.reload.status).to eq 'cancelled'
-        end
-
-        it 'leaves the move that did not match by date' do
-          sweeper.call
-          expect(move_yesterday.reload.status).to eq 'requested'
-        end
+      it 'empties the nomis_event_ids array' do
+        sweeper.call
+        expect(outdated_move.reload.nomis_event_ids).to be_empty
       end
 
-      context 'with an additional for a different location' do
-        let!(:court_move) do
-          Move.create!(
-            date: attributes[:date],
-            time_due: attributes[:time_due],
-            nomis_event_ids: [],
-            person: Person.find_by(nomis_prison_number: attributes[:person_nomis_prison_number]),
-            from_location: wood_green_court,
-            to_location: Location.find_by(nomis_agency_id: attributes[:to_location_nomis_agency_id])
-          )
-        end
-
-        it 'cancels one move' do
-          expect { sweeper.call }.to change { Move.where(status: :cancelled).count }.by(1)
-        end
-
-        it 'cancels the move that did match' do
-          sweeper.call
-          expect(outdated_move.reload.status).to eq 'cancelled'
-        end
-
-        it 'leaves the move that did not match by location' do
-          sweeper.call
-          expect(court_move.reload.status).to eq 'requested'
-        end
-      end
-
-      context 'with multiple locations' do
-        let(:locations) { [brixton_prison, wood_green_court] }
-        let!(:court_move) do
-          Move.create!(
-            date: attributes[:date],
-            time_due: attributes[:time_due],
-            nomis_event_ids: [487_463_208],
-            person: Person.find_by(nomis_prison_number: attributes[:person_nomis_prison_number]),
-            from_location: wood_green_court,
-            to_location: Location.find_by(nomis_agency_id: attributes[:to_location_nomis_agency_id])
-          )
-        end
-
-        it 'cancels two moves' do
-          expect { sweeper.call }.to change { Move.where(status: :cancelled).count }.by(2)
-        end
-
-        it 'cancels the move that matched the first location' do
-          sweeper.call
-          expect(outdated_move.reload.status).to eq 'cancelled'
-        end
-
-        it 'cancels the move that matched the second location' do
-          sweeper.call
-          expect(court_move.reload.status).to eq 'cancelled'
-        end
-      end
-
-      context 'with a move with multiple nomis_event_ids' do
-        let!(:multiple_nomis_ids_move) do
-          Move.create!(
-            date: attributes[:date],
-            time_due: attributes[:time_due],
-            nomis_event_ids: [attributes[:nomis_event_id], 123_456_789],
-            person: prisoner_one,
-            from_location: brixton_prison,
-            to_location: wood_green_court
-          )
-        end
-
-        it 'removes the outdated nomis_event_id' do
-          sweeper.call
-          expect(multiple_nomis_ids_move.reload.nomis_event_ids).to eq([attributes[:nomis_event_id]])
-        end
+      it 'cancels the outdated move' do
+        sweeper.call
+        expect(outdated_move.reload.status).to eq('cancelled')
       end
     end
   end

--- a/spec/services/moves/sweeper_spec.rb
+++ b/spec/services/moves/sweeper_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe Moves::Sweeper do
     ]
   end
 
+  context 'when initialising' do
+    let(:locations) { [brixton_prison, wood_green_court] }
+
+    it 'cleans up locations that are not prisons' do
+      expect(sweeper.locations).to eq([brixton_prison])
+    end
+  end
+
   context 'with records for newly imported moves' do
     let(:attributes) { input_data.first }
 


### PR DESCRIPTION
The old fix dealing with duplicate moves has been ported to deal with the new `nomis_event_ids` field