### PR TITLE
P4-879, P4-882 update supplier allocations

### DIFF
--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -61,6 +61,8 @@ namespace :reference_data do
         DST2
         DST3
         GCS1
+        GWN1
+        GWN2
         LCS1
         LCS2
         LCS3

--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -46,8 +46,6 @@ namespace :reference_data do
         AVS1
         AVS2
         AVS3
-        BDS1
-        BDS2
         CHE1
         CHE2
         CHE3
@@ -105,6 +103,8 @@ namespace :reference_data do
         WWM7
       ],
       serco: %w[
+        BDS1
+        BDS2
         BTP1
         BTP2
         BTP4


### PR DESCRIPTION
- Adds Gwent custodies x2 (P4-882)
- Moves Bedfordshire custodies to Serco (P4-879)