### PR TITLE
Allow to update nomis_alert_type, nomis_alert_type_description, nomis…

### DIFF
--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -44,7 +44,7 @@ module Api
         :gender_additional_information,
         assessment_answers: [%i[key date expiry_data category title comments assessment_question_id
                                 nomis_alert_type nomis_alert_type_description nomis_alert_code nomis_alert_description
-                                created_at expires_at]],
+                                created_at expires_at imported_from_nomis]],
         identifiers: [%i[value identifier_type]],
       ].freeze
       PERMITTED_PERSON_PARAMS = [:type, attributes: PERSON_ATTRIBUTES, relationships: {}].freeze

--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -43,7 +43,8 @@ module Api
         :date_of_birth,
         :gender_additional_information,
         assessment_answers: [%i[key date expiry_data category title comments assessment_question_id
-                                nomis_alert_type nomis_alert_type_description nomis_alert_code nomis_alert_description]],
+                                nomis_alert_type nomis_alert_type_description nomis_alert_code nomis_alert_description
+                                created_at expires_at]],
         identifiers: [%i[value identifier_type]],
       ].freeze
       PERMITTED_PERSON_PARAMS = [:type, attributes: PERSON_ATTRIBUTES, relationships: {}].freeze

--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -42,7 +42,8 @@ module Api
         :last_name,
         :date_of_birth,
         :gender_additional_information,
-        assessment_answers: [%i[key date expiry_data category title comments assessment_question_id]],
+        assessment_answers: [%i[key date expiry_data category title comments assessment_question_id
+                                nomis_alert_type nomis_alert_type_description nomis_alert_code nomis_alert_description]],
         identifiers: [%i[value identifier_type]],
       ].freeze
       PERMITTED_PERSON_PARAMS = [:type, attributes: PERSON_ATTRIBUTES, relationships: {}].freeze

--- a/spec/requests/api/v1/people_controller_update_spec.rb
+++ b/spec/requests/api/v1/people_controller_update_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
                 nomis_alert_type_description: 'alert type description',
                 nomis_alert_code: 'alert code',
                 nomis_alert_description: 'alert description',
+                imported_from_nomis: 'true',
                 created_at: '2020-01-30',
                 expires_at: '2020-12-30' },
 
@@ -75,6 +76,7 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
                 nomis_alert_type_description: 'alert type description',
                 nomis_alert_code: 'alert code',
                 nomis_alert_description: 'alert description',
+                imported_from_nomis: 'true',
                 created_at: '2020-01-30',
                 expires_at: '2020-12-30' },
               { title: risk_type_2.title, assessment_question_id: risk_type_2.id },

--- a/spec/requests/api/v1/people_controller_update_spec.rb
+++ b/spec/requests/api/v1/people_controller_update_spec.rb
@@ -25,7 +25,12 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
             last_name: 'Roberts',
             date_of_birth: Date.civil(1980, 1, 1),
             assessment_answers: [
-              { title: 'Escape risk', assessment_question_id: risk_type_1.id },
+              { title: 'Escape risk', assessment_question_id: risk_type_1.id,
+                comments: 'Needs an inhaler',
+                nomis_alert_type: 'alert type',
+                nomis_alert_type_description: 'alert type description',
+                nomis_alert_code: 'alert code',
+                nomis_alert_description: 'alert description' },
               { title: 'Violent', assessment_question_id: risk_type_2.id },
             ],
             identifiers: [
@@ -61,7 +66,12 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
             last_name: 'Roberts',
             date_of_birth: Date.civil(1980, 1, 1).iso8601,
             assessment_answers: [
-              { title: risk_type_1.title, assessment_question_id: risk_type_1.id },
+              { title: risk_type_1.title, assessment_question_id: risk_type_1.id,
+                comments: 'Needs an inhaler',
+                nomis_alert_type: 'alert type',
+                nomis_alert_type_description: 'alert type description',
+                nomis_alert_code: 'alert code',
+                nomis_alert_description: 'alert description' },
               { title: risk_type_2.title, assessment_question_id: risk_type_2.id },
             ],
             identifiers: [

--- a/spec/requests/api/v1/people_controller_update_spec.rb
+++ b/spec/requests/api/v1/people_controller_update_spec.rb
@@ -30,7 +30,10 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
                 nomis_alert_type: 'alert type',
                 nomis_alert_type_description: 'alert type description',
                 nomis_alert_code: 'alert code',
-                nomis_alert_description: 'alert description' },
+                nomis_alert_description: 'alert description',
+                created_at: '2020-01-30',
+                expires_at: '2020-12-30' },
+
               { title: 'Violent', assessment_question_id: risk_type_2.id },
             ],
             identifiers: [
@@ -71,7 +74,9 @@ RSpec.describe Api::V1::PeopleController, with_client_authentication: true do
                 nomis_alert_type: 'alert type',
                 nomis_alert_type_description: 'alert type description',
                 nomis_alert_code: 'alert code',
-                nomis_alert_description: 'alert description' },
+                nomis_alert_description: 'alert description',
+                created_at: '2020-01-30',
+                expires_at: '2020-12-30' },
               { title: risk_type_2.title, assessment_question_id: risk_type_2.id },
             ],
             identifiers: [

--- a/swagger/v1/assessment_answer.json
+++ b/swagger/v1/assessment_answer.json
@@ -11,7 +11,7 @@
         "format": "date",
         "example": "2019-05-06",
         "description": "The date on which this attribute was added to the profile",
-        "readOnly": true
+        "readOnly": false
       },
       "expires_at": {
         "oneOf": [
@@ -21,7 +21,8 @@
           { "type": "null" }
         ],
         "example": "2019-06-06",
-        "description": "The date on which this attribute expires (null if it doesn't expire)"
+        "description": "The date on which this attribute expires (null if it doesn't expire)",
+        "readOnly": false
       },
       "title": {
         "type": "string",
@@ -63,7 +64,8 @@
           { "type": "null" }
         ],
         "example": "R",
-        "description": "NOMIS alert type code"
+        "description": "NOMIS alert type code",
+        "readOnly": false
       },
       "nomis_alert_type_description": {
         "oneOf": [
@@ -71,7 +73,8 @@
           { "type": "null" }
         ],
         "example": "Risk",
-        "description": "Description of the alert type from NOMIS"
+        "description": "Description of the alert type from NOMIS",
+        "readOnly": false
       },
       "nomis_alert_code": {
         "oneOf": [
@@ -79,7 +82,8 @@
           { "type": "null" }
         ],
         "example": "RPB",
-        "description": "NOMIS alert code"
+        "description": "NOMIS alert code",
+        "readOnly": false
       },
       "nomis_alert_description": {
         "oneOf": [
@@ -87,7 +91,8 @@
           { "type": "null" }
         ],
         "example": "Risk to Public - Community",
-        "description": "Description of the alert code from NOMIS"
+        "description": "Description of the alert code from NOMIS",
+        "readOnly": false
       }
     }
   }

--- a/swagger/v1/assessment_answer.json
+++ b/swagger/v1/assessment_answer.json
@@ -93,6 +93,11 @@
         "example": "Risk to Public - Community",
         "description": "Description of the alert code from NOMIS",
         "readOnly": false
+      },
+      "imported_from_nomis": {
+        "type": "Boolean",
+        "example": true,
+        "description": "A flag to indicate whether the data to update has been imported from NOMIS"
       }
     }
   }


### PR DESCRIPTION
Fixes https://dsdmoj.atlassian.net/browse/P4-1132

## Proposed Changes
Allow to update nomis_alert_type, nomis_alert_type_description, nomis_alert_code, nomis_alert_description and imported_from_nomis  by patch /people endpoint

## To test/demo change
Try to update the attributes using patch /people endpoint

## Things to check & link
- [ ] API docs has been updated if necessary
- [ ] New environment variables have been added to staging configuration
