### PR TITLE
Removes the Serco -> Brixton association

### DIFF
--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -41,7 +41,7 @@ namespace :reference_data do
 
   desc 'create locations/suppliers relationship'
   task link_suppliers: :environment do
-    { geoamey: %w[SRY016 SFCUSU STCUSU], serco: %w[BXI CLP1] }.each do |supplier, codes|
+    { geoamey: %w[SRY016 SFCUSU STCUSU], serco: %w[CLP1] }.each do |supplier, codes|
       locations = codes.collect { |code| Location.find_by(nomis_agency_id: code) }
       locations.reject(&:nil?).each do |location|
         location.suppliers << Supplier.find_by(key: supplier.to_s)


### PR DESCRIPTION
Removes the Serco -> Brixton association as that's not ready to rollout yet in production.

Note that this PR doesn't remove the association from any instances where it's already been made, so we'll also need to go into prod and remove that manually:

```
PECS_APP=api
PECS_ENV=production
kubectl --namespace=hmpps-book-secure-move-${PECS_APP}-${PECS_ENV} exec -it `kubectl get pods --namespace=hmpps-book-secure-move-${PECS_APP}-${PECS_ENV} -o json |  jq -r '.items[0].metadata.name'` rails c
```
and
```
serco = Supplier.find_by(name: 'Serco')
serco.locations = serco.locations.all.reject{|location| location.key == 'bxi'}
```