### PR TITLE
move SCH9 from serco to GeoAmey due to error

### DIFF
--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -150,6 +150,7 @@ namespace :reference_data do
         SCH5
         SCH6
         SCH8
+        SCH9
         STC2
         STC3
         SFCUSU
@@ -265,7 +266,6 @@ namespace :reference_data do
         NFL2
         NFL3
         NFL4
-        SCH9
         SFL1
         SFL2
       ],


### PR DESCRIPTION
Fixes P4-1080

## Proposed Changes

Move SCH9 (Vinney Green) from Serco to GeoAmey (linked in error)

## To test/demo change

run rake reference_data::link_suppliers on env after deploy. Check that VinneyGreen (SCH9) only linked to GeoAmey and not to Serco

## Manual steps to deploy/dependencies

rake reference_data::link_suppliers
