### PR TITLE
add default to move_agreed so that old data is still valid

### DIFF
--- a/db/migrate/20200225142710_move_agreed_default_false.rb
+++ b/db/migrate/20200225142710_move_agreed_default_false.rb
@@ -1,0 +1,12 @@
+class MoveAgreedDefaultFalse < ActiveRecord::Migration[5.2]
+  def up
+    Move.update_all(move_agreed: false)
+    change_column_default :moves, :move_agreed, false
+    change_column_null :moves, :move_agreed, false
+  end
+
+  def down
+    change_column_null :moves, :move_agreed, true
+    change_column_default :moves, :move_agreed, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_21_120126) do
+ActiveRecord::Schema.define(version: 2020_02_25_142710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -119,7 +119,7 @@ ActiveRecord::Schema.define(version: 2020_02_21_120126) do
     t.text "cancellation_reason_comment"
     t.integer "nomis_event_ids", default: [], null: false, array: true
     t.uuid "profile_id"
-    t.boolean "move_agreed"
+    t.boolean "move_agreed", default: false, null: false
     t.string "move_agreed_by"
     t.index ["from_location_id", "to_location_id", "person_id", "date"], name: "index_on_move_uniqueness", unique: true
     t.index ["reference"], name: "index_moves_on_reference", unique: true


### PR DESCRIPTION
Fixes problem with existing Move(type: prison_transfer) records where move_agreed was nil, so the validation failed when loading and re-saving

## Proposed Changes

- make move_agreed non-nullable defaulting to false

## To test/demo change

- check that rake move_profile:backfill_moves can be executed

