### PR TITLE
Fix sentry for create court hearing

### DIFF
--- a/app/lib/nomis_client/court_hearing.rb
+++ b/app/lib/nomis_client/court_hearing.rb
@@ -7,6 +7,17 @@ module NomisClient
         court_cases_route = "/bookings/#{booking_id}/court-cases/#{court_case_id}/prison-to-court-hearings"
 
         NomisClient::Base.post(court_cases_route, body: body_params.to_json).body
+      rescue OAuth2::Error => e
+        Raven.capture_message('CourtHearings:CreateInNomis Error!',
+                              extra: {
+                                  court_cases_route: court_cases_route,
+                                  body_params: body_params,
+                                  nomis_response: {
+                                      status: e.response.status,
+                                      body: e.response.body,
+                                  },
+                              },
+                              level: 'warning')
       end
     end
   end

--- a/app/services/court_hearings/create_in_nomis.rb
+++ b/app/services/court_hearings/create_in_nomis.rb
@@ -19,9 +19,6 @@ module CourtHearings
           new_hearing_id = JSON.parse(response.body)['id']
 
           hearing.update(nomis_hearing_id: new_hearing_id, saved_to_nomis: true)
-        else
-          message = { move_id: move.id, court_hearing_id: hearing.id, nomis_response: response.inspect }
-          Raven.capture_message("CourtHearings:CreateInNomis: #{message}", level: 'warning')
         end
       end
     end

--- a/spec/lib/nomis_client/court_hearings_spec.rb
+++ b/spec/lib/nomis_client/court_hearings_spec.rb
@@ -19,5 +19,15 @@ RSpec.describe NomisClient::CourtHearing do
       expect(NomisClient::Base).to have_received(:post)
                                        .with("/bookings/#{booking_id}/court-cases/#{court_case_id}/prison-to-court-hearings", body: '{}')
     end
+
+    context 'when Nomis returns an error' do
+      it 'pushes error the warning to Sentry' do
+        allow(Raven).to receive(:capture_message)
+
+        court_hearing_post
+
+        expect(Raven).to have_received(:capture_message)
+      end
+    end
   end
 end

--- a/spec/services/court_hearings/create_in_nomis_spec.rb
+++ b/spec/services/court_hearings/create_in_nomis_spec.rb
@@ -57,14 +57,6 @@ RSpec.describe CourtHearings::CreateInNomis do
     context 'when Nomis returns an error' do
       let(:nomis_response_status) { 400 }
 
-      it 'pushes error the warning to Sentry' do
-        allow(Raven).to receive(:capture_message)
-
-        create_hearing_in_nomis
-
-        expect(Raven).to have_received(:capture_message)
-      end
-
       it 'does NOT set nomis_hearing_id and saved_to_nomis' do
         create_hearing_in_nomis
 


### PR DESCRIPTION
This PR fixes the way sentry notifies when creating court hearings.