### PR TITLE
Specify localhost in database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,7 @@
 default: &default
   adapter: postgresql
   username: <%= ENV["DB_USERNAME"] %>
+  host: localhost
 
 development:
   <<: *default


### PR DESCRIPTION
Issue: 
If you run Postgress by Docker,
and you issue: `bundle exec rake db:create` you get the following error:

```
> bundle exec rake db:create
Created database 'pecs-move-platform-backend'
could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
Couldn't create 'pecs_move_platform_backend_test' database. Please check your configuration.
rake aborted!
PG::ConnectionBad: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
/Users/ale/.rvm/gems/ruby-2.6.2/gems/pg-1.0.0/lib/pg.rb:56:in `initialize'
/Users/ale/.rvm/gems/ruby-2.6.2/gems/pg-1.0.0/lib/pg.rb:56:in `new
...
```

This is fixed specifying the localhost in `database.yml`

## Proposed Changes

Specifying the `host` remove the error:

```
> bundle exec rake db:create
Created database 'pecs-move-platform-backend'
Created database 'pecs_move_platform_backend_test'
```

## To test/demo change

- issue docker: `docker run --rm --name pg-docker -p 5432:5432 -v $HOME/docker/volumes/postgres:/usr/local/var/postgres postgres` 

- issue: `bundle exec rake db:create`


## Things to check & link
- [ ] API docs has been updated if necessary
- [ ] New environment variables have been added to staging configuration

## Manual steps to deploy/dependencies

- TODO (or remove)
