### PR TITLE
Enable Swagger UI to run against prod, staging and localhost

### DIFF
--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -6,8 +6,16 @@
   },
   "servers": [
     {
+      "url": "http://localhost:3000/api/v1",
+      "description": "Local development (localhost)"
+    },
+    {
       "url": "https://hmpps-book-secure-move-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/api/v1",
-      "description": "Staging server"
+      "description": "Staging API"
+    },
+    {
+      "url": "https://api.bookasecuremove.service.justice.gov.uk/api/v1",
+      "description": "Production API"
     }
   ],
   "components": {


### PR DESCRIPTION
After chasing my tail for 30 minutes trying to figure out why CORS options weren't being honoured, I realised our Swagger JSON is static, and always reference staging.

This PR adds production and `localhost:3000` as options for Swagger UI requests. 

I think there's a more elegant way to add localhost only for dev environments with a lambda, but my Internet connection is pretty poor right now (🚂), so if that's possible I'll raise another PR.