### PR TITLE
Add support for move_agreed and move_agreed_by in the apis

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -52,7 +52,8 @@ module Api
       PERMITTED_MOVE_PARAMS = [
         :type,
         attributes: %i[date time_due status move_type additional_information
-                       cancellation_reason cancellation_reason_comment],
+                       cancellation_reason cancellation_reason_comment
+                       move_agreed move_agreed_by],
         relationships: {},
       ].freeze
       PERMITTED_PATCH_MOVE_PARAMS = [attributes: %i[date time_due status additional_information

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -2,7 +2,7 @@
 
 class MoveSerializer < ActiveModel::Serializer
   attributes :id, :reference, :status, :updated_at, :time_due, :date, :move_type, :additional_information,
-             :cancellation_reason, :cancellation_reason_comment
+             :cancellation_reason, :cancellation_reason_comment, :move_agreed, :move_agreed_by
 
   has_one :person, serializer: PersonSerializer
   has_one :from_location, serializer: LocationSerializer

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -12,7 +12,14 @@ RSpec.describe Api::V1::MovesController do
   describe 'POST /moves' do
     let(:schema) { load_json_schema('post_moves_responses.json') }
 
-    let(:move_attributes) { attributes_for(:move) }
+    let(:move_attributes) {
+      { date: Date.today,
+        time_due: Time.now,
+        status: 'requested',
+        additional_information: 'some more info',
+        move_type: 'court_appearance' }
+    }
+
     let!(:from_location) { create :location }
     let!(:to_location) { create :location, :court }
     let!(:person) { create(:person) }
@@ -110,6 +117,24 @@ RSpec.describe Api::V1::MovesController do
 
         it 'sets the move_type to `prison_recall`' do
           expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'prison_recall'
+        end
+      end
+
+      context 'with explicit move_agreed and move_agreed_by' do
+        let(:move_attributes) {
+          {
+            date: Date.today,
+            move_agreed: 'true',
+            move_agreed_by: 'John Doe',
+          }
+        }
+
+        it 'sets move_agreed' do
+          expect(response_json.dig('data', 'attributes', 'move_agreed')).to eq true
+        end
+
+        it 'sets move_agreed_by' do
+          expect(response_json.dig('data', 'attributes', 'move_agreed_by')).to eq 'John Doe'
         end
       end
 

--- a/spec/swagger/definitions/move.json
+++ b/spec/swagger/definitions/move.json
@@ -43,6 +43,19 @@
             "enum": ["court_appearance", "prison_recall", "prison_transfer"],
             "description": "Indicates the type of move, e.g. prison transfer or court appearance"
           },
+          "move_agreed": {
+            "type": "boolean",
+            "example":  "true",
+            "description": "Indicates if the moved has been agreed"
+          },
+          "move_agreed_by": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "null" }
+            ],
+            "example":  "John Does",
+            "description": "Indicates the name of the person who agreed the move"
+          },
           "time_due": {
             "type": "string",
             "format": "date-time",

--- a/swagger/v1/move.json
+++ b/swagger/v1/move.json
@@ -43,6 +43,19 @@
             "enum": ["court_appearance", "prison_recall", "prison_transfer"],
             "description": "Indicates the type of move, e.g. prison transfer or court appearance"
           },
+          "move_agreed": {
+            "type": "boolean",
+            "example":  "true",
+            "description": "Indicates if the moved has been agreed"
+          },
+          "move_agreed_by": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "null" }
+            ],
+            "example":  "John Does",
+            "description": "Indicates the name of the person who agreed the move"
+          },
           "time_due": {
             "type": "string",
             "format": "date-time",


### PR DESCRIPTION
## Proposed Changes
Add support for the fields:
- move_agreed
- move_agreed_by in the apis

in move endpoints (see specs)

## Jira
https://dsdmoj.atlassian.net/browse/P4-1077

## Things to check & link
- [x ] API docs has been updated if necessary
