### PR TITLE
Do not log AR in production + filter sensitive data

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, :first_names, :last_name, :profile_identifiers, :date_of_birth]


### PR DESCRIPTION
Fixes https://dsdmoj.atlassian.net/browse/P4-790

AR logs are now going to /dev/null and most sensitive data are filtered out