### PR TITLE
Supplier/Location rake task replaces locations for each supplier

### DIFF
--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -161,14 +161,12 @@ namespace :reference_data do
       ]
     }
 
+    # Set the supplier locations. This is an authoritative change, making the
+    # suppliers have exactly the locations listed above.
     supplier_locations.each do |supplier_name, codes|
       supplier = Supplier.find_by(key: supplier_name.to_s)
       locations = codes.collect { |code| Location.find_by(nomis_agency_id: code) }.compact
-      locations.each do |location|
-        location.suppliers << supplier
-      rescue ActiveRecord::RecordNotUnique
-        puts "#{location.nomis_agency_id} <=> #{supplier_name} already exists"
-      end
+      supplier.locations = locations
     end
 
     puts


### PR DESCRIPTION
Prior to this commit the rake task would attempt to add any locations listed in the hash to each supplier, but would not remove any already in place.

This commit alters that behaviour to make the list in the Rake task authoritative. This enables (for example) moving a location from one supplier to another with a single change/command.