### PR TITLE
Fixes broken swagger documentation generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
 
       - run:
           name: generate swagger documentation
-          command: bundle exec rspec spec/swagger && bundle exec rake rswag:specs:swaggerize
+          command: bundle exec rspec spec/swagger --format Rswag::Specs::SwaggerFormatter --order defined
 
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
 
       - run:
           name: generate swagger documentation
-          command: bundle exec rspec spec/swagger --format Rswag::Specs::SwaggerFormatter --order defined
+          command: bundle exec rspec spec/swagger spec/requests --format Rswag::Specs::SwaggerFormatter --order defined
 
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
 
       - run:
           name: generate swagger documentation
-          command: bundle exec rake rswag:specs:swaggerize
+          command: bundle exec rspec spec/swagger && bundle exec rake rswag:specs:swaggerize
 
       - persist_to_workspace:
           root: .

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -8,7 +8,7 @@ Fixes P4-<TODO>
 
 - TODO
 
-## Things to check & link
+## Things to check and link
 - [ ] API docs has been updated if necessary
 - [ ] New environment variables have been added to staging configuration
 


### PR DESCRIPTION
## Background

We've just deployed a new api and our frontend team have noticed that we're missing a bunch of sections that they're interested in interfacing with.

The problem that was causing this is that we're using the swaggerize rake task after a recent change https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/352 where we were previously running all of the tests.

The swaggerize task doesn't match our rspec directory pattern (`spec/swagger/api/v1/*`) so they don't get run (see: [swaggerize rake task](https://github.com/rswag/rswag/blob/master/rswag-specs/lib/tasks/rswag-specs_tasks.rake#L11))

## Proposed Changes

- Stop using swaggerize to generate documentation since we don't have a pattern that rswag expects

## To test/demo change

- Check documentation in staging