### PR TITLE
[P4-1413] Change plural form of timetable

### DIFF
--- a/app/serializers/timetable_serializer.rb
+++ b/app/serializers/timetable_serializer.rb
@@ -1,5 +1,5 @@
 class TimetableSerializer < ActiveModel::Serializer
-  type 'timetable'
+  type 'timetable_entries'
 
   attributes :start_time, :reason, :nomis_type
 

--- a/swagger/v1/timetable_entry.yaml
+++ b/swagger/v1/timetable_entry.yaml
@@ -12,10 +12,10 @@ TimetableEntry:
       description: The unique identifier (UUID) of this object
     type:
       type: string
-      example: timetable
+      example: timetable_entries
       enum:
-        - timetable
-      description: The type of this object - always `timetable`
+        - timetable_entries
+      description: The type of this object - always `timetable_entries`
     attributes:
       type: object
       required:


### PR DESCRIPTION
### Jira link

P4-1413

### What?

I have added/removed/altered:

- [x] Rename type from timetable -> timetable_entries

### Why?

I am doing this because:

- Pluralization libs don't understand this type

### Have you? (optional)

- [x] Updated API docs if necessary	