### PR TITLE
Update supplier location:

### DIFF
--- a/lib/tasks/data/supplier_locations.yml
+++ b/lib/tasks/data/supplier_locations.yml
@@ -101,6 +101,7 @@ geoamey:
   - NYK1
   - NYK2
   - NYK3
+  - PRI
   - SCH1
   - SCH2
   - SCH3
@@ -172,6 +173,7 @@ serco:
   - BTP2
   - BTP4
   - BTP5
+  - BZI
   - CAM1
   - CAM3
   - CAM4


### PR DESCRIPTION
### Jira link
https://dsdmoj.atlassian.net/browse/P4-1377

### What?
Update supplier location:
- Link PRI to GeoAmey
- Link BZI to Serco

### Why?
there are more location supported 

### Deployment risks (optional)

REMEMBER to run the task:
`rake reference_data:link_suppliers`
to update the locations for the suppliers