### PR TITLE
Add support for nomis offender id to v1 people endpoint

### DIFF
--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -4,7 +4,12 @@ module Api
   module V1
     class PeopleController < ApiController
       def index
+        person_nomis_prison_number = filter_params[:nomis_offender_no]
+
+        Moves::ImportPeople.new([person_nomis_prison_number: person_nomis_prison_number]).call if person_nomis_prison_number
+
         people = People::Finder.new(filter_params).call
+
         paginate people, include: PersonSerializer::INCLUDED_DETAIL
       end
 
@@ -20,7 +25,7 @@ module Api
 
     private
 
-      PERMITTED_FILTER_PARAMS = [:police_national_computer].freeze
+      PERMITTED_FILTER_PARAMS = %i[police_national_computer nomis_offender_no].freeze
       PERSON_ATTRIBUTES = [
         :first_names,
         :last_name,

--- a/app/services/moves/import_people.rb
+++ b/app/services/moves/import_people.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Moves
+  class ImportPeople
+    attr_accessor :items
+
+    def initialize(items)
+      self.items = items
+    end
+
+    def call
+      import_people
+    end
+
+  private
+
+    def import_people
+      people_nomis_prison_numbers = items.map { |item| item.fetch(:person_nomis_prison_number) }
+      people = NomisClient::People.get(people_nomis_prison_numbers).map { |p| [p.fetch(:prison_number), p] }.to_h
+      alerts = NomisClient::Alerts.get(people_nomis_prison_numbers).group_by { |p| p.fetch(:offender_no) }
+      personal_care_needs = NomisClient::PersonalCareNeeds
+                            .get(people_nomis_prison_numbers)
+                            .group_by { |p| p.fetch(:offender_no) }
+
+      new_person_count = 0
+      changed_profile_count = 0
+      people.each do |offender_no, person_data|
+        profile = People::Importer.new(person_data).call
+        new_person_count += 1 if profile.new_record?
+        Alerts::Importer.new(profile: profile, alerts: alerts.fetch(offender_no, [])).call
+        PersonalCareNeeds::Importer.new(profile: profile,
+                                        personal_care_needs: personal_care_needs.fetch(offender_no, [])).call
+        if profile.changed?
+          changed_profile_count += 1
+          profile.save!
+        end
+      end
+      if new_person_count.positive? || changed_profile_count.positive?
+        Rails.logger.info("[Moves::Importer] people new[#{new_person_count}] updated[#{changed_profile_count}]")
+      end
+    end
+  end
+end

--- a/app/services/moves/importer.rb
+++ b/app/services/moves/importer.rb
@@ -9,38 +9,12 @@ module Moves
     end
 
     def call
-      import_people
+      Moves::ImportPeople.new(items).call
+
       import_moves
     end
 
   private
-
-    def import_people
-      people_nomis_prison_numbers = items.map { |item| item.fetch(:person_nomis_prison_number) }
-      people = NomisClient::People.get(people_nomis_prison_numbers).map { |p| [p.fetch(:prison_number), p] }.to_h
-      alerts = NomisClient::Alerts.get(people_nomis_prison_numbers).group_by { |p| p.fetch(:offender_no) }
-      personal_care_needs = NomisClient::PersonalCareNeeds
-                            .get(people_nomis_prison_numbers)
-                            .group_by { |p| p.fetch(:offender_no) }
-
-      new_person_count = 0
-      changed_profile_count = 0
-      people.each do |offender_no, person_data|
-        profile = People::Importer.new(person_data).call
-        new_person_count += 1 if profile.new_record?
-        Alerts::Importer.new(profile: profile, alerts: alerts.fetch(offender_no, [])).call
-        PersonalCareNeeds::Importer.new(profile: profile,
-                                        personal_care_needs: personal_care_needs.fetch(offender_no, [])).call
-        if profile.changed?
-          changed_profile_count += 1
-          profile.save!
-        end
-      end
-      if new_person_count.positive? || changed_profile_count.positive?
-        Rails.logger.info("[Moves::Importer] people new[#{new_person_count}] updated[#{changed_profile_count}]")
-      end
-    end
-
     def import_moves
       new_count = 0
       update_count = 0

--- a/app/services/people/finder.rb
+++ b/app/services/people/finder.rb
@@ -12,7 +12,7 @@ module People
       apply_filters(Person)
     end
 
-    private
+  private
 
     def apply_filters(scope)
       scope = scope.joins(:profiles)

--- a/app/services/people/finder.rb
+++ b/app/services/people/finder.rb
@@ -12,7 +12,7 @@ module People
       apply_filters(Person)
     end
 
-  private
+    private
 
     def apply_filters(scope)
       scope = scope.joins(:profiles)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   username: <%= ENV["DB_USERNAME"] %>
-  
+
 development:
   <<: *default
   database: pecs_move_platform_backend_development

--- a/spec/lib/nomis_client/people_webmock_spec.rb
+++ b/spec/lib/nomis_client/people_webmock_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'nomis_client'
+require 'nomis_client/moves'
+
+RSpec.describe NomisClient::People do
+  describe '.get', with_nomis_client_authentication: true do
+    let(:prison_numbers) { %w[G3239GV GV345VG G3325XX] }
+
+    context 'when resources are found' do
+      let(:response_status) { 200 }
+      let(:response_body) { file_fixture('nomis_post_prisoners_200.json').read }
+
+      it 'returns the correct people data' do
+        described_class.get(prison_numbers)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/people_controller_index_spec.rb
+++ b/spec/requests/api/v1/people_controller_index_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:response_json) { JSON.parse(response.body) }
 
+  let(:schema) { load_json_schema('get_people_responses.json') }
+
   describe 'GET /people' do
-    let(:schema) { load_json_schema('get_people_responses.json') }
-
-    let!(:people) { create_list :person, 5 }
-
     describe 'filtering the results' do
+      let!(:people) { create_list :person, 5 }
+
       let(:params) { { filter: { police_national_computer: 'AB/1234567' } } }
 
       context 'when called with police_national_computer filter' do
@@ -30,6 +30,24 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
         get '/api/v1/people', headers: headers, params: params
 
         expect(People::Finder).to have_received(:new).with(police_national_computer: 'AB/1234567')
+      end
+    end
+
+    context 'when Nomis offender number no is provided' do
+      let(:nomis_offender_no) { 'G5033UT' }
+      let(:params) { { filter: { nomis_offender_no: 'G5033UT' } } }
+      let(:people_finder) { instance_double('People::Finder', call: Person.all) }
+
+      before do
+        allow(People::Finder).to receive(:new).and_return(people_finder)
+        allow(Moves::ImportPeople).to receive(:new).with([person_nomis_prison_number: nomis_offender_no])
+                                                   .and_return(instance_double('Moves::ImportPeople', call: nil))
+      end
+
+      it 'requests data from NOMIS', with_json_schema: true do
+        get '/api/v1/people', headers: headers, params: params
+
+        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/spec/services/moves/import_people_spec.rb
+++ b/spec/services/moves/import_people_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moves::ImportPeople do
+  subject(:importer) { described_class.new(input_data) }
+
+  let(:input_data) do
+    [person_nomis_prison_number: prisoner_one.nomis_prison_number]
+  end
+
+  let!(:brixton_prison) { create(:location, nomis_agency_id: 'BXI', location_type: 'prison') }
+  let!(:wood_green_court) { create(:location, nomis_agency_id: 'WDGRCC', location_type: 'court') }
+  let!(:prisoner_one) { create(:person, :nomis_synced) }
+  let!(:prisoner_two) { create(:person, :nomis_synced) }
+  let!(:profile_one) { create(:profile, person: prisoner_one) }
+  let!(:profile_two) { create(:profile, person: prisoner_two) }
+
+  let(:alerts_response) do
+    [{ offender_no: prisoner_one.nomis_prison_number, alert_code: 'ACCU9', alert_type: 'MATSTAT' },
+     { offender_no: prisoner_two.nomis_prison_number, alert_code: 'ACCU9', alert_type: 'MATSTAT' },
+     { offender_no: prisoner_two.nomis_prison_number, alert_code: 'ACCU4', alert_type: 'MATSTAT' }]
+  end
+  let(:offender_numbers_response) { [{ offender_no: 'G3239GV' }, { offender_no: 'G7157AB' }] }
+  let(:prison_numbers_response) do
+    [{ prison_number: prisoner_one.nomis_prison_number, first_name: 'Bob' },
+     { prison_number: prisoner_two.nomis_prison_number, first_name: 'Bob' }]
+  end
+  let(:personal_care_needs_response) do
+    [{ offender_no: prisoner_one.nomis_prison_number, problem_type: 'MATSTAT', problem_code: 'ACCU9' },
+     { offender_no: prisoner_two.nomis_prison_number, problem_type: 'MATSTAT', problem_code: 'ACCU9' },
+     { offender_no: prisoner_two.nomis_prison_number, problem_type: 'MATSTAT', problem_code: 'ACCU4' }]
+  end
+
+  before do
+    allow(NomisClient::People).to receive(:get).and_return(prison_numbers_response)
+    allow(NomisClient::Alerts).to receive(:get).and_return(alerts_response)
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return(personal_care_needs_response)
+    # create fallback questions for PersonalCareNeeds importer and Alerts importer
+    create(:assessment_question, :care_needs_fallback)
+    create(:assessment_question, :alerts_fallback)
+  end
+
+  context 'with one existing record' do
+    it 'keeps people the same' do
+      expect { importer.call }.not_to change(Person, :count)
+    end
+
+    it 'keeps profiles the same' do
+      expect { importer.call }.not_to change(Profile, :count)
+    end
+  end
+end

--- a/spec/services/people/finder_spec.rb
+++ b/spec/services/people/finder_spec.rb
@@ -30,5 +30,13 @@ RSpec.describe People::Finder do
         expect(people_finder.call).to eq [person]
       end
     end
+
+    context 'when matching nomis_offender_no filter' do
+      let(:filter_params) { { nomis_offender_no: 'ABCDEFG' } }
+
+      it 'returns people matching the police_national_computer' do
+        expect(people_finder.call.pluck(:id)).to eq [person.id]
+      end
+    end
   end
 end

--- a/spec/services/people/finder_spec.rb
+++ b/spec/services/people/finder_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe People::Finder do
     context 'when matching nomis_offender_no filter' do
       let(:filter_params) { { nomis_offender_no: 'ABCDEFG' } }
 
-      it 'returns people matching the police_national_computer' do
+      it 'returns people matching the Nomis offender number' do
         expect(people_finder.call.pluck(:id)).to eq [person.id]
       end
     end


### PR DESCRIPTION
This PR add support for the params `nomis_offender_no` to the `People` controller.

Also, whenever `nomis_offender_no` is used, it update the data regarding the Person from Nomis.
(Note that the way we sync this could change in the future)

Tech Details:
- A new service `Moves::ImportPeople` was added, to sync just the person
- `Moves::Importer` was refactored to use `Moves::ImportPeople`
