### PR TITLE
Moves can be filtered by supplier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'oauth2'
 gem 'pager_api'
 gem 'pg', '~> 1.0.0'
 gem 'prometheus_exporter'
-gem 'puma', '~> 3.11'
+gem 'puma', '~> 3.12.2'
 gem 'rails', '~> 5.2.3'
 gem 'sentry-raven'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,8 +178,8 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.1)
-    puma (3.12.1)
-    rack (2.0.8)
+    puma (3.12.2)
+    rack (2.1.1)
     rack-cors (1.1.0)
       rack (>= 2.0.0)
     rack-test (1.1.0)
@@ -323,7 +323,7 @@ DEPENDENCIES
   prometheus_exporter
   pry-byebug
   pry-rails
-  puma (~> 3.11)
+  puma (~> 3.12.2)
   rack-cors
   rails (~> 5.2.3)
   rspec-json_expectations

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -40,7 +40,9 @@ module Api
 
       private
 
-      PERMITTED_FILTER_PARAMS = %i[date_from date_to location_type status from_location_id to_location_id].freeze
+      PERMITTED_FILTER_PARAMS = %i[
+        date_from date_to location_type status from_location_id to_location_id supplier_id
+      ].freeze
       PERMITTED_MOVE_PARAMS = [
         :type,
         attributes: %i[date time_due status move_type additional_information

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -19,6 +19,8 @@ class Location < ApplicationRecord
   validates :title, presence: true
   validates :location_type, presence: true
 
+  scope :supplier, ->(supplier_id) { joins(:suppliers).where(locations_suppliers: { supplier_id: supplier_id }) }
+
   def prison?
     location_type.to_s == LOCATION_TYPE_PRISON
   end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -50,6 +50,8 @@ class Move < ApplicationRecord
   before_validation :set_move_type
   before_validation :ensure_event_nomis_ids_uniqueness
 
+  scope :served_by, ->(supplier_id) { where('from_location_id IN (?)', Location.supplier(supplier_id).pluck(:id)) }
+
   def nomis_event_id=(event_id)
     nomis_event_ids << event_id
   end

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -21,6 +21,7 @@ module Moves
       scope = apply_location_type_filters(scope)
       scope = apply_location_from_filters(scope)
       scope = apply_location_to_filters(scope)
+      scope = apply_supplier_filters(scope)
       scope
     end
 
@@ -50,6 +51,12 @@ module Moves
 
       to_location = filter_params[:to_location_id].split(',')
       scope.where(to_location_id: to_location)
+    end
+
+    def apply_supplier_filters(scope)
+      return scope unless filter_params.key?(:supplier_id)
+
+      scope.served_by(filter_params[:supplier_id])
     end
   end
 end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -7,6 +7,12 @@ FactoryBot.define do
     location_type { Location::LOCATION_TYPE_PRISON }
     nomis_agency_id { 'PEI' }
 
+    trait :with_moves do
+      after(:create) do |location, _|
+        create_list :move, 10, from_location: location
+      end
+    end
+
     trait :court do
       key { 'guildford_crown_court' }
       title { 'Guildford Crown Court' }

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -33,4 +33,31 @@ RSpec.describe Location do
     it { expect(location.police?).to be false }
     it { expect(location.court?).to be true }
   end
+
+  describe '#supplier' do
+    let(:supplier_one) { create(:supplier) }
+    let(:supplier_two) { create(:supplier, name: 'Test Supplier 2') }
+    let!(:location_one) { create(:location, suppliers: [supplier_one]) }
+    let!(:location_two) { create(:location, suppliers: [supplier_two]) }
+
+    context 'when querying with first supplier' do
+      it 'finds the right location' do
+        expect(described_class.supplier(supplier_one.id)).to include(location_one)
+      end
+
+      it 'finds the right number of locations' do
+        expect(described_class.supplier(supplier_one.id).count).to eq(1)
+      end
+    end
+
+    context 'when querying with second supplier' do
+      it 'finds the right location' do
+        expect(described_class.supplier(supplier_two.id)).to include(location_two)
+      end
+
+      it 'finds the right number of locations' do
+        expect(described_class.supplier(supplier_two.id).count).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -139,4 +139,21 @@ RSpec.describe Move do
       end
     end
   end
+
+  describe '#served_by' do
+    let(:supplier) { create :supplier }
+    let!(:location) { create :location, suppliers: [supplier] }
+    let!(:move_with_supplier) { create :move, from_location: location }
+    let!(:move_without_supplier) { create :move }
+
+    context 'when querying with supplier' do
+      it 'returns the right move' do
+        expect(described_class.served_by(supplier.id)).to include(move_with_supplier)
+      end
+
+      it 'does not return moves with no supplier' do
+        expect(described_class.served_by(supplier.id)).not_to include(move_without_supplier)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/moves_controller_filter_spec.rb
+++ b/spec/requests/api/v1/moves_controller_filter_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::MovesController, with_client_authentication: true do
+  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:response_json) { JSON.parse(response.body) }
+
+  describe 'GET /moves' do
+    context 'when filtering' do
+      let!(:supplier) { create :supplier }
+      let!(:location) { create :location, :with_moves, suppliers: [supplier] }
+      let!(:filtered_out_moves) { create_list :move, 10 }
+      let(:filter_params) { { filter: { supplier_id: supplier.id } } }
+
+      before do
+        get '/api/v1/moves', headers: headers, params: filter_params
+      end
+
+      describe 'by supplier_id' do
+        it 'returns the right amount of moves' do
+          expect(response_json['data'].size).to eq(10)
+        end
+
+        it 'returns the right moves' do
+          expect(response_json['data'].map { |move| move['id'] }.sort).to eq(location.moves_from.pluck(:id).sort)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Moves::Finder do
       end
     end
 
+    context 'with supplier filter' do
+      let(:supplier) { create :supplier }
+      let!(:location) { create :location, :with_moves, suppliers: [supplier] }
+      let(:filter_params) { { supplier_id: supplier.id } }
+
+      it 'returns moves matching the supplier' do
+        expect(move_finder.call.pluck(:id).sort).to eql location.moves_from.pluck(:id).sort
+      end
+    end
+
     context 'with mis-matching location filter' do
       let(:filter_params) { { from_location_id: Random.uuid } }
 


### PR DESCRIPTION
- Adds the `supplier_id` filter to `/api/v1/moves` backporting some scopes from the RBAC branch
- Updates rack and puma to fix the security alerts

Fixes https://dsdmoj.atlassian.net/browse/P4-872