### PR TITLE
remove webmock (for now) as it doesn't work in this project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'timecop'
-  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,8 +79,6 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
     crass (1.0.5)
     diff-lcs (1.3)
     discard (1.1.0)
@@ -106,7 +104,6 @@ GEM
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    hashdiff (1.0.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -268,7 +265,6 @@ GEM
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    safe_yaml (1.0.5)
     sentry-raven (2.11.0)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (4.1.2)
@@ -309,10 +305,6 @@ GEM
     validate_url (1.0.8)
       activemodel (>= 3.0.0)
       public_suffix
-    webmock (3.7.2)
-      addressable (>= 2.3.6)
-      crack (>= 0.3.2)
-      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -366,7 +358,6 @@ DEPENDENCIES
   timecop
   tty-prompt
   validate_url (~> 1.0.8)
-  webmock
 
 RUBY VERSION
    ruby 2.6.2p47

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,8 +28,6 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
-require 'webmock/rspec'
-WebMock.disable_net_connect! allow: /oauth/
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
Something to do with our usage of OAuth2::Client means that webmock doesn't work in this project. As we have a consistent API for accessing NOMIS, the lack of webmock can be effectively worked-around by mocking NomisClient::Moves#get_response (et al)