### PR TITLE
Data migration to update profile ID with the correct profile.

### DIFF
--- a/lib/tasks/move_profile.rake
+++ b/lib/tasks/move_profile.rake
@@ -1,8 +1,24 @@
-namespace :move_profile do
-  desc 'backfill move profile ids'
-  task backfill: :environment do
-    Move.includes(person: :profiles).find_each.reject { |m| m.profile_id.present? }.each do |move|
-      move.update!(profile_id: move.person.latest_profile.id)
+namespace :moves do
+  desc 'Set all profile ids in all the moves'
+  task set_profiles: :environment do
+    moves = Move.where(profile_id: nil).includes(person: :profiles)
+
+    total = moves.count
+
+    if moves.empty?
+      puts 'All profiles IDs were already updated.'
+      return
     end
+
+    moves.find_each(batch_size: 200).with_index do |move, n|
+      puts "#{n}/#{total} moves processed ..." if (n % 200).zero? # Show progression
+      profile = move.person.profiles.order(:updated_at).last # Take the profile that was most recently updated
+
+      # update only profile and skip validations: some moves are invalid because of uniqueness of 'date', but that does
+      # not impact the correctness of this data migration.
+      move.update_attribute(:profile_id, profile.id)
+    end
+
+    puts "#{moves.count} profile IDs have been successfully updated."
   end
 end


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-1449

### What?

Update the profile_in the moves, with the the profile that was most recently updated.

### Why?
This is the first step to change the relationship Move-Person to Move-Profile

### Deployment risks (optional)
run the rake task
`bundle exec rake moves:set_profiles`

