### PR TITLE
/%s/rails/rake/g in Create reference data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ To create reference data (seed data) needed in production run the
 following rake tasks:
 
 ```
-bundle exec rails reference_data:create_assessment_questions
-bundle exec rails reference_data:create_ethnicities
-bundle exec rails reference_data:create_genders
-bundle exec rails reference_data:create_identifier_types
-bundle exec rails reference_data:create_locations
-bundle exec rails reference_data:create_nomis_alerts
-bundle exec rails reference_data:create_suppliers
+bundle exec rake reference_data:create_assessment_questions
+bundle exec rake reference_data:create_ethnicities
+bundle exec rake reference_data:create_genders
+bundle exec rake reference_data:create_identifier_types
+bundle exec rake reference_data:create_locations
+bundle exec rake reference_data:create_nomis_alerts
+bundle exec rake reference_data:create_suppliers
 ```
 
 Some of these tasks pull data from NOMIS and therefore require


### PR DESCRIPTION
Minor FIX to the README giving the wrong instruction to run rake tasks.