### PR TITLE
[P4-1433] Removes unused supplier serializer code

### DIFF
--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -4,8 +4,4 @@ class LocationSerializer < ActiveModel::Serializer
   type 'locations'
 
   attributes :id, :key, :title, :location_type, :nomis_agency_id, :can_upload_documents, :disabled_at, :suppliers
-
-  def suppliers
-    object.suppliers.each { |supplier| SupplierSerializer.new(supplier) }
-  end
 end

--- a/spec/serializers/location_serializer_spec.rb
+++ b/spec/serializers/location_serializer_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe LocationSerializer do
   end
 
   it 'contains a suppliers attribute' do
-    expect(attributes[:suppliers]).not_to be_nil
+    expect(attributes[:suppliers]).to eq(
+      [
+        {
+          created_at: supplier.created_at.xmlschema,
+          id: supplier.id,
+          key: supplier.key,
+          name:supplier.name,
+          updated_at: supplier.updated_at.xmlschema,
+        }
+      ]
+    )
   end
 end

--- a/spec/serializers/location_serializer_spec.rb
+++ b/spec/serializers/location_serializer_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe LocationSerializer do
   let(:result_data) { result[:data] }
   let(:attributes) { result_data[:attributes] }
 
+  let(:expected_suppliers) do
+    [
+      {
+        created_at: supplier.created_at.xmlschema,
+        id: supplier.id,
+        key: supplier.key,
+        name: supplier.name,
+        updated_at: supplier.updated_at.xmlschema,
+      },
+    ]
+  end
+
   it 'contains a type property' do
     expect(result_data[:type]).to eql 'locations'
   end
@@ -45,16 +57,6 @@ RSpec.describe LocationSerializer do
   end
 
   it 'contains a suppliers attribute' do
-    expect(attributes[:suppliers]).to eq(
-      [
-        {
-          created_at: supplier.created_at.xmlschema,
-          id: supplier.id,
-          key: supplier.key,
-          name:supplier.name,
-          updated_at: supplier.updated_at.xmlschema,
-        }
-      ]
-    )
+    expect(attributes[:suppliers]).to eq(expected_suppliers)
   end
 end


### PR DESCRIPTION
### Jira link

P4-1433

### What?

This [pr](https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/143/)
incorrectly added a suppliers relationship as one of the attributes of
the LocationSerializer.

This code never returns SupplierSerializer objects and actually returns the result of just calling Location#suppliers so I can't see any harm removing it. AMS eventually just calls to_json on instances of Supplier and never uses the SupplierSerializer.

In a separate PR/in future I propose we remove the attribute `suppliers` that are each getting `Supplier#to_json` called on them everytime we return a location and instead use includes/relationships in the way specified by json:api.

### Why?

- This code is not used