### PR TITLE
P4-885 step 2 = add task to back-fill profile data

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -140,18 +140,23 @@ namespace :fake_data do
     people = Person.all
     prisons = Location.where(location_type: 'prison').all
     courts = Location.where(location_type: 'court').all
-    500.times do
+    20000.times do
       date = Faker::Date.between(from: 10.days.ago, to: 20.days.from_now)
       time = date.to_time
       time = time.change(hour: [9, 12, 14].sample)
-      Move.create!(
-        date: date,
-        time_due: time,
-        person: people.sample,
-        from_location: prisons.sample,
-        to_location: courts.sample,
-        status: %w[requested completed cancelled].sample,
-      )
+      person = people.sample
+      from_location = prisons.sample
+      to_location = courts.sample
+      unless Move.find_by(date: date, person: person, from_location: from_location, to_location: to_location)
+        Move.create!(
+          date: date,
+          time_due: time,
+          person: person,
+          from_location: from_location,
+          to_location: to_location,
+          status: %w[requested completed cancelled].sample,
+        )
+      end
     end
   end
 

--- a/lib/tasks/move_profile.rake
+++ b/lib/tasks/move_profile.rake
@@ -1,0 +1,8 @@
+namespace :move_profile do
+  desc 'backfill move profile ids'
+  task backfill: :environment do
+    Move.includes(person: :profiles).find_each.reject { |m| m.profile_id.present? }.each do |move|
+      move.update!(profile_id: move.person.latest_profile.id)
+    end
+  end
+end


### PR DESCRIPTION
Part of P4-885

## Proposed Changes

- Backfill task so that the migration can be deployed without having to do all the back-filling

## To test/demo change

- rake move_profile:backfill

## Manual steps to deploy/dependencies

- task need to be run on production a few times so that actual migration is quick
