### PR TITLE
P4 1104 add date_from and date_to to move entity

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,11 @@ RSpec/LetSetup:
 RSpec/LeakyConstantDeclaration:
   Enabled: false
 
+# It's not unreasonable to have 2 expectations, especially when there are similar
+# rather than being forced to create another 'it' block for the second one
+RSpec/MultipleExpectations:
+  Max: 2
+
 # This seems very much personal choice, and would alter every string
 # if we switched to the GDS standard.
 Style/StringLiterals:

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -53,12 +53,12 @@ module Api
         :type,
         attributes: %i[date time_due status move_type additional_information
                        cancellation_reason cancellation_reason_comment
-                       reason_comment move_agreed move_agreed_by],
+                       reason_comment move_agreed move_agreed_by date_from date_to],
         relationships: {},
       ].freeze
       PERMITTED_PATCH_MOVE_PARAMS = [attributes: %i[date time_due status additional_information
                                                     cancellation_reason cancellation_reason_comment
-                                                    reason_comment move_agreed move_agreed_by]].freeze
+                                                    reason_comment move_agreed move_agreed_by date_from date_to]].freeze
 
       def filter_params
         params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -52,6 +52,8 @@ class Move < VersionedModel
 
   validates :status, inclusion: { in: statuses }
 
+  validate :date_to_after_date_from
+
   before_validation :set_reference
   before_validation :set_move_type
   before_validation :ensure_event_nomis_ids_uniqueness
@@ -73,6 +75,14 @@ class Move < VersionedModel
   end
 
 private
+
+  def date_to_after_date_from
+    if date_from.present? && date_to.present?
+      if date_to < date_from
+        errors.add(:date_to, 'must be after date from')
+      end
+    end
+  end
 
   def set_reference
     self.reference ||= Moves::ReferenceGenerator.new.call

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -2,7 +2,7 @@
 
 class MoveSerializer < ActiveModel::Serializer
   attributes :id, :reference, :status, :updated_at, :created_at, :time_due, :date, :move_type, :additional_information,
-             :cancellation_reason, :cancellation_reason_comment, :move_agreed, :move_agreed_by
+             :cancellation_reason, :cancellation_reason_comment, :move_agreed, :move_agreed_by, :date_from, :date_to
 
   has_one :person, serializer: PersonSerializer
   has_one :from_location, serializer: LocationSerializer

--- a/db/migrate/20200302102905_move_add_date_from_to.rb
+++ b/db/migrate/20200302102905_move_add_date_from_to.rb
@@ -1,0 +1,8 @@
+class MoveAddDateFromTo < ActiveRecord::Migration[5.2]
+  def change
+    change_table :moves do |t|
+      t.date :date_from
+      t.date :date_to
+    end
+  end
+end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Move do
     )
   end
 
+  it 'prevents date_from > date_to' do
+    expect(build(:move, date_from: '2020-03-04', date_to: '2020-03-03')).not_to be_valid
+  end
+
+  it 'allows date_from == date_to' do
+    expect(build(:move, date_from: '2020-03-04', date_to: '2020-03-04')).to be_valid
+  end
+
   it 'does NOT permit duplicate nomis_event_ids' do
     move = create(:move, nomis_event_ids: [123_456])
     move.nomis_event_ids << 123_456

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -133,13 +133,27 @@ RSpec.describe Api::V1::MovesController do
       end
 
       context 'with explicit move_agreed and move_agreed_by' do
+        let(:date_from) { Date.yesterday }
+        let(:date_to) { Date.tomorrow }
         let(:move_attributes) {
           {
             date: Date.today,
             move_agreed: 'true',
             move_agreed_by: 'John Doe',
+            date_from: date_from,
+            date_to: date_to,
           }
         }
+
+        it 'sets date_from' do
+          expect(response_json.dig('data', 'attributes', 'date_from')).to eq date_from.to_s
+          expect(move.date_from).to eq date_from
+        end
+
+        it 'sets date_to' do
+          expect(response_json.dig('data', 'attributes', 'date_to')).to eq date_to.to_s
+          expect(move.date_to).to eq date_to
+        end
 
         it 'sets move_agreed' do
           expect(response_json.dig('data', 'attributes', 'move_agreed')).to eq true

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
     let!(:move) { create :move, move_type: 'prison_recall' }
     let(:move_id) { move.id }
     let(:person) { create(:person) }
+    let(:date_from) { Date.yesterday }
+    let(:date_to) { Date.tomorrow }
 
     let(:move_params) do
       {
@@ -31,6 +33,8 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
           move_type: 'court_appearance',
           move_agreed: true,
           move_agreed_by: 'Fred Bloggs',
+          date_from: date_from,
+          date_to: date_to,
         },
       }
     end
@@ -60,6 +64,14 @@ RSpec.describe Api::V1::MovesController, with_client_authentication: true do
 
       it 'updates move_agreed_by' do
         expect(result.move_agreed_by).to eq 'Fred Bloggs'
+      end
+
+      it 'updates date_from' do
+        expect(result.date_from).to eq date_from
+      end
+
+      it 'updates date_to' do
+        expect(result.date_to).to eq date_to
       end
 
       it 'updates the additional_information of a move' do

--- a/swagger/v1/move.json
+++ b/swagger/v1/move.json
@@ -80,6 +80,28 @@
             "example": "2020-05-17",
             "description": "Date on which the move is scheduled"
           },
+          "date_from": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              { "type": "null" }
+            ],
+            "example": "2020-05-17",
+            "description": "Start date for potential move"
+          },
+          "date_to": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              { "type": "null" }
+            ],
+            "example": "2020-05-17",
+            "description": "End date for potential move"
+          },
           "additional_information": {
             "oneOf": [
               { "type": "string" },


### PR DESCRIPTION
Fixes P4-1104

## Proposed Changes

- Adds a date_from and date_to field to the 'Move' object

## To test/demo change

- add a date_from and date_to to a 'move update' and see that the move gets updated

## Things to check & link
- [X ] API docs has been updated if necessary
