### PR TITLE
P4-1274 Added data model to support allocations

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Allocation < VersionedModel
+  enum prisoner_category: {
+    b: 'B',
+    c: 'C',
+    d: 'D',
+  }
+
+  enum sentence_length: {
+    short: '16_or_less',
+    long: 'more_than_16',
+  }
+
+  belongs_to :from_location, class_name: 'Location'
+  belongs_to :to_location, class_name: 'Location'
+
+  validates :from_location, presence: true
+  validates :to_location, presence: true
+
+  validates :prisoner_category, inclusion: { in: prisoner_categories }, allow_nil: true
+  validates :sentence_length, inclusion: { in: sentence_lengths }, allow_nil: true
+
+  validates :moves_count, presence: true
+  validates :date, presence: true
+end

--- a/db/migrate/20200415091520_create_allocations.rb
+++ b/db/migrate/20200415091520_create_allocations.rb
@@ -1,0 +1,19 @@
+class CreateAllocations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :allocations, id: :uuid do |t|
+      t.uuid :from_location_id, null: false
+      t.uuid :to_location_id, null: false
+      t.date :date, null: false, index: true
+      t.string :prisoner_category
+      t.string :sentence_length
+      t.jsonb :complex_cases
+      t.integer :moves_count, null: false
+      t.boolean :complete_in_full, default: false, null: false
+      t.text :other_criteria
+      t.timestamps
+    end
+
+    add_foreign_key :allocations, :locations, column: :from_location_id, name: :fk_rails_allocations_from_location_id
+    add_foreign_key :allocations, :locations, column: :to_location_id, name: :fk_rails_allocations_to_location_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_104553) do
+ActiveRecord::Schema.define(version: 2020_04_15_091520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -34,6 +34,21 @@ ActiveRecord::Schema.define(version: 2020_04_14_104553) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "allocations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "from_location_id", null: false
+    t.uuid "to_location_id", null: false
+    t.date "date", null: false
+    t.string "prisoner_category"
+    t.string "sentence_length"
+    t.jsonb "complex_cases"
+    t.integer "moves_count", null: false
+    t.boolean "complete_in_full", default: false, null: false
+    t.text "other_criteria"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["date"], name: "index_allocations_on_date"
   end
 
   create_table "assessment_questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -300,6 +315,8 @@ ActiveRecord::Schema.define(version: 2020_04_14_104553) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "allocations", "locations", column: "from_location_id", name: "fk_rails_allocations_from_location_id"
+  add_foreign_key "allocations", "locations", column: "to_location_id", name: "fk_rails_allocations_to_location_id"
   add_foreign_key "court_hearings", "moves"
   add_foreign_key "documents", "moves"
   add_foreign_key "locations_suppliers", "locations"

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :allocation do
+    association(:from_location, factory: :location)
+    association(:to_location, factory: :location)
+    sequence(:date) { |n| Date.today + n.days }
+
+    prisoner_category { Allocation.prisoner_categories.values.sample }
+    sentence_length { Allocation.sentence_lengths.values.sample }
+    moves_count { Faker::Number.digit }
+    complete_in_full { false }
+  end
+end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Allocation do
+  it { is_expected.to belong_to(:from_location) }
+  it { is_expected.to belong_to(:to_location) }
+
+  it { is_expected.to validate_presence_of(:from_location) }
+  it { is_expected.to validate_presence_of(:to_location) }
+
+  it { is_expected.to allow_value(nil).for(:prisoner_category) }
+  it { is_expected.to define_enum_for(:prisoner_category).backed_by_column_of_type(:string) }
+  it { is_expected.to allow_value(nil).for(:sentence_length) }
+  it { is_expected.to define_enum_for(:sentence_length).backed_by_column_of_type(:string) }
+
+  it { is_expected.to validate_presence_of(:moves_count) }
+  it { is_expected.to validate_presence_of(:date) }
+
+  context 'with versioning' do
+    let(:allocation) { create(:allocation) }
+
+    it 'has a version record for the create' do
+      expect(allocation.versions.map(&:event)).to eq(%w[create])
+    end
+  end
+end


### PR DESCRIPTION
Fixes P4-1274

## Proposed Changes

This is the first pass that does not yet support associating people with the allocation (that will come in a later sprint). Eventually it's likely that an allocation will support a collection of moves, but that's also out of scope for the time being, as is allocation status. I've elected to use JSON storage for the complex case flags - the same approach is used elsewhere e.g. assessment answers to avoid over normalising the schema.

## To test/demo change

This PR doesn't do much yet, but I'm keen to get agreement on model & attribute names before proceeding further to add API docs etc.