### PR TITLE
P4-1159 cancel NOMIS synched moves from prisons

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -32,6 +32,8 @@ class Location < ApplicationRecord
 
   scope :ordered_by_title, ->(direction) { order('locations.title' => direction) }
 
+  scope :prisons, -> { where(location_type: LOCATION_TYPE_PRISON) }
+
   def prison?
     location_type.to_s == LOCATION_TYPE_PRISON
   end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -25,8 +25,10 @@ class Move < VersionedModel
     prison_transfer: 'prison_transfer',
   }
 
+  MOVE_CANCELLATION_REASON_MADE_IN_ERROR = 'made_in_error'
+
   enum cancellation_reason: {
-    made_in_error: 'made_in_error',
+    made_in_error: MOVE_CANCELLATION_REASON_MADE_IN_ERROR,
     supplier_declined_to_move: 'supplier_declined_to_move',
     other: 'other',
   }

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -19,6 +19,18 @@ namespace :data_maintenance do
     end
   end
 
+  desc 'cancel all NOMIS synched moves from prisons'
+  task cancel_synched_prison_moves: :environment do
+    Location.prisons.each do |prison|
+      from_moves = prison.moves_from.requested.select(&:from_nomis?).each do |move|
+        move.update!(status: Move::MOVE_STATUS_CANCELLED,
+                     cancellation_reason: Move::MOVE_CANCELLATION_REASON_MADE_IN_ERROR)
+      end
+
+      puts "Prison #{prison.title} cancelled #{from_moves.size} moves" if from_moves.any?
+    end
+  end
+
   desc 'move old nomis_event_id to nomis_event_ids'
   task move_event_id_to_event_ids: :environment do
     Move.where.not(nomis_event_id: nil).each do |move|

--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -148,7 +148,7 @@ namespace :fake_data do
       from_location = prisons.sample
       to_location = courts.sample
       nomis_event_ids = []
-      nomis_event_ids << (1_000_000..1_500_000).to_a.sample if rand(2) == 0
+      nomis_event_ids << (1_000_000..1_500_000).to_a.sample if rand(2).zero?
       unless Move.find_by(date: date, person: person, from_location: from_location, to_location: to_location)
         Move.create!(
           date: date,
@@ -157,7 +157,7 @@ namespace :fake_data do
           from_location: from_location,
           to_location: to_location,
           status: %w[requested completed cancelled].sample,
-          nomis_event_ids: nomis_event_ids
+          nomis_event_ids: nomis_event_ids,
         )
       end
     end

--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -147,6 +147,8 @@ namespace :fake_data do
       person = people.sample
       from_location = prisons.sample
       to_location = courts.sample
+      nomis_event_ids = []
+      nomis_event_ids << (1_000_000..1_500_000).to_a.sample if rand(2) == 0
       unless Move.find_by(date: date, person: person, from_location: from_location, to_location: to_location)
         Move.create!(
           date: date,
@@ -155,6 +157,7 @@ namespace :fake_data do
           from_location: from_location,
           to_location: to_location,
           status: %w[requested completed cancelled].sample,
+          nomis_event_ids: nomis_event_ids
         )
       end
     end
@@ -313,7 +316,7 @@ namespace :fake_data do
     'HMP Ashfield',
     'HMP Ashwell',
     'HMP Rye Hill',
-    'HMYOI Aylesbury',
+    'HMP Aylesbury',
     'HMP Ranby',
     'HMP/YOI Belmarsh',
     'HMP Risley',
@@ -376,7 +379,7 @@ namespace :fake_data do
     'HMP/YOI Lewes',
     'HMP Leyhill',
     'HMP Dorchester',
-    'HMYOI Deerbolt',
+    'HMP/YOI Deerbolt',
     'HMIRC Dover',
     'HMP/YOI Downview',
     'HMP Usk and HMP/YOI Prescoed',
@@ -404,7 +407,7 @@ namespace :fake_data do
     'HMP/YOI Foston Hall',
     'HMP North Sea Camp',
     'HMP Frankland',
-    'HMYOI Feltham',
+    'HMP/YOI Feltham',
     'HMP Full Sutton',
     'HMP/YOI Norwich',
     'HMP The Weare',
@@ -417,7 +420,7 @@ namespace :fake_data do
     'HMP/YOI Warren Hill',
     'HMP Wayland',
     'HMP/YOI Wymott',
-    'HMYOI Werrington',
+    'HMP/YOI Werrington',
     'HMP Wolds',
     'HMP Whitemoor',
     'HMP/YOI Wormwood Scrubs',
@@ -425,7 +428,7 @@ namespace :fake_data do
     'HMP Onley',
     'HMP/YOI Wandsworth',
     'HMP Garth',
-    'HMYOI Wetherby',
+    'HMP/YOI Wetherby',
     'HMP Gloucester',
     'HMP Guys Marsh',
     'HMP Grendon/Spring Hill',


### PR DESCRIPTION
Fixes P4-1159

## Proposed Changes

- Adds a rake task to cancel NOMIS synched moves from prisons

## To test/demo change

- run rake data_maintenance:cancel_synched_prison_moves

## Manual steps to deploy/dependencies

- rake task has to be run manually