### PR TITLE
Reinstates pending court_hearings_spec examples

### DIFF
--- a/spec/lib/nomis_client/court_hearings_spec.rb
+++ b/spec/lib/nomis_client/court_hearings_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe NomisClient::CourtHearing do
+RSpec.describe NomisClient::CourtHearing, with_nomis_client_authentication: true do
   describe '.post' do
     subject(:court_hearing_post) {
       described_class.post(booking_id: booking_id, court_case_id: court_case_id, body_params: {})
@@ -10,23 +10,59 @@ RSpec.describe NomisClient::CourtHearing do
 
     let(:booking_id) { 1111 }
     let(:court_case_id) { 2222 }
+    let(:response_status) { 201 }
+    let(:response_body) { '{}' }
 
-    xit 'creates prison-to-court-hearing in Nomis ' do
-      allow(NomisClient::Base).to receive(:post).and_return(instance_double('OAuth2::Response', body: nil))
+    it 'creates prison-to-court-hearing in Nomis ' do
+      court_hearing_post
+
+      expect(token)
+        .to have_received(:post)
+        .with('/elite2api/api/bookings/1111/court-cases/2222/prison-to-court-hearings', body: '{}', headers: { Accept: 'application/json', 'Content-Type': 'application/json' })
+    end
+
+    it 'pushes a success warning to Sentry' do
+      allow(Raven).to receive(:capture_message)
 
       court_hearing_post
 
-      expect(NomisClient::Base).to have_received(:post)
-                                       .with("/bookings/#{booking_id}/court-cases/#{court_case_id}/prison-to-court-hearings", body: '{}')
+      expect(Raven).
+        to have_received(:capture_message).
+        with(
+          "CourtHearings:CreateInNomis success!",
+          extra: {
+            body_params: {},
+            court_cases_route: '/bookings/1111/court-cases/2222/prison-to-court-hearings',
+            nomis_response: { body: '{}', status: 201 }
+          },
+          level: 'warning'
+      )
     end
 
     context 'when Nomis returns an error' do
-      xit 'pushes error the warning to Sentry' do
+      before do
+        allow(oauth2_response).to receive(:error=)
+        allow(token).to receive(:post).and_raise(OAuth2::Error.new(oauth2_response))
+      end
+
+      let(:response_status) { 500 }
+
+      it 'pushes an error warning to Sentry' do
         allow(Raven).to receive(:capture_message)
 
         court_hearing_post
 
-        expect(Raven).to have_received(:capture_message)
+        expect(Raven).
+          to have_received(:capture_message).
+          with(
+            "CourtHearings:CreateInNomis Error!",
+            extra: {
+              body_params: {},
+              court_cases_route: '/bookings/1111/court-cases/2222/prison-to-court-hearings',
+              nomis_response: { body: '{}', status: 500 }
+            },
+            level: 'warning'
+          )
       end
     end
   end


### PR DESCRIPTION
## Proposed Changes

We recently made some specs pending so we could carry on validating an integration with nomis to create court hearings in staging. The way we were mocking was leaking into other tests in the suite

- [x] Reinstate pending specs with correct mocking
- [x] Adds extra spec after additional functionality 