### PR TITLE
P4-1316 fix court hearing swagger

### DIFF
--- a/spec/swagger/api/v1/court_hearings_controller_create_spec.rb
+++ b/spec/swagger/api/v1/court_hearings_controller_create_spec.rb
@@ -23,14 +23,70 @@ RSpec.describe Api::V1::CourtHearingsController, :with_client_authentication, :r
           If you're testing interactively in the web UI, you can ignore this field
         DESCRIPTION
 
-      parameter name: :court_hearing,
+      parameter name: :body,
         description: 'The court hearing to create',
         in: :body,
-        attributes: {
-          schema: '#/definitions/court_hearing/CourtHearing',
+        schema: {
+          type: 'object',
+          properties: {
+            data:  {
+              type: 'object',
+              properties: {
+                type: {
+                  type: 'string',
+                  enum: ['court_hearings']
+                },
+                attributes: {
+                  type: 'object',
+                  required: ['start_time'],
+                  properties: {
+                    start_time: {
+                      type: 'string',
+                      format: 'date-time',
+                      example: '2018-01-01T18:57Z',
+                      description: 'ISO8601 compatible timestamp'
+                    },
+                    case_number: {
+                      type: 'string',
+                      example: 'T32423423423',
+                      description: 'The third party reference for the case of the current hearing'
+                    },
+                    nomis_case_id: {
+                      type: 'integer',
+                      example: 4232423,
+                      description: 'The nomis reference for the case of the current hearing.'
+                    },
+                    case_type: {
+                      type: 'string',
+                      example: 'Adult',
+                      enum: ['Adult'],
+                      description: 'The type of the court that the court hearing is being held in.'
+                    },
+                    comments: {
+                      type: 'string',
+                      example: 'Witness for Joe Bloggs in Foo Bar court hearing.',
+                      description: 'Arbitrary comments that are useful for humans but not touched by computers.'
+                    },
+                    case_start_date: {
+                      type: 'string',
+                      format: 'date',
+                      example: '2020-01-01',
+                      description: 'ISO8601-compatible date indicating when the case started.'
+                    },
+                  }
+                },
+                relationships: {
+                  type: 'object',
+                  properties: {
+                    move: { '$ref' => '#/definitions/move_reference/MoveReference' }
+                  }
+                }
+              }
+            }
+          }
         }
 
-      let(:court_hearing) do
+      let(:body) do
         {
           data: {
             type: 'court_hearings',

--- a/spec/swagger/api/v1/court_hearings_controller_create_spec.rb
+++ b/spec/swagger/api/v1/court_hearings_controller_create_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::CourtHearingsController, :with_client_authentication, :r
 
   path '/court_hearings' do
     post 'Creates a court hearing' do
-      tags 'CourtHearings'
+      tags 'Court Hearings'
       consumes 'application/vnd.api+json'
       produces 'application/vnd.api+json'
 

--- a/spec/swagger/api/v1/court_hearings_controller_create_spec.rb
+++ b/spec/swagger/api/v1/court_hearings_controller_create_spec.rb
@@ -34,56 +34,56 @@ RSpec.describe Api::V1::CourtHearingsController, :with_client_authentication, :r
               properties: {
                 type: {
                   type: 'string',
-                  enum: ['court_hearings']
+                  enum: %w[court_hearings],
                 },
                 attributes: {
                   type: 'object',
-                  required: ['start_time'],
+                  required: %w[start_time],
                   properties: {
                     start_time: {
                       type: 'string',
                       format: 'date-time',
                       example: '2018-01-01T18:57Z',
-                      description: 'ISO8601 compatible timestamp'
+                      description: 'ISO8601 compatible timestamp',
                     },
                     case_number: {
                       type: 'string',
                       example: 'T32423423423',
-                      description: 'The third party reference for the case of the current hearing'
+                      description: 'The third party reference for the case of the current hearing',
                     },
                     nomis_case_id: {
                       type: 'integer',
                       example: 4232423,
-                      description: 'The nomis reference for the case of the current hearing.'
+                      description: 'The nomis reference for the case of the current hearing.',
                     },
                     case_type: {
                       type: 'string',
                       example: 'Adult',
-                      enum: ['Adult'],
-                      description: 'The type of the court that the court hearing is being held in.'
+                      enum: %w[Adult],
+                      description: 'The type of the court that the court hearing is being held in.',
                     },
                     comments: {
                       type: 'string',
                       example: 'Witness for Joe Bloggs in Foo Bar court hearing.',
-                      description: 'Arbitrary comments that are useful for humans but not touched by computers.'
+                      description: 'Arbitrary comments that are useful for humans but not touched by computers.',
                     },
                     case_start_date: {
                       type: 'string',
                       format: 'date',
                       example: '2020-01-01',
-                      description: 'ISO8601-compatible date indicating when the case started.'
+                      description: 'ISO8601-compatible date indicating when the case started.',
                     },
-                  }
+                  },
                 },
                 relationships: {
                   type: 'object',
                   properties: {
-                    move: { '$ref' => '#/definitions/move_reference/MoveReference' }
-                  }
-                }
-              }
-            }
-          }
+                    move: { '$ref' => '#/definitions/move_reference/MoveReference' },
+                  },
+                },
+              },
+            },
+          },
         }
 
       let(:body) do

--- a/spec/swagger/definitions/court_hearing.json
+++ b/spec/swagger/definitions/court_hearing.json
@@ -15,12 +15,6 @@
         "type": "object",
         "required": ["start_time"],
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "example": "22036201-4301-4021-8ee6-80bc415b8534",
-            "description": "The universally unique and sequential primary identifier for this entity"
-          },
           "start_time": {
             "type": "string",
             "format": "date-time",

--- a/spec/swagger/definitions/court_hearing.json
+++ b/spec/swagger/definitions/court_hearing.json
@@ -1,5 +1,6 @@
 {
   "CourtHearing": {
+    "description": "The schema of an individual court hearing. This is what gets bundled in an includes or GET /court_hearings/:id response",
     "type": "object",
     "required": ["id", "type", "attributes"],
     "properties": {

--- a/swagger/v1/court_hearing.json
+++ b/swagger/v1/court_hearing.json
@@ -15,12 +15,6 @@
         "type": "object",
         "required": ["start_time"],
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "example": "22036201-4301-4021-8ee6-80bc415b8534",
-            "description": "The universally unique and sequential primary identifier for this entity"
-          },
           "start_time": {
             "type": "string",
             "format": "date-time",

--- a/swagger/v1/court_hearing.json
+++ b/swagger/v1/court_hearing.json
@@ -1,5 +1,6 @@
 {
   "CourtHearing": {
+    "description": "The schema of an individual court hearing. This is what gets bundled in an includes or GET /court_hearings/:id response",
     "type": "object",
     "required": ["id", "type", "attributes"],
     "properties": {


### PR DESCRIPTION
P4-1316

## Proposed Changes

- [x] Removes duplicate id in CourtHearing attributes
- [x] Fixes request body (which is very different from a CourtHearing response)
- [x] Adds space in Court Hearing tag for consistency

## To test/demo change

- Run passed Dom/Jonny

## Things to check and link

- [x] API docs has been updated if necessary
- [x] New environment variables have been added to staging configuration