### PR TITLE
Add POLICE agency type to NOMIS location import

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -7,7 +7,8 @@ class Location < ApplicationRecord
 
   NOMIS_AGENCY_TYPES = {
     'INST' => LOCATION_TYPE_PRISON,
-    'CRT' => LOCATION_TYPE_COURT
+    'CRT' => LOCATION_TYPE_COURT,
+    'POLICE' => LOCATION_TYPE_POLICE
   }.freeze
 
   has_and_belongs_to_many :suppliers

--- a/spec/fixtures/files/nomis_get_locations_200.json
+++ b/spec/fixtures/files/nomis_get_locations_200.json
@@ -1,8 +1,8 @@
 [
   {
     "agencyId":"218434",
-    "description":"Havant Probation Office",
-    "agencyType":"COMM"
+    "description":"Test Police Custody",
+    "agencyType":"POLICE"
   },
   {
     "agencyId":"456740",

--- a/spec/lib/nomis_client/locations_spec.rb
+++ b/spec/lib/nomis_client/locations_spec.rb
@@ -10,11 +10,16 @@ RSpec.describe NomisClient::Locations, with_nomis_client_authentication: true do
     let(:response_body) { file_fixture('nomis_get_locations_200.json').read }
 
     it 'has the correct number of results' do
-      expect(response.count).to be 4
+      expect(response.count).to be 5
     end
 
-    it 'returns the correct data for the first match' do
+    it 'returns POLICE agencies' do
       expect(response.first)
+        .to include(key: '218434', nomis_agency_id: '218434', title: 'Test Police Custody', location_type: 'police')
+    end
+
+    it 'returns the correct data for the first COURT match' do
+      expect(response.second)
         .to eq(key: 'abdrct', nomis_agency_id: 'ABDRCT', title: 'Aberdare County Court', location_type: 'court')
     end
 


### PR DESCRIPTION
This PR adds  the `POLICE` agency type to the NOMIS importer, so we can pull police custodies.
