### PR TITLE
P4 1357 patch people notifications

### DIFF
--- a/app/controllers/api/v1/move_events_controller.rb
+++ b/app/controllers/api/v1/move_events_controller.rb
@@ -66,7 +66,7 @@ module Api
       end
 
       def move
-        @move ||= Move.accessible_by(current_ability).find_by(id: params.require(:move_id))
+        @move ||= Move.accessible_by(current_ability).find(params.require(:move_id))
       end
 
       def fake_event_object

--- a/app/controllers/api/v1/move_events_controller.rb
+++ b/app/controllers/api/v1/move_events_controller.rb
@@ -18,7 +18,13 @@ module Api
 
         case event_name
         when 'redirect'
-          move.update(to_location: to_location)
+          # NB: rather than update immediately, we need to detect whether the location has actually changed (or not) to
+          # prevent triggering duplicate webhook/email notifications
+          move.to_location = to_location
+          if move.to_location_id_changed?
+            move.save!
+            Notifier.prepare_notifications(topic: move, action_name: 'update')
+          end
           render json: fake_event_object, status: :created
         else
           render status: :bad_request, json: {

--- a/app/jobs/prepare_move_notifications_job.rb
+++ b/app/jobs/prepare_move_notifications_job.rb
@@ -40,14 +40,10 @@ private
   end
 
   def should_email?(move)
-    # NB: only email for current moves (not back-dated ones):
-    #   * move.status must be Requested or Cancelled (not Proposed), AND
-    #   * move.date is not in the past OR move.to_date is not in the past
-
-    [Move::MOVE_STATUS_REQUESTED, Move::MOVE_STATUS_CANCELLED].include?(move.status) &&
-      ((move.date.present? && move.date >= Time.zone.today) ||
-          (move.date.nil? && move.date_to.present? && move.date_to >= Time.zone.today)
-      )
+    # NB: only email for:
+    #   * move.status must be Requested or Cancelled (not Proposed or Completed) moves, AND
+    #   * move must be current (i.e. move.date is not in the past OR move.to_date is not in the past)
+    [Move::MOVE_STATUS_REQUESTED, Move::MOVE_STATUS_CANCELLED].include?(move.status) && move.current?
   end
 
   def event_type(action_name)

--- a/app/jobs/prepare_move_notifications_job.rb
+++ b/app/jobs/prepare_move_notifications_job.rb
@@ -11,14 +11,15 @@ class PrepareMoveNotificationsJob < ApplicationJob
       supplier.subscriptions.kept.each do |subscription|
         next unless subscription.enabled?
 
-        # always notify the webhook (if defined) on any change
+        # NB: always notify the webhook (if defined) on any change, even for back-dated historic moves
         if subscription.callback_url.present?
           NotifyWebhookJob.perform_later(
             build_notification_id(subscription, NotificationType::WEBHOOK, move, action_name),
           )
         end
 
-        if subscription.email_address.present? && should_email?(move, action_name)
+        # NB: only email in certain conditions (should_email?)
+        if subscription.email_address.present? && should_email?(move)
           NotifyEmailJob.perform_later(
             build_notification_id(subscription, NotificationType::EMAIL, move, action_name),
           )
@@ -38,9 +39,15 @@ private
           ).id }
   end
 
-  def should_email?(move, action_name)
-    # NB: only notify by email on move requested and move cancellation
-    [Move::MOVE_STATUS_REQUESTED, Move::MOVE_STATUS_CANCELLED].include?(move.status) && %w(create update_status).include?(action_name)
+  def should_email?(move)
+    # NB: only email for current moves (not back-dated ones):
+    #   * move.status must be Requested or Cancelled (not Proposed), AND
+    #   * move.date is not in the past OR move.to_date is not in the past
+
+    [Move::MOVE_STATUS_REQUESTED, Move::MOVE_STATUS_CANCELLED].include?(move.status) &&
+      ((move.date.present? && move.date >= Time.zone.today) ||
+          (move.date.nil? && move.date_to.present? && move.date_to >= Time.zone.today)
+      )
   end
 
   def event_type(action_name)

--- a/app/jobs/prepare_person_notifications_job.rb
+++ b/app/jobs/prepare_person_notifications_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This job is responsible for identifying the moves related to the specified person and then notifying via
+# PrepareMoveNotificationsJob
+class PreparePersonNotificationsJob < ApplicationJob
+  queue_as :notifications
+
+  def perform(topic_id:, action_name:)
+    Person.find(topic_id).moves.find_each do |move|
+      PrepareMoveNotificationsJob.perform_now(topic_id: move.id, action_name: action_name)
+    end
+  end
+end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -91,6 +91,13 @@ class Move < VersionedModel
     existing&.id
   end
 
+  def current?
+    # NB: a current move relates to a move happening today or in the future (as opposed to a back-dated or historic move)
+    (self.date.present? && self.date >= Time.zone.today) ||
+      (self.date.nil? && self.date_to.present? && self.date_to >= Time.zone.today) ||
+      (self.date.nil? && self.date_to.nil? && self.date_from.present? && self.date_from >= Time.zone.today)
+  end
+
 private
 
   def date_to_after_date_from

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -4,9 +4,9 @@ class Notifier
   def self.prepare_notifications(topic:, action_name:)
     case topic
     when Move
-      ::PrepareMoveNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name)
+      PrepareMoveNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name)
+    when Person
+      PreparePersonNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name)
     end
-    # when Person
-    # It's built to support more notification `types`, it just happens we have only one right now
   end
 end

--- a/spec/jobs/prepare_person_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_notifications_job_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe PreparePersonNotificationsJob, type: :job do
+  # TODO: add some tests
+end

--- a/spec/jobs/prepare_person_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_notifications_job_spec.rb
@@ -1,5 +1,36 @@
 # frozen_string_literal: true
 
 RSpec.describe PreparePersonNotificationsJob, type: :job do
-  # TODO: add some tests
+  subject(:perform) { described_class.new.perform(topic_id: person.id, action_name: action_name) }
+
+  let(:person) { create :person }
+  let!(:move1) { create :move, person: person }
+  let!(:move2) { create :move,  person: person }
+  let!(:other_move) { create :move }
+
+  before do
+    allow(PrepareMoveNotificationsJob).to receive(:perform_now)
+    perform
+  end
+
+  context 'when updating a person' do
+    let(:action_name) { 'update' }
+
+    it 'calls PrepareMoveNotificationsJob for the related moves but not for the unrelated moves' do
+      expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move1.id, action_name: action_name)
+      expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move2.id, action_name: action_name)
+      expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name)
+    end
+
+  end
+
+  context 'when creating a person' do
+    let(:action_name) { 'create' }
+
+    it 'calls PrepareMoveNotificationsJob for the related moves but not for the unrelated moves' do
+      expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move1.id, action_name: action_name)
+      expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move2.id, action_name: action_name)
+      expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name)
+    end
+  end
 end

--- a/spec/jobs/prepare_person_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_notifications_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PreparePersonNotificationsJob, type: :job do
 
   let(:person) { create :person }
   let!(:move1) { create :move, person: person }
-  let!(:move2) { create :move,  person: person }
+  let!(:move2) { create :move, person: person }
   let!(:other_move) { create :move }
 
   before do
@@ -16,21 +16,20 @@ RSpec.describe PreparePersonNotificationsJob, type: :job do
   context 'when updating a person' do
     let(:action_name) { 'update' }
 
-    it 'calls PrepareMoveNotificationsJob for the related moves but not for the unrelated moves' do
-      expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move1.id, action_name: action_name)
-      expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move2.id, action_name: action_name)
-      expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name)
+    describe 'it calls PrepareMoveNotificationsJob for the related moves' do
+      it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move1.id, action_name: action_name) }
+      it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move2.id, action_name: action_name) }
+      it { expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name) }
     end
-
   end
 
   context 'when creating a person' do
     let(:action_name) { 'create' }
 
-    it 'calls PrepareMoveNotificationsJob for the related moves but not for the unrelated moves' do
-      expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move1.id, action_name: action_name)
-      expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move2.id, action_name: action_name)
-      expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name)
+    describe 'it calls PrepareMoveNotificationsJob for the related moves' do
+      it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move1.id, action_name: action_name) }
+      it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move2.id, action_name: action_name) }
+      it { expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name) }
     end
   end
 end

--- a/spec/jobs/prepare_person_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_notifications_job_spec.rb
@@ -13,23 +13,23 @@ RSpec.describe PreparePersonNotificationsJob, type: :job do
     perform
   end
 
-  context 'when updating a person' do
-    let(:action_name) { 'update' }
-
-    describe 'it calls PrepareMoveNotificationsJob for the related moves' do
-      it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move1.id, action_name: action_name) }
-      it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move2.id, action_name: action_name) }
-      it { expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name) }
-    end
+  shared_examples 'it calls PrepareMoveNotificationsJob for the related moves' do
+    it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move1.id, action_name: action_name) }
+    it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move2.id, action_name: action_name) }
+    it { expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name) }
   end
 
+  # NB: we are testing here that creating a person and updating a person behave in the same way from the perspective of PreparePersonNotificationsJob.
+  # NB: note however that the PeopleController however does not call PreparePersonNotificationsJob on creating a person, to reduce duplicate emails.
   context 'when creating a person' do
     let(:action_name) { 'create' }
 
-    describe 'it calls PrepareMoveNotificationsJob for the related moves' do
-      it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move1.id, action_name: action_name) }
-      it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move2.id, action_name: action_name) }
-      it { expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name) }
-    end
+    it_behaves_like 'it calls PrepareMoveNotificationsJob for the related moves'
+  end
+
+  context 'when updating a person' do
+    let(:action_name) { 'update' }
+
+    it_behaves_like 'it calls PrepareMoveNotificationsJob for the related moves'
   end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -247,6 +247,70 @@ RSpec.describe Move do
     end
   end
 
+  describe '#current?' do
+    subject { move.current? }
+
+    context 'with date' do
+      context 'when yesterday' do
+        let(:move) { build :move, date: 1.day.ago }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when today' do
+        let(:move) { build :move, date: Time.zone.today }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when tomorrow' do
+        let(:move) { build :move, date: 1.day.from_now }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'with date_to' do
+      context 'when yesterday' do
+        let(:move) { build :move, date: nil, date_to: 1.day.ago }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when today' do
+        let(:move) { build :move, date: nil, date_to: Time.zone.today }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when tomorrow' do
+        let(:move) { build :move, date: nil, date_to: 1.day.from_now }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'with date_from' do
+      context 'when yesterday' do
+        let(:move) { build :move, date: nil, date_to: nil, date_from: 1.day.ago }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when today' do
+        let(:move) { build :move, date: nil, date_to: nil, date_from: Time.zone.today }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when tomorrow' do
+        let(:move) { build :move, date: nil, date_to: nil, date_from: 1.day.from_now }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+
   context 'with versioning' do
     let(:move) { create(:move) }
 

--- a/spec/requests/api/v1/people_controller_create_spec.rb
+++ b/spec/requests/api/v1/people_controller_create_spec.rb
@@ -125,6 +125,17 @@ RSpec.describe Api::V1::PeopleController do
           post '/api/v1/people', params: person_params, headers: headers, as: :json
         end.to change(Person, :count).by(1)
       end
+
+      describe 'webhook and email notifications' do
+        before do
+          allow(Notifier).to receive(:prepare_notifications)
+          post '/api/v1/people', params: person_params, headers: headers, as: :json
+        end
+
+        it 'does NOT call the notifier when creating a person' do
+          expect(Notifier).not_to have_received(:prepare_notifications)
+        end
+      end
     end
 
     context 'with gender_additional_information' do

--- a/spec/requests/api/v1/people_controller_update_spec.rb
+++ b/spec/requests/api/v1/people_controller_update_spec.rb
@@ -111,6 +111,17 @@ RSpec.describe Api::V1::PeopleController do
         put "/api/v1/people/#{person.id}", params: person_params, headers: headers, as: :json
         expect(person.latest_profile.reload.first_names).to include(expected_data[:attributes][:first_names])
       end
+
+      describe 'webhook and email notifications' do
+        before do
+          allow(Notifier).to receive(:prepare_notifications)
+          put "/api/v1/people/#{person.id}", params: person_params, headers: headers, as: :json
+        end
+
+        it 'calls the notifier when updating a person' do
+          expect(Notifier).to have_received(:prepare_notifications).with(topic: person, action_name: 'update')
+        end
+      end
     end
 
     context 'with gender_additional_information' do

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Notifier do
     end
   end
 
+  context 'when scheduled with a person' do
+    let(:topic) { create(:person) }
+
+    it 'queues a job' do
+      expect(PreparePersonNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, action_name: action_name)
+    end
+  end
+
   context 'when called with another object' do
     let(:topic) { Object.new }
 


### PR DESCRIPTION
### Jira link

[P4-1357](https://dsdmoj.atlassian.net/browse/P4-1357)

### What?

I have added/removed/altered:

- [X] triggers notifications (webhooks/emails) on patching to the /people endpoint
- [X] updated notification rules to prevent emails for back-dated moves (but allow webhooks for these)

### Why?

I am doing this because:

- the "update a move" workflow in the frontend actually patches the profile (/people) and currently doesn't trigger notifications



### Deployment risks (optional)

- Will send duplicate emails; this is a known and accepted limitation


