### PR TITLE
P4-1142 created_at_to search needs to be inclusive

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,9 +31,6 @@ Metrics/BlockLength:
 RSpec/NestedGroups:
   Max: 6
 
-RSpec/MultipleExpectations:
-  Max: 2
-
 RSpec/LetSetup:
   Enabled: false
 

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -63,8 +63,9 @@ module Moves
     def apply_date_range_filters(scope)
       scope = scope.where('date >= ?', filter_params[:date_from]) if filter_params.key?(:date_from)
       scope = scope.where('date <= ?', filter_params[:date_to]) if filter_params.key?(:date_to)
+      # created_at is a date/time, so inclusive filtering has to be subtlely different
       scope = scope.where('moves.created_at >= ?', filter_params[:created_at_from]) if filter_params.key?(:created_at_from)
-      scope = scope.where('moves.created_at <= ?', filter_params[:created_at_to]) if filter_params.key?(:created_at_to)
+      scope = scope.where('moves.created_at < ?', Date.parse(filter_params[:created_at_to]) + 1) if filter_params.key?(:created_at_to)
       scope
     end
 

--- a/app/services/moves/params_validator.rb
+++ b/app/services/moves/params_validator.rb
@@ -4,9 +4,9 @@ module Moves
   class ParamsValidator
     include ActiveModel::Validations
 
-    attr_reader :date_from, :date_to, :sort_by, :sort_direction
+    attr_reader :date_from, :date_to, :created_at_from, :created_at_to, :sort_by, :sort_direction
 
-    validates_each :date_from, :date_to, allow_nil: true do |record, attr, value|
+    validates_each :date_from, :date_to, :created_at_from, :created_at_to, allow_nil: true do |record, attr, value|
       Date.strptime(value, '%Y-%m-%d')
     rescue ArgumentError
       record.errors.add attr, 'is not a valid date.'
@@ -21,6 +21,8 @@ module Moves
     def initialize(filter_params, sort_params)
       @date_from = filter_params[:date_from]
       @date_to = filter_params[:date_to]
+      @created_at_from = filter_params[:created_at_from]
+      @created_at_to = filter_params[:created_at_to]
 
       @sort_by = sort_params[:by]
       @sort_direction = sort_params[:direction]


### PR DESCRIPTION
Fixes P4-1142
## Proposed Changes

- Make the created_at_to filter inclusive rather than exclusive (as its a date/time not a date)

## To test/demo change

- check the created_at_to filter on moves to make sure that it is inclusive
