### PR TITLE
Fix for empty latest_nomis_booking_id when retrieving image from nomis

### DIFF
--- a/app/services/people/retrieve_image.rb
+++ b/app/services/people/retrieve_image.rb
@@ -4,6 +4,7 @@ module People
   class RetrieveImage
     def self.call(person)
       return true if person.image.attached?
+      return false unless person.latest_nomis_booking_id
 
       image_blob = NomisClient::Image::get(person.latest_nomis_booking_id)
 

--- a/spec/services/people/retrieve_image_spec.rb
+++ b/spec/services/people/retrieve_image_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe People::RetrieveImage do
+  subject(:retrieve_image) { described_class.call(person) }
+
+  let(:person) { build(:person) }
+
+  it 'returns false if latest_nomis_booking_id is empty' do
+    person.latest_profile.update(latest_nomis_booking_id: nil)
+
+    expect(retrieve_image).to eq(false)
+  end
+end


### PR DESCRIPTION
##Bigfix 
Jira: P4 https://dsdmoj.atlassian.net/browse/P4-1201
Sentry: https://sentry.service.dsd.io/mojds/bookasecuremove-production/issues/45695

## Proposed Changes
If the `latest_nomis_booking_id` is nil it does not get the image from Nomis

## To test/demo change
Run the enpoint /people/<ID>/images
passing a person with no latest_nomis_booking_id

