### PR TITLE
Update filter for people with prison_number

### DIFF
--- a/app/services/people/finder.rb
+++ b/app/services/people/finder.rb
@@ -21,8 +21,8 @@ module People
         scope = scope.where('profiles.profile_identifiers @> ?', police_national_computer.to_json)
       end
 
-      if filter_params.key?(:nomis_offender_no)
-        scope = scope.where('profiles.profile_identifiers @> ?', nomis_offender_no.to_json)
+      if filter_params.key?(:prison_number)
+        scope = scope.where('profiles.profile_identifiers @> ?', prison_number.to_json)
       end
 
       scope
@@ -32,8 +32,8 @@ module People
       [{ identifier_type: 'police_national_computer', value: filter_params[:police_national_computer] }]
     end
 
-    def nomis_offender_no
-      [{ identifier_type: 'prison_number', value: filter_params[:nomis_offender_no] }]
+    def prison_number
+      [{ identifier_type: 'prison_number', value: filter_params[:prison_number] }]
     end
   end
 end

--- a/spec/services/people/finder_spec.rb
+++ b/spec/services/people/finder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe People::Finder do
   end
 
   describe 'filtering' do
-    context 'when matching police_national_computer filter' do
+    context 'when filtering by police_national_computer' do
       let(:filter_params) { { police_national_computer: 'AB/1234567' } }
 
       it 'returns people matching the police_national_computer' do
@@ -23,19 +23,11 @@ RSpec.describe People::Finder do
       end
     end
 
-    context 'when matching nomis_offender_no filter' do
-      let(:filter_params) { { nomis_offender_no: 'ABCDEFG' } }
+    context 'when filtering by prison_number' do
+      let(:filter_params) { { prison_number: 'ABCDEFG' } }
 
-      it 'returns people matching the police_national_computer' do
+      it 'returns people matching the prison_number' do
         expect(people_finder.call).to eq [person]
-      end
-    end
-
-    context 'when matching nomis_offender_no filter' do
-      let(:filter_params) { { nomis_offender_no: 'ABCDEFG' } }
-
-      it 'returns people matching the Nomis offender number' do
-        expect(people_finder.call.pluck(:id)).to eq [person.id]
       end
     end
   end


### PR DESCRIPTION
This is something necessary to completed `P4-1125`
I realized the lack after the merge.

## Proposed Changes
Update people filter with prison_number.

## To test/demo change
Try to filter the get /people  filtering by prison_number

## Things to check & link
- [x] API docs has been updated if necessary
