### PR TITLE
P4-1263 Minor tweak for move date attribute API spec

### DIFF
--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Api::V1::MovesController do
       end
 
       context 'with a proposed move' do
-        let(:move_attributes) { attributes_for(:move, status: 'proposed') }
+        let(:move_attributes) { attributes_for(:move).except(:date).merge(status: 'proposed') }
 
         it_behaves_like 'an endpoint that responds with success 201'
       end

--- a/swagger/v1/move.json
+++ b/swagger/v1/move.json
@@ -74,8 +74,13 @@
             "readOnly": true
           },
           "date": {
-            "type": "string",
-            "format": "date",
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              { "type": "null" }
+            ],
             "example": "2020-05-17",
             "description": "Date on which the move is scheduled (mandatory unless status is proposed)"
           },


### PR DESCRIPTION
Fixes P4-1263

## Proposed Changes

This is an optional field now (for proposed moves) so the API needs to allow values of either `nil` or a date. Updated API spec to reflect this behaviour and demonstrate successful creation of proposed move.

## To test/demo change

- See updated API spec

## Things to check & link
- [x] API docs has been updated if necessary