### PR TITLE
P4 885 move profile rework

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -72,9 +72,10 @@ module Api
       end
 
       def move_attributes
-        # moves are always created against the latest_profile for the person
+        # latest_profile is fine here, as this is used by create/update which should only be allowed
+        # for moves which haven't been completed.
         move_params[:attributes].merge(
-          person: Person.find(move_params.dig(:relationships, :person, :data, :id)),
+          profile: Person.find(move_params.dig(:relationships, :person, :data, :id)).latest_profile,
           from_location: Location.find(move_params.dig(:relationships, :from_location, :data, :id)),
           to_location: Location.find_by(id: move_params.dig(:relationships, :to_location, :data, :id)),
           documents: Document.where(id: (move_params.dig(:relationships, :documents, :data) || []).map { |doc| doc[:id] }),
@@ -92,7 +93,7 @@ module Api
       def find_move
         Move
           .accessible_by(current_ability)
-          .includes(:from_location, :to_location, person: { profiles: %i[gender ethnicity] })
+          .includes(:from_location, :to_location, profile: %i[gender ethnicity])
           .find(params[:id])
       end
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -33,7 +33,7 @@ class Move < VersionedModel
 
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location', optional: true
-  belongs_to :person
+  belongs_to :profile
   # using https://github.com/jhawthorn/discard for documents, so only include the non-soft-deleted documents here
   has_many :documents, -> { kept }, dependent: :destroy, inverse_of: :move
   has_many :notifications, as: :topic, dependent: :destroy # NB: polymorphic association
@@ -46,7 +46,7 @@ class Move < VersionedModel
   )
   validates :date, presence: true
   validates :move_type, inclusion: { in: move_types }
-  validates :person, presence: true
+  validates :profile, presence: true
   validates :reference, presence: true
 
   validates :status, inclusion: { in: statuses }
@@ -68,7 +68,9 @@ class Move < VersionedModel
   end
 
   def existing
-    Move.find_by(date: date, person_id: person_id, from_location_id: from_location_id, to_location_id: to_location_id)
+    Move.joins(:profile)
+        .merge(Profile.where(person_id: profile.person_id))
+        .find_by(date: date, from_location_id: from_location_id, to_location_id: to_location_id)
   end
 
 private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -2,7 +2,7 @@
 
 class Person < VersionedModel
   has_many :profiles, dependent: :destroy
-  has_many :moves, dependent: :destroy
+  has_many :moves, through: :profiles
 
   def latest_profile
     profiles.last

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -6,6 +6,7 @@ class Profile < VersionedModel
   belongs_to :person
   belongs_to :ethnicity, optional: true
   belongs_to :gender, optional: true
+  has_many :moves, dependent: :destroy
 
   validates :person, presence: true
   validates :last_name, presence: true

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -4,13 +4,13 @@ class MoveSerializer < ActiveModel::Serializer
   attributes :id, :reference, :status, :updated_at, :time_due, :date, :move_type, :additional_information,
              :cancellation_reason, :cancellation_reason_comment, :move_agreed, :move_agreed_by
 
-  has_one :person, serializer: PersonSerializer
+  has_one :profile, serializer: ProfileSerializer
   has_one :from_location, serializer: LocationSerializer
   has_one :to_location, serializer: LocationSerializer, if: -> { object.to_location.present? }
   has_many :documents, serializer: DocumentSerializer
 
   INCLUDED_ATTRIBUTES = {
-    person: %i[first_names last_name date_of_birth assessment_answers indentifiers ethnicity gender],
+    profile: %i[first_names last_name date_of_birth assessment_answers indentifiers ethnicity gender],
     from_location: %i[location_type description],
     to_location: %i[location_type description],
     documents: %i[url filename filesize content_type],

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -4,15 +4,19 @@ class MoveSerializer < ActiveModel::Serializer
   attributes :id, :reference, :status, :updated_at, :time_due, :date, :move_type, :additional_information,
              :cancellation_reason, :cancellation_reason_comment, :move_agreed, :move_agreed_by
 
-  has_one :profile, serializer: ProfileSerializer
+  has_one :person, serializer: ProfileSerializer
   has_one :from_location, serializer: LocationSerializer
   has_one :to_location, serializer: LocationSerializer, if: -> { object.to_location.present? }
   has_many :documents, serializer: DocumentSerializer
 
   INCLUDED_ATTRIBUTES = {
-    profile: %i[first_names last_name date_of_birth assessment_answers indentifiers ethnicity gender],
+    person: %i[first_names last_name date_of_birth assessment_answers indentifiers ethnicity gender],
     from_location: %i[location_type description],
     to_location: %i[location_type description],
     documents: %i[url filename filesize content_type],
   }.freeze
+
+  def person
+    object.profile
+  end
 end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ProfileSerializer < ActiveModel::Serializer
+  attributes(
+    :id,
+    :first_names,
+    :last_name,
+    :date_of_birth,
+    :assessment_answers,
+    :identifiers,
+    :gender_additional_information,
+  )
+
+  # although we are serialising a 'profile', to the outside world this is a person.
+  type 'people'
+
+  has_one :ethnicity, serializer: EthnicitySerializer
+  has_one :gender, serializer: GenderSerializer
+
+  def id
+    object.person.id
+  end
+
+  def identifiers
+    object.profile_identifiers
+  end
+end

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -17,7 +17,7 @@ module Moves
 
     def apply_filters(scope)
       scope = scope.accessible_by(ability)
-      scope = scope.includes(:from_location, :to_location, person: { profiles: %i[gender ethnicity] })
+      scope = scope.includes(:from_location, :to_location, profile: %i[gender ethnicity])
       scope = apply_filter(scope, :status)
       scope = apply_date_range_filters(scope)
       scope = apply_location_type_filters(scope)

--- a/app/services/moves/importer.rb
+++ b/app/services/moves/importer.rb
@@ -20,10 +20,11 @@ module Moves
       new_count = 0
       update_count = 0
       items.map { |m| move_params(m) }.each do |move|
-        new_move = Move.new(move)
+        person = Person.find_by!(nomis_prison_number: move.fetch(:person_nomis_prison_number))
+        new_move = person.latest_profile.moves.build(move.except(:person_nomis_prison_number))
         existing_move = Move.find_by(nomis_event_ids: [move[:nomis_event_id]]) || new_move.existing
         if existing_move
-          existing_move.assign_attributes(move)
+          existing_move.assign_attributes(move.except(:person_nomis_prison_number))
           if existing_move.changed?
             update_count += 1
             existing_move.save!
@@ -39,8 +40,7 @@ module Moves
     end
 
     def move_params(move)
-      move.slice(:date, :time_due, :status, :nomis_event_id).merge(
-        person: Person.find_by(nomis_prison_number: move[:person_nomis_prison_number]),
+      move.slice(:date, :time_due, :status, :nomis_event_id, :person_nomis_prison_number).merge(
         from_location: Location.find_by(nomis_agency_id: move[:from_location_nomis_agency_id]),
         to_location: Location.find_by(nomis_agency_id: move[:to_location_nomis_agency_id]),
         move_agreed: false,

--- a/app/services/moves/sweeper.rb
+++ b/app/services/moves/sweeper.rb
@@ -46,8 +46,9 @@ module Moves
 
     def update_nomis_event_ids_when_duplicate(scope)
       items.map do |item|
-        move = scope.find_by(
-          person: Person.where(nomis_prison_number: item[:person_nomis_prison_number]),
+        person = Person.find_by!(nomis_prison_number: item[:person_nomis_prison_number])
+        move_scope = scope.where(profile_id: person.profiles.map(&:id))
+        move = move_scope.find_by(
           to_location: Location.where(nomis_agency_id: item[:to_location_nomis_agency_id]),
         )
         move.update(nomis_event_ids: move.nomis_event_ids << item[:nomis_event_id])

--- a/db/migrate/20200210150200_associate_move_with_profile_part2.rb
+++ b/db/migrate/20200210150200_associate_move_with_profile_part2.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AssociateMoveWithProfilePart2 < ActiveRecord::Migration[5.2]
+  def up
+    Move.find_each do |move|
+      move.profile_id = Person.find_by!(id: move.person_id).latest_profile.id
+      move.save!
+    end
+
+    change_column_null :moves, :profile_id, false
+    add_foreign_key :moves, :profiles
+
+    change_table :moves do |t|
+      t.index [:from_location_id, :to_location_id, :profile_id, :date], name: "index_move_loc_profile_date", unique: true
+    end
+
+    # person_id is unused after this migration, so it has to be nullable
+    change_column_null(:moves, :person_id, true)
+    remove_foreign_key :moves, :people
+  end
+
+  def down
+    remove_foreign_key :moves, :profiles
+    change_column_null :moves, :profile_id, true
+
+    Move.find_each do |move|
+      move.person_id = move.profile.person.id
+      move.save!
+    end
+
+    remove_index :moves, name: "index_move_loc_profile_date"
+
+    change_column_null(:moves, :person_id, false)
+    add_foreign_key :moves, :people
+  end
+end

--- a/db/migrate/20200210150200_associate_move_with_profile_part2.rb
+++ b/db/migrate/20200210150200_associate_move_with_profile_part2.rb
@@ -10,13 +10,11 @@ class AssociateMoveWithProfilePart2 < ActiveRecord::Migration[5.2]
     change_column_null :moves, :profile_id, false
     add_foreign_key :moves, :profiles
 
-    change_table :moves do |t|
-      t.index [:from_location_id, :to_location_id, :profile_id, :date], name: "index_move_loc_profile_date", unique: true
-    end
-
     # person_id is unused after this migration, so it has to be nullable
     change_column_null(:moves, :person_id, true)
     remove_foreign_key :moves, :people
+    # old unique index has to be removed now person_id is unused
+    remove_index :moves, name: "index_on_move_uniqueness"
   end
 
   def down
@@ -27,8 +25,6 @@ class AssociateMoveWithProfilePart2 < ActiveRecord::Migration[5.2]
       move.person_id = move.profile.person.id
       move.save!
     end
-
-    remove_index :moves, name: "index_move_loc_profile_date"
 
     change_column_null(:moves, :person_id, false)
     add_foreign_key :moves, :people

--- a/db/migrate/20200210150200_associate_move_with_profile_part2.rb
+++ b/db/migrate/20200210150200_associate_move_with_profile_part2.rb
@@ -2,7 +2,7 @@
 
 class AssociateMoveWithProfilePart2 < ActiveRecord::Migration[5.2]
   def up
-    Move.find_each do |move|
+    Move.find_each.reject { |m| m.profile_id.present? }.each do |move|
       move.profile_id = Person.find_by!(id: move.person_id).latest_profile.id
       move.save!
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,7 +106,7 @@ ActiveRecord::Schema.define(version: 2020_02_25_142710) do
     t.date "date", null: false
     t.uuid "from_location_id", null: false
     t.uuid "to_location_id"
-    t.uuid "person_id", null: false
+    t.uuid "person_id"
     t.string "status", default: "requested", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -118,10 +118,11 @@ ActiveRecord::Schema.define(version: 2020_02_25_142710) do
     t.string "cancellation_reason"
     t.text "cancellation_reason_comment"
     t.integer "nomis_event_ids", default: [], null: false, array: true
-    t.uuid "profile_id"
+    t.uuid "profile_id", null: false
     t.boolean "move_agreed", default: false, null: false
     t.string "move_agreed_by"
     t.index ["from_location_id", "to_location_id", "person_id", "date"], name: "index_on_move_uniqueness", unique: true
+    t.index ["from_location_id", "to_location_id", "profile_id", "date"], name: "index_move_loc_profile_date", unique: true
     t.index ["reference"], name: "index_moves_on_reference", unique: true
   end
 
@@ -270,7 +271,7 @@ ActiveRecord::Schema.define(version: 2020_02_25_142710) do
   add_foreign_key "locations_suppliers", "suppliers"
   add_foreign_key "moves", "locations", column: "from_location_id", name: "fk_rails_moves_from_location_id"
   add_foreign_key "moves", "locations", column: "to_location_id", name: "fk_rails_moves_to_location_id"
-  add_foreign_key "moves", "people", name: "fk_rails_moves_person_id"
+  add_foreign_key "moves", "profiles"
   add_foreign_key "notifications", "subscriptions"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"

--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -144,14 +144,14 @@ namespace :fake_data do
       date = Faker::Date.between(from: 10.days.ago, to: 20.days.from_now)
       time = date.to_time
       time = time.change(hour: [9, 12, 14].sample)
-      person = people.sample
+      profile = people.sample.latest_profile
       from_location = prisons.sample
       to_location = courts.sample
-      unless Move.find_by(date: date, person: person, from_location: from_location, to_location: to_location)
+      unless Move.find_by(date: date, profile: profile, from_location: from_location, to_location: to_location)
         Move.create!(
           date: date,
           time_due: time,
-          person: person,
+          profile: profile,
           from_location: from_location,
           to_location: to_location,
           status: %w[requested completed cancelled].sample,

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :move do
-    association(:person)
+    association(:profile)
     association(:from_location, factory: :location)
     association(:to_location, :court, factory: :location)
     date { Date.today }
@@ -19,7 +19,7 @@ FactoryBot.define do
   end
 
   factory :from_court_to_prison, class: Move do
-    association(:person)
+    association(:profile)
     association(:from_location, :court, factory: :location)
     association(:to_location, factory: :location)
     date { Date.today }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 RSpec.describe Move do
   it { is_expected.to belong_to(:from_location) }
   it { is_expected.to belong_to(:to_location).optional }
-  it { is_expected.to belong_to(:person) }
+  it { is_expected.to belong_to(:profile) }
   it { is_expected.to have_many(:notifications) }
 
   it { is_expected.to validate_presence_of(:from_location) }
-  it { is_expected.to validate_presence_of(:person) }
+  it { is_expected.to validate_presence_of(:profile) }
   it { is_expected.to validate_presence_of(:date) }
   it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.values) }
 
@@ -132,7 +132,11 @@ RSpec.describe Move do
 
   describe '#existing' do
     let!(:move) { create :move }
-    let(:duplicate) { described_class.new(move.attributes) }
+    let(:duplicate) {
+      move.profile.moves.build(date: move.date,
+                               from_location: move.from_location,
+                               to_location: move.to_location)
+    }
 
     context 'when querying for existing moves' do
       it 'finds the right move' do

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -61,11 +61,11 @@ RSpec.describe MoveSerializer do
   end
 
   describe 'person' do
-    let(:adapter_options) { { include: { person: %I[first_names last_name] } } }
+    let(:adapter_options) { { include: { profile: %I[first_names last_name] } } }
     let(:expected_json) do
       [
         {
-          id: move.person_id,
+          id: move.profile.person.id,
           type: 'people',
           attributes: { first_names: 'Bob', last_name: 'Roberts', date_of_birth: '1980-10-20' },
         },

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe MoveSerializer do
     let(:adapter_options) { { include: MoveSerializer::INCLUDED_ATTRIBUTES } }
 
     it 'contains a person' do
-      expect(result_data[:relationships][:person]).to eq(data: { id: move.person.id, type: 'people' })
+      expect(result_data[:relationships][:person]).to eq(data: { id: move.profile.person.id, type: 'people' })
     end
 
     it 'contains an included person' do
@@ -61,7 +61,7 @@ RSpec.describe MoveSerializer do
   end
 
   describe 'person' do
-    let(:adapter_options) { { include: { profile: %I[first_names last_name] } } }
+    let(:adapter_options) { { include: { person: %I[first_names last_name] } } }
     let(:expected_json) do
       [
         {

--- a/spec/services/moves/importer_spec.rb
+++ b/spec/services/moves/importer_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Moves::Importer do
 
     it 'sets the person of the move' do
       importer.call
-      expect(move.person).to eq prisoner_one
+      expect(move.profile.person).to eq prisoner_one
     end
   end
 

--- a/spec/services/moves/sweeper_spec.rb
+++ b/spec/services/moves/sweeper_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Moves::Sweeper do
           date: attributes[:date],
           time_due: attributes[:time_due],
           nomis_event_ids: [attributes[:nomis_event_id]],
-          person: Person.find_by(nomis_prison_number: attributes[:person_nomis_prison_number]),
+          profile: Person.find_by(nomis_prison_number: attributes[:person_nomis_prison_number]).latest_profile,
           from_location: Location.find_by(nomis_agency_id: attributes[:from_location_nomis_agency_id]),
           to_location: Location.find_by(nomis_agency_id: attributes[:to_location_nomis_agency_id]),
           move_agreed: false,
@@ -141,7 +141,7 @@ RSpec.describe Moves::Sweeper do
         ]
       end
       let(:outdated_move) do
-        Move.find_by(from_location: brixton_prison, to_location: brixton_prison, person: prisoner_two)
+        Move.find_by(from_location: brixton_prison, to_location: brixton_prison, profile: prisoner_two.latest_profile)
       end
 
       before do
@@ -149,7 +149,7 @@ RSpec.describe Moves::Sweeper do
           date: '2019-09-15',
           from_location: brixton_prison,
           to_location: brixton_prison,
-          person: prisoner_two,
+          profile: prisoner_two.latest_profile,
           status: 'requested',
           time_due: '2019-08-19 08:00:00',
           nomis_event_ids: [487_463_210],


### PR DESCRIPTION
Fixes P4-885

## Proposed Changes

- This brings back the move->profile->person re-structuring. 

## To test/demo change

- Nothing should have changed anywhere from an interface perspective

## Manual steps to deploy/dependencies

- rake move_profile:backfill_data needs to be run before deploying this to ensure that the data migration  is trivial.