### PR TITLE
port specs to doorkeeper test auth

### DIFF
--- a/spec/requests/api/v1/documents_controller_destroy_spec.rb
+++ b/spec/requests/api/v1/documents_controller_destroy_spec.rb
@@ -2,8 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::DocumentsController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+RSpec.describe Api::V1::DocumentsController do
   let(:content_type) { described_class::CONTENT_TYPE }
   let(:response_json) { JSON.parse(response.body) }
 
@@ -14,6 +13,8 @@ RSpec.describe Api::V1::DocumentsController, with_client_authentication: true do
   let(:detail_404) { "Couldn't find Document with 'id'=UUID-not-found" }
 
   describe 'DELETE /moves/{move_id}/documents/{document_id}' do
+    let(:token) { create(:access_token) }
+    let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{token.token}") }
     let(:schema) { load_json_schema('delete_document_responses.json') }
 
     let!(:move) { create :move }
@@ -60,7 +61,9 @@ RSpec.describe Api::V1::DocumentsController, with_client_authentication: true do
       end
     end
 
-    context 'when not authorized', with_invalid_auth_headers: true do
+    context 'when not authorized' do
+      let(:content_type) { ApiController::CONTENT_TYPE }
+      let(:headers) { { 'CONTENT_TYPE': content_type } }
       let(:detail_401) { 'Token expired or invalid' }
 
       it_behaves_like 'an endpoint that responds with error 401'

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Api::V1::MovesController do
       post '/api/v1/moves', params: { data: data, access_token: token.token }, as: :json
     end
 
-    context 'when not authorized', :skip_before, :with_client_authentication, :with_invalid_auth_headers do
+    context 'when not authorized', :skip_before, :with_invalid_auth_headers do
       let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
       let(:content_type) { ApiController::CONTENT_TYPE }
       let(:detail_401) { 'Token expired or invalid' }
@@ -60,7 +60,7 @@ RSpec.describe Api::V1::MovesController do
       it_behaves_like 'an endpoint that responds with error 401'
     end
 
-    context 'with an invalid CONTENT_TYPE header', with_client_authentication: true do
+    context 'with an invalid CONTENT_TYPE header', :with_client_authentication, :slow do
       let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
       let(:content_type) { 'application/xml' }
 

--- a/spec/requests/api/v1/moves_controller_destroy_spec.rb
+++ b/spec/requests/api/v1/moves_controller_destroy_spec.rb
@@ -2,10 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::MovesController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+RSpec.describe Api::V1::MovesController do
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:response_json) { JSON.parse(response.body) }
+  let(:access_token) { create(:access_token).token }
 
   let(:resource_to_json) do
     JSON.parse(ActionController::Base.render(json: move, include: MoveSerializer::INCLUDED_ATTRIBUTES))
@@ -15,6 +15,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
 
   describe 'DELETE /moves/{move_id}' do
     let(:schema) { load_json_schema('delete_move_responses.json') }
+    let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
 
     let!(:move) { create :move }
     let(:move_id) { move.id }
@@ -42,8 +43,9 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
       end
     end
 
-    context 'when not authorized', with_invalid_auth_headers: true do
+    context 'when not authorized', :with_invalid_auth_headers do
       let(:detail_401) { 'Token expired or invalid' }
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
 
       it_behaves_like 'an endpoint that responds with error 401'
     end

--- a/spec/requests/api/v1/moves_controller_filter_spec.rb
+++ b/spec/requests/api/v1/moves_controller_filter_spec.rb
@@ -2,29 +2,41 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::MovesController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-  let(:content_type) { ApiController::CONTENT_TYPE }
+RSpec.describe Api::V1::MovesController do
   let(:response_json) { JSON.parse(response.body) }
+  let!(:application) { create(:application, owner_id: supplier.id) }
+  let!(:access_token) { create(:access_token, application: application).token }
+  let(:content_type) { ApiController::CONTENT_TYPE }
 
   describe 'GET /moves' do
+    let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
+
     context 'when filtering' do
       let!(:supplier) { create :supplier }
       let!(:location) { create :location, :with_moves, suppliers: [supplier] }
       let!(:filtered_out_moves) { create_list :move, 10 }
-      let(:filter_params) { { filter: { supplier_id: supplier.id } } }
+
+      before do
+        get '/api/v1/moves', params: filter_params, headers: headers
+      end
 
       describe 'by supplier_id' do
-        before do
-          get '/api/v1/moves', headers: headers, params: filter_params
-        end
+        let(:filter_params) { { filter: { supplier_id: supplier.id } } }
 
         it 'returns the right amount of moves' do
           expect(response_json['data'].size).to eq(10)
         end
 
         it 'returns the right moves' do
-          expect(response_json['data'].map { |move| move['id'] }.sort).to eq(location.moves_from.pluck(:id).sort)
+          expect(response_json['data'].map { |move| move['id'] }).to match_array(location.moves_from.pluck(:id))
+        end
+      end
+
+      describe 'by from_location_id' do
+        let(:filter_params) { { filter: { from_location_id: location.id } } }
+
+        it 'only returns moves from the location' do
+          expect(response_json['data'].map { |move| move['id'] }).to match_array(location.moves_from.pluck(:id))
         end
       end
 
@@ -36,7 +48,10 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
         let(:target_move) { Move.find_by(created_at: first_date) }
         let(:target_move2) { Move.find_by(created_at:  middle_date) }
         let(:target_move3) { Move.find_by(created_at:  last_date) }
-        let(:filter_params) { { filter: { created_at_from: first_date.to_s, created_at_to: last_date.to_s } } }
+        let(:filter_params) {
+          { filter: { created_at_from: first_date.to_s,
+                                          created_at_to: last_date.to_s } }
+        }
         let(:all_dates) { [first_date, middle_date, last_date] }
 
         before do
@@ -49,7 +64,7 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
           get '/api/v1/moves', headers: headers, params: filter_params
 
           expect(response_json['data'].map { |x| x['attributes']['created_at'] }).
-            to match_array all_dates.map(&:to_datetime).map(&:iso8601)
+            to match_array(all_dates.map(&:to_datetime).map(&:iso8601))
         end
       end
     end

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -2,8 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::MovesController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+RSpec.describe Api::V1::MovesController do
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:response_json) { JSON.parse(response.body) }
 
@@ -45,144 +44,148 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
       patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
     end
 
-    context 'when successful' do
-      let(:result) { move.reload }
-
-      it_behaves_like 'an endpoint that responds with success 200'
-
-      it 'updates the status of a move' do
-        expect(result.status).to eq 'cancelled'
-      end
-
-      it 'does not update the move type' do
-        expect(result.move_type).to eq('prison_recall')
-      end
-
-      it 'updates move_agreed' do
-        expect(result.move_agreed).to be true
-      end
-
-      it 'updates move_agreed_by' do
-        expect(result.move_agreed_by).to eq 'Fred Bloggs'
-      end
-
-      it 'updates date_from' do
-        expect(result.date_from).to eq date_from
-      end
-
-      it 'updates date_to' do
-        expect(result.date_to).to eq date_to
-      end
-
-      it 'updates the additional_information of a move' do
-        expect(result.additional_information).to eq 'some more info'
-      end
-
-      it 'updates the cancellation_reason of a move' do
-        expect(result.cancellation_reason).to eq 'other'
-      end
-
-      it 'updates the cancellation_reason_comment of a move' do
-        expect(result.cancellation_reason_comment).to eq 'some other reason'
-      end
-
-      it 'returns the correct data' do
-        expect(response_json).to eq resource_to_json
-      end
-    end
-
-    context 'with a read-only attribute' do
-      let!(:move) { create :move }
-
-      let(:move_params) do
-        {
-          type: 'moves',
-          attributes: {
-            status: 'cancelled',
-            reference: 'new reference',
-          },
-        }
-      end
-
-      it_behaves_like 'an endpoint that responds with success 200'
-
-      it 'updates the status of a move', skip_before: true do
-        patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
-        expect(move.reload.status).to eq 'cancelled'
-      end
-
-      it 'does NOT update the reference of a move', skip_before: true do
-        expect { patch("/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json) }.not_to(
-          change { move.reload.reference },
-        )
-      end
-    end
-
-    context 'with a bad request' do
-      let(:move_params) { nil }
-
-      it_behaves_like 'an endpoint that responds with error 400'
-    end
-
     context 'when not authorized', with_invalid_auth_headers: true do
       let(:detail_401) { 'Token expired or invalid' }
 
       it_behaves_like 'an endpoint that responds with error 401'
     end
 
-    context 'when from nomis' do
-      let(:nomis_event_id) { 12_345_678 }
-      let!(:move) { create :move, nomis_event_ids: [nomis_event_id] }
-      let(:detail_403) { 'Can\'t change moves coming from Nomis' }
+    context 'when authorized' do
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{token.token}") }
+      let(:token) { create(:access_token) }
 
-      let(:move_params) do
-        {
-          type: 'moves',
-          attributes: {
-            status: 'cancelled',
-            reference: 'new reference',
-          },
-        }
+      context 'when successful' do
+        let(:result) { move.reload }
+
+        it_behaves_like 'an endpoint that responds with success 200'
+
+        it 'updates the status of a move' do
+          expect(result.status).to eq 'cancelled'
+        end
+
+        it 'does not update the move type' do
+          expect(result.move_type).to eq('prison_recall')
+        end
+
+        it 'updates move_agreed' do
+          expect(result.move_agreed).to be true
+        end
+
+        it 'updates move_agreed_by' do
+          expect(result.move_agreed_by).to eq 'Fred Bloggs'
+        end
+
+        it 'updates date_from' do
+          expect(result.date_from).to eq date_from
+        end
+
+        it 'updates date_to' do
+          expect(result.date_to).to eq date_to
+        end
+        it 'updates the additional_information of a move' do
+          expect(result.additional_information).to eq 'some more info'
+        end
+
+        it 'updates the cancellation_reason of a move' do
+          expect(result.cancellation_reason).to eq 'other'
+        end
+
+        it 'updates the cancellation_reason_comment of a move' do
+          expect(result.cancellation_reason_comment).to eq 'some other reason'
+        end
+
+        it 'returns the correct data' do
+          expect(response_json).to eq resource_to_json
+        end
       end
 
-      it_behaves_like 'an endpoint that responds with error 403'
-    end
+      context 'with a read-only attribute' do
+        let!(:move) { create :move }
 
-    context 'with a missing move' do
-      let(:move_id) { 'null' }
-      let(:detail_404) { "Couldn't find Move with 'id'=null" }
-
-      it_behaves_like 'an endpoint that responds with error 404'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
-
-    context 'with validation errors' do
-      let(:move_params) do
-        {
-          type: 'moves',
-          attributes: {
-            status: 'invalid',
-          },
-        }
-      end
-
-      let(:errors_422) do
-        [
+        let(:move_params) do
           {
-            'title' => 'Unprocessable entity',
-            'detail' => 'Status is not included in the list',
-            'source' => { 'pointer' => '/data/attributes/status' },
-            'code' => 'inclusion',
-          },
-        ]
+            type: 'moves',
+            attributes: {
+              status: 'cancelled',
+              reference: 'new reference',
+            },
+          }
+        end
+
+        it_behaves_like 'an endpoint that responds with success 200'
+
+        it 'updates the status of a move', skip_before: true do
+          patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
+          expect(move.reload.status).to eq 'cancelled'
+        end
+
+        it 'does NOT update the reference of a move', skip_before: true do
+          expect { patch("/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json) }.not_to(
+            change { move.reload.reference },
+            )
+        end
       end
 
-      it_behaves_like 'an endpoint that responds with error 422'
+      context 'with a bad request' do
+        let(:move_params) { nil }
+
+        it_behaves_like 'an endpoint that responds with error 400'
+      end
+
+      context 'when from nomis' do
+        let(:nomis_event_id) { 12_345_678 }
+        let!(:move) { create :move, nomis_event_ids: [nomis_event_id] }
+        let(:detail_403) { 'Can\'t change moves coming from Nomis' }
+
+        let(:move_params) do
+          {
+            type: 'moves',
+            attributes: {
+              status: 'cancelled',
+              reference: 'new reference',
+            },
+          }
+        end
+
+        it_behaves_like 'an endpoint that responds with error 403'
+      end
+
+      context 'with a missing move' do
+        let(:move_id) { 'null' }
+        let(:detail_404) { "Couldn't find Move with 'id'=null" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+
+      context 'with an invalid CONTENT_TYPE header' do
+        let(:content_type) { 'application/xml' }
+
+        it_behaves_like 'an endpoint that responds with error 415'
+      end
+
+      context 'with validation errors' do
+        let(:move_params) do
+          {
+            type: 'moves',
+            attributes: {
+              status: 'invalid',
+            },
+          }
+        end
+
+        let(:errors_422) do
+          [
+            {
+              'title' => 'Unprocessable entity',
+              'detail' => 'Status is not included in the list',
+              'source' => { 'pointer' => '/data/attributes/status' },
+              'code' => 'inclusion',
+            },
+          ]
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422'
+      end
     end
   end
 end

--- a/spec/requests/api/v1/people_controller_create_spec.rb
+++ b/spec/requests/api/v1/people_controller_create_spec.rb
@@ -2,10 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-  let(:content_type) { ApiController::CONTENT_TYPE }
+RSpec.describe Api::V1::PeopleController do
   let(:response_json) { JSON.parse(response.body) }
+  let(:access_token) { create(:access_token).token }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
 
   describe 'POST /people' do
     let(:schema) { load_json_schema('post_people_responses.json') }
@@ -136,13 +137,15 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
     end
 
     context 'with a bad request' do
-      before { post '/api/v1/people', params: nil, headers: headers, as: :json }
+      before { post '/api/v1/people', params: {}, headers: headers, as: :json }
 
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized', with_invalid_auth_headers: true do
+    context 'when not authorized', :with_invalid_auth_headers do
       let(:detail_401) { 'Token expired or invalid' }
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+      let(:content_type) { ApiController::CONTENT_TYPE }
 
       before { post '/api/v1/people', params: person_params, headers: headers, as: :json }
 

--- a/spec/requests/api/v1/people_controller_index_spec.rb
+++ b/spec/requests/api/v1/people_controller_index_spec.rb
@@ -2,9 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-  let(:content_type) { ApiController::CONTENT_TYPE }
+RSpec.describe Api::V1::PeopleController do
+  let!(:token) { create(:access_token) }
   let(:response_json) { JSON.parse(response.body) }
   let(:image_urls) { response_json['data'].map { |x| x['attributes']['image_url'] } }
 
@@ -14,7 +13,7 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
     let(:prison_number) { 'G5033UT' }
 
     describe 'filtering the results' do
-      let(:params) { { filter: { police_national_computer: 'AB/1234567' } } }
+      let(:params) { { filter: { police_national_computer: 'AB/1234567' }, access_token: token.token } }
 
       context 'when called with police_national_computer filter' do
         let!(:people) { create_list :person, 5, :nomis_synced }
@@ -58,7 +57,7 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
     context 'when the filter prison_number is used' do
       let!(:people) { create_list :person, 5 }
 
-      let(:params) { { filter: { prison_number: prison_number } } }
+      let(:params) { { filter: { prison_number: prison_number }, access_token: token.token } }
       let(:people_finder) { instance_double('People::Finder', call: Person.all) }
 
       before do

--- a/spec/requests/api/v1/people_controller_update_spec.rb
+++ b/spec/requests/api/v1/people_controller_update_spec.rb
@@ -2,10 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-  let(:content_type) { ApiController::CONTENT_TYPE }
+RSpec.describe Api::V1::PeopleController do
+  let!(:access_token) { create(:access_token).token }
   let(:response_json) { JSON.parse(response.body) }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
 
   describe 'PUT /api/v1/people' do
     let!(:person) { create :person }
@@ -110,7 +111,8 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized' do
+    context 'when not authorized', :with_invalid_auth_headers do
+      let(:content_type) { ApiController::CONTENT_TYPE }
       let(:headers) { { 'CONTENT_TYPE': content_type } }
       let(:detail_401) { 'Token expired or invalid' }
 

--- a/spec/requests/api/v1/reference/assessment_questions_controller_spec.rb
+++ b/spec/requests/api/v1/reference/assessment_questions_controller_spec.rb
@@ -2,10 +2,9 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::Reference::AssessmentQuestionsController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-  let(:content_type) { ApiController::CONTENT_TYPE }
+RSpec.describe Api::V1::Reference::AssessmentQuestionsController do
   let(:response_json) { JSON.parse(response.body) }
+  let!(:token) { create(:access_token) }
 
   describe 'GET /api/v1/reference/assessment_questions' do
     let(:schema) { load_json_schema('get_assessment_questions_responses.json') }
@@ -27,7 +26,7 @@ RSpec.describe Api::V1::Reference::AssessmentQuestionsController, with_client_au
     let(:params) { {} }
 
     before do
-      get '/api/v1/reference/assessment_questions', headers: headers, params: params
+      get '/api/v1/reference/assessment_questions', params: params, headers: { 'Authorization' => "Bearer #{token.token}" }
     end
 
     context 'when successful' do
@@ -38,14 +37,25 @@ RSpec.describe Api::V1::Reference::AssessmentQuestionsController, with_client_au
       end
     end
 
-    context 'when not authorized', with_invalid_auth_headers: true do
+    context 'when not authorized', :with_invalid_auth_headers do
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+      let(:content_type) { ApiController::CONTENT_TYPE }
       let(:detail_401) { 'Token expired or invalid' }
+
+      before do
+        get '/api/v1/reference/assessment_questions', params: params, headers: headers
+      end
 
       it_behaves_like 'an endpoint that responds with error 401'
     end
 
     context 'with an invalid CONTENT_TYPE header' do
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{token.token}") }
       let(:content_type) { 'application/xml' }
+
+      before do
+        get '/api/v1/reference/assessment_questions', params: params, headers: headers
+      end
 
       it_behaves_like 'an endpoint that responds with error 415'
     end

--- a/spec/requests/api/v1/reference/ethnicities_controller_spec.rb
+++ b/spec/requests/api/v1/reference/ethnicities_controller_spec.rb
@@ -2,10 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::Reference::EthnicitiesController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-  let(:content_type) { ApiController::CONTENT_TYPE }
+RSpec.describe Api::V1::Reference::EthnicitiesController do
+  let!(:access_token) { create(:access_token).token }
   let(:response_json) { JSON.parse(response.body) }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
 
   describe 'GET /api/v1/reference/ethnicities' do
     let(:schema) { load_json_schema('get_ethnicities_responses.json') }
@@ -33,11 +34,13 @@ RSpec.describe Api::V1::Reference::EthnicitiesController, with_client_authentica
 
     before do
       data.each { |ethnicity| Ethnicity.create!(ethnicity[:attributes]) }
-
-      get '/api/v1/reference/ethnicities', headers: headers
     end
 
     context 'when successful' do
+      before do
+        get '/api/v1/reference/ethnicities', headers: headers
+      end
+
       it_behaves_like 'an endpoint that responds with success 200'
 
       it 'returns the correct data' do
@@ -45,14 +48,24 @@ RSpec.describe Api::V1::Reference::EthnicitiesController, with_client_authentica
       end
     end
 
-    context 'when not authorized', with_invalid_auth_headers: true do
+    context 'when not authorized', :with_invalid_auth_headers do
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+      let(:content_type) { ApiController::CONTENT_TYPE }
       let(:detail_401) { 'Token expired or invalid' }
+
+      before do
+        get '/api/v1/reference/ethnicities', headers: headers
+      end
 
       it_behaves_like 'an endpoint that responds with error 401'
     end
 
     context 'with an invalid CONTENT_TYPE header' do
       let(:content_type) { 'application/xml' }
+
+      before do
+        get '/api/v1/reference/ethnicities', headers: headers
+      end
 
       it_behaves_like 'an endpoint that responds with error 415'
     end

--- a/spec/requests/api/v1/reference/genders_controller_spec.rb
+++ b/spec/requests/api/v1/reference/genders_controller_spec.rb
@@ -2,10 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::Reference::GendersController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-  let(:content_type) { ApiController::CONTENT_TYPE }
+RSpec.describe Api::V1::Reference::GendersController do
   let(:response_json) { JSON.parse(response.body) }
+  let(:access_token) { create(:access_token).token }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
 
   describe 'GET /api/v1/reference/genders' do
     let(:schema) { load_json_schema('get_genders_responses.json') }
@@ -41,11 +42,13 @@ RSpec.describe Api::V1::Reference::GendersController, with_client_authentication
 
     before do
       data.each { |gender| Gender.create!(gender[:attributes]) }
-
-      get '/api/v1/reference/genders', headers: headers
     end
 
     context 'when successful' do
+      before do
+        get '/api/v1/reference/genders', headers: headers
+      end
+
       it_behaves_like 'an endpoint that responds with success 200'
 
       it 'returns the correct data' do
@@ -53,14 +56,24 @@ RSpec.describe Api::V1::Reference::GendersController, with_client_authentication
       end
     end
 
-    context 'when not authorized', with_invalid_auth_headers: true do
+    context 'when not authorized', :with_invalid_auth_headers do
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+      let(:content_type) { ApiController::CONTENT_TYPE }
       let(:detail_401) { 'Token expired or invalid' }
+
+      before do
+        get '/api/v1/reference/genders', headers: headers
+      end
 
       it_behaves_like 'an endpoint that responds with error 401'
     end
 
     context 'with an invalid CONTENT_TYPE header' do
       let(:content_type) { 'application/xml' }
+
+      before do
+        get '/api/v1/reference/genders', headers: headers
+      end
 
       it_behaves_like 'an endpoint that responds with error 415'
     end

--- a/spec/requests/api/v1/reference/identifier_types_controller_spec.rb
+++ b/spec/requests/api/v1/reference/identifier_types_controller_spec.rb
@@ -2,10 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::Reference::IdentifierTypesController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-  let(:content_type) { ApiController::CONTENT_TYPE }
+RSpec.describe Api::V1::Reference::IdentifierTypesController do
   let(:response_json) { JSON.parse(response.body) }
+  let(:access_token) { create(:access_token).token }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
 
   describe 'GET /api/v1/reference/identifier_types' do
     let(:schema) { load_json_schema('get_identifier_types_responses.json') }
@@ -32,11 +33,11 @@ RSpec.describe Api::V1::Reference::IdentifierTypesController, with_client_authen
       end
     end
 
-    before do
-      get '/api/v1/reference/identifier_types', headers: headers
-    end
-
     context 'when successful' do
+      before do
+        get '/api/v1/reference/identifier_types', headers: headers
+      end
+
       it_behaves_like 'an endpoint that responds with success 200'
 
       it 'returns the correct data' do
@@ -44,14 +45,24 @@ RSpec.describe Api::V1::Reference::IdentifierTypesController, with_client_authen
       end
     end
 
-    context 'when not authorized', with_invalid_auth_headers: true do
+    context 'when not authorized', :with_invalid_auth_headers do
       let(:detail_401) { 'Token expired or invalid' }
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+      let(:content_type) { ApiController::CONTENT_TYPE }
+
+      before do
+        get '/api/v1/reference/identifier_types', headers: headers
+      end
 
       it_behaves_like 'an endpoint that responds with error 401'
     end
 
     context 'with an invalid CONTENT_TYPE header' do
       let(:content_type) { 'application/xml' }
+
+      before do
+        get '/api/v1/reference/identifier_types', headers: headers
+      end
 
       it_behaves_like 'an endpoint that responds with error 415'
     end

--- a/spec/requests/api/v1/reference/nationalities_controller_spec.rb
+++ b/spec/requests/api/v1/reference/nationalities_controller_spec.rb
@@ -2,10 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::Reference::NationalitiesController, with_client_authentication: true do
-  let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-  let(:content_type) { ApiController::CONTENT_TYPE }
+RSpec.describe Api::V1::Reference::NationalitiesController do
   let(:response_json) { JSON.parse(response.body) }
+  let(:access_token) { create(:access_token).token }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
 
   describe 'GET /api/v1/reference/nationalities' do
     let(:schema) { load_json_schema('get_nationalities_responses.json') }
@@ -31,11 +32,13 @@ RSpec.describe Api::V1::Reference::NationalitiesController, with_client_authenti
 
     before do
       data.each { |nationality| Nationality.create!(nationality[:attributes]) }
-
-      get '/api/v1/reference/nationalities', headers: headers
     end
 
     context 'when successful' do
+      before do
+        get '/api/v1/reference/nationalities', headers: headers
+      end
+
       it_behaves_like 'an endpoint that responds with success 200'
 
       it 'returns the correct data' do
@@ -43,14 +46,24 @@ RSpec.describe Api::V1::Reference::NationalitiesController, with_client_authenti
       end
     end
 
-    context 'when not authorized', with_invalid_auth_headers: true do
+    context 'when not authorized', :with_invalid_auth_headers do
       let(:detail_401) { 'Token expired or invalid' }
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+      let(:content_type) { ApiController::CONTENT_TYPE }
+
+      before do
+        get '/api/v1/reference/nationalities', headers: headers
+      end
 
       it_behaves_like 'an endpoint that responds with error 401'
     end
 
     context 'with an invalid CONTENT_TYPE header' do
       let(:content_type) { 'application/xml' }
+
+      before do
+        get '/api/v1/reference/nationalities', headers: headers
+      end
 
       it_behaves_like 'an endpoint that responds with error 415'
     end

--- a/spec/requests/api_controller_spec.rb
+++ b/spec/requests/api_controller_spec.rb
@@ -2,13 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe ApiController, type: :request, with_client_authentication: true do
+RSpec.describe ApiController, type: :request do
   subject(:api_controller) { described_class.new }
 
-  let!(:application) { Doorkeeper::Application.create(name: 'test') }
+  let!(:token) { create(:access_token) }
 
   context 'when with empty body accepts requests with no Content-Type' do
-    let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+    let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{token.token}") }
     let(:content_type) { ApiController::CONTENT_TYPE }
     let(:api_endpoint) { '/api/v1/reference/genders' }
     let(:response_json) { JSON.parse(response.body) }


### PR DESCRIPTION
Speeds up tests by around 100% (4 minutes -> 2mins 20)

## Proposed Changes

- convert quite a few tests from using request-level actual auth to doorkeeper test auth

## To test/demo change

- run all tests 

