### PR TITLE
Fixes Rakefile for production environment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,13 +4,15 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative 'config/application'
-require 'github_changelog_generator/task'
 
 Rails.application.load_tasks
 Doorkeeper::Rake.load_tasks
 
+if Rails.env.development?
+  require 'github_changelog_generator/task'
 
-GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  config.user = 'ministryofjustice'
-  config.project = 'hmpps-book-secure-move-api'
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    config.user = 'ministryofjustice'
+    config.project = 'hmpps-book-secure-move-api'
+  end
 end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

The Rakefile is loaded when building Docker images for production

- [x] Only load development task when in development

### Why?

- To fix broken builds


