### PR TITLE
P4-1275 Added support for filtering by location on GET /allocations endpoint

### DIFF
--- a/app/controllers/api/v1/allocations_controller.rb
+++ b/app/controllers/api/v1/allocations_controller.rb
@@ -28,6 +28,8 @@ module Api
 
     private
 
+      PERMITTED_FILTER_PARAMS = %i[date_from date_to locations from_locations to_locations].freeze
+
       PERMITTED_ALLOCATION_PARAMS = [
         :type,
         attributes: %i[date prisoner_category sentence_length moves_count complete_in_full other_criteria],
@@ -37,7 +39,7 @@ module Api
       PERMITTED_COMPLEX_CASE_PARAMS = %i[key title answer allocation_complex_case_id].freeze
 
       def filter_params
-        params.fetch(:filter, {}).permit(:date_from, :date_to).to_h
+        params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h
       end
 
       def allocation_params

--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -14,15 +14,27 @@ module Allocations
 
   private
 
+    def location_id_params(name)
+      filter_params[name].split(',')
+    end
+
     def apply_filters(scope)
       scope = scope.includes(from_location: :suppliers, to_location: :suppliers)
       scope = apply_date_range_filters(scope)
+      scope = apply_location_filters(scope)
       scope
     end
 
     def apply_date_range_filters(scope)
       scope = scope.where('date >= ?', filter_params[:date_from]) if filter_params.key?(:date_from)
       scope = scope.where('date <= ?', filter_params[:date_to]) if filter_params.key?(:date_to)
+      scope
+    end
+
+    def apply_location_filters(scope)
+      scope = scope.where(from_location_id: location_id_params(:from_locations)) if filter_params.key?(:from_locations)
+      scope = scope.where(to_location_id: location_id_params(:to_locations)) if filter_params.key?(:to_locations)
+      scope = scope.where(from_location_id: location_id_params(:locations)).or(scope.where(to_location_id: location_id_params(:locations))) if filter_params.key?(:locations)
       scope
     end
   end

--- a/app/services/allocations/params_validator.rb
+++ b/app/services/allocations/params_validator.rb
@@ -4,7 +4,7 @@ module Allocations
   class ParamsValidator
     include ActiveModel::Validations
 
-    attr_reader :date_from, :date_to
+    attr_reader :date_from, :date_to, :locations, :from_locations, :to_locations
 
     validates_each :date_from, :date_to, allow_nil: true do |record, attr, value|
       Date.strptime(value, '%Y-%m-%d')
@@ -12,9 +12,16 @@ module Allocations
       record.errors.add attr, 'is not a valid date.'
     end
 
+    validates_each :locations, allow_blank: true do |record, attr, _value|
+      record.errors.add attr, 'may not be used in combination with `from_locations` or `to_locations` filters.' if record.from_locations.present? || record.to_locations.present?
+    end
+
     def initialize(filter_params)
       @date_from = filter_params[:date_from]
       @date_to = filter_params[:date_to]
+      @locations = filter_params[:locations]
+      @from_locations = filter_params[:from_locations]
+      @to_locations = filter_params[:to_locations]
     end
   end
 end

--- a/spec/requests/api/v1/allocations_controller_index_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_index_spec.rb
@@ -25,8 +25,9 @@ RSpec.describe Api::V1::AllocationsController do
     context 'when successful' do
       it_behaves_like 'an endpoint that responds with success 200'
 
-      describe 'filtering results' do
-        let(:date_from) { allocations.last.date }
+      describe 'filtering results by date' do
+        let(:allocation) { allocations.last }
+        let(:date_from) { allocation.date }
         let(:filters) do
           {
             bar: 'bar',
@@ -50,7 +51,21 @@ RSpec.describe Api::V1::AllocationsController do
         end
 
         it 'returns the allocation that matches the filter' do
-          expect(response_json).to include_json(data: [{ id: allocations.last.id }])
+          expect(response_json).to include_json(data: [{ id: allocation.id }])
+        end
+      end
+
+      describe 'filtering results by location' do
+        let(:allocation) { allocations.last }
+        let(:location) { allocations.last.from_location }
+        let(:params) { { filter: { from_locations: location.id } } }
+
+        it 'filters the results' do
+          expect(response_json['data'].size).to be 1
+        end
+
+        it 'returns the allocation that matches the filter' do
+          expect(response_json).to include_json(data: [{ id: allocation.id }])
         end
       end
 

--- a/spec/requests/api/v1/allocations_controller_index_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_index_spec.rb
@@ -111,6 +111,29 @@ RSpec.describe Api::V1::AllocationsController do
           expect(response.body).to eq('{"error":{"date_from":["is not a valid date."]}}')
         end
       end
+
+      describe 'validating locations before running queries' do
+        let(:filters) do
+          {
+            from_locations: 'foo',
+            to_locations: 'bar',
+            locations: 'baz',
+          }
+        end
+        let(:params) { { filter: filters } }
+
+        before do
+          get '/api/v1/allocations', params: params, headers: headers
+        end
+
+        it 'is a bad request' do
+          expect(response.status).to eq(400)
+        end
+
+        it 'returns errors' do
+          expect(response.body).to eq('{"error":{"locations":["may not be used in combination with `from_locations` or `to_locations` filters."]}}')
+        end
+      end
     end
 
     context 'when not authorized', :skip_before, :with_invalid_auth_headers do

--- a/spec/services/allocations/params_validator_spec.rb
+++ b/spec/services/allocations/params_validator_spec.rb
@@ -7,24 +7,63 @@ RSpec.describe Allocations::ParamsValidator do
 
   let(:filter_params) { { date_from: date_from, date_to: date_to } }
   let(:good_date) { '2019-05-05' }
+  let(:date_from) { good_date }
+  let(:date_to) { good_date }
 
   context 'with correct dates' do
-    let(:date_from) { good_date }
-    let(:date_to) { '2019-05-06' }
-
     it { is_expected.to be_valid }
   end
 
   context 'with an unparsable date_from' do
     let(:date_from) { 'ABCD-22-15' }
-    let(:date_to) { good_date }
 
     it { is_expected.not_to be_valid }
   end
 
   context 'with an unparsable date_to' do
-    let(:date_from) { good_date }
     let(:date_to) { 'YYYY-10-Tu' }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with from_locations only' do
+    let(:filter_params) { { from_locations: 'foo' } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with to_locations only' do
+    let(:filter_params) { { to_locations: 'foo' } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with locations only' do
+    let(:filter_params) { { locations: 'foo' } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with both from_locations and to_locations' do
+    let(:filter_params) { { from_locations: 'foo', to_locations: 'bar' } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with both from_locations and locations' do
+    let(:filter_params) { { from_locations: 'foo', locations: 'bar' } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with both to_locations and locations' do
+    let(:filter_params) { { to_locations: 'foo', locations: 'bar' } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with from_locations, to_locations and locations' do
+    let(:filter_params) { { from_locations: 'foo', to_locations: 'bar', locations: 'baz' } }
 
     it { is_expected.not_to be_valid }
   end

--- a/spec/swagger/definitions/hand_coded_paths.yaml
+++ b/spec/swagger/definitions/hand_coded_paths.yaml
@@ -6,42 +6,61 @@
     consumes:
     - application/vnd.api+json
     parameters:
-    - name: Content-Type
-      in: header
-      description: Accepted request content type
-      schema:
-        type: string
-        default: application/vnd.api+json
-      required: true
+    - $ref: content_type_parameter.yaml#/ContentType
     - name: filter[date_from]
       in: query
       description: Filters results to only include allocations on and after the given
         date, e.g. `2019-05-02`
       schema:
         type: string
-        example: '2019-05-09'
       format: date
+      example: '2019-05-09'
     - name: filter[date_to]
       in: query
       description: Filters results to only include allocations up to and including
-        the given date, e.g. `2019-05-09`
+        the given date, e.g. `2021-05-09`
       schema:
         type: string
-        example: '2019-05-09'
       format: date
-    - name: page
+      example: '2021-05-09'
+    - name: filter[locations]
       in: query
-      description: The page of records to return, defaults to 1 (the first page)
+      description: |
+        Filters results to only include allocations with the specified `from_location` or `to_location` identifier.
+
+        Multiple location id's can be specified using a comma separator if required.
+
+        Note that this filter __cannot__ be used in combination with `filter[from_locations]` or `filter[to_locations]`.
       schema:
-        type: integer
-      example: 1
-    - name: per_page
+        type: string
+      format: uuid
+      example: '02cf0c8e-bf28-4e36-bf08-1e15fefa279b,0351fc23-5b8c-409e-aa87-1f7c4adb1ed6'
+    - name: filter[from_locations]
       in: query
-      description: Number of records to return in a single response, defaults to 20,
-        maximum value is 100.
+      description: |
+        Filters results to only include allocations with the specified `from_location` identifier.
+
+        Multiple location id's can be specified using a comma separator if required.
+
+        Note that this filter __cannot__ be used in combination with `filter[locations]`.
       schema:
-        type: integer
-      example: 1
+        type: string
+      example: '02cf0c8e-bf28-4e36-bf08-1e15fefa279b,0351fc23-5b8c-409e-aa87-1f7c4adb1ed6'
+      format: uuid
+    - name: filter[to_locations]
+      in: query
+      description: |
+        Filters results to only include allocations with the specified `to_location` identifier.
+
+        Multiple location id's can be specified using a comma separator if required.
+
+        Note that this filter __cannot__ be used in combination with `filter[locations]`.
+      schema:
+        type: string
+      example: '02cf0c8e-bf28-4e36-bf08-1e15fefa279b,0351fc23-5b8c-409e-aa87-1f7c4adb1ed6'
+      format: uuid
+    - $ref: pagination_parameters.yaml#/Page
+    - $ref: pagination_parameters.yaml#/PerPage
     responses:
       '200':
         description: success

--- a/swagger/v1/pagination_parameters.yaml
+++ b/swagger/v1/pagination_parameters.yaml
@@ -4,6 +4,8 @@ Page:
   description: The page of records to return, defaults to 1 (the first page)
   schema:
     type: integer
+    default: 1
+    minimum: 1
   example: 1
 PerPage:
   name: per_page
@@ -12,4 +14,6 @@ PerPage:
     value is 100.
   schema:
     type: integer
-  example: 1
+    default: 20
+    maximum: 100
+  example: 20


### PR DESCRIPTION
### Jira link

P4-1275

### What?

- [x] Adds a few new filter options to specify a list of `from_locations`, `to_locations` or `locations` id's. Results are scoped accordingly with `from_locations` and `to_locations` matching only on corresponding attribute, but `locations` matching on either `from_location` or `to_location`.
- [x] Adapted parameter validation to prevent `locations` filter being used in combination with `from_locations` or `to_locations`
- [x] Added swagger documentation for new `GET/allocations` endpoint filters
- [x] Refactored swagger docs slightly to make use of shared params fragments

### Why?

This is needed to support a few front end scenarios around allocations; we've decided to let the front end handle the concept of regions so rather than passing a region to filter allocations on, it will pass a list of location id's to filter on (which will eventually be derived from a regions reference data endpoint).

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- The API is still not used in production so is risk free
