### PR TITLE
use standard doorkeeper mechanism for move controller create spec

### DIFF
--- a/spec/factories/access_token.rb
+++ b/spec/factories/access_token.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :access_token, class: 'Doorkeeper::AccessToken' do
+  end
+end

--- a/spec/factories/application.rb
+++ b/spec/factories/application.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :application, class: 'Doorkeeper::Application' do
+    sequence(:name) { |n| "test#{n}" }
+  end
+end


### PR DESCRIPTION
Our request specs are somewhat torturous (and extremely slow) as we authenticate for every interaction. This PR demonstrates a more standard doorkeeper mechanism