### PR TITLE
P4-1213 Use StringIO rather than temp file to serialize image blob

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -15,15 +15,13 @@ class Person < VersionedModel
   end
 
   def attach_image(image_blob)
-    filename = id + '.jpg'
-
-    tempfile = Tempfile.new('temp.jpg').binmode
-    tempfile.write image_blob
-    tempfile.rewind
-
-    image.attach(io: tempfile, filename: filename, content_type: 'image/jpg')
-    tempfile.close
-
-    filename
+    "#{id}.jpg".tap do |filename|
+      image_io = StringIO.new(image_blob).binmode
+      begin
+        image.attach(io: image_io, filename: filename, content_type: 'image/jpg')
+      ensure
+        image_io.close
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes P4-1213

## Proposed Changes

Previously this implementation made use of a Tempfile to write and then immediately read back the image content retrieved from Nomis API. That didn't feel like a great technique as the entire image blob is already held in memory at that point as a string. Wrapping the same string with a `StringIO` instance means it can be passed directly to active storage for attachment.

I was able to reproduce a consistent test failure on Circle CI prior to this change, and the same seed passes with the change so it looks very likely that using temp files on Circle CI is a little bit brittle.

## To test/demo change

Tested `RetrieveImage` service locally and ensured that prisoner images are successfully fetched from Nomis and persisted using active storage when calling `/people/{id}/images` endpoint.