### PR TITLE
remove inline rails migration

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 cd /usr/src/app
 
-bundle exec rake db:create db:migrate
 bundle exec puma -p $PUMA_PORT


### PR DESCRIPTION
Fixes issue with inline rails migration

## Proposed Changes

Remove rails db:migrate from run.sh

## To test/demo change

Rollback environment by 1 database migration. Deploy and check that migration runs forward correctly

