### PR TITLE
Add the new nomis_offender_id profile identifier without removing pri…

### DIFF
--- a/app/models/profile/profile_identifiers.rb
+++ b/app/models/profile/profile_identifiers.rb
@@ -14,6 +14,8 @@ class Profile
 
       add_alias_nomis_offender_no(collection)
 
+      # binding.pry
+
       @collection = collection.reject(&:empty?)
     end
 
@@ -24,8 +26,12 @@ class Profile
   private
 
     def add_alias_nomis_offender_no(collection)
-      identifier = collection.find { |e| e.identifier_type == :prison_number }
-      collection << Profile::ProfileIdentifier.new(value: identifier.value, identifier_type: :nomis_offender_no) if identifier
+      prison_number_identifier = collection.find { |e| e.identifier_type == 'prison_number' }
+      nomis_offender_no_identifier = collection.find { |e| e.identifier_type == 'nomis_offender_no' }
+
+      if prison_number_identifier && nomis_offender_no_identifier.nil?
+        collection << Profile::ProfileIdentifier.new(value: prison_number_identifier.value, identifier_type: 'nomis_offender_no')
+      end
     end
   end
 end

--- a/app/models/profile/profile_identifiers.rb
+++ b/app/models/profile/profile_identifiers.rb
@@ -12,11 +12,20 @@ class Profile
         item.is_a?(Profile::ProfileIdentifier) ? item : Profile::ProfileIdentifier.new(item)
       end
 
+      add_alias_nomis_offender_no(collection)
+
       @collection = collection.reject(&:empty?)
     end
 
     def to_a
       @collection
+    end
+
+  private
+
+    def add_alias_nomis_offender_no(collection)
+      identifier = collection.find { |e| e.identifier_type == :prison_number }
+      collection << Profile::ProfileIdentifier.new(value: identifier.value, identifier_type: :nomis_offender_no) if identifier
     end
   end
 end

--- a/spec/models/profile/profile_identifiers_spec.rb
+++ b/spec/models/profile/profile_identifiers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Profile::ProfileIdentifiers, type: :model do
       },
       {
         value: 'XYZ123456',
-        identifier_type: :prison_number,
+        identifier_type: :criminal_records_office,
       },
     ]
   end
@@ -45,6 +45,25 @@ RSpec.describe Profile::ProfileIdentifiers, type: :model do
 
       it 'parses JSON and converts the items to Profile::ProfileIdentifier objects' do
         expect(profile_identifiers.to_a).to all(be_a Profile::ProfileIdentifier)
+      end
+    end
+
+    context 'when an identifier is prison_number' do
+      let(:data) do
+        [
+            {
+                value: 'ABC123456',
+                identifier_type: :prison_number,
+            },
+        ]
+      end
+
+      it 'contains nomis_offender_no as alias of prison_number' do
+        types_and_values = profile_identifiers.map(&:as_json)
+
+        profile_identifiers.as_json
+
+        expect(types_and_values).to include(identifier_type: :nomis_offender_no, value: 'ABC123456')
       end
     end
   end

--- a/spec/models/profile/profile_identifiers_spec.rb
+++ b/spec/models/profile/profile_identifiers_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe Profile::ProfileIdentifiers, type: :model do
     [
       {
         value: 'ABC123456',
-        identifier_type: :police_national_computer,
+        identifier_type: 'police_national_computer',
       },
       {
         value: 'XYZ123456',
-        identifier_type: :criminal_records_office,
+        identifier_type: 'criminal_records_office',
       },
     ]
   end
@@ -53,7 +53,7 @@ RSpec.describe Profile::ProfileIdentifiers, type: :model do
         [
             {
                 value: 'ABC123456',
-                identifier_type: :prison_number,
+                identifier_type: 'prison_number',
             },
         ]
       end
@@ -61,9 +61,26 @@ RSpec.describe Profile::ProfileIdentifiers, type: :model do
       it 'contains nomis_offender_no as alias of prison_number' do
         types_and_values = profile_identifiers.map(&:as_json)
 
-        profile_identifiers.as_json
+        expect(types_and_values).to include(identifier_type: 'prison_number', value: 'ABC123456')
+        expect(types_and_values).to include(identifier_type: 'nomis_offender_no', value: 'ABC123456')
+      end
+    end
 
-        expect(types_and_values).to include(identifier_type: :nomis_offender_no, value: 'ABC123456')
+    context 'when an identifier is not prison_number' do
+      let(:data) do
+        [
+            {
+                value: 'ABC123456',
+                identifier_type: 'nomis_offender_no',
+            },
+        ]
+      end
+
+      it 'does not add a alias' do
+        types_and_values = profile_identifiers.map(&:as_json)
+
+        expect(types_and_values).not_to include(identifier_type: 'prison_number', value: 'ABC123456')
+        expect(types_and_values).to include(identifier_type: 'nomis_offender_no', value: 'ABC123456')
       end
     end
   end

--- a/swagger/v1/identifier_type.json
+++ b/swagger/v1/identifier_type.json
@@ -27,7 +27,7 @@
           "key": {
             "type": "string",
             "example": "police_national_computer",
-            "enum": ["police_national_computer", "criminal_records_office", "prison_number", "niche_reference", "athena_reference"],
+            "enum": ["police_national_computer", "criminal_records_office", "prison_number", "nomis_offender_no", "niche_reference", "athena_reference"],
             "description": "The unique string key (alias of `id`)"
           },
           "title": {


### PR DESCRIPTION
Fixes P4-https://dsdmoj.atlassian.net/browse/P4-1076

## Proposed Changes
This PR add a new the identifier type `nomis_offender_no` to the API responses.
`nomis_offender_no`is a "alias" of `prison_number`.

For consistency the `prison_number` has not been removed. 
This was discussed with @teneightfive and @spikeheap 

## Things to check & link
- [V ] API docs has been updated if necessary
- [V ] New environment variables have been added to staging configuration
