### PR TITLE
Add supplier/location mappings to rake task for December 2019 rollout

### DIFF
--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -56,8 +56,27 @@ namespace :reference_data do
         WWM3
         WWM2
         WWM4
+        CHE1
+        CHE2
+        CHE3
+        CVL3
+        DRB2
+        DRB3
+        DRB5
+        NWA1
+        NWA4
+        NWA5
+        NYK1
+        NYK2
+        NYK3
+        STF2
+        STF4
+        WLT1
+        WLT4
       ],
       serco: %w[
+        BTP1
+        BTP4
         CAM5
         CAM1
         CAM3


### PR DESCRIPTION
This PR adds the remaining supplier/location mappings to the rake task for December 2019.

For https://dsdmoj.atlassian.net/browse/P4-811 (see recent comments for the requested codes for validation).

Once this has been merged it needs to be:
- Deployed to staging, preprod & production
- Log in to each environment & run the rake task
- Flush each environment's Redis cache