### PR TITLE
Fixes validation when file is missing + attachment url

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -7,11 +7,11 @@ module Api
 
       CONTENT_TYPE = 'multipart/form-data'
 
-      rescue_from ActiveSupport::MessageVerifier::InvalidSignature, with: :render_unprocessable_entity_error
-
       def create
         document = Document.create!(document_attributes)
         render json: document, status: 201, content_type: ApiController::CONTENT_TYPE
+      rescue ActiveSupport::MessageVerifier::InvalidSignature
+        Document.create!(file: nil)
       end
 
       def destroy
@@ -38,13 +38,6 @@ module Api
 
       def set_force_content_type
         @force_content_type = true
-      end
-
-      def render_unprocessable_entity_error
-        render(
-          json: { errors: { file: 'can\'t be blank' } },
-          status: 422
-        )
       end
     end
   end

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -7,6 +7,8 @@ module Api
 
       CONTENT_TYPE = 'multipart/form-data'
 
+      rescue_from ActiveSupport::MessageVerifier::InvalidSignature, with: :render_unprocessable_entity_error
+
       def create
         document = Document.create!(document_attributes)
         render json: document, status: 201, content_type: ApiController::CONTENT_TYPE
@@ -36,6 +38,13 @@ module Api
 
       def set_force_content_type
         @force_content_type = true
+      end
+
+      def render_unprocessable_entity_error
+        render(
+          json: { errors: { file: 'can\'t be blank' } },
+          status: 422
+        )
       end
     end
   end

--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DocumentSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers 
+  
   attributes :id, :url, :filename, :content_type
 
   def url

--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class DocumentSerializer < ActiveModel::Serializer
-  attributes :id, :filename, :content_type
+  attributes :id, :url, :filename, :content_type
+
+  def url
+    rails_blob_path(object.file)
+  end
 
   def filename
     object.file.filename

--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class DocumentSerializer < ActiveModel::Serializer
-  include Rails.application.routes.url_helpers 
-  
+  include Rails.application.routes.url_helpers
+
   attributes :id, :url, :filename, :content_type
 
   def url

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -13,6 +13,6 @@ class MoveSerializer < ActiveModel::Serializer
     person: %i[first_names last_name date_of_birth assessment_answers indentifiers ethnicity gender],
     from_location: %i[location_type description],
     to_location: %i[location_type description],
-    documents: %i[filename content_type]
+    documents: %i[url filename content_type]
   }.freeze
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,5 +55,5 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Default host for url generation
-  routes.default_url_options[:host] = 'localhost:4000'
+  routes.default_url_options[:host] = "localhost:#{ENV['PORT'] || 3000}"
 end

--- a/swagger/v1/document.json
+++ b/swagger/v1/document.json
@@ -21,10 +21,16 @@
       "attributes": {
         "type": "object",
         "required": [
+          "url",
           "filename",
           "content_type"
         ],
         "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "example": "http://localhost:4000/storage/image.png"
+          },
           "filename": {
             "type": "string",
             "example": "file.doc",


### PR DESCRIPTION
This fixes a weird bug happening when POSTing to `documents/` with an empty `file` attribute, for some reasons the server returns a `ActiveSupport::MessageVerifier::InvalidSignature` instead of generating a validation error (https://groups.google.com/forum/#!topic/rubyonrails-core/xI5HPnxIAIE).

It also adds the url attribute to the Document's JSON serializer.