### PR TITLE
P4-1091 added created_at to move with filters

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -47,7 +47,7 @@ module Api
     private
 
       PERMITTED_FILTER_PARAMS = %i[
-        date_from date_to location_type status from_location_id to_location_id supplier_id
+        date_from date_to created_at_from created_at_to location_type status from_location_id to_location_id supplier_id
       ].freeze
       PERMITTED_MOVE_PARAMS = [
         :type,

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MoveSerializer < ActiveModel::Serializer
-  attributes :id, :reference, :status, :updated_at, :time_due, :date, :move_type, :additional_information,
+  attributes :id, :reference, :status, :updated_at, :created_at, :time_due, :date, :move_type, :additional_information,
              :cancellation_reason, :cancellation_reason_comment, :move_agreed, :move_agreed_by
 
   has_one :person, serializer: PersonSerializer

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -38,6 +38,8 @@ module Moves
     def apply_date_range_filters(scope)
       scope = scope.where('date >= ?', filter_params[:date_from]) if filter_params.key?(:date_from)
       scope = scope.where('date <= ?', filter_params[:date_to]) if filter_params.key?(:date_to)
+      scope = scope.where('created_at >= ?', filter_params[:created_at_from]) if filter_params.key?(:created_at_from)
+      scope = scope.where('created_at <= ?', filter_params[:created_at_to]) if filter_params.key?(:created_at_to)
       scope
     end
 

--- a/db/migrate/20200226113423_add_index_to_move_created_at.rb
+++ b/db/migrate/20200226113423_add_index_to_move_created_at.rb
@@ -1,0 +1,8 @@
+class AddIndexToMoveCreatedAt < ActiveRecord::Migration[5.2]
+  def change
+    change_table :moves do |t|
+      t.index :created_at
+      t.index :date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_25_142710) do
+ActiveRecord::Schema.define(version: 2020_02_26_113423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -121,6 +121,8 @@ ActiveRecord::Schema.define(version: 2020_02_25_142710) do
     t.uuid "profile_id"
     t.boolean "move_agreed", default: false, null: false
     t.string "move_agreed_by"
+    t.index ["created_at"], name: "index_moves_on_created_at"
+    t.index ["date"], name: "index_moves_on_date"
     t.index ["from_location_id", "to_location_id", "person_id", "date"], name: "index_on_move_uniqueness", unique: true
     t.index ["reference"], name: "index_moves_on_reference", unique: true
   end
@@ -270,7 +272,7 @@ ActiveRecord::Schema.define(version: 2020_02_25_142710) do
   add_foreign_key "locations_suppliers", "suppliers"
   add_foreign_key "moves", "locations", column: "from_location_id", name: "fk_rails_moves_from_location_id"
   add_foreign_key "moves", "locations", column: "to_location_id", name: "fk_rails_moves_to_location_id"
-  add_foreign_key "moves", "people", name: "fk_rails_moves_person_id"
+  add_foreign_key "moves", "people"
   add_foreign_key "notifications", "subscriptions"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"

--- a/spec/requests/api/v1/moves_controller_filter_spec.rb
+++ b/spec/requests/api/v1/moves_controller_filter_spec.rb
@@ -14,17 +14,42 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
       let!(:filtered_out_moves) { create_list :move, 10 }
       let(:filter_params) { { filter: { supplier_id: supplier.id } } }
 
-      before do
-        get '/api/v1/moves', headers: headers, params: filter_params
-      end
-
       describe 'by supplier_id' do
+        before do
+          get '/api/v1/moves', headers: headers, params: filter_params
+        end
+
         it 'returns the right amount of moves' do
           expect(response_json['data'].size).to eq(10)
         end
 
         it 'returns the right moves' do
           expect(response_json['data'].map { |move| move['id'] }.sort).to eq(location.moves_from.pluck(:id).sort)
+        end
+      end
+
+      describe 'by created_at' do
+        let(:first_date) { Date.new(2019, 12, 25) }
+        let(:last_date) { Date.new(2019, 12, 27) }
+        let(:middle_date) { Date.new(2019, 12, 26) }
+
+        let(:target_move) { Move.find_by(created_at: first_date) }
+        let(:target_move2) { Move.find_by(created_at:  middle_date) }
+        let(:target_move3) { Move.find_by(created_at:  last_date) }
+        let(:filter_params) { { filter: { created_at_from: first_date.to_s, created_at_to: last_date.to_s } } }
+        let(:all_dates) { [first_date, middle_date, last_date] }
+
+        before do
+          create(:move, created_at: first_date)
+          create(:move, created_at: middle_date)
+          create(:move, created_at: last_date)
+        end
+
+        it 'returns the right amount of moves' do
+          get '/api/v1/moves', headers: headers, params: filter_params
+
+          expect(response_json['data'].map { |x| x['attributes']['created_at'] }).
+            to match_array all_dates.map(&:to_datetime).map(&:iso8601)
         end
       end
     end

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe MoveSerializer do
       expect(attributes[:updated_at]).to eql move.updated_at.iso8601
     end
 
+    it 'contains an created_at attribute' do
+      expect(attributes[:created_at]).to eql move.created_at.iso8601
+    end
+
     it 'contains an additional_information attribute' do
       expect(attributes[:additional_information]).to eql move.additional_information
     end

--- a/spec/swagger/definitions/hand_coded_paths.json
+++ b/spec/swagger/definitions/hand_coded_paths.json
@@ -40,6 +40,26 @@
           "format": "date"
         },
         {
+          "name": "filter[created_at_from]",
+          "in": "query",
+          "description": "Filters results to only include moves created on or after the given date, e.g. `2019-05-02`",
+          "schema": {
+            "type": "string",
+            "example": "2019-05-09"
+          },
+          "format": "date"
+        },
+        {
+          "name": "filter[created_at_to]",
+          "in": "query",
+          "description": "Filters results to only include moves created on or before the given date, e.g. `2019-05-09`",
+          "schema": {
+            "type": "string",
+            "example": "2019-05-09"
+          },
+          "format": "date"
+        },
+        {
           "name": "filter[status]",
           "in": "query",
           "explode": false,

--- a/swagger/v1/move.json
+++ b/swagger/v1/move.json
@@ -68,6 +68,12 @@
             "description": "Timestamp of when the move was last created or updated",
             "readOnly": true
           },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when the move was created",
+            "readOnly": true
+          },
           "date": {
             "type": "string",
             "format": "date",


### PR DESCRIPTION
Fixes P4-1091

## Proposed Changes

- adds created_at to move model, and created_at_from and created_at_to as filter parameters

## To test/demo change

- execute query with new parameters, show that created_at date range is respected

## Things to check & link
- [X] API docs has been updated if necessary
