### PR TITLE
Change db table declaration to be nice with UUIDS

### DIFF
--- a/db/migrate/20191114122923_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20191114122923_create_active_storage_tables.active_storage.rb
@@ -1,7 +1,7 @@
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
-    create_table :active_storage_blobs do |t|
+    create_table :active_storage_blobs, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
       t.string   :key,        null: false
       t.string   :filename,   null: false
       t.string   :content_type
@@ -13,10 +13,12 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.index [ :key ], unique: true
     end
 
-    create_table :active_storage_attachments do |t|
+    create_table :active_storage_attachments, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
       t.string     :name,     null: false
-      t.references :record,   null: false, polymorphic: true, index: false
-      t.references :blob,     null: false
+      
+      t.uuid :record_id, null: false     # replaces t.references :record
+      t.string :record_type, null: false # replaces t.references :record
+      t.uuid :blob_id,     null: false   # replaces t.references :blob
 
       t.datetime :created_at, null: false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,17 +16,16 @@ ActiveRecord::Schema.define(version: 2019_11_18_103125) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "active_storage_attachments", force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
+    t.uuid "record_id", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.uuid "blob_id", null: false
     t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"

--- a/spec/requests/api/v1/documents_controller_create_spec.rb
+++ b/spec/requests/api/v1/documents_controller_create_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Api::V1::DocumentsController, with_client_authentication: true do
       it 'attaches a file to the document' do
         expect(move.documents.last.file).to be_attached
       end
+
+      it 'adds the right file to the document' do
+        expect(move.documents.last.file.filename).to eq 'file-sample_100kB.doc'
+      end
     end
 
     context 'with a bad request' do


### PR DESCRIPTION
This changes the DB schema to use UUIDs in the ActiveStorage attachments table.

This is a framework bug: https://github.com/rails/rails/issues/35746

1) Pull
2) `cd $YOURLOCATION/hmpps-book-secure-move-api`
3) `bundle exec rake db:migrate VERSION=20191106121438` # this will wipe the broken table from your local db
4) `bundle exec rake db:migrate`
