### PR TITLE
Retries on timeout and connection failed

### DIFF
--- a/spec/lib/nomis_client/base_spec.rb
+++ b/spec/lib/nomis_client/base_spec.rb
@@ -100,6 +100,36 @@ RSpec.describe NomisClient::Base do
         expect(client_credentials).to have_received(:get_token).twice
       end
     end
+
+    context 'when the endpoint raises a ConnectionFailed' do
+      let(:token_expires_at) { 1.hour.from_now.to_i }
+      let(:response_body) { '' }
+      let(:response_status) { 200 }
+
+      before do
+        allow(token).to receive(:get).and_raise(Faraday::ConnectionFailed, 'connection failed')
+        described_class.get(api_endpoint)
+      end
+
+      it 'is called MAX_RETRIES times' do
+        expect(token).to have_received(:get).exactly(3).times
+      end
+    end
+
+    context 'when the endpoint raises a TimeoutError' do
+      let(:token_expires_at) { 1.hour.from_now.to_i }
+      let(:response_body) { '' }
+      let(:response_status) { 200 }
+
+      before do
+        allow(token).to receive(:get).and_raise(Faraday::TimeoutError)
+        described_class.get(api_endpoint)
+      end
+
+      it 'is called MAX_RETRIES times' do
+        expect(token).to have_received(:get).exactly(3).times
+      end
+    end
   end
 
   describe '.post' do
@@ -182,10 +212,40 @@ RSpec.describe NomisClient::Base do
       let(:response_status) { 200 }
 
       it 'gets a new token' do
-        described_class.get(api_endpoint)
-        described_class.get(api_endpoint)
+        described_class.post(api_endpoint)
+        described_class.post(api_endpoint)
 
         expect(client_credentials).to have_received(:get_token).twice
+      end
+    end
+
+    context 'when the endpoint raises a ConnectionFailed' do
+      let(:token_expires_at) { 1.hour.from_now.to_i }
+      let(:response_body) { '' }
+      let(:response_status) { 200 }
+
+      before do
+        allow(token).to receive(:post).and_raise(Faraday::ConnectionFailed, 'connection failed')
+        described_class.post(api_endpoint)
+      end
+
+      it 'is called MAX_RETRIES times' do
+        expect(token).to have_received(:post).exactly(3).times
+      end
+    end
+
+    context 'when the endpoint raises a TimeoutError' do
+      let(:token_expires_at) { 1.hour.from_now.to_i }
+      let(:response_body) { '' }
+      let(:response_status) { 200 }
+
+      before do
+        allow(token).to receive(:post).and_raise(Faraday::TimeoutError)
+        described_class.post('/example')
+      end
+
+      it 'is called MAX_RETRIES times' do
+        expect(token).to have_received(:post).exactly(3).times
       end
     end
   end


### PR DESCRIPTION
Implements retries when the `NomisClient` raises a Faraday::ConnectionFailed or a Faraday::TimeoutError.
The number of retries is hardcoded to 3.

Solves https://dsdmoj.atlassian.net/browse/P4-768