### PR TITLE
Supplier relationship rake output

### DIFF
--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -62,12 +62,13 @@ namespace :reference_data do
       ]
     }
 
-    supplier_locations.each do |supplier, codes|
+    supplier_locations.each do |supplier_name, codes|
+      supplier = Supplier.find_by(key: supplier_name.to_s)
       locations = codes.collect { |code| Location.find_by(nomis_agency_id: code) }.compact
       locations.each do |location|
-        location.suppliers << Supplier.find_by(key: supplier.to_s)
+        location.suppliers << supplier
       rescue ActiveRecord::RecordNotUnique
-        puts "#{location.nomis_agency_id} <=> #{supplier} already exists"
+        puts "#{location.nomis_agency_id} <=> #{supplier_name} already exists"
       end
     end
   end

--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -73,8 +73,8 @@ namespace :reference_data do
     end
 
     puts
-    puts "Summary of relationships"
-    puts "========================"
+    puts 'Summary of relationships'
+    puts '========================'
     Supplier.all.each do |supplier|
       puts
       puts "Supplier #{supplier.name}:"

--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -71,6 +71,17 @@ namespace :reference_data do
         puts "#{location.nomis_agency_id} <=> #{supplier_name} already exists"
       end
     end
+
+    puts
+    puts "Summary of relationships"
+    puts "========================"
+    Supplier.all.each do |supplier|
+      puts
+      puts "Supplier #{supplier.name}:"
+      supplier.locations.each do |location|
+        puts " - #{location.nomis_agency_id}: #{location.title}"
+      end
+    end
   end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
This PR:

- does a minor refactor to only query once per supplier for the supplier details (previously once per location)
- adds console output to make validating the run easier