### PR TITLE
Add support for nomis_offender_no to the /api/v1/people - Part1

### DIFF
--- a/app/services/people/finder.rb
+++ b/app/services/people/finder.rb
@@ -19,14 +19,25 @@ module People
     end
 
     def apply_police_national_computer_filters(scope)
-      return unless filter_params.key?(:police_national_computer)
-
       scope = scope.joins(:profiles)
-      scope.where('profiles.profile_identifiers @> ?', police_national_computer)
+
+      if filter_params.key?(:police_national_computer)
+        scope.where('profiles.profile_identifiers @> ?', police_national_computer.to_json)
+      end
+
+      if filter_params.key?(:nomis_offender_no)
+        scope.where('profiles.nomis_offender_no @> ?', nomis_offender_no.to_json)
+      end
+
+      scope
     end
 
     def police_national_computer
-      [{ identifier_type: 'police_national_computer', value: filter_params[:police_national_computer] }].to_json
+      [{ identifier_type: 'police_national_computer', value: filter_params[:police_national_computer] }]
+    end
+
+    def nomis_offender_no
+      [{ identifier_type: 'prison_number', value: filter_params[:nomis_offender_no] }]
     end
   end
 end

--- a/spec/factories/profile.rb
+++ b/spec/factories/profile.rb
@@ -5,7 +5,10 @@ FactoryBot.define do
     first_names { 'Bob' }
     last_name { 'Roberts' }
     date_of_birth { Date.new(1980, 10, 20) }
-    profile_identifiers { [{ identifier_type: 'police_national_computer', value: 'AB/1234567' }] }
+    profile_identifiers {
+      [{ identifier_type: 'police_national_computer', value: 'AB/1234567' },
+       { identifier_type: 'prison_number', value: 'ABCDEFG' }]
+    }
     association(:ethnicity)
     association(:gender)
   end

--- a/spec/services/people/finder_spec.rb
+++ b/spec/services/people/finder_spec.rb
@@ -16,5 +16,13 @@ RSpec.describe People::Finder do
         expect(people_finder.call.pluck(:id)).to eq [person.id]
       end
     end
+
+    context 'when matching nomis_offender_no filter' do
+      let(:filter_params) { { nomis_offender_no: 'ABCDEFG' } }
+
+      it 'returns people matching the police_national_computer' do
+        expect(people_finder.call.pluck(:id)).to eq [person.id]
+      end
+    end
   end
 end


### PR DESCRIPTION
This is part of the ticket: BE - Add support for nomis_offender_no to the /api/v1/people

We'll need to add the support to search for `nomis_offender_no`, this first PR simplyadd the search by nomis_offender_no to the `People::Finder`

Ticket: https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=303&projectKey=P4&modal=detail&selectedIssue=P4-977
