### PR TITLE
p4-1114 add disabled_at to prison_transfer_reasons entity

### DIFF
--- a/app/serializers/prison_transfer_reason_serializer.rb
+++ b/app/serializers/prison_transfer_reason_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class PrisonTransferReasonSerializer < ActiveModel::Serializer
-  attributes :id, :title, :key
+  attributes :id, :title, :key, :disabled_at
 end

--- a/db/migrate/20200302115111_add_disabled_at_to_transfer_reason.rb
+++ b/db/migrate/20200302115111_add_disabled_at_to_transfer_reason.rb
@@ -1,0 +1,7 @@
+class AddDisabledAtToTransferReason < ActiveRecord::Migration[5.2]
+  def change
+    change_table :prison_transfer_reasons do |t|
+      t.datetime :disabled_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_26_113423) do
+ActiveRecord::Schema.define(version: 2020_03_02_115111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -123,6 +123,8 @@ ActiveRecord::Schema.define(version: 2020_02_26_113423) do
     t.string "move_agreed_by"
     t.uuid "prison_transfer_reason_id"
     t.text "reason_comment"
+    t.date "date_from"
+    t.date "date_to"
     t.index ["created_at"], name: "index_moves_on_created_at"
     t.index ["date"], name: "index_moves_on_date"
     t.index ["from_location_id", "to_location_id", "person_id", "date"], name: "index_on_move_uniqueness", unique: true
@@ -224,6 +226,7 @@ ActiveRecord::Schema.define(version: 2020_02_26_113423) do
   create_table "prison_transfer_reasons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "title", null: false
+    t.datetime "disabled_at"
     t.index ["key"], name: "index_prison_transfer_reasons_on_key"
   end
 

--- a/spec/serializers/prison_transfer_reason_serializer_spec.rb
+++ b/spec/serializers/prison_transfer_reason_serializer_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe PrisonTransferReasonSerializer do
   subject(:serializer) { described_class.new(reason) }
 
-  let(:reason) { create :prison_transfer_reason }
+  let(:disabled_at) { Time.new(2019, 1, 1) }
+  let(:reason) { create :prison_transfer_reason, disabled_at: disabled_at }
   let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys }
 
   it 'contains a type property' do
@@ -22,5 +23,9 @@ RSpec.describe PrisonTransferReasonSerializer do
 
   it 'contains a `title` attribute' do
     expect(result[:data][:attributes][:title]).to eql 'Other'
+  end
+
+  it 'contains a `disabled_at` attribute' do
+    expect(Time.parse(result[:data][:attributes][:disabled_at])).to eql disabled_at
   end
 end

--- a/swagger/v1/prison_transfer_reason.json
+++ b/swagger/v1/prison_transfer_reason.json
@@ -35,6 +35,19 @@
             "type": "string",
             "example": "Others",
             "description": "The label of the reason"
+          },
+          "disabled_at": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "2017-07-21T17:32:28Z",
+            "description": "The date-time at which a value was disabled, in ISO-8601 format, or null if it is enabled"
           }
         }
       }


### PR DESCRIPTION
Fixes P4-1114

## Proposed Changes

- Adds disabled_at to prison transfer reason

## To test/demo change

- call prison_transfer_reasons endpoint and see disabled_at property for a disabled entity

## Things to check & link
- [X] API docs has been updated if necessary
