### PR TITLE
P4-1027 Non-unique move return error rather than crashing

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -53,6 +53,10 @@ class Move < VersionedModel
   validates :reference, presence: true
 
   validates :status, inclusion: { in: statuses }
+  # we need to avoid creating/updating a move with the same person/date/from/to if there is already one in the same state
+  # except that we need to allow multiple cancelled moves
+  validates :date, uniqueness: { scope: %i[status person_id from_location_id to_location_id] },
+            unless: -> { status == MOVE_STATUS_CANCELLED }
 
   validate :date_to_after_date_from
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -67,6 +67,7 @@ class Move < VersionedModel
   delegate :suppliers, to: :from_location
 
   scope :served_by, ->(supplier_id) { where('from_location_id IN (?)', Location.supplier(supplier_id).pluck(:id)) }
+  scope :not_cancelled, -> { where.not(status: MOVE_STATUS_CANCELLED) }
 
   def nomis_event_id=(event_id)
     nomis_event_ids << event_id
@@ -77,7 +78,11 @@ class Move < VersionedModel
   end
 
   def existing
-    Move.find_by(date: date, person_id: person_id, from_location_id: from_location_id, to_location_id: to_location_id)
+    self.class.not_cancelled.find_by(date: date, person_id: person_id, from_location_id: from_location_id, to_location_id: to_location_id)
+  end
+
+  def existing_id
+    existing&.id
   end
 
 private

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -13,6 +13,10 @@ FactoryBot.define do
     sequence(:created_at) { |n| Time.now - n.minutes }
     sequence(:date_from) { |n| Date.today - n.days }
 
+    trait :requested do
+      status { 'requested' }
+    end
+
     trait :cancelled do
       status { 'cancelled' }
       cancellation_reason { 'other' }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -146,6 +146,21 @@ RSpec.describe Move do
       it 'finds the right move' do
         expect(duplicate.existing).to eq(move)
       end
+
+      it 'ignores cancelled moves' do
+        move.update(status: :cancelled)
+        expect(duplicate.existing).to be_nil
+      end
+    end
+  end
+
+  describe '#existing_id' do
+    let!(:move) { build :move }
+
+    context 'when there is no existing move' do
+      it 'returns nil' do
+        expect(move.existing_id).to be_nil
+      end
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,7 +15,7 @@ if ENV['COVERAGE']
 
     # The intention of this value is that it should never go down after a PR
     # It is a (very) naive attempt to prevent untested code entering the codebase
-    minimum_coverage 98.75
+    minimum_coverage 98.79
     # cope with a small drop from last time due to potential branch differences
     maximum_coverage_drop 0.25
   end

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Api::V1::MovesController do
               detail: 'Date has already been taken',
               source: { 'pointer' => '/data/attributes/date' },
               code: 'taken',
-              meta: { 'move_id' => old_move.id },
+              meta: { 'existing_id' => old_move.id },
             }.stringify_keys,
           ]
         end

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -41,12 +41,14 @@ RSpec.describe Api::V1::MovesController do
     end
     let(:supplier) { create(:supplier) }
     let!(:application) { create(:application, owner_id: supplier.id) }
-    let!(:token)       { create(:access_token, application: application) }
+    let(:access_token) { create(:access_token, application: application).token }
+    let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
+    let(:content_type) { ApiController::CONTENT_TYPE }
 
     before do
       next if RSpec.current_example.metadata[:skip_before]
 
-      post '/api/v1/moves', params: { data: data, access_token: token.token }, as: :json
+      post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
     end
 
     context 'when not authorized', :skip_before, :with_invalid_auth_headers do
@@ -61,8 +63,7 @@ RSpec.describe Api::V1::MovesController do
       it_behaves_like 'an endpoint that responds with error 401'
     end
 
-    context 'with an invalid CONTENT_TYPE header', :with_client_authentication, :slow do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+    context 'with an invalid CONTENT_TYPE header' do
       let(:content_type) { 'application/xml' }
 
       before do
@@ -78,7 +79,7 @@ RSpec.describe Api::V1::MovesController do
       it_behaves_like 'an endpoint that responds with success 201'
 
       it 'creates a move', skip_before: true do
-        expect { post '/api/v1/moves', params: { data: data, access_token: token.token }, as: :json }
+        expect { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
           .to change(Move, :count).by(1)
       end
 
@@ -114,7 +115,7 @@ RSpec.describe Api::V1::MovesController do
         before do
           allow(Faraday).to receive(:new).and_return(faraday_client)
           perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
-            post '/api/v1/moves', params: { data: data, access_token: token.token }, as: :json
+            post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
           end
         end
 
@@ -141,7 +142,7 @@ RSpec.describe Api::V1::MovesController do
         before do
           allow(MoveMailer).to receive(:notify).and_return(notify_response)
           perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyEmailJob]) do
-            post '/api/v1/moves', params: { data: data, access_token: token.token }, as: :json
+            post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
           end
         end
 
@@ -170,7 +171,7 @@ RSpec.describe Api::V1::MovesController do
         it_behaves_like 'an endpoint that responds with success 201'
 
         it 'creates a move', skip_before: true do
-          expect { post '/api/v1/moves', params: { data: data, access_token: token.token }, as: :json }
+          expect { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
             .to change(Move, :count).by(1)
         end
 
@@ -223,7 +224,7 @@ RSpec.describe Api::V1::MovesController do
         it_behaves_like 'an endpoint that responds with success 201'
 
         it 'creates a move', skip_before: true do
-          expect { post '/api/v1/moves', params: { data: data, access_token: token.token }, as: :json }
+          expect { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
             .to change(Move, :count).by(1)
         end
 
@@ -267,6 +268,45 @@ RSpec.describe Api::V1::MovesController do
       end
 
       it_behaves_like 'an endpoint that responds with error 422'
+    end
+
+    context 'with a duplicate move', :skip_before do
+      let(:profile) { create(:profile) }
+      let(:person) { profile.person }
+      let(:move_attributes) do
+        attributes_for(:move).merge(date: old_move.date,
+                                    person: person,
+                                    from_location: from_location,
+                                    to_location: to_location)
+      end
+
+      before do
+        post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
+      end
+
+      context 'when there are multiple cancelled duplicates' do
+        let!(:old_move) { create(:move, :cancelled, person: person, from_location: from_location, to_location: to_location) }
+        let!(:old_move2) { create(:move, :cancelled, person: person, from_location: from_location, to_location: to_location, date: old_move.date) }
+
+        it_behaves_like 'an endpoint that responds with success 201'
+      end
+
+      context 'when duplicate is active' do
+        let!(:old_move) { create(:move, person: person, from_location: from_location, to_location: to_location) }
+        let(:errors_422) do
+          [
+            {
+              title: 'Unprocessable entity',
+              detail: 'Date has already been taken',
+              source: { 'pointer' => '/data/attributes/date' },
+              code: 'taken',
+              meta: { 'move_id' => old_move.id },
+            }.stringify_keys,
+          ]
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422'
+      end
     end
   end
 end

--- a/spec/requests/api_controller_spec.rb
+++ b/spec/requests/api_controller_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe ApiController, type: :request do
     validates :status, inclusion: { in: %w[requested accepted] }
     validates :email, presence: true
     validates :email, format: { with: /\A\S+@.+\.\S+\z/ }
+
+    validate :name_is_unique
+
+    def existing_id
+      1
+    end
+
+    def name_is_unique
+      errors.add(:name, :taken)
+    end
   end
 
   describe '#validation_errors' do
@@ -42,6 +52,13 @@ RSpec.describe ApiController, type: :request do
           detail: "Name can't be blank",
           source: { pointer: '/data/attributes/name' },
           code: :blank,
+        },
+        {
+          title: 'Unprocessable entity',
+          detail: 'Name has already been taken',
+          source: { pointer: '/data/attributes/name' },
+          code: :taken,
+          meta: { existing_id: model.existing_id },
         },
         {
           title: 'Unprocessable entity',
@@ -67,7 +84,7 @@ RSpec.describe ApiController, type: :request do
     before { model.valid? }
 
     it 'returns the correct errors' do
-      expect(api_controller.send(:validation_errors, model.errors)).to eq errors
+      expect(api_controller.send(:validation_errors, model)).to match errors
     end
   end
 end

--- a/spec/support/responds_with_error_422.rb
+++ b/spec/support/responds_with_error_422.rb
@@ -10,7 +10,9 @@ RSpec.shared_examples 'an endpoint that responds with error 422' do
   end
 
   it 'returns a valid 422 JSON response', with_json_schema: true do
-    expect(JSON::Validator.validate!(schema, response_json, strict: true, fragment: '#/422')).to be true
+    # validates against draft V4 of the spec. Doesn't need strict = true - it actually breaks some things
+    # https://github.com/ruby-json-schema/json-schema/issues/139
+    expect(JSON::Validator.validate!(schema, response_json, strict: false, fragment: '#/422')).to be true
   end
 
   it 'sets the correct content type header' do

--- a/swagger/v1/errors.json
+++ b/swagger/v1/errors.json
@@ -75,7 +75,7 @@
       "meta": {
         "type": "object",
         "properties": {
-          "move_id": {
+          "existing_id": {
             "type": "string",
             "format": "uuid",
             "example": "88089bbd-8719-4192-b309-f9db9105d3e1",

--- a/swagger/v1/errors.json
+++ b/swagger/v1/errors.json
@@ -66,10 +66,22 @@
   },
   "UnprocessableEntity": {
     "type": "object",
+    "required": ["code", "detail", "source", "title"],
     "properties": {
       "title": {
         "type": "string",
         "example": "Unprocessable entity"
+      },
+      "meta": {
+        "type": "object",
+        "properties": {
+          "move_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "88089bbd-8719-4192-b309-f9db9105d3e1",
+            "description": "The unique identifier (UUID) of the move object that caused the error"
+          }
+        }
       },
       "code": {
         "type": "string",


### PR DESCRIPTION
Fixes P4-1027

## Proposed Changes

- Add validation to move to prevent duplicate creation, but allow multiple cancelled moves

## To test/demo change

- create a move, then create another move with the same person/to/from/date - nice error message returned

## Things to check & link
- [X] API docs has been updated if necessary

## Manual steps to deploy/dependencies

Front-end will not understand this error particularily well - it probably needs some specific work to allow it to cope nicely
