### PR TITLE
Only notify slack on CircleCI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,14 @@
 #
 version: 2.1
 
+orbs:
+  slack: circleci/slack@3.4.2
+
+aliases:
+  - &notify_slack
+    slack/notify-on-failure:
+      only_for_branches: master
+
 references:
   app_containers: &app_containers
     docker:
@@ -134,6 +142,8 @@ jobs:
       - persist_to_workspace:
           root: swagger/v1
           paths: swagger.yaml
+
+      - *notify_slack
 
   build_staging:
     <<: *cloud_container


### PR DESCRIPTION
This uses the slack Orb in CircleCI config to only alert the channel
on master failures, not branches.