### PR TITLE
Add move_date to email personalisation

### DIFF
--- a/app/mailers/move_mailer.rb
+++ b/app/mailers/move_mailer.rb
@@ -2,6 +2,7 @@
 
 class MoveMailer < GovukNotifyRails::Mailer
   TIME_FORMAT = '%d/%m/%Y %T'
+  DATE_FORMAT = '%d/%m/%Y'
 
   def notify(notification)
     set_template(ENV.fetch('GOVUK_NOTIFY_TEMPLATE_ID', nil))
@@ -12,6 +13,7 @@ class MoveMailer < GovukNotifyRails::Mailer
         'from-location': move.from_location.title,
         # to_location isn't set for prison_recall moves
         'to-location': move.to_location&.title,
+        'move-date': move.date.strftime(DATE_FORMAT),
         'move-created-at': move.created_at.strftime(TIME_FORMAT),
         'move-updated-at': move.updated_at.strftime(TIME_FORMAT),
         'notification-created-at': Time.current.strftime(TIME_FORMAT),

--- a/spec/mailer/move_mailer_spec.rb
+++ b/spec/mailer/move_mailer_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe MoveMailer, type: :mailer do
     it { is_expected.to include('move-reference': 'MOVEREF1') }
     it { is_expected.to include('from-location': move.from_location.title) }
     it { is_expected.to include('to-location': move.to_location.title) }
+    it { is_expected.to include('move-date': move.date.strftime('%d/%m/%Y')) }
     it { is_expected.to include('move-created-at': move.created_at.strftime('%d/%m/%Y %T')) }
     it { is_expected.to include('move-updated-at': move.updated_at.strftime('%d/%m/%Y %T')) }
     it { is_expected.to include('move-action': 'requested') }


### PR DESCRIPTION
Fixes P4-1186

## Proposed Changes

- Adds the move-date to the email personalisation fields

## To test/demo change

- Tested locally

## Things to check & link

## Manual steps to deploy/dependencies

*IMPORTANT* do not alter the email template in govuk_notify service until this code is deployed to production - otherwise all emails will break!
