### PR TITLE
Use url_for across all environments to retrieve service URL.

### DIFF
--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -7,9 +7,7 @@ class DocumentSerializer < ActiveModel::Serializer
   attributes :id, :url, :filename, :filesize, :content_type
 
   def url
-    rails_blob_url(object.file)
-  rescue ArgumentError
-    object.file.service_url
+    url_for(object.file)
   end
 
   def filename


### PR DESCRIPTION
This PR reconciles local and production behaviour by using a consistent URL generation scheme. The previous approach raised an exception in development and fell-back to a different approach, meaning the behaviour in each environment was different.

`url_for` retrieves the local URL for the attachment, which redirects to S3 when in use.

If we experience any errors in Cloud Platform with hostname being required, these should be added to the relevant environment configs. We'll be able to test this on staging.