### PR TITLE
P4 982 audit API accesses

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# This is 'our' application model, which knows that there are read audits attached.
+class Application < Doorkeeper::Application
+  has_many :request_audits, dependent: :destroy
+end

--- a/app/models/request_audit.rb
+++ b/app/models/request_audit.rb
@@ -1,0 +1,4 @@
+class RequestAudit < ApplicationRecord
+  belongs_to :application, class_name: 'Doorkeeper::Application'
+  has_many :response_audits, dependent: :destroy
+end

--- a/app/models/response_audit.rb
+++ b/app/models/response_audit.rb
@@ -1,0 +1,9 @@
+class ResponseAudit < ApplicationRecord
+  belongs_to :request_audit
+
+  scope :person_reads, ->(person_id) do
+    direct_query = { id: person_id, type: 'people' }.to_json
+    relationship_query = { relationships: { person: { data: { id: person_id, type: 'people' } } } }.to_json
+    where('response @> ?', direct_query).or(where('response @> ?', relationship_query))
+  end
+end

--- a/db/migrate/20200208115530_create_request_audits.rb
+++ b/db/migrate/20200208115530_create_request_audits.rb
@@ -1,0 +1,17 @@
+class CreateRequestAudits < ActiveRecord::Migration[5.2]
+  def change
+    create_table :request_audits, id: :uuid do |t|
+      t.bigint :application_id, null: false
+      t.foreign_key :oauth_applications, column: :application_id
+      t.string :request, null: false
+
+      t.timestamps
+    end
+
+    create_table :response_audits, id: :uuid do |t|
+      t.uuid :request_audit_id, null: false
+      t.jsonb :response, null: false
+      t.index :response, using: :gin
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -232,6 +232,13 @@ ActiveRecord::Schema.define(version: 2020_02_12_132542) do
     t.integer "latest_nomis_booking_id"
   end
 
+  create_table "request_audits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "application_id", null: false
+    t.string "request", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "supplier_id", null: false
     t.string "callback_url", null: false
@@ -243,6 +250,12 @@ ActiveRecord::Schema.define(version: 2020_02_12_132542) do
     t.index ["callback_url"], name: "index_subscriptions_on_callback_url"
     t.index ["discarded_at"], name: "index_subscriptions_on_discarded_at"
     t.index ["supplier_id"], name: "index_subscriptions_on_supplier_id"
+  end
+
+  create_table "response_audits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "request_audit_id", null: false
+    t.jsonb "response", null: false
+    t.index ["response"], name: "index_response_audits_on_response", using: :gin
   end
 
   create_table "suppliers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -274,5 +287,6 @@ ActiveRecord::Schema.define(version: 2020_02_12_132542) do
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "profiles", "people", name: "profiles_person_id"
+  add_foreign_key "request_audits", "oauth_applications", column: "application_id"
   add_foreign_key "subscriptions", "suppliers"
 end

--- a/spec/factories/request_audits.rb
+++ b/spec/factories/request_audits.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :request_audit do
+    request { 'url_with_parameters' }
+
+    association :application
+  end
+end

--- a/spec/models/request_audit_spec.rb
+++ b/spec/models/request_audit_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe RequestAudit, type: :model do
+  it 'belongs to an application' do
+    expect(build(:request_audit).application).not_to be_nil
+  end
+
+  it 'can be persisted' do
+    expect(create(:request_audit)).not_to be_nil
+  end
+end


### PR DESCRIPTION
Spike for auditing all accesses through the API. 
Had to create response detail records to make the JSON queryable, and had to know exactly where the JSON fields were present in order to do the queries