### PR TITLE
Add CORS for Swagger UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ NOMIS_CLIENT_SECRET='client_secret'
 NOMIS_AUTH_SCHEME='auth_scheme'
 NOMIS_API_PATH_PREFIX='/api_prefix'
 NOMIS_AUTH_PATH_PREFIX='/auth_prefix'
+
+# Only necessary for non-dev environments. Included here for completeness,
+# and needed for Swagger UI
+CORS_ALLOWED_ORIGINS=api.bookasecuremove.service.justice.gov.uk

--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,13 @@ gem 'pg', '~> 1.0.0'
 gem 'prometheus_exporter'
 gem 'puma', '~> 3.11'
 gem 'rails', '~> 5.2.3'
+gem 'sentry-raven'
+
+# Swagger API documentation. We need CORS to enable the Swagger UI to make requests
+# against the API without an Access-Control-Allow-Origin error.
+gem 'rack-cors'
 gem 'rswag-api'
 gem 'rswag-ui'
-gem 'sentry-raven'
 
 # Augments Rails logging to output JSON for Fluentd/Kibana
 # on Cloud Platform

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ GEM
     public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
+    rack-cors (1.0.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -290,6 +291,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 3.11)
+  rack-cors
   rails (~> 5.2.3)
   rspec-json_expectations
   rspec-rails

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,19 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors, :logger => (-> { Rails.logger }) do
+
+  # Allow any origins for dev environments, because we might be tunnelling, using Docker, etc.
+  # otherwise pull from an environment variable for production/staging
+  allowed_origins = Rails.env.development? ? '*' : ENV["CORS_ALLOWED_ORIGINS"]
+  
+  if allowed_origins.present?
+    allow do
+      origins allowed_origins
+
+      resource '*',
+        headers: :any,
+        methods: [:get, :post, :put, :patch, :delete, :options, :head]
+    end
+  end
+end


### PR DESCRIPTION
Attempting to use the Swagger UI locally yields the following error for any request:

```
TypeError: Origin http://localhost:3000 is not allowed by Access-Control-Allow-Origin.
```

This PR:

- Adds CORS support
- Adds a blanket allow for development environments
- Uses a new environment variable (`CORS_ALLOWED_ORIGINS`) to specify allowed origins in production & staging environments