### PR TITLE
Reintroduce dependency for staging build on test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
+#
+#
 version: 2.1
 
 orbs:
@@ -249,30 +251,31 @@ workflows:
             - build_dev
       - build_staging:
           <<: *only_master_and_tags
+          requires:
+            - test
       - deploy_staging:
           <<: *only_master_and_tags
           requires:
-          - test
-          - build_staging
+            - build_staging
       - build_preprod:
           <<: *only_master_and_tags
           requires:
-          - test
+            - test
       - deploy_preprod:
           <<: *only_master_and_tags
           requires:
-          - build_preprod
+            - build_preprod
       - build_production:
           <<: *only_deploy_tags
           requires:
-          - test
+            - test
       - hold_production:
           <<: *only_deploy_tags
           type: approval
           requires:
-          - test
-          - build_production
+            - test
+            - build_production
       - deploy_production:
           <<: *only_deploy_tags
           requires:
-          - hold_production
+            - hold_production


### PR DESCRIPTION
Fixes P4-1189

## Proposed Changes

This reverts the previous parallel running of build and test jobs for staging environment (done in an effort to improve the build time) but unfortunately this introduces a race condition where the swagger.yaml file is not available when performing the docker build; hence the docker image does not include the swagger files so online API docs are not available.

Also took the opportunity to clean up some inconsistent indentation across the workflow definitions.

I've explored a few other options to resolve this but none really are viable sadly..

1. Running `bundle exec rake rswag:specs:swaggerize` as part of the build rather than test phase.
This works but only when the `development` and `test` gems are included in the docker image. It would be bad practice to add those as it bloats the size of the deploy image and increases surface area for potential security issues.

2. Add some synchronisation to the test and build jobs.
Something like `dockerize -wait file:///swagger/v1/swagger.yaml -timeout 30s` as an extra run step in the build job would work to ensure that the test job has generated the swagger file before continuing. Unfortunately this needs to be right at the start of the build job so the amount of parallel work remaining would be tiny meaning the added complexity really isn't worthwhile. Ideally some of the docker steps such as fetching the OS base image could be performed in parallel while waiting for tests but this too would mean extensive refactoring and added complexity to achieve.

On balance, I think the simple course of action is to remove the parallelism for now. In future we could look at improving test execution time perhaps by optimising the slowest tests in the suite or looking at running individual tests in parallel within the test job.

## To test/demo change

- Requires merge and deployment to staging
