### PR TITLE
[P4-1444] Handle unparseable errors from Azure API Gateway

### DIFF
--- a/app/lib/nomis_client/api_error.rb
+++ b/app/lib/nomis_client/api_error.rb
@@ -13,6 +13,9 @@ module NomisClient
 
       @title = nomis_error['userMessage'].to_s
       @details = "#{nomis_error['developerMessage']} #{nomis_error['moreInfo']}".strip
+    rescue JSON::ParserError
+      @title = 'Unparseable error from Nomis'
+      @details = "Status #{status}. We tried to parse an error from Nomis and failed. Is the Elite2API routeable?"
     end
 
     def json_api_error

--- a/spec/lib/nomis_client/api_error_spec.rb
+++ b/spec/lib/nomis_client/api_error_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe NomisClient::ApiError do
   describe '#json_api_error' do
-    subject(:error) { described_class.new(status: status, error_body: error_body)}
+    subject(:error) { described_class.new(status: status, error_body: error_body) }
 
     let(:status) { 400 }
 
@@ -12,7 +12,7 @@ RSpec.describe NomisClient::ApiError do
       {
         'userMessage' => 'User message.',
         'developerMessage' => 'Developer message.',
-        'moreInfo' => 'More info.'
+        'moreInfo' => 'More info.',
       }.to_json
     end
 

--- a/spec/lib/nomis_client/api_error_spec.rb
+++ b/spec/lib/nomis_client/api_error_spec.rb
@@ -3,13 +3,37 @@
 require 'rails_helper'
 
 RSpec.describe NomisClient::ApiError do
-  it '#json_api_error' do
-    nomis_error = described_class.new(status: 400, error_body: {
-        'userMessage' => 'User message.', 'developerMessage' => 'Developer message.', 'moreInfo' => 'More info.'
-    }.to_json)
+  describe '#json_api_error' do
+    subject(:error) { described_class.new(status: status, error_body: error_body)}
 
-    expect(nomis_error.json_api_error).to eq(code: 'NOMIS-ERROR',
-                                             status: 400, title: 'User message.',
-                                             details: 'Developer message. More info.')
+    let(:status) { 400 }
+
+    let(:error_body) do
+      {
+        'userMessage' => 'User message.',
+        'developerMessage' => 'Developer message.',
+        'moreInfo' => 'More info.'
+      }.to_json
+    end
+
+    it 'returns a properly formatted api error' do
+      expect(error.json_api_error).to eq(
+        code: 'NOMIS-ERROR',
+        status: 400, title: 'User message.',
+        details: 'Developer message. More info.'
+      )
+    end
+
+    context 'when parsing the error_body raises a JSON::ParserError' do
+      let(:error_body) { '<html></html>' }
+
+      it 'returns a properly formatted api error' do
+        expect(error.json_api_error).to eq(
+          code: 'NOMIS-ERROR',
+          status: 400, title: 'Unparseable error from Nomis',
+          details: "Status #{status}. We tried to parse an error from Nomis and failed. Is the Elite2API routeable?"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
### Jira link

P4-1444

### What?

When the Nomis app isn't routeable from the Azure API Gateway the API Gateway returns a html error and 502 status code. The elite2api is a json api so we hadn't previously added handling for non-json mime types.

This adds a special condition in the html case and returns a cleaner error message to the frontend/supplier.

- [x] Adds handling for non-json return body on error in Azure API Gateway

### Why?

This is quicker/simpler than getting an infrastructure change to update the default error templates.