### PR TITLE
Speed up circle ci builds by using cached deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ commands:
       - run:
           name: install dependencies
           command: |
-            bundle check || bundle install
+            bundle check || bundle install --path vendor/bundle
             yarn install
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v2-dependencies-{{ checksum "Gemfile.lock" }}
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
       # Database setup
       - run: bundle exec rake db:create
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,8 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "Gemfile.lock" }}
-            # fallback to using the latest cache if no exact match is found
-            - v2-dependencies-
+            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+            - v1-dependencies-
 
       - run:
           name: install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,14 +79,12 @@ commands:
       - run:
           name: install dependencies
           command: |
-            bundle check || bundle install --path vendor/bundle
+            bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
             yarn install
-
       - save_cache:
           paths:
             - ./vendor/bundle
           key: v2-dependencies-{{ checksum "Gemfile.lock" }}
-
       # Database setup
       - run: bundle exec rake db:create
 


### PR DESCRIPTION
### Proposed Changes

We currently install all dependencies over the wire over and over.

Specify cache directory for bundled gems so that we actually can restore from a cache.

We already had the caching functionality configured but we weren't using it because we weren't installing to the correct path


### Before

![Screenshot 2020-04-17 at 15 19 40](https://user-images.githubusercontent.com/8156884/79579160-266ce100-80bf-11ea-9827-51a38050c2f7.png)


### After

![Screenshot 2020-04-17 at 15 19 43](https://user-images.githubusercontent.com/8156884/79579172-2a006800-80bf-11ea-94bf-c6d6ccafb1b2.png)
