### PR TITLE
Fix timetable after integration highlighted bug

### DIFF
--- a/app/lib/nomis_client/activities.rb
+++ b/app/lib/nomis_client/activities.rb
@@ -9,7 +9,7 @@ module NomisClient
           headers: { 'Page-Limit' => '1000' },
         )
 
-        response.body
+        response.parsed
       end
     end
   end

--- a/app/lib/nomis_client/court_hearings.rb
+++ b/app/lib/nomis_client/court_hearings.rb
@@ -6,10 +6,12 @@ module NomisClient
       def get(booking_id, start_date = Time.zone.today, end_date = Time.zone.today)
         court_hearings_path = "/bookings/#{booking_id}/court-hearings?fromDate=#{start_date.iso8601}&toDate=#{end_date.iso8601}"
 
-        NomisClient::Base.get(
+        response = NomisClient::Base.get(
           court_hearings_path,
           headers: { 'Page-Limit' => '1000' },
         )
+
+        response.parsed
       end
 
       def post(booking_id:, court_case_id:, body_params: {})

--- a/spec/lib/nomis_client/activities_spec.rb
+++ b/spec/lib/nomis_client/activities_spec.rb
@@ -20,5 +20,9 @@ RSpec.describe NomisClient::Activities, with_nomis_client_authentication: true d
         headers: { 'Page-Limit' => '1000' },
       )
     end
+
+    it 'returns a parsed response body' do
+      expect(activities_get).to be_a(Array)
+    end
   end
 end

--- a/spec/lib/nomis_client/court_hearings_spec.rb
+++ b/spec/lib/nomis_client/court_hearings_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe NomisClient::CourtHearings, with_nomis_client_authentication: tru
         headers: { 'Page-Limit' => '1000' },
       )
     end
+
+    it 'returns a parsed response body' do
+      expect(court_hearings_get).to be_a(Hash)
+    end
   end
 
   describe '.post' do


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

- [x] Added `OAuth2::Response#parsed` call in the activities and court hearings client implementations
- [x] Added corresponding tests to avoid regressions

### Why?

I am doing this because:

- The retrieval services expect parsed json from the client
