### PR TITLE
Add ADR to keep track of the Architech Decisions

### DIFF
--- a/adr/0001-record-architecture-decisions.md
+++ b/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2020-02-06
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project (Pecs).
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md).
+
+## Consequences
+
+We can captures an important architectural decision made along with its context and consequences.

--- a/adr/0002-API-params-naming.md
+++ b/adr/0002-API-params-naming.md
@@ -1,0 +1,26 @@
+# 2. Name API parameters to match DPS APIs
+Date: 2020-02-06
+
+## Status
+
+Accepted
+
+## Context
+
+The naming of the params used in the APIs needs be consistent.
+
+For example:
+nomis_offender_id, prison_number and nomis_prison_number refer to the same data.
+
+## Decision
+Use param names similar to those used on [DPS APIs](https://gateway.prod.nomis-api.service.hmpps.dsd.io/elite2api/swagger-ui.html#//offenders/getAddressesByOffenderNoUsingGET)
+
+Use snake_case in place of camelCase.
+Consider to prefix the param with `nomis_` to clarify the source.
+
+For example:
+`offenderNo` -> `nomis_offender_no`
+
+
+## Consequences
+We will be able achieve consistency on naming API params.


### PR DESCRIPTION
This PR add a template for ADR (see [Michael Nygard's template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md) )

It also adds a simple ADR about API params naming.

