### PR TITLE
P4-1274 Add new endpoint to GET /allocations

### DIFF
--- a/app/controllers/api/v1/allocations_controller.rb
+++ b/app/controllers/api/v1/allocations_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class AllocationsController < ApiController
+      def index
+        allocations_params = Allocations::ParamsValidator.new(filter_params)
+        if allocations_params.valid?
+          allocations = Allocations::Finder.new(filter_params).call
+          paginate allocations, include: AllocationSerializer::INCLUDED_ATTRIBUTES
+        else
+          render json: { error: allocations_params.errors }, status: :bad_request
+        end
+      end
+
+      private
+
+      def filter_params
+        params.fetch(:filter, {}).permit(:date_from, :date_to).to_h
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/allocations_controller.rb
+++ b/app/controllers/api/v1/allocations_controller.rb
@@ -13,7 +13,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def filter_params
         params.fetch(:filter, {}).permit(:date_from, :date_to).to_h

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -6,5 +6,5 @@ class AllocationSerializer < ActiveModel::Serializer
   has_one :from_location
   has_one :to_location
 
-  INCLUDED_ATTRIBUTES = [:from_location, :to_location]
+  INCLUDED_ATTRIBUTES = %i[from_location to_location].freeze
 end

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AllocationSerializer < ActiveModel::Serializer
-  attributes :moves_count, :date, :prisoner_category, :sentence_length, :complex_cases, :complete_in_full, :other_criteria
+  attributes :moves_count, :date, :prisoner_category, :sentence_length, :complex_cases, :complete_in_full, :other_criteria, :created_at, :updated_at
 
   has_one :from_location
   has_one :to_location

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AllocationSerializer < ActiveModel::Serializer
+  attributes :moves_count, :date, :prisoner_category, :sentence_length, :complex_cases, :complete_in_full, :other_criteria
+
+  has_one :from_location
+  has_one :to_location
+
+  INCLUDED_ATTRIBUTES = [:from_location, :to_location]
+end

--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Allocations
+  class Finder
+    attr_reader :filter_params
+
+    def initialize(filter_params)
+      @filter_params = filter_params
+    end
+
+    def call
+      apply_filters(Allocation)
+    end
+
+  private
+
+    def apply_filters(scope)
+      scope = scope.includes(from_location: :suppliers, to_location: :suppliers)
+      scope = apply_date_range_filters(scope)
+      scope
+    end
+
+    def apply_date_range_filters(scope)
+      scope = scope.where('date >= ?', filter_params[:date_from]) if filter_params.key?(:date_from)
+      scope = scope.where('date <= ?', filter_params[:date_to]) if filter_params.key?(:date_to)
+      scope
+    end
+  end
+end

--- a/app/services/allocations/params_validator.rb
+++ b/app/services/allocations/params_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Allocations
+  class ParamsValidator
+    include ActiveModel::Validations
+
+    attr_reader :date_from, :date_to
+
+    validates_each :date_from, :date_to, allow_nil: true do |record, attr, value|
+      Date.strptime(value, '%Y-%m-%d')
+    rescue ArgumentError
+      record.errors.add attr, 'is not a valid date.'
+    end
+
+    def initialize(filter_params)
+      @date_from = filter_params[:date_from]
+      @date_to = filter_params[:date_to]
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      resources :allocations, only: :index
       resources :documents, only: %i[create]
       resources :court_hearings, only: %i[create]
       resources :people, only: %i[index create update] do

--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -171,11 +171,29 @@ namespace :fake_data do
     end
   end
 
+  desc 'create fake allocations'
+  task create_allocations: :environment do
+    puts 'create_allocations...'
+    prisons = Location.where(location_type: 'prison').all
+    50.times do
+      date = Faker::Date.between(from: 10.days.ago, to: 20.days.from_now)
+      Allocation.create!(
+        date: date,
+        from_location: prisons.sample,
+        to_location: prisons.sample,
+        prisoner_category: Allocation.prisoner_categories.values.sample,
+        sentence_length: Allocation.sentence_lengths.values.sample,
+        moves_count: Faker::Number.digit,
+        complete_in_full: Faker::Boolean.boolean,
+      )
+    end
+  end
+
   desc 'drop all the fake data - CAUTION: this deletes all existing data'
   task drop_all: :environment do
     puts 'drop_all...'
     if Rails.env.development? || Rails.env.test?
-      [Move, Location, Profile, Person, AssessmentQuestion, Ethnicity, Gender, IdentifierType, Supplier].each(&:destroy_all)
+      [Allocation, Move, Location, Profile, Person, AssessmentQuestion, Ethnicity, Gender, IdentifierType, Supplier].each(&:destroy_all)
     else
       puts 'you can only run this in the development or test environments'
     end
@@ -193,6 +211,7 @@ namespace :fake_data do
       Rake::Task['fake_data:create_prisons'].invoke
       Rake::Task['fake_data:create_courts'].invoke
       Rake::Task['fake_data:create_moves'].invoke
+      Rake::Task['fake_data:create_allocations'].invoke
     else
       puts 'you can only run this in the development or test environments'
     end

--- a/spec/serializers/allocation_complex_case_serializer_spec.rb
+++ b/spec/serializers/allocation_complex_case_serializer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AllocationComplexCaseSerializer do
     expect(result[:data][:id]).to eql allocation_complex_case.id
   end
 
-  it 'contains a key property' do
+  it 'contains a key attribute' do
     expect(result[:data][:attributes][:key]).to eql allocation_complex_case.key
   end
 

--- a/spec/serializers/allocation_serializer_spec.rb
+++ b/spec/serializers/allocation_serializer_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AllocationSerializer do
+  subject(:serializer) { described_class.new(allocation) }
+
+  let(:allocation) { create :allocation }
+  let(:result) do
+    JSON.parse(ActiveModelSerializers::Adapter.create(serializer, adapter_options).to_json).deep_symbolize_keys
+  end
+  let(:result_data) { result[:data] }
+  let(:attributes) { result_data[:attributes] }
+
+  context 'with no options' do
+    let(:adapter_options) { {} }
+
+    it 'contains a type property' do
+      expect(result_data[:type]).to eql 'allocations'
+    end
+
+    it 'contains an id property' do
+      expect(result_data[:id]).to eql allocation.id
+    end
+
+    it 'contains a moves_count attribute' do
+      expect(attributes[:moves_count]).to eql allocation.moves_count
+    end
+
+    it 'contains a date attribute' do
+      expect(attributes[:date]).to eql allocation.date.iso8601
+    end
+
+    it 'contains a prisoner_category attribute' do
+      expect(attributes[:prisoner_category]).to eql allocation.prisoner_category
+    end
+
+    it 'contains a sentence_length attribute' do
+      expect(attributes[:sentence_length]).to eql allocation.sentence_length
+    end
+
+    it 'contains a complex_cases attribute' do
+      expect(attributes[:complex_cases]).to eql allocation.complex_cases
+    end
+
+    it 'contains a complete_in_full attribute' do
+      expect(attributes[:complete_in_full]).to eql allocation.complete_in_full
+    end
+
+    it 'contains a other_criteria attribute' do
+      expect(attributes[:other_criteria]).to eql allocation.other_criteria
+    end
+
+    it 'contains a created_at attribute' do
+      expect(attributes[:created_at]).to eql allocation.created_at.iso8601
+    end
+
+    it 'contains an updated_at attribute' do
+      expect(attributes[:updated_at]).to eql allocation.updated_at.iso8601
+    end
+  end
+
+  describe 'locations' do
+    let(:adapter_options) do
+      {
+        include: {
+          from_location: %I[location_type title],
+          to_location: %I[location_type title],
+        },
+      }
+    end
+    let(:expected_json) do
+      [
+        {
+          id: allocation.from_location_id,
+          type: 'locations',
+          attributes: { location_type: 'prison', title: allocation.from_location.title },
+        },
+        {
+          id: allocation.to_location_id,
+          type: 'locations',
+          attributes: { location_type: 'prison', title: allocation.to_location.title },
+        },
+      ]
+    end
+
+    it 'contains an included from and to location' do
+      expect(result[:included]).to(include_json(expected_json))
+    end
+  end
+end

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Allocations::Finder do
+  subject(:allocation_finder) { described_class.new(filter_params) }
+
+  let!(:allocation) { create :allocation }
+  let(:filter_params) { {} }
+
+  describe 'filtering' do
+    context 'with matching date range' do
+      before do
+        create(:allocation, date: allocation.date + 6.days)
+        create(:allocation, date: allocation.date - 1.day)
+      end
+
+      let!(:allocation_5_days_future) { create(:allocation, date: allocation.date + 5.days) }
+      let(:filter_params) { { date_from: allocation.date.to_s, date_to: (allocation.date + 5.days).to_s } }
+
+      it 'returns allocations matching date range' do
+        expect(allocation_finder.call).to match_array [allocation, allocation_5_days_future]
+      end
+    end
+
+    context 'with mis-matching mismatched date range in past' do
+      let(:filter_params) { { date_from: (allocation.date - 5.days).to_s, date_to: (allocation.date - 2.days).to_s } }
+
+      it 'returns empty result set' do
+        expect(allocation_finder.call).to be_empty
+      end
+    end
+
+    context 'with mis-matching mismatched date range in future' do
+      let(:filter_params) { { date_from: (allocation.date + 2.days).to_s, date_to: (allocation.date + 5.days).to_s } }
+
+      it 'returns empty result set' do
+        expect(allocation_finder.call).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/allocations/params_validator_spec.rb
+++ b/spec/services/allocations/params_validator_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Allocations::ParamsValidator do
+  subject(:params_validator) { described_class.new(filter_params) }
+
+  let(:filter_params) { { date_from: date_from, date_to: date_to } }
+  let(:good_date) { '2019-05-05' }
+
+  context 'with correct dates' do
+    let(:date_from) { good_date }
+    let(:date_to) { '2019-05-06' }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with an unparsable date_from' do
+    let(:date_from) { 'ABCD-22-15' }
+    let(:date_to) { good_date }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with an unparsable date_to' do
+    let(:date_from) { good_date }
+    let(:date_to) { 'YYYY-10-Tu' }
+
+    it { is_expected.not_to be_valid }
+  end
+end

--- a/spec/swagger/definitions/hand_coded_paths.json
+++ b/spec/swagger/definitions/hand_coded_paths.json
@@ -1,4 +1,97 @@
 {
+  "/allocations": {
+    "get": {
+      "summary": "Returns a list of allocations",
+      "tags": [
+        "Allocations"
+      ],
+      "consumes": [
+        "application/vnd.api+json"
+      ],
+      "parameters": [
+        {
+          "name": "Content-Type",
+          "in": "header",
+          "description": "Accepted request content type",
+          "schema": {
+            "type": "string",
+            "default": "application/vnd.api+json"
+          },
+          "required": true
+        },
+        {
+          "name": "filter[date_from]",
+          "in": "query",
+          "description": "Filters results to only include allocations on and after the given date, e.g. `2019-05-02`",
+          "schema": {
+            "type": "string",
+            "example": "2019-05-09"
+          },
+          "format": "date"
+        },
+        {
+          "name": "filter[date_to]",
+          "in": "query",
+          "description": "Filters results to only include allocations up to and including the given date, e.g. `2019-05-09`",
+          "schema": {
+            "type": "string",
+            "example": "2019-05-09"
+          },
+          "format": "date"
+        },
+        {
+          "name": "page",
+          "in": "query",
+          "description": "The page of records to return, defaults to 1 (the first page)",
+          "schema": {
+            "type": "integer"
+          },
+          "example": 1
+        },
+        {
+          "name": "per_page",
+          "in": "query",
+          "description": "Number of records to return in a single response, defaults to 20, maximum value is 100.",
+          "schema": {
+            "type": "integer"
+          },
+          "example": 1
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "success",
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "get_allocations_responses.json#/200"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "unauthorized",
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "get_allocations_responses.json#/401"
+              }
+            }
+          }
+        },
+        "415": {
+          "description": "invalid media type",
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "get_allocations_responses.json#/415"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "/moves": {
     "get": {
       "summary": "Returns a list of moves",

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -75,6 +75,9 @@ RSpec.configure do |config|
           },
         },
         schemas: {
+          Allocation: {
+            "$ref": 'allocation.json#/Allocation',
+          },
           AllocationComplexCase: {
             "$ref": 'allocation_complex_case.json#/AllocationComplexCase',
           },

--- a/swagger/v1/allocation.json
+++ b/swagger/v1/allocation.json
@@ -1,0 +1,120 @@
+{
+  "Allocation": {
+    "type": "object",
+    "required": [
+      "id",
+      "type",
+      "attributes"
+    ],
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "example": "f0a91e16-1b0e-4e1f-93fe-319dda9933e6",
+        "description": "The unique identifier (UUID) of this object"
+      },
+      "type": {
+        "type": "string",
+        "example": "allocations",
+        "enum": ["allocations"],
+        "description": "The type of this object - always `allocations`"
+      },
+      "attributes": {
+        "type": "object",
+        "required": [
+          "moves_count",
+          "date"
+        ],
+        "properties": {
+          "moves_count": {
+            "type": "integer",
+            "example": 5,
+            "description": "The number of prisoners to move in this allocation"
+          },
+          "prisoner_category": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": ["b", "c", "d"]
+              },
+              { "type": "null" }
+            ],
+            "example": "b",
+            "description": "Indicates the prisoner category"
+          },
+          "sentence_length": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": ["short", "long"]
+              },
+              { "type": "null" }
+            ],
+            "example": "short",
+            "description": "Indicates the sentence length - short is 16 months or less, long is over 16 months"
+          },
+          "complex_cases": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "allocation_complex_case.json#/AllocationComplexCase"
+                }
+              },
+              { "type": "null" }
+            ],
+            "example": "null",
+            "description": "Collection of indicators for complex cases"
+          },
+          "complete_in_full": {
+            "type": "boolean",
+            "example":  "true",
+            "description": "Indicates if allocation must be completed (i.e. populated with prisoners) in full"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when the allocation was last created or updated",
+            "readOnly": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when the allocation was created",
+            "readOnly": true
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "example": "2020-05-17",
+            "description": "Date on which the allocation is scheduled"
+          },
+          "other_criteria": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "null" }
+            ],
+            "description": "Additional information about the allocation"
+          }
+        }
+      },
+      "relationships": {
+        "type": "object",
+        "required": [
+          "from_location",
+          "to_location"
+        ],
+        "properties": {
+          "from_location": {
+            "$ref": "location_reference.json#/LocationReference",
+            "description": "The location (prison) that the people are being moved from"
+          },
+          "to_location": {
+            "$ref": "location_reference.json#/LocationReference",
+            "description": "The location (prison) that the people are being moved to"
+          }
+        }
+      }
+    }
+  }
+}

--- a/swagger/v1/get_allocations_responses.json
+++ b/swagger/v1/get_allocations_responses.json
@@ -1,0 +1,77 @@
+{
+  "200": {
+    "type": "object",
+    "required": [
+      "data"
+    ],
+    "properties": {
+      "data": {
+        "type": "array",
+        "items": {
+          "$ref": "allocation.json#/Allocation"
+        }
+      },
+      "included": {
+        "type": "array",
+        "items": {
+          "anyOf": [
+            { "$ref": "location.json#/Location" }
+          ]
+        }
+      },
+      "links": {
+        "$ref": "pagination_links.json#/PaginationLinks"
+      },
+      "meta": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "pagination.json#/Pagination"
+          }
+        }
+      }
+    }
+  },
+  "415": {
+    "type": "object",
+    "required": [
+      "errors"
+    ],
+    "properties": {
+      "errors": {
+        "type": "array",
+        "items": {
+          "$ref": "errors.json#/UnsupportedMediaType"
+        }
+      }
+    }
+  },
+  "400": {
+    "type": "object",
+    "required": [
+      "errors"
+    ],
+    "properties": {
+      "errors": {
+        "type": "array",
+        "items": {
+          "$ref": "errors.json#/BadRequest"
+        }
+      }
+    }
+  },
+  "401": {
+    "type": "object",
+    "required": [
+      "errors"
+    ],
+    "properties": {
+      "errors": {
+        "type": "array",
+        "items": {
+          "$ref": "errors.json#/NotAuthorisedError"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Jira link

P4-1274

### What?

I have added/removed/altered:

- [x] Added a new `GET /allocations` endpoint, route, controller etc.
- [x] Added a new rake task to setup some fake allocation data - run `bundle exec rake fake_data:create_allocations`
- [x] Added associated specs
- [x] Added API documentation for new endpoint and schema types

### Why?

- This supports the front end functionality