### PR TITLE
Save the CourtHearing.post response and Fix the time format

### DIFF
--- a/app/lib/nomis_client/court_hearing.rb
+++ b/app/lib/nomis_client/court_hearing.rb
@@ -6,7 +6,6 @@ module NomisClient
       def post(booking_id:, court_case_id:, body_params: {})
         court_cases_route = "/bookings/#{booking_id}/court-cases/#{court_case_id}/prison-to-court-hearings"
 
-
         NomisClient::Base.post(court_cases_route, body: body_params.to_json).body
       end
     end

--- a/spec/services/court_hearings/create_in_nomis_spec.rb
+++ b/spec/services/court_hearings/create_in_nomis_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CourtHearings::CreateInNomis do
     let(:nomis_case_id) { 1111111 }
     let(:from_nomis_agency_id) { 'LEI' }
     let(:to_nomis_agency_id) { 'LEEDCC' }
-    let(:hearing_date_time) { Time.new(2020, 12, 1).utc.iso8601 }
+    let(:hearing_date_time) { Time.parse("2020-04-15T17:36:02+01:00") }
     let(:comments) { 'Restricted access to parking level.' }
     let(:booking_id) { 123 }
 
@@ -40,7 +40,7 @@ RSpec.describe CourtHearings::CreateInNomis do
           court_case_id: nomis_case_id,
           body_params: {
               'fromPrisonLocation': from_nomis_agency_id, 'toCourtLocation': to_nomis_agency_id,
-              'courtHearingDateTime': hearing_date_time, 'comments': comments
+              'courtHearingDateTime': hearing_date_time.utc.iso8601, 'comments': comments
           },
         )
       end

--- a/spec/services/court_hearings/create_in_nomis_spec.rb
+++ b/spec/services/court_hearings/create_in_nomis_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CourtHearings::CreateInNomis do
     let(:nomis_case_id) { 1111111 }
     let(:from_nomis_agency_id) { 'LEI' }
     let(:to_nomis_agency_id) { 'LEEDCC' }
-    let(:hearing_date_time) { Time.parse("2020-04-15T17:36:02+01:00") }
+    let(:hearing_date_time) { Time.parse('2020-04-15T17:36:02+01:00') }
     let(:comments) { 'Restricted access to parking level.' }
     let(:booking_id) { 123 }
 


### PR DESCRIPTION
This PR allow to Save the CourtHearing.post response and Fix the time format (UTC)

In case the response is not 201 it pushes the result to sentry to easily debug the error.
