### PR TITLE
add Node, Yarn, and run asset precompile with dummy secret. WIP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM ministryofjustice/ruby:2.6.2-webapp-onbuild
+
+# Install Node & Yarn for the asset pipeline
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 FROM ministryofjustice/ruby:2.6.2-webapp-onbuild
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+  && apt-get update \
+  && apt-get install -y nodejs yarn \
+  && apt-get clean
 
 ARG APP_BUILD_DATE
 ENV APP_BUILD_DATE ${APP_BUILD_DATE}
@@ -22,6 +28,7 @@ EXPOSE $PUMA_PORT
 ENV APPUID 1000
 USER $APPUID
 
-RUN rails assets:precompile
+RUN yarn install
+RUN SECRET_KEY_BASE=doesntmatter rails assets:precompile
 
 ENTRYPOINT ["./run.sh"]


### PR DESCRIPTION
## Proposed Changes

- Adds Node & Yarn depedencies to build assets

## To test/demo change

- `docker build .`

This is a WIP. Running this locally gives the following error in the asset pipeline:

```
Step 15/16 : RUN SECRET_KEY_BASE=doesntmatter rails assets:precompile
 ---> Running in 9db7dd5eb007
I, [2020-02-20T12:33:20.919971 #7]  INFO -- : Writing /usr/src/app/public/assets/app-logotype-crest@2x-32c082fbb9218f7886ae62395dbe9bb63c90bd7144b6a51b31f0cd5a0fdde3fc.png
I, [2020-02-20T12:33:20.931610 #7]  INFO -- : Writing /usr/src/app/public/assets/application-4c392bc960339ef7f65ba4d6124b304a9997169d944bd886f2197ea6189a2a69.js
I, [2020-02-20T12:33:20.931880 #7]  INFO -- : Writing /usr/src/app/public/assets/application-4c392bc960339ef7f65ba4d6124b304a9997169d944bd886f2197ea6189a2a69.js.gz
rails aborted!
SassC::SyntaxError: Error: "calc(0px)" is not a number for `max'
        on line 1159:20 of stdin, in function `max`
        from line 1159:20 of stdin
>> @supports (margin: max(calc(0px))) {

   -------------------^
stdin:1159
/usr/local/bundle/gems/sassc-2.2.1/lib/sassc/engine.rb:49:in `render'
/usr/local/bundle/gems/sassc-rails-2.1.2/lib/sassc/rails/compressor.rb:29:in `call'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/sass_compressor.rb:28:in `call'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:75:in `call_processor'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:57:in `block in call_processors'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:56:in `reverse_each'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/processor_utils.rb:56:in `call_processors'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/loader.rb:134:in `load_from_unloaded'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/loader.rb:60:in `block in load'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/loader.rb:317:in `fetch_asset_from_dependency_cache'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/loader.rb:44:in `load'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/cached_environment.rb:20:in `block in initialize'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/cached_environment.rb:47:in `load'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/base.rb:66:in `find_asset'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/base.rb:73:in `find_all_linked_assets'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/manifest.rb:142:in `block in find'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/legacy.rb:114:in `block (2 levels) in logical_paths'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/path_utils.rb:228:in `block in stat_tree'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/path_utils.rb:212:in `block in stat_directory'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/path_utils.rb:209:in `each'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/path_utils.rb:209:in `stat_directory'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/path_utils.rb:227:in `stat_tree'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/legacy.rb:105:in `each'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/legacy.rb:105:in `block in logical_paths'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/legacy.rb:104:in `each'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/legacy.rb:104:in `logical_paths'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/manifest.rb:140:in `find'
/usr/local/bundle/gems/sprockets-3.7.2/lib/sprockets/manifest.rb:186:in `compile'
/usr/local/bundle/gems/sprockets-rails-3.2.1/lib/sprockets/rails/task.rb:68:in `block (3 levels) in define'
/usr/local/bundle/gems/sprockets-3.7.2/lib/rake/sprocketstask.rb:147:in `with_logger'
/usr/local/bundle/gems/sprockets-rails-3.2.1/lib/sprockets/rails/task.rb:67:in `block (2 levels) in define'
/usr/local/bundle/gems/railties-5.2.3/lib/rails/commands/rake/rake_command.rb:23:in `block in perform'
/usr/local/bundle/gems/railties-5.2.3/lib/rails/commands/rake/rake_command.rb:20:in `perform'
/usr/local/bundle/gems/railties-5.2.3/lib/rails/command.rb:48:in `invoke'
/usr/local/bundle/gems/railties-5.2.3/lib/rails/commands.rb:18:in `<main>'
/usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
/usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
/usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
/usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
bin/rails:9:in `<main>'
Tasks: TOP => assets:precompile
(See full trace by running task with --trace)
````