### PR TITLE
P4-1200 fix old migration to be reversible

### DIFF
--- a/db/migrate/20200207111034_remove_documents_move_constraint.rb
+++ b/db/migrate/20200207111034_remove_documents_move_constraint.rb
@@ -1,5 +1,8 @@
 class RemoveDocumentsMoveConstraint < ActiveRecord::Migration[5.2]
-  def change
-    change_column :documents, :move_id, :uuid, null: true
+  def up
+    change_column_null :documents, :move_id, :uuid, true
+  end
+  def down
+    change_column_null :documents, :move_id, :uuid, false
   end
 end

--- a/db/migrate/20200207111034_remove_documents_move_constraint.rb
+++ b/db/migrate/20200207111034_remove_documents_move_constraint.rb
@@ -1,8 +1,12 @@
 class RemoveDocumentsMoveConstraint < ActiveRecord::Migration[5.2]
   def up
-    change_column_null :documents, :move_id, :uuid, true
+    change_column_null :documents, :move_id, true
   end
+
   def down
-    change_column_null :documents, :move_id, :uuid, false
+    # This is safe - we are simply destroying orphaned documents
+    Document.where.not(move_id: nil).destroy_all
+
+    change_column_null :documents, :move_id, false
   end
 end

--- a/db/migrate/20200207111034_remove_documents_move_constraint.rb
+++ b/db/migrate/20200207111034_remove_documents_move_constraint.rb
@@ -5,7 +5,7 @@ class RemoveDocumentsMoveConstraint < ActiveRecord::Migration[5.2]
 
   def down
     # This is safe - we are simply destroying orphaned documents
-    Document.where.not(move_id: nil).destroy_all
+    Document.where(move_id: nil).destroy_all
 
     change_column_null :documents, :move_id, false
   end


### PR DESCRIPTION
To do with P4-1200

One of the migrations that we need to re-run on production to fix the documents issue turned out to be irreversible - so this fixes it to be reversible. It was missed during the initial analysis.

## Proposed Changes

Make old migration reversible so that it can be re-run

