### PR TITLE
P4-1263 Updated unique date validation to exclude proposed moves

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -54,7 +54,7 @@ class Move < VersionedModel
   # we need to avoid creating/updating a move with the same person/date/from/to if there is already one in the same state
   # except that we need to allow multiple cancelled moves
   validates :date, uniqueness: { scope: %i[status person_id from_location_id to_location_id] },
-            unless: -> { status == MOVE_STATUS_CANCELLED }
+            unless: -> { [MOVE_STATUS_PROPOSED, MOVE_STATUS_CANCELLED].include?(status) }
   validates :date, presence: true,
             unless: -> { status == MOVE_STATUS_PROPOSED }
   validates :date_from, presence: true,

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -13,10 +13,6 @@ FactoryBot.define do
     sequence(:created_at) { |n| Time.now - n.minutes }
     sequence(:date_from) { |n| Date.today - n.days }
 
-    trait :requested do
-      status { 'requested' }
-    end
-
     trait :cancelled do
       status { 'cancelled' }
       cancellation_reason { 'other' }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe Move do
     )
   end
 
+  it 'validates uniqueness of `date` if `status` is NOT proposed or cancelled' do
+    expect(create(:move)).to(
+      validate_uniqueness_of(:date).scoped_to(:status, :person_id, :from_location_id, :to_location_id),
+    )
+  end
+
+  it 'does NOT validate uniqueness of `date` if `status` is cancelled' do
+    expect(build(:move, status: :cancelled)).not_to(
+      validate_uniqueness_of(:date),
+    )
+  end
+
+  it 'does NOT validate uniqueness of `date` if `status` is proposed' do
+    expect(build(:move, status: :proposed)).not_to(
+      validate_uniqueness_of(:date),
+    )
+  end
+
   it 'validates presence of `date` if `status` is NOT proposed' do
     expect(build(:move)).to(
       validate_presence_of(:date),


### PR DESCRIPTION
Fixes P4-1263

## Proposed Changes

Proposed moves will initially set a `nil` date on creation, and may then be updated to specify a potential fixed date. We should only enforce validation of a unique move date when the move changes to requested or completed state. Updated model and specs.

This was preventing more than one proposed move being created for the same person, from location and to location (was reported as working intermittently).