### PR TITLE
Nomis Error handling

### DIFF
--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -38,12 +38,20 @@ module Api
       def court_cases
         person = Person.find(params[:person_id])
 
-        court_cases = People::RetrieveCourtCases.call(person, court_case_filter_params)
+        response = People::RetrieveCourtCases.call(person, court_case_filter_params)
 
-        render json: court_cases, each_serializer: CourtCaseSerializer, include: :location
+        if response.success?
+          render json: response.court_cases, each_serializer: CourtCaseSerializer, include: :location
+        else
+          render json: json_api_errors_for(response.error)
+        end
       end
 
     private
+
+      def json_api_errors_for(error)
+        { errors: [error.json_api_error] }
+      end
 
       def import_person_from_nomis prison_number
         # This prevents us from blaming the current user/application for the NOMIS sync

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -13,7 +13,7 @@ class ApiController < ApplicationController
   rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_error
   rescue_from ActiveRecord::ReadOnlyRecord, with: :render_resource_readonly_error
   rescue_from CanCan::AccessDenied, with: :render_unauthorized_error
-  rescue_from Faraday::ConnectionFailed, Faraday::TimeoutError, with: :connection_error
+  rescue_from Faraday::ConnectionFailed, Faraday::TimeoutError, with: :render_connection_error
 
   def current_user
     doorkeeper_token&.application
@@ -109,11 +109,11 @@ private
     )
   end
 
-  def connection_error(exception)
+  def render_connection_error(exception)
     render(
       json: { errors: [{
         title: 'Connection Error',
-        detail: exception.to_s,
+        detail: "#{exception.exception.class}: #{exception.message}",
       }] },
       status: :service_unavailable,
     )

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -113,9 +113,9 @@ private
     render(
       json: { errors: [{
         title: 'Connection Error',
-        detail: exception.to_s
+        detail: exception.to_s,
       }] },
-      status: service_unavailable,
+      status: :service_unavailable,
     )
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -13,6 +13,7 @@ class ApiController < ApplicationController
   rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_error
   rescue_from ActiveRecord::ReadOnlyRecord, with: :render_resource_readonly_error
   rescue_from CanCan::AccessDenied, with: :render_unauthorized_error
+  rescue_from Faraday::ConnectionFailed, Faraday::TimeoutError, with: :connection_error
 
   def current_user
     doorkeeper_token&.application
@@ -105,6 +106,16 @@ private
         detail: exception.to_s,
       }] },
       status: :unauthorized,
+    )
+  end
+
+  def connection_error(exception)
+    render(
+      json: { errors: [{
+        title: 'Connection Error',
+        detail: exception.to_s
+      }] },
+      status: service_unavailable,
     )
   end
 

--- a/app/lib/nomis_client/api_error.rb
+++ b/app/lib/nomis_client/api_error.rb
@@ -1,0 +1,27 @@
+module NomisClient
+  class ApiError
+    # This is a simple PORO build to serialize generic Nomis errors.
+    # This is used in place of the AMS error serializer, since there is not an AR Model linked to this error.
+
+    attr_reader :code, :status, :title, :details
+
+    def initialize(status:, error_body:)
+      @status = status
+      @code = 'NOMIS-ERROR'
+
+      nomis_error = JSON.parse(error_body)
+
+      @title = nomis_error['userMessage'].to_s
+      @details = "#{nomis_error['developerMessage']} #{nomis_error['moreInfo']}".strip
+    end
+
+    def json_api_error
+      {
+          code: code,
+          status: status,
+          title: title,
+          details: details,
+      }
+    end
+  end
+end

--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -51,11 +51,11 @@ module NomisClient
         Rails.logger.info "NomisClient request took (#{total_request_seconds}s): #{ENV['NOMIS_API_PATH_PREFIX']}#{path}"
 
         response
-      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => err
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
         retries += 1
         retry if retries <= MAX_RETRIES
 
-        raise err
+        raise e
       end
 
       def update_json_headers(params)

--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -51,9 +51,11 @@ module NomisClient
         Rails.logger.info "NomisClient request took (#{total_request_seconds}s): #{ENV['NOMIS_API_PATH_PREFIX']}#{path}"
 
         response
-      rescue Faraday::ConnectionFailed, Faraday::TimeoutError
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => err
         retries += 1
         retry if retries <= MAX_RETRIES
+
+        raise err
       end
 
       def update_json_headers(params)

--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -55,7 +55,7 @@ module NomisClient
         retries += 1
         retry if retries <= MAX_RETRIES
 
-        raise e
+        raise e, 'Nomis Connection Error'
       end
 
       def update_json_headers(params)

--- a/app/serializers/nomis_api_error_serializer.rb
+++ b/app/serializers/nomis_api_error_serializer.rb
@@ -1,0 +1,3 @@
+class NomisApiErrorSerializer < ActiveModel::Serializer::ErrorSerializer
+  attributes :code, :status, :title, :details
+end

--- a/app/services/people/retrieve_court_cases.rb
+++ b/app/services/people/retrieve_court_cases.rb
@@ -5,9 +5,14 @@ module People
     def self.call(person, filter_params)
       nomis_court_cases_response = NomisClient::CourtCases.get(person.latest_nomis_booking_id, filter_params)
 
-      JSON.parse(nomis_court_cases_response).map do |court_case|
+      court_cases = JSON.parse(nomis_court_cases_response).map do |court_case|
         CourtCase.new.build_from_nomis(court_case)
       end
+
+      OpenStruct.new(success?: true, court_cases: court_cases, errors: nil)
+    rescue OAuth2::Error => err
+      nomis_error = NomisClient::ApiError.new(status: err.response.status, error_body: err.response.body)
+      OpenStruct.new(success?: false, court_cases: [], error: nomis_error)
     end
   end
 end

--- a/app/services/people/retrieve_court_cases.rb
+++ b/app/services/people/retrieve_court_cases.rb
@@ -10,8 +10,8 @@ module People
       end
 
       OpenStruct.new(success?: true, court_cases: court_cases, errors: nil)
-    rescue OAuth2::Error => err
-      nomis_error = NomisClient::ApiError.new(status: err.response.status, error_body: err.response.body)
+    rescue OAuth2::Error => e
+      nomis_error = NomisClient::ApiError.new(status: e.response.status, error_body: e.response.body)
       OpenStruct.new(success?: false, court_cases: [], error: nomis_error)
     end
   end

--- a/spec/lib/nomis_client/api_error_spec.rb
+++ b/spec/lib/nomis_client/api_error_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe NomisClient::ApiError do
-  it '#to_json_api_errorjson' do
+  it '#json_api_error' do
     nomis_error = described_class.new(status: 400, error_body: {
         'userMessage' => 'User message.', 'developerMessage' => 'Developer message.', 'moreInfo' => 'More info.'
     }.to_json)

--- a/spec/lib/nomis_client/api_error_spec.rb
+++ b/spec/lib/nomis_client/api_error_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NomisClient::ApiError do
+  it '#to_json_api_errorjson' do
+    nomis_error = described_class.new(status: 400, error_body: {
+        'userMessage' => 'User message.', 'developerMessage' => 'Developer message.', 'moreInfo' => 'More info.'
+    }.to_json)
+
+    expect(nomis_error.json_api_error).to eq(code: 'NOMIS-ERROR',
+                                             status: 400, title: 'User message.',
+                                             details: 'Developer message. More info.')
+  end
+end

--- a/spec/lib/nomis_client/base_spec.rb
+++ b/spec/lib/nomis_client/base_spec.rb
@@ -108,10 +108,13 @@ RSpec.describe NomisClient::Base do
 
       before do
         allow(token).to receive(:get).and_raise(Faraday::ConnectionFailed, 'connection failed')
-        described_class.get(api_endpoint)
       end
 
-      it 'is called MAX_RETRIES times' do
+      it 'is called MAX_RETRIES + 1 times' do
+        expect {
+          described_class.get(api_endpoint)
+        }.to raise_exception(Faraday::ConnectionFailed)
+
         expect(token).to have_received(:get).exactly(3).times
       end
     end
@@ -123,10 +126,13 @@ RSpec.describe NomisClient::Base do
 
       before do
         allow(token).to receive(:get).and_raise(Faraday::TimeoutError)
-        described_class.get(api_endpoint)
       end
 
-      it 'is called MAX_RETRIES times' do
+      it 'is called MAX_RETRIES + 1 times' do
+        expect {
+          described_class.get(api_endpoint)
+        }.to raise_exception(Faraday::TimeoutError)
+
         expect(token).to have_received(:get).exactly(3).times
       end
     end
@@ -226,10 +232,13 @@ RSpec.describe NomisClient::Base do
 
       before do
         allow(token).to receive(:post).and_raise(Faraday::ConnectionFailed, 'connection failed')
-        described_class.post(api_endpoint)
       end
 
       it 'is called MAX_RETRIES times' do
+        expect {
+          described_class.post(api_endpoint)
+        }.to raise_exception(Faraday::ConnectionFailed)
+
         expect(token).to have_received(:post).exactly(3).times
       end
     end
@@ -241,10 +250,13 @@ RSpec.describe NomisClient::Base do
 
       before do
         allow(token).to receive(:post).and_raise(Faraday::TimeoutError)
-        described_class.post('/example')
       end
 
       it 'is called MAX_RETRIES times' do
+        expect {
+          described_class.post('/example')
+        }.to raise_exception(Faraday::TimeoutError)
+
         expect(token).to have_received(:post).exactly(3).times
       end
     end

--- a/spec/lib/nomis_client/court_cases_spec.rb
+++ b/spec/lib/nomis_client/court_cases_spec.rb
@@ -4,26 +4,20 @@ require 'rails_helper'
 
 RSpec.describe NomisClient::CourtCases, with_nomis_client_authentication: true do
   describe '.get' do
-    let(:nomis_client) { class_double(NomisClient::Base).as_stubbed_const }
-
     let(:booking_id) { '1495077' }
     let(:filter_params) { nil }
 
     it 'calls the nomis client with the correct booking id' do
-      allow(nomis_client).to receive(:get).and_return(instance_double('OAuth2::Response', body: response_body))
-
       described_class.get(booking_id, filter_params)
 
-      expect(nomis_client).to have_received(:get).with("/bookings/#{booking_id}/court-cases")
+      expect(token).to have_received(:get).with("/elite2api/api/bookings/1495077/court-cases", {})
     end
 
     context 'when no filter_params are passed' do
       it 'returns active court cases' do
-        allow(nomis_client).to receive(:get).and_return(instance_double('OAuth2::Response', body: response_body))
-
         described_class.get(booking_id)
 
-        expect(nomis_client).to have_received(:get).with("/bookings/#{booking_id}/court-cases?activeOnly=true")
+        expect(token).to have_received(:get).with("/elite2api/api/bookings/#{booking_id}/court-cases?activeOnly=true", {})
       end
     end
 
@@ -31,11 +25,9 @@ RSpec.describe NomisClient::CourtCases, with_nomis_client_authentication: true d
       let(:filter_params) { ActionController::Parameters.new(active: 'true') }
 
       it 'returns active court cases' do
-        allow(nomis_client).to receive(:get).and_return(instance_double('OAuth2::Response', body: response_body))
-
         described_class.get(booking_id, filter_params)
 
-        expect(nomis_client).to have_received(:get).with("/bookings/#{booking_id}/court-cases?activeOnly=true")
+        expect(token).to have_received(:get).with("/elite2api/api/bookings/#{booking_id}/court-cases?activeOnly=true", {})
       end
     end
   end

--- a/spec/lib/nomis_client/court_cases_spec.rb
+++ b/spec/lib/nomis_client/court_cases_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NomisClient::CourtCases, with_nomis_client_authentication: true d
     it 'calls the nomis client with the correct booking id' do
       described_class.get(booking_id, filter_params)
 
-      expect(token).to have_received(:get).with("/elite2api/api/bookings/1495077/court-cases", {})
+      expect(token).to have_received(:get).with('/elite2api/api/bookings/1495077/court-cases', {})
     end
 
     context 'when no filter_params are passed' do

--- a/spec/requests/api/v1/people_controller_court_cases_spec.rb
+++ b/spec/requests/api/v1/people_controller_court_cases_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe Api::V1::PeopleController do
       end
     end
 
+    context 'when person does not exist' do
+      it 'returns success' do
+        person_id = 'non-existent-person'
+
+        get "/api/v1/people/#{person_id}/court_cases", params: { access_token: token.token }
+
+        expect(response_json['errors'][0]['title']).to eq('Resource not found')
+      end
+    end
+
     context 'when the court cases are NOT present in Nomis' do
       let(:booking_id) { '123456789' }
 

--- a/spec/requests/api/v1/people_controller_court_cases_spec.rb
+++ b/spec/requests/api/v1/people_controller_court_cases_spec.rb
@@ -9,42 +9,55 @@ RSpec.describe Api::V1::PeopleController do
 
   context 'when person is present ' do
     let(:person) { create(:profile, :nomis_synced).person }
-    let(:court_cases_from_nomis) {
-      OpenStruct.new(success?: true, court_cases:
-          [CourtCase.new.build_from_nomis('id' => '1495077', 'beginDate' => '2020-01-01', 'agency' => { 'agencyId' => 'SNARCC' }),
-           CourtCase.new.build_from_nomis('id' => '2222222', 'beginDate' => '2020-01-02', 'agency' => { 'agencyId' => 'SNARCC' })])
-    }
 
-    before do
-      person.latest_profile.update(latest_nomis_booking_id: booking_id)
-      create :location, nomis_agency_id: 'SNARCC', title: 'Snaresbrook Crown Court', location_type: 'CRT'
-    end
+    context 'when the court cases are present in Nomis ' do
+      let(:court_cases_from_nomis) {
+        OpenStruct.new(success?: true, court_cases:
+            [CourtCase.new.build_from_nomis('id' => '1495077', 'beginDate' => '2020-01-01', 'agency' => { 'agencyId' => 'SNARCC' }),
+             CourtCase.new.build_from_nomis('id' => '2222222', 'beginDate' => '2020-01-02', 'agency' => { 'agencyId' => 'SNARCC' })])
+      }
 
-    it 'returns success' do
-      allow(People::RetrieveCourtCases).to receive(:call).with(person, nil).and_return(court_cases_from_nomis)
+      before do
+        person.latest_profile.update(latest_nomis_booking_id: booking_id)
 
-      get "/api/v1/people/#{person.id}/court_cases", params: { access_token: token.token }
-
-      expect(response_json['data'][0]['id']).to eq('1495077')
-      expect(response_json['included']).not_to be_nil
-    end
-
-    context 'when we pass a filter in the query params' do
-      let(:query) { '?filter[active]=true' }
-
-      it 'passes the filter to the RetrieveCourtCases service' do
         allow(People::RetrieveCourtCases).to receive(:call).and_return(court_cases_from_nomis)
+      end
 
-        get "/api/v1/people/#{person.id}/court_cases#{query}", params: { access_token: token.token }
+      it 'returns success' do
+        get "/api/v1/people/#{person.id}/court_cases", params: { access_token: token.token }
 
-        expect(People::RetrieveCourtCases).to have_received(:call).with(person, 'active' => 'true')
+        expect(response_json['data'][0]['id']).to eq('1495077')
+      end
+
+      it 'includes location in the response' do
+        create :location, nomis_agency_id: 'SNARCC', title: 'Snaresbrook Crown Court', location_type: 'CRT'
+
+        get "/api/v1/people/#{person.id}/court_cases", params: { access_token: token.token }
+
+        expect(response_json['included']).to be_a_kind_of Array
+        expect(response_json['included'].first['type']).to eq 'locations'
+      end
+
+
+      context 'when we pass a filter in the query params' do
+        let(:query) { '?filter[active]=true' }
+
+        it 'passes the filter to the RetrieveCourtCases service' do
+          get "/api/v1/people/#{person.id}/court_cases#{query}", params: { access_token: token.token }
+
+          expect(People::RetrieveCourtCases).to have_received(:call).with(person, 'active' => 'true')
+        end
       end
     end
 
-    context 'when booking id is NOT present in Nomis' do
+    context 'when the court cases are NOT present in Nomis' do
       let(:booking_id) { '123456789' }
 
+      let(:court_cases_from_nomis) { OpenStruct.new(success?: false, error: NomisClient::ApiError.new(status: 404, error_body: '{}')) }
+
       it 'return 404 not found' do
+        allow(People::RetrieveCourtCases).to receive(:call).and_return(court_cases_from_nomis)
+
         get "/api/v1/people/#{person.id}/court_cases", params: { access_token: token.token }
 
         expect(response_json['errors']).to be_a_kind_of Array

--- a/spec/requests/api/v1/people_controller_court_cases_spec.rb
+++ b/spec/requests/api/v1/people_controller_court_cases_spec.rb
@@ -10,11 +10,10 @@ RSpec.describe Api::V1::PeopleController do
   context 'when person is present ' do
     let(:person) { create(:profile, :nomis_synced).person }
     let(:court_cases_from_nomis) {
-      [CourtCase.new.build_from_nomis('id' => '1495077', 'beginDate' => '2020-01-01', 'agency' => { 'agencyId' => 'SNARCC' }),
-       CourtCase.new.build_from_nomis('id' => '2222222', 'beginDate' => '2020-01-02', 'agency' => { 'agencyId' => 'SNARCC' })]
+      OpenStruct.new(success?: true, court_cases:
+          [CourtCase.new.build_from_nomis('id' => '1495077', 'beginDate' => '2020-01-01', 'agency' => { 'agencyId' => 'SNARCC' }),
+           CourtCase.new.build_from_nomis('id' => '2222222', 'beginDate' => '2020-01-02', 'agency' => { 'agencyId' => 'SNARCC' })])
     }
-
-    let(:query) { '' }
 
     before do
       person.latest_profile.update(latest_nomis_booking_id: booking_id)
@@ -24,7 +23,7 @@ RSpec.describe Api::V1::PeopleController do
     it 'returns success' do
       allow(People::RetrieveCourtCases).to receive(:call).with(person, nil).and_return(court_cases_from_nomis)
 
-      get "/api/v1/people/#{person.id}/court_cases#{query}", params: { access_token: token.token }
+      get "/api/v1/people/#{person.id}/court_cases", params: { access_token: token.token }
 
       expect(response_json['data'][0]['id']).to eq('1495077')
       expect(response_json['included']).not_to be_nil
@@ -39,6 +38,16 @@ RSpec.describe Api::V1::PeopleController do
         get "/api/v1/people/#{person.id}/court_cases#{query}", params: { access_token: token.token }
 
         expect(People::RetrieveCourtCases).to have_received(:call).with(person, 'active' => 'true')
+      end
+    end
+
+    context 'when booking id is NOT present in Nomis' do
+      let(:booking_id) { '123456789' }
+
+      it 'return 404 not found' do
+        get "/api/v1/people/#{person.id}/court_cases", params: { access_token: token.token }
+
+        expect(response_json['errors']).to be_a_kind_of Array
       end
     end
   end

--- a/spec/services/people/retrieve_court_cases_spec.rb
+++ b/spec/services/people/retrieve_court_cases_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe People::RetrieveCourtCases do
   it 'returns an array of CourtCase' do
     court_cases_response = described_class.call(person, filter_params)
 
-    expect(court_cases_response).to all(be_a(CourtCase))
+    expect(court_cases_response.court_cases).to all(be_a(CourtCase))
   end
 end

--- a/spec/swagger/api/v1/people_controller_court_cases_spec.rb
+++ b/spec/swagger/api/v1/people_controller_court_cases_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Api::V1::PeopleController, :rswag, :with_client_authentication, t
         }
 
         before do
-          allow(People::RetrieveCourtCases).to receive(:call).with(person, nil).and_return(court_cases_from_nomis)
+          allow(People::RetrieveCourtCases).to receive(:call).with(person, nil).and_return(OpenStruct.new(success?: true, court_cases: court_cases_from_nomis))
         end
 
         schema '$ref' => 'get_court_cases_responses.json#/200'


### PR DESCRIPTION
Jira link: https://dsdmoj.atlassian.net/browse/P4-1261

- Fix error propagation from Nomis Api Calls
- Add Api:Json error in Get people#court_cases

Note: this PR is not yet handling the Timeout error, a new PR will follow soon

### What?

I have added/removed/altered:

- [x] Fix Nomis error propagation
- [x] Support Api:Json error
- [x] Add Nomis timeout error

### Why?
To give more info to the caller about Nomis failures.
To have a standard way to handle errors (Api:Json)

### Have you? (optional)
- [ ] Updated API docs if necessary	
