### PR TITLE
Add missing 'dev' environment to list in docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ aliases:
       branches:
         only:
         - master
-        - p4-1200-create-dev-env
+        - dev-auth-from-docs
   - &only_deploy_tags
     filters:
       tags:

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -52,6 +52,10 @@ RSpec.configure do |config|
           description: 'Local development (localhost)',
         },
         {
+          url: 'https://hmpps-book-secure-move-api-dev.apps.live-1.cloud-platform.service.justice.gov.uk/api/v1',
+          description: 'Dev API',
+        },
+        {
           url: 'https://hmpps-book-secure-move-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/api/v1',
           description: 'Staging API',
         },


### PR DESCRIPTION
'dev' environment was missing from the swagger docs, so it is not possible to use swagger
to talk to the dev API