### PR TITLE
Hotfix limit multipart to document creation

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -3,17 +3,19 @@
 module Api
   module V1
     class DocumentsController < ApiController
+      prepend_before_action :set_force_content_type
+
       CONTENT_TYPE = 'multipart/form-data'
 
       def create
         document = Document.create!(document_attributes)
-        render json: document, status: 201
+        render json: document, status: 201, content_type: ApiController::CONTENT_TYPE
       end
 
       def destroy
         document = Document.find(params[:id])
         document.destroy!
-        render json: document, status: 200
+        render json: document, status: 200, content_type: ApiController::CONTENT_TYPE
       end
 
       private
@@ -30,6 +32,10 @@ module Api
         document_params[:attributes].merge(
           move: Move.find(params.dig(:move_id))
         )
+      end
+
+      def set_force_content_type
+        @force_content_type = true
       end
     end
   end

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -3,11 +3,11 @@
 module Api
   module V1
     class DocumentsController < ApiController
-      prepend_before_action :set_restricted_content_type, only: :create
+      prepend_before_action :set_restricted_request_content_type, only: :create
 
       def create
         document = Document.create!(document_attributes)
-        render json: document, status: 201, content_type: ApiController::CONTENT_TYPE
+        render json: document, status: 201
       rescue ActiveSupport::MessageVerifier::InvalidSignature
         Document.create!(file: nil)
       end
@@ -15,7 +15,7 @@ module Api
       def destroy
         document = Document.find(params[:id])
         document.destroy!
-        render json: document, status: 200, content_type: ApiController::CONTENT_TYPE
+        render json: document, status: 200
       end
 
       private
@@ -36,8 +36,8 @@ module Api
 
       protected
 
-      def set_restricted_content_type
-        @restricted_content_type = 'multipart/form-data'
+      def set_restricted_request_content_type
+        @restricted_request_content_type = 'multipart/form-data'
       end
     end
   end

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -9,6 +9,10 @@ module Api
         document = Document.create!(document_attributes)
         render json: document, status: 201
       rescue ActiveSupport::MessageVerifier::InvalidSignature
+        # A call to this action with an empty file raises an InvalidSignature exception and
+        # and not a RecordInvalid one, this is the only way I found to have a behaviour that
+        # is consistent: Document.create!(file: nil) raises a RecordInvalid exception and
+        # responds with the right error json
         Document.create!(file: nil)
       end
 

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -8,6 +8,8 @@ module Api
       def create
         document = Document.create!(document_attributes)
         render json: document, status: 201, content_type: ApiController::CONTENT_TYPE
+      rescue ActiveSupport::MessageVerifier::InvalidSignature
+        Document.create!(file: nil)
       end
 
       def destroy

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -3,9 +3,7 @@
 module Api
   module V1
     class DocumentsController < ApiController
-      prepend_before_action :set_force_content_type
-
-      CONTENT_TYPE = 'multipart/form-data'
+      prepend_before_action :set_restricted_content_type, only: :create
 
       def create
         document = Document.create!(document_attributes)
@@ -34,8 +32,10 @@ module Api
         )
       end
 
-      def set_force_content_type
-        @force_content_type = true
+      protected
+
+      def set_restricted_content_type
+        @restricted_content_type = 'multipart/form-data'
       end
     end
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -2,8 +2,8 @@
 
 class ApiController < ApplicationController
   before_action :doorkeeper_authorize!
-  before_action :restrict_content_type
-  after_action :set_content_type
+  before_action :restrict_content_type, unless: -> { @force_content_type }
+  after_action :set_content_type, unless: -> { @force_content_type }
 
   CONTENT_TYPE = 'application/vnd.api+json'
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -2,8 +2,8 @@
 
 class ApiController < ApplicationController
   before_action :doorkeeper_authorize!
-  before_action :restrict_content_type, unless: -> { @force_content_type }
-  after_action :set_content_type, unless: -> { @force_content_type }
+  before_action :restrict_request_content_type
+  before_action :set_content_type
 
   CONTENT_TYPE = 'application/vnd.api+json'
 
@@ -27,12 +27,12 @@ class ApiController < ApplicationController
     }
   end
 
-  def restricted_content_type
-    defined?(@restricted_content_type) ? @restricted_content_type : CONTENT_TYPE
+  def restricted_request_content_type
+    defined?(@restricted_request_content_type) ? @restricted_request_content_type : CONTENT_TYPE
   end
 
-  def restrict_content_type
-    return if request.content_type == restricted_content_type
+  def restrict_request_content_type
+    return if request.content_type == restricted_request_content_type
 
     render_invalid_media_type_error
   end
@@ -65,7 +65,7 @@ class ApiController < ApplicationController
     render(
       json: { errors: [{
         title: 'Invalid Media Type',
-        detail: "Content-Type must be #{restricted_content_type}"
+        detail: "Content-Type must be #{restricted_request_content_type}"
       }] },
       status: 415
     )

--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class DocumentSerializer < ActiveModel::Serializer
-  attributes :id, :filename, :content_type
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :url, :filename, :content_type
+
+  def url
+    rails_blob_path(object.file)
+  end
 
   def filename
     object.file.filename

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -13,6 +13,6 @@ class MoveSerializer < ActiveModel::Serializer
     person: %i[first_names last_name date_of_birth assessment_answers indentifiers ethnicity gender],
     from_location: %i[location_type description],
     to_location: %i[location_type description],
-    documents: %i[filename content_type]
+    documents: %i[url filename content_type]
   }.freeze
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,5 +55,5 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Default host for url generation
-  routes.default_url_options[:host] = 'localhost:4000'
+  routes.default_url_options[:host] = "localhost:#{ENV['PORT'] || 3000}"
 end

--- a/spec/requests/api/v1/documents_controller_create_spec.rb
+++ b/spec/requests/api/v1/documents_controller_create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::DocumentsController, with_client_authentication: true do
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-  let(:content_type) { described_class::CONTENT_TYPE }
+  let(:content_type) { 'multipart/form-data' }
   let(:response_json) { JSON.parse(response.body) }
 
   before do

--- a/spec/requests/api/v1/documents_controller_destroy_spec.rb
+++ b/spec/requests/api/v1/documents_controller_destroy_spec.rb
@@ -63,5 +63,11 @@ RSpec.describe Api::V1::DocumentsController, with_client_authentication: true do
 
       it_behaves_like 'an endpoint that responds with error 404'
     end
+
+    context 'with an invalid CONTENT_TYPE header' do
+      let(:content_type) { 'application/xml' }
+
+      it_behaves_like 'an endpoint that responds with error 415'
+    end
   end
 end

--- a/spec/requests/api/v1/documents_controller_destroy_spec.rb
+++ b/spec/requests/api/v1/documents_controller_destroy_spec.rb
@@ -28,7 +28,17 @@ RSpec.describe Api::V1::DocumentsController, with_client_authentication: true do
     end
 
     context 'when successful' do
-      it_behaves_like 'an endpoint that responds with success 200'
+      it 'returns a success code' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns a valid 200 JSON response', with_json_schema: true do
+        expect(JSON::Validator.validate!(schema, response_json, fragment: '#/200')).to be true
+      end
+
+      it 'forces the content type to ApiController::CONTENT_TYPE' do
+        expect(response.headers['Content-Type']).to match(Regexp.escape(ApiController::CONTENT_TYPE))
+      end
 
       it 'deletes the move', skip_before: true do
         expect { delete "/api/v1/moves/#{move_id}/documents/#{document_id}", headers: headers }
@@ -52,12 +62,6 @@ RSpec.describe Api::V1::DocumentsController, with_client_authentication: true do
       let(:document_id) { 'UUID-not-found' }
 
       it_behaves_like 'an endpoint that responds with error 404'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415'
     end
   end
 end

--- a/spec/requests/api/v1/documents_controller_destroy_spec.rb
+++ b/spec/requests/api/v1/documents_controller_destroy_spec.rb
@@ -28,17 +28,7 @@ RSpec.describe Api::V1::DocumentsController, with_client_authentication: true do
     end
 
     context 'when successful' do
-      it 'returns a success code' do
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'returns a valid 200 JSON response', with_json_schema: true do
-        expect(JSON::Validator.validate!(schema, response_json, fragment: '#/200')).to be true
-      end
-
-      it 'forces the content type to ApiController::CONTENT_TYPE' do
-        expect(response.headers['Content-Type']).to match(Regexp.escape(ApiController::CONTENT_TYPE))
-      end
+      it_behaves_like 'an endpoint that responds with success 200'
 
       it 'deletes the move', skip_before: true do
         expect { delete "/api/v1/moves/#{move_id}/documents/#{document_id}", headers: headers }
@@ -62,6 +52,12 @@ RSpec.describe Api::V1::DocumentsController, with_client_authentication: true do
       let(:document_id) { 'UUID-not-found' }
 
       it_behaves_like 'an endpoint that responds with error 404'
+    end
+
+    context 'with an invalid CONTENT_TYPE header' do
+      let(:content_type) { 'application/xml' }
+
+      it_behaves_like 'an endpoint that responds with error 415'
     end
   end
 end

--- a/spec/support/responds_with_success_200.rb
+++ b/spec/support/responds_with_success_200.rb
@@ -10,6 +10,6 @@ RSpec.shared_examples 'an endpoint that responds with success 200' do
   end
 
   it 'sets the correct content type header' do
-    expect(response.headers['Content-Type']).to match(Regexp.escape(described_class::CONTENT_TYPE))
+    expect(response.headers['Content-Type']).to match(Regexp.escape(ApiController::CONTENT_TYPE))
   end
 end

--- a/spec/support/responds_with_success_201.rb
+++ b/spec/support/responds_with_success_201.rb
@@ -10,6 +10,6 @@ RSpec.shared_examples 'an endpoint that responds with success 201' do
   end
 
   it 'sets the correct content type header' do
-    expect(response.headers['Content-Type']).to match(Regexp.escape(described_class::CONTENT_TYPE))
+    expect(response.headers['Content-Type']).to match(Regexp.escape(ApiController::CONTENT_TYPE))
   end
 end

--- a/swagger/v1/document.json
+++ b/swagger/v1/document.json
@@ -21,10 +21,16 @@
       "attributes": {
         "type": "object",
         "required": [
+          "url",
           "filename",
           "content_type"
         ],
         "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "example": "http://localhost:4000/storage/image.png"
+          },
           "filename": {
             "type": "string",
             "example": "file.doc",


### PR DESCRIPTION
Limit multipart Content-Type to document creation and leave everything else to JSON API

The reason for doing this is that we're returning JSON with content-type `multipart/form-data` which doesn't get parsed by the HTTP library the frontend is using.
This limits the `multipart/form-data` to the document creation, and returns JSON API for everything else.