### PR TITLE
P4-1392 Patch a moves document relationships

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,3 +69,7 @@ Rails/TimeZone:
   Exclude:
     - "spec/**/**/*"
     - "app/services/moves/anonymiser.rb"
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -15,8 +15,6 @@ module Api
       end
 
       def show
-        move = find_move
-
         render_move(move, 200)
       end
 
@@ -31,7 +29,6 @@ module Api
       end
 
       def update
-        move = find_move
         raise ActiveRecord::ReadOnlyRecord, 'Can\'t change moves coming from Nomis' if move.from_nomis?
 
         # NB: rather than update directly, we need to detect whether the move status has changed before saving the record
@@ -44,7 +41,6 @@ module Api
       end
 
       def destroy
-        move = find_move
         move.destroy! # TODO: we probably should not be destroying moves
         Notifier.prepare_notifications(topic: move, action_name: 'destroy')
         render_move(move, 200)
@@ -98,8 +94,8 @@ module Api
         render json: move, status: status, include: MoveSerializer::INCLUDED_ATTRIBUTES
       end
 
-      def find_move
-        Move
+      def move
+        @move ||= Move
           .accessible_by(current_ability)
           .includes(:from_location, :to_location, person: { profiles: %i[gender ethnicity] })
           .find(params[:id])

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Api::V1::MovesController do
     let(:date_from) { Date.yesterday }
     let(:date_to) { Date.tomorrow }
     let(:move) { Move.find_by(status: 'proposed') }
+    let(:before_documents) { create_list(:document, 2) }
 
     let(:move_params) do
       {
@@ -42,11 +43,11 @@ RSpec.describe Api::V1::MovesController do
     end
 
     before do
-      create :move, :proposed, move_type: 'prison_recall', from_location: from_location
+      create :move, :proposed, move_type: 'prison_recall', from_location: from_location, documents: before_documents
 
       next if RSpec.current_example.metadata[:skip_before]
 
-      patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
+      do_patch
     end
 
     context 'when not authorized', :with_invalid_auth_headers do
@@ -66,7 +67,7 @@ RSpec.describe Api::V1::MovesController do
                  from_location: move.from_location,
                  to_location: move.to_location,
                  date: move.date)
-          patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
+          do_patch
         end
 
         let(:errors_422) do
@@ -127,6 +128,47 @@ RSpec.describe Api::V1::MovesController do
           expect(response_json).to eq resource_to_json
         end
 
+        context 'when changing a moves documents', :skip_before do
+          let(:after_documents) { [after_document] }
+          let(:move_params) do
+            documents = after_documents.map { |d| { id: d.id, type: d.type } }
+            {
+              type: 'moves',
+              attributes: {
+                status: 'requested',
+                additional_information: 'some more info',
+                cancellation_reason: 'other',
+                cancellation_reason_comment: 'some other reason',
+                move_type: 'court_appearance',
+                move_agreed: true,
+                move_agreed_by: 'Fred Bloggs',
+                date_from: date_from,
+                date_to: date_to,
+              },
+              relationships: { documents: { data: documents } },
+            }
+          end
+
+          it 'updates the moves documents' do
+            expect { do_patch }.
+              to change { move.reload.documents }.
+              from(before_documents).
+              to(after_documents)
+          end
+
+          it 'does not affect other relationships' do
+            expect { do_patch }.not_to change { move.reload.from_location }
+          end
+
+          it 'returns the updated documents in the response body' do
+            do_patch
+
+            expect(
+              response_json.dig('data', 'relationships', 'documents', 'data').map { |document| document['id'] },
+            ).to eq(after_documents.pluck(:id))
+          end
+        end
+
         context 'when cancelling a move' do
           context 'when the supplier has a webhook subscription', :skip_before do
             let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
@@ -140,7 +182,7 @@ RSpec.describe Api::V1::MovesController do
             before do
               allow(Faraday).to receive(:new).and_return(faraday_client)
               perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
-                patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
+                do_patch
               end
             end
 
@@ -165,7 +207,7 @@ RSpec.describe Api::V1::MovesController do
             before do
               allow(MoveMailer).to receive(:notify).and_return(notify_response)
               perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyEmailJob]) do
-                patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
+                do_patch
               end
             end
 
@@ -199,7 +241,7 @@ RSpec.describe Api::V1::MovesController do
             before do
               allow(Faraday).to receive(:new).and_return(faraday_client)
               perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
-                patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
+                do_patch
               end
             end
 
@@ -233,7 +275,7 @@ RSpec.describe Api::V1::MovesController do
             before do
               allow(MoveMailer).to receive(:notify).and_return(notify_response)
               perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyEmailJob]) do
-                patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
+                do_patch
               end
             end
 
@@ -260,12 +302,12 @@ RSpec.describe Api::V1::MovesController do
         it_behaves_like 'an endpoint that responds with success 200'
 
         it 'updates the status of a move', skip_before: true do
-          patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
+          do_patch
           expect(move.reload.status).to eq 'cancelled'
         end
 
         it 'does NOT update the reference of a move', skip_before: true do
-          expect { patch("/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json) }.not_to(
+          expect { do_patch }.not_to(
             change { move.reload.reference },
             )
         end
@@ -332,5 +374,9 @@ RSpec.describe Api::V1::MovesController do
         it_behaves_like 'an endpoint that responds with error 422'
       end
     end
+  end
+
+  def do_patch
+    patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json
   end
 end

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Api::V1::MovesController do
         context 'when changing a moves documents', :skip_before do
           let(:after_documents) { create_list(:document, 2) }
           let(:move_params) do
-            documents = after_documents.map { |d| { id: d.id, type: d.type } }
+            documents = after_documents.map { |d| { id: d.id, type: 'documents' } }
             {
               type: 'moves',
               attributes: {

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Api::V1::MovesController do
         end
 
         context 'when changing a moves documents', :skip_before do
-          let(:after_documents) { [after_document] }
+          let(:after_documents) { create_list(:document, 2) }
           let(:move_params) do
             documents = after_documents.map { |d| { id: d.id, type: d.type } }
             {

--- a/swagger/v1/document_reference.yaml
+++ b/swagger/v1/document_reference.yaml
@@ -1,0 +1,23 @@
+DocumentReference:
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      type: object
+      required:
+      - id
+      - type
+      properties:
+        type:
+          type: string
+          example: documents
+          enum:
+          - documents
+          description: The type of this object - always `documents`
+        id:
+          type: string
+          format: uuid
+          example: 3561f372-9f1c-4e13-997e-b11e1647cce1
+          description: The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v1/document_reference.yaml
+++ b/swagger/v1/document_reference.yaml
@@ -4,20 +4,22 @@ DocumentReference:
   - data
   properties:
     data:
-      type: object
-      required:
-      - id
-      - type
-      properties:
-        type:
-          type: string
-          example: documents
-          enum:
-          - documents
-          description: The type of this object - always `documents`
-        id:
-          type: string
-          format: uuid
-          example: 3561f372-9f1c-4e13-997e-b11e1647cce1
-          description: The unique identifier (UUID) of the object that this reference
-            points to
+      type: array
+      items:
+        type: object
+        required:
+        - id
+        - type
+        properties:
+          type:
+            type: string
+            example: documents
+            enum:
+            - documents
+            description: The type of this object - always `documents`
+          id:
+            type: string
+            format: uuid
+            example: 3561f372-9f1c-4e13-997e-b11e1647cce1
+            description: The unique identifier (UUID) of the object that this reference
+              points to

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -128,6 +128,9 @@ Move:
         prison_transfer_reason:
           $ref: prison_transfer_reason_reference.yaml#/PrisonTransferReasonReference
           description: The reason for this prison transfer
+        documents:
+          $ref: documents_reference.yaml#/PrisonTransferReasonReference
+          description: The documents associated with this Move
         court_hearing:
           $ref: court_hearing_reference.yaml#/CourtHearingReference
           description: A court hearing generated when creating a move. May have corresponding

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -129,7 +129,7 @@ Move:
           $ref: prison_transfer_reason_reference.yaml#/PrisonTransferReasonReference
           description: The reason for this prison transfer
         documents:
-          $ref: documents_reference.yaml#/PrisonTransferReasonReference
+          $ref: document_reference.yaml#/DocumentReference
           description: The documents associated with this Move
         court_hearing:
           $ref: court_hearing_reference.yaml#/CourtHearingReference


### PR DESCRIPTION
### Jira link

P4-1392

### What?

- [x] Added support for patching a Move's documents via `PATCH /moves/:id`
- [x] Updates swagger relationship references for a Move to include documents

### Why?

The frontend are creating a page for viewing and changing a move's documents and they need this for associating/disassociating created documents with the move.

### Have you? (optional)

- [x] Updated API docs if necessary	

