### PR TITLE
Removes unused env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-DATABASE_URL=postgresql://postgres@localhost/pecs-move-platform-backend
 NOMIS_SITE='https://nomis-api.example.com'
 NOMIS_CLIENT_ID='client_id'
 NOMIS_CLIENT_SECRET='client_secret'


### PR DESCRIPTION
### Jira link

[P4-1250](https://dsdmoj.atlassian.net/browse/P4-1250)

### What?

- [x] Remove `DATABASE_URL` env var from example .env file

### Why?

- This is not the way the setup docs prescribe to configure the database.
