### PR TITLE
Re-add schema definitions to swagger_helper

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -74,6 +74,53 @@ RSpec.configure do |config|
             },
           },
         },
+        schemas: {
+          Move: {
+            "$ref": "move.json#/Move"
+          },
+          PersonReference: {
+            "$ref": "person_reference.json#/PersonReference"
+          },
+          LocationReference: {
+            "$ref": "location_reference.json#/LocationReference"
+          },
+          Location: {
+            "$ref": "location.json#/Location"
+          },
+          Person: {
+            "$ref": "person.json#/Person"
+          },
+          Ethnicity: {
+            "$ref": "ethnicity.json#/Ethnicity"
+          },
+          Gender: {
+            "$ref": "gender.json#/Gender"
+          },
+          Nationality: {
+            "$ref": "nationality.json#/Nationality"
+          },
+          Supplier: {
+            "$ref": "supplier.json#/Supplier"
+          },
+          Document: {
+            "$ref": "document.json/Document"
+          },
+          AssessmentAnswer: {
+            "$ref": "assessment_answer.json#/AssessmentAnswer"
+          },
+          AssessmentQuestion: {
+            "$ref": "assessment_question.json#/AssessmentQuestion"
+          },
+          ProfileIdentifier: {
+            "$ref": "profile_identifier.json#/ProfileIdentifier"
+          },
+          PaginationLinks: {
+            "$ref": "pagination_links.json#/PaginationLinks"
+          },
+          Pagination: {
+            "$ref": "pagination.json#/Pagination"
+          }
+        }
       },
       definitions: {
         location_reference: load_swagger_json('location_reference.json'),

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -76,51 +76,51 @@ RSpec.configure do |config|
         },
         schemas: {
           Move: {
-            "$ref": "move.json#/Move"
+            "$ref": 'move.json#/Move',
           },
           PersonReference: {
-            "$ref": "person_reference.json#/PersonReference"
+            "$ref": 'person_reference.json#/PersonReference',
           },
           LocationReference: {
-            "$ref": "location_reference.json#/LocationReference"
+            "$ref": 'location_reference.json#/LocationReference',
           },
           Location: {
-            "$ref": "location.json#/Location"
+            "$ref": 'location.json#/Location',
           },
           Person: {
-            "$ref": "person.json#/Person"
+            "$ref": 'person.json#/Person',
           },
           Ethnicity: {
-            "$ref": "ethnicity.json#/Ethnicity"
+            "$ref": 'ethnicity.json#/Ethnicity',
           },
           Gender: {
-            "$ref": "gender.json#/Gender"
+            "$ref": 'gender.json#/Gender',
           },
           Nationality: {
-            "$ref": "nationality.json#/Nationality"
+            "$ref": 'nationality.json#/Nationality',
           },
           Supplier: {
-            "$ref": "supplier.json#/Supplier"
+            "$ref": 'supplier.json#/Supplier',
           },
           Document: {
-            "$ref": "document.json/Document"
+            "$ref": 'document.json/Document',
           },
           AssessmentAnswer: {
-            "$ref": "assessment_answer.json#/AssessmentAnswer"
+            "$ref": 'assessment_answer.json#/AssessmentAnswer',
           },
           AssessmentQuestion: {
-            "$ref": "assessment_question.json#/AssessmentQuestion"
+            "$ref": 'assessment_question.json#/AssessmentQuestion',
           },
           ProfileIdentifier: {
-            "$ref": "profile_identifier.json#/ProfileIdentifier"
+            "$ref": 'profile_identifier.json#/ProfileIdentifier',
           },
           PaginationLinks: {
-            "$ref": "pagination_links.json#/PaginationLinks"
+            "$ref": 'pagination_links.json#/PaginationLinks',
           },
           Pagination: {
-            "$ref": "pagination.json#/Pagination"
-          }
-        }
+            "$ref": 'pagination.json#/Pagination',
+          },
+        },
       },
       definitions: {
         location_reference: load_swagger_json('location_reference.json'),


### PR DESCRIPTION
These were omitted from the original introduction of RSwag. There's likely a cleaner way we can achieve this in the long run, but as a first pass to get the models back into the UI it'll do.

<img width="1444" alt="Screenshot 2020-01-30 at 19 59 48" src="https://user-images.githubusercontent.com/464482/73485525-26502580-439b-11ea-9c40-627b475036af.png">
