### PR TITLE
P4-875 - crashes when >10 offenders, and when no personal care records

### DIFF
--- a/app/lib/nomis_client/people.rb
+++ b/app/lib/nomis_client/people.rb
@@ -10,8 +10,11 @@ module NomisClient
       end
 
       def get_response(nomis_offender_numbers:)
+        # The /prisoners endpoint is very quirky - even when passing in 12 offender numbers, it still
+        # defaults to paging at (by default) 10 items so set page limit to our offender count
         NomisClient::Base.post(
           '/prisoners',
+          headers: { 'Page-Limit' => nomis_offender_numbers.size.to_s },
           body: { 'offenderNos': nomis_offender_numbers }.to_json
         ).parsed
       end

--- a/app/lib/nomis_client/personal_care_needs.rb
+++ b/app/lib/nomis_client/personal_care_needs.rb
@@ -10,7 +10,7 @@ module NomisClient
           personal_care_needs['personalCareNeeds'].map do |personal_care_need_attributes|
             attributes_for(personal_care_needs['offenderNo'], personal_care_need_attributes)
           end
-        end.flatten!
+        end.flatten
       end
 
       def get_response(nomis_offender_numbers:)

--- a/spec/lib/nomis_client/people_spec.rb
+++ b/spec/lib/nomis_client/people_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe NomisClient::People do
       allow(NomisClient::Base).to(
         receive(:post)
         .with('/prisoners',
+              headers: { 'Page-Limit' => nomis_offender_numbers.size.to_s },
               body: { offenderNos: nomis_offender_numbers }.to_json)
         .and_return(nomis_response)
       )

--- a/spec/lib/nomis_client/personal_care_needs_spec.rb
+++ b/spec/lib/nomis_client/personal_care_needs_spec.rb
@@ -31,10 +31,21 @@ RSpec.describe NomisClient::PersonalCareNeeds, with_nomis_client_authentication:
 
     context 'when a resource is found' do
       let(:response_status) { 200 }
-      let(:response_body) { file_fixture('nomis_post_personal_care_needs_200.json').read }
 
-      it 'returns the correct person data' do
-        expect(response.map(&:symbolize_keys)).to eq client_response
+      context 'with a non-empty body' do
+        let(:response_body) { file_fixture('nomis_post_personal_care_needs_200.json').read }
+
+        it 'returns the correct person data' do
+          expect(response.map(&:symbolize_keys)).to eq client_response
+        end
+      end
+
+      context 'with an empty response body' do
+        let(:response_body) { [].to_json }
+
+        it 'returns an empty array' do
+          expect(response).to eq([])
+        end
       end
     end
   end


### PR DESCRIPTION
fix crash when > 10 offenders requested, and also when no personal_care_needs records are returned