### PR TITLE
P4-1263 Update date validation rules around proposed moves

### DIFF
--- a/app/mailers/move_mailer.rb
+++ b/app/mailers/move_mailer.rb
@@ -13,7 +13,10 @@ class MoveMailer < GovukNotifyRails::Mailer
         'from-location': move.from_location.title,
         # NB: to_location isn't set for prison_recall moves, so use N/A instead (GovUK Notify will error if nil is supplied)
         'to-location': move.to_location&.title || 'N/A',
-        'move-date': move.date.strftime(DATE_FORMAT),
+        # NB: date isn't set for proposed moves, so use N/A instead (GovUK Notify will error if nil is supplied)
+        'move-date': move.date&.strftime(DATE_FORMAT) || 'N/A',
+        'move-date-from': move.date_from&.strftime(DATE_FORMAT) || 'N/A',
+        'move-date-to': move.date_to&.strftime(DATE_FORMAT) || 'N/A',
         'move-created-at': move.created_at.strftime(TIME_FORMAT),
         'move-updated-at': move.updated_at.strftime(TIME_FORMAT),
         'notification-created-at': Time.current.strftime(TIME_FORMAT),

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -47,18 +47,22 @@ class Move < VersionedModel
     presence: true,
     unless: ->(move) { move.move_type == 'prison_recall' },
   )
-  validates :date, presence: true
   validates :move_type, inclusion: { in: move_types }
   validates :person, presence: true
   validates :reference, presence: true
 
-  validates :status, inclusion: { in: statuses }
   # we need to avoid creating/updating a move with the same person/date/from/to if there is already one in the same state
   # except that we need to allow multiple cancelled moves
   validates :date, uniqueness: { scope: %i[status person_id from_location_id to_location_id] },
             unless: -> { status == MOVE_STATUS_CANCELLED }
+  validates :date, presence: true,
+            unless: -> { status == MOVE_STATUS_PROPOSED }
+  validates :date_from, presence: true,
+            if: -> { status == MOVE_STATUS_PROPOSED }
 
   validate :date_to_after_date_from
+
+  validates :status, inclusion: { in: statuses }
 
   before_validation :set_reference
   before_validation :set_move_type

--- a/db/migrate/20200407130150_change_move_date_to_allow_null.rb
+++ b/db/migrate/20200407130150_change_move_date_to_allow_null.rb
@@ -1,0 +1,5 @@
+class ChangeMoveDateToAllowNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :moves, :date, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_04_121217) do
+ActiveRecord::Schema.define(version: 2020_04_07_130150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -103,7 +103,7 @@ ActiveRecord::Schema.define(version: 2020_03_04_121217) do
   end
 
   create_table "moves", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.date "date", null: false
+    t.date "date"
     t.uuid "from_location_id", null: false
     t.uuid "to_location_id"
     t.uuid "person_id", null: false

--- a/spec/mailer/move_mailer_spec.rb
+++ b/spec/mailer/move_mailer_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe MoveMailer, type: :mailer do
     it { is_expected.to include('from-location': move.from_location.title) }
     it { is_expected.to include('to-location': move.to_location.title) }
     it { is_expected.to include('move-date': move.date.strftime('%d/%m/%Y')) }
+    it { is_expected.to include('move-date-from': move.date_from.strftime('%d/%m/%Y')) }
+    it { is_expected.to include('move-date-to': 'N/A') }
     it { is_expected.to include('move-created-at': move.created_at.strftime('%d/%m/%Y %T')) }
     it { is_expected.to include('move-updated-at': move.updated_at.strftime('%d/%m/%Y %T')) }
     it { is_expected.to include('move-action': 'requested') }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -25,6 +25,30 @@ RSpec.describe Move do
     )
   end
 
+  it 'validates presence of `date` if `status` is NOT proposed' do
+    expect(build(:move)).to(
+      validate_presence_of(:date),
+    )
+  end
+
+  it 'does NOT validate presence of `date` if `status` is proposed' do
+    expect(build(:move, status: :proposed)).not_to(
+      validate_presence_of(:date),
+    )
+  end
+
+  it 'validates presence of `date_from` if `status` is proposed' do
+    expect(build(:move, status: :proposed)).to(
+      validate_presence_of(:date_from),
+    )
+  end
+
+  it 'does NOT validate presence of `date_from` if `status` is NOT proposed' do
+    expect(build(:move)).not_to(
+      validate_presence_of(:date_from),
+    )
+  end
+
   it 'prevents date_from > date_to' do
     expect(build(:move, date_from: '2020-03-04', date_to: '2020-03-03')).not_to be_valid
   end

--- a/swagger/v1/move.json
+++ b/swagger/v1/move.json
@@ -23,7 +23,6 @@
         "type": "object",
         "required": [
           "status",
-          "date",
           "move_type"
         ],
         "properties": {
@@ -78,7 +77,7 @@
             "type": "string",
             "format": "date",
             "example": "2020-05-17",
-            "description": "Date on which the move is scheduled"
+            "description": "Date on which the move is scheduled (mandatory unless status is proposed)"
           },
           "date_from": {
             "oneOf": [
@@ -89,7 +88,7 @@
               { "type": "null" }
             ],
             "example": "2020-05-17",
-            "description": "Start date for potential move"
+            "description": "Start date for potential move (mandatory if status is proposed)"
           },
           "date_to": {
             "oneOf": [
@@ -100,7 +99,7 @@
               { "type": "null" }
             ],
             "example": "2020-05-17",
-            "description": "End date for potential move"
+            "description": "End date for potential move. Must be after date_from"
           },
           "additional_information": {
             "oneOf": [


### PR DESCRIPTION
Fixes P4-1263

## Proposed Changes

Proposed moves will not specify a date, but will specify a date_from and may specify a date to. This updates the date validation rules on Move model accordingly to make them conditional on the appropriate move status. This also extends the variables passed to notification emails to include date_from and date_to, with those and also date defaulting to `N/A` if nil. This then allows the notify email template to be updated in a subsequent ticket to support from/to dates while also ensuring that nothing breaks in the meantime.