### PR TITLE
p4-1188 emails for prison recall moves

### DIFF
--- a/app/mailers/move_mailer.rb
+++ b/app/mailers/move_mailer.rb
@@ -10,7 +10,8 @@ class MoveMailer < GovukNotifyRails::Mailer
       set_personalisation(
         'move-reference': move.reference,
         'from-location': move.from_location.title,
-        'to-location': move.to_location.title,
+        # to_location isn't set for prison_recall moves
+        'to-location': move.to_location&.title,
         'move-created-at': move.created_at.strftime(TIME_FORMAT),
         'move-updated-at': move.updated_at.strftime(TIME_FORMAT),
         'notification-created-at': Time.current.strftime(TIME_FORMAT),

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -19,6 +19,16 @@ FactoryBot.define do
       cancellation_reason_comment { 'some other reason' }
     end
 
+    trait :prison_recall do
+      move_type { 'prison_recall' }
+      to_location { nil }
+    end
+
+    trait :requested do
+      move_type { 'requested' }
+      to_location { nil }
+    end
+
     trait :proposed do
       status { 'proposed' }
     end

--- a/spec/mailer/move_mailer_spec.rb
+++ b/spec/mailer/move_mailer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe MoveMailer, type: :mailer do
   subject(:mail) { described_class.notify(notification) }
 
@@ -38,5 +40,22 @@ RSpec.describe MoveMailer, type: :mailer do
     it { is_expected.to include('move-status': 'requested') }
     it { is_expected.to include('environment': 'www.example.org') }
     it { is_expected.to include('supplier': 'Test Supplier') }
+  end
+
+  context 'when move is a prison recall' do
+    let(:move) { create(:move, :prison_recall, :requested) }
+
+    describe 'govuk_notify_personalisation' do
+      subject(:govuk_notify_personalisation) { mail.govuk_notify_personalisation }
+
+      it { is_expected.to include('move-reference': move.reference) }
+      it { is_expected.to include('from-location': move.from_location.title) }
+      it { is_expected.to include('move-created-at': move.created_at.strftime('%d/%m/%Y %T')) }
+      it { is_expected.to include('move-updated-at': move.updated_at.strftime('%d/%m/%Y %T')) }
+      it { is_expected.to include('move-action': 'requested') }
+      it { is_expected.to include('move-status': 'requested') }
+      it { is_expected.to include('environment': 'www.example.org') }
+      it { is_expected.to include('supplier': 'Test Supplier') }
+    end
   end
 end


### PR DESCRIPTION
Fixes P4-1188

## Proposed Changes

- Prison recall moves don't have to locations, so attempt to set them in the email

## To test/demo change

- create a prison recall move when an email subscription is present - notice that the email arrives

