### PR TITLE
P4-1385 Allow move creation and serialisation without a person

### DIFF
--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -4,7 +4,7 @@ class MoveSerializer < ActiveModel::Serializer
   attributes :id, :reference, :status, :updated_at, :created_at, :time_due, :date, :move_type, :additional_information,
              :cancellation_reason, :cancellation_reason_comment, :move_agreed, :move_agreed_by, :date_from, :date_to
 
-  has_one :person, serializer: PersonSerializer
+  has_one :person, serializer: PersonSerializer, if: -> { object.person.present? }
   has_one :from_location, serializer: LocationSerializer
   has_one :to_location, serializer: LocationSerializer, if: -> { object.to_location.present? }
   has_one :prison_transfer_reason, serializer: PrisonTransferReasonSerializer, if: -> { object.prison_transfer_reason.present? }

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -4,7 +4,7 @@ class MoveSerializer < ActiveModel::Serializer
   attributes :id, :reference, :status, :updated_at, :created_at, :time_due, :date, :move_type, :additional_information,
              :cancellation_reason, :cancellation_reason_comment, :move_agreed, :move_agreed_by, :date_from, :date_to
 
-  has_one :person, serializer: PersonSerializer, if: -> { object.person.present? }
+  has_one :person, serializer: PersonSerializer
   has_one :from_location, serializer: LocationSerializer
   has_one :to_location, serializer: LocationSerializer, if: -> { object.to_location.present? }
   has_one :prison_transfer_reason, serializer: PrisonTransferReasonSerializer, if: -> { object.prison_transfer_reason.present? }

--- a/db/migrate/20200428134954_remove_null_constraint_from_person_on_moves.rb
+++ b/db/migrate/20200428134954_remove_null_constraint_from_person_on_moves.rb
@@ -1,0 +1,5 @@
+class RemoveNullConstraintFromPersonOnMoves < ActiveRecord::Migration[5.2]
+  def change
+    change_column :moves, :person_id, :uuid, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_28_091726) do
+ActiveRecord::Schema.define(version: 2020_04_28_134954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -179,7 +179,7 @@ ActiveRecord::Schema.define(version: 2020_04_28_091726) do
     t.date "date"
     t.uuid "from_location_id", null: false
     t.uuid "to_location_id"
-    t.uuid "person_id", null: false
+    t.uuid "person_id"
     t.string "status", default: "requested", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -5,12 +5,11 @@ require 'rails_helper'
 RSpec.describe Move do
   it { is_expected.to belong_to(:from_location) }
   it { is_expected.to belong_to(:to_location).optional }
-  it { is_expected.to belong_to(:person) }
+  it { is_expected.to belong_to(:person).optional }
   it { is_expected.to have_many(:notifications) }
   it { is_expected.to have_many(:journeys) }
 
   it { is_expected.to validate_presence_of(:from_location) }
-  it { is_expected.to validate_presence_of(:person) }
   it { is_expected.to validate_presence_of(:date) }
   it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.values) }
 
@@ -23,6 +22,24 @@ RSpec.describe Move do
   it 'does NOT validate presence of `to_location` if `move_type` is prison_recall' do
     expect(build(:move, move_type: 'prison_recall')).not_to(
       validate_presence_of(:to_location),
+    )
+  end
+
+  it 'validates presence of `person` if `status` is NOT requested or cancelled' do
+    expect(build(:move, status: :proposed)).to(
+      validate_presence_of(:person),
+    )
+  end
+
+  it 'does NOT validates presence of `person` if `status` is requested' do
+    expect(build(:move, status: :requested)).not_to(
+      validate_presence_of(:person),
+    )
+  end
+
+  it 'does NOT validates presence of `person` if `status` is cancelled' do
+    expect(build(:move, status: :cancelled)).not_to(
+      validate_presence_of(:person),
     )
   end
 
@@ -40,6 +57,12 @@ RSpec.describe Move do
 
   it 'does NOT validate uniqueness of `date` if `status` is proposed' do
     expect(build(:move, status: :proposed)).not_to(
+      validate_uniqueness_of(:date),
+    )
+  end
+
+  it 'does NOT validate uniqueness of `date` if `person_id` is nil' do
+    expect(build(:move, status: :requested, person: nil)).not_to(
       validate_uniqueness_of(:date),
     )
   end

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -271,8 +271,8 @@ RSpec.describe Api::V1::MovesController do
     end
 
     context 'with a reference to a missing relationship' do
-      let(:person) { Person.new }
-      let(:detail_404) { "Couldn't find Person without an ID" }
+      let(:from_location) { build(:location) }
+      let(:detail_404) { "Couldn't find Location without an ID" }
 
       it_behaves_like 'an endpoint that responds with error 404'
     end

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -65,20 +65,35 @@ RSpec.describe MoveSerializer do
   end
 
   describe 'person' do
-    let(:adapter_options) { { include: { person: %I[first_names last_name] } } }
-    let(:expected_json) do
-      [
-        {
-          id: move.person_id,
-          type: 'people',
-          attributes: { first_names: move.person.latest_profile.first_names,
-                        last_name: move.person.latest_profile.last_name, date_of_birth: '1980-10-20' },
-        },
-      ]
+    context 'with a person' do
+      let(:adapter_options) { { include: { person: %I[first_names last_name] } } }
+      let(:expected_json) do
+        [
+          {
+            id: move.person_id,
+            type: 'people',
+            attributes: { first_names: move.person.latest_profile.first_names,
+                          last_name: move.person.latest_profile.last_name, date_of_birth: '1980-10-20' },
+          },
+        ]
+      end
+
+      it 'contains an included person' do
+        expect(result[:included]).to(include_json(expected_json))
+      end
     end
 
-    it 'contains an included person' do
-      expect(result[:included]).to(include_json(expected_json))
+    context 'without a person' do
+      let(:adapter_options) { { include: MoveSerializer::INCLUDED_ATTRIBUTES } }
+      let(:move) { create(:move, person: nil) }
+
+      it 'does not contain a person' do
+        expect(result_data[:relationships][:person]).to be_nil
+      end
+
+      it 'does not contain an included person' do
+        expect(result[:included].map { |r| r[:type] }).to match_array(%w[locations locations])
+      end
     end
   end
 

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe MoveSerializer do
       let(:adapter_options) { { include: MoveSerializer::INCLUDED_ATTRIBUTES } }
       let(:move) { create(:move, person: nil) }
 
-      it 'does not contain a person' do
-        expect(result_data[:relationships][:person]).to be_nil
+      it 'contains an empty person' do
+        expect(result_data[:relationships][:person]).to eq(data: nil)
       end
 
       it 'does not contain an included person' do

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -113,7 +113,6 @@ Move:
     relationships:
       type: object
       required:
-      - person
       - from_location
       properties:
         person:


### PR DESCRIPTION
### Jira link

[P4-1385](https://dsdmoj.atlassian.net/browse/P4-1385)

### What?

- [x] Removed the database constraint for person on move
- [x] Altered the person validation to specific statuses relevant to the singleton flow
- [x] Added an extra scope to date uniqueness validation to not be enforced if a person is not associated with records
- [x] Added tests for the move serialiser to check for empty values for a person

### Why?

When a PMU allocation is created, we would like to associate it with moves, for each of the people required for the allocation. However at the time moves are created, they will not be associated with a person, as those will be added later by the OCA.

Allow a move to be created without a person, only if it is a request or a cancellation. As proposed moves coming from the singleton flow always will require a person associated, while moves created for an association will always start with the request status.

Also validate on uniqueness of date unless the person is not associated with a move to not group `nil` people moves together created for an allocation and deem them as invalid.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

