### PR TITLE
P4-1273 Add importer class to populate regions reference data

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -20,6 +20,7 @@ class Location < ApplicationRecord
   NOMIS_TYPES_WITH_DOCUMENTS = %w[STC SCH].freeze
 
   has_and_belongs_to_many :suppliers
+  has_and_belongs_to_many :regions
   # Deleting locations isn't really a thing in practice - so dependent: :destroy is a pragmatic choice
   has_many :moves_from, class_name: 'Move', foreign_key: :from_location_id, inverse_of: :from_location, dependent: :destroy
   has_many :moves_to, class_name: 'Move', foreign_key: :to_location_id, inverse_of: :to_location, dependent: :destroy

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Region < ApplicationRecord
+  has_and_belongs_to_many :locations
+
+  validates :name, :key, presence: true, uniqueness: true
+end

--- a/app/services/regions/importer.rb
+++ b/app/services/regions/importer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Regions
+  class Importer
+    attr_accessor :items
+
+    def initialize(items)
+      self.items = items.with_indifferent_access
+    end
+
+    def call
+      items.each do |key, details|
+        region = Region.find_or_initialize_by(key: key.to_s)
+        region.locations = Location.where(nomis_agency_id: details[:locations])
+        region.update(name: details[:name])
+      end
+    end
+  end
+end

--- a/db/migrate/20200506105933_create_regions.rb
+++ b/db/migrate/20200506105933_create_regions.rb
@@ -1,0 +1,17 @@
+class CreateRegions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :regions, id: :uuid do |t|
+      t.string :name, null: false
+      t.string :key, null: false, index: true
+      t.timestamps
+    end
+
+    create_join_table :locations, :regions do |t|
+      t.references :location, type: :uuid, null: false, index: true, foreign_key: true
+      t.references :region, type: :uuid, null: false, index: true, foreign_key: true
+      t.index %i[location_id region_id], unique: true
+      t.index %i[region_id location_id], unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_04_081233) do
+ActiveRecord::Schema.define(version: 2020_05_06_105933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -162,6 +162,17 @@ ActiveRecord::Schema.define(version: 2020_05_04_081233) do
     t.string "key", null: false
     t.datetime "disabled_at"
     t.boolean "can_upload_documents", default: false, null: false
+  end
+
+  create_table "locations_regions", id: false, force: :cascade do |t|
+    t.uuid "location_id", null: false
+    t.uuid "region_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id", "region_id"], name: "index_locations_regions_on_location_id_and_region_id", unique: true
+    t.index ["location_id"], name: "index_locations_regions_on_location_id"
+    t.index ["region_id", "location_id"], name: "index_locations_regions_on_region_id_and_location_id", unique: true
+    t.index ["region_id"], name: "index_locations_regions_on_region_id"
   end
 
   create_table "locations_suppliers", id: false, force: :cascade do |t|
@@ -327,6 +338,14 @@ ActiveRecord::Schema.define(version: 2020_05_04_081233) do
     t.integer "latest_nomis_booking_id"
   end
 
+  create_table "regions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_regions_on_key"
+  end
+
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "supplier_id", null: false
     t.string "callback_url"
@@ -371,6 +390,8 @@ ActiveRecord::Schema.define(version: 2020_05_04_081233) do
   add_foreign_key "journeys", "locations", column: "to_location_id"
   add_foreign_key "journeys", "moves"
   add_foreign_key "journeys", "suppliers"
+  add_foreign_key "locations_regions", "locations"
+  add_foreign_key "locations_regions", "regions"
   add_foreign_key "locations_suppliers", "locations"
   add_foreign_key "locations_suppliers", "suppliers"
   add_foreign_key "moves", "allocations"

--- a/lib/tasks/data/regions.yml
+++ b/lib/tasks/data/regions.yml
@@ -1,0 +1,151 @@
+---
+  1:
+    name: South of England
+    locations:
+    - ASI
+    - BLI
+    - BNI
+    - CWI
+    - CLI
+    - DAI
+    - EYI
+    - EEI
+    - EXI
+    - FDI
+    - GNI
+    - GMI
+    - LWI
+    - LYI
+    - PDI
+    - RCI
+    - SPI
+    - EHI
+    - VEI
+    - WCI
+  2:
+    name: London and the East of England
+    locations:
+    - BFI
+    - BAI
+    - BXI
+    - BRI
+    - CDI
+    - HOI
+    - HPI
+    - HBI
+    - ISI
+    - LTI
+    - NWI
+    - PVI
+    - PBI
+    - TSI
+    - MTI
+    - WWI
+    - WII
+    - WLI
+    - WSI
+    - FMI
+  3:
+    name: Midlands and York and Humberside
+    locations:
+    - BMI
+    - BSI
+    - DNI
+    - DGI
+    - FSI
+    - HDI
+    - HEI
+    - HLI
+    - HMI
+    - LEI
+    - LCI
+    - LII
+    - LHI
+    - MDI
+    - NSI
+    - NMI
+    - OWI
+    - ONI
+    - RNI
+    - SFI
+    - SKI
+    - SHI
+    - SUI
+    - SNI
+    - WEI
+    - WTI
+  4:
+    name: North East and North West
+    locations:
+    - ACI
+    - BCI
+    - DTI
+    - DMI
+    - FBI
+    - HVI
+    - HII
+    - HHI
+    - KMI
+    - KVI
+    - LFI
+    - LPI
+    - NLI
+    - PNI
+    - RSI
+    - TCI
+    - WMI
+  5A:
+    name: Wales
+    locations:
+    - BWI
+    - CFI
+    - UPI
+    - SWI
+    - UKI
+    - PRI
+  5B:
+    name: Female Estate
+    locations:
+    - AGI
+    - BZI
+    - DWI
+    - DHI
+    - ESI
+    - EWI
+    - FHI
+    - LNI
+    - NHI
+    - PFI
+    - SDI
+    - STI
+  6:
+    name: FNO Prisons and IRCs
+    locations:
+    - HCI
+    - MSI
+    - MHI
+  7:
+    name: Long Term High Security Estate
+    locations:
+    - AYI
+    - FKI
+    - FNI
+    - GHI
+    - GTI
+    - IWI
+    - LLI
+    - LGI
+    - MRI
+    - RHI
+    - SLI
+    - WDI
+    - WRI
+    - WHI
+  8:
+    name: Youth Custody Service
+    locations:
+    - FMI
+    - PRI
+    - CKI
+    - WNI
+    - WYI

--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -36,6 +36,12 @@ namespace :reference_data do
     NomisAlerts::Importer.new(alert_codes: NomisClient::AlertCodes.get).call
   end
 
+  desc 'create regions'
+  task create_regions: :environment do
+    regions = YAML.safe_load(File.read('./lib/tasks/data/regions.yml'))
+    Regions::Importer.new(regions).call
+  end
+
   desc 'create suppliers'
   task create_suppliers: :environment do
     require 'active_record/fixtures'

--- a/spec/services/regions/importer_spec.rb
+++ b/spec/services/regions/importer_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Regions::Importer do
+  subject(:importer) { described_class.new(input_data) }
+
+  let!(:linked_location1) { create :location, nomis_agency_id: 'FOO' }
+  let!(:linked_location2) { create :location, nomis_agency_id: 'BAR' }
+  let!(:unlinked_location) { create :location, nomis_agency_id: 'BAZ' }
+
+  let(:input_data) do
+    {
+      '1': {
+        name: 'First region',
+        locations: %w(FOO BAR),
+      },
+      '2A': {
+        name: 'Second region',
+        locations: %w(FOO BUZZ),
+      },
+    }
+  end
+
+  let(:region1) { Region.find_by(key: '1') }
+  let(:region2) { Region.find_by(key: '2A') }
+
+  context 'with no existing records' do
+    it 'creates all the input items' do
+      expect { importer.call }.to change(Region, :count).by(2)
+    end
+
+    it 'populates correct name' do
+      importer.call
+
+      expect(region1.name).to eq 'First region'
+    end
+
+    it 'links to correct locations' do
+      importer.call
+
+      expect(region1.locations.map(&:nomis_agency_id)).to match %w(FOO BAR)
+    end
+
+    it 'does not link to missing locations' do
+      importer.call
+
+      expect(region2.locations.map(&:nomis_agency_id)).to match %w(FOO)
+    end
+  end
+
+  context 'with one existing record' do
+    before do
+      Region.create!(key: '1', name: 'First region')
+    end
+
+    it 'creates only the missing items' do
+      expect { importer.call }.to change(Region, :count).by(1)
+    end
+  end
+
+  context 'with one existing record with the wrong name' do
+    let!(:existing) { Region.create!(key: '2A', name: 'Wrong', locations: [unlinked_location]) }
+
+    it 'updates the title of the existing record' do
+      importer.call
+      expect(existing.reload.name).to eq 'Second region'
+    end
+
+    it 'updates links to correct locations' do
+      importer.call
+      expect(existing.reload.locations.map(&:nomis_agency_id)).to match %w(FOO)
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

P4-1273

### What?

- [x] Added new region model and corresponding migration including join table with locations (regions have many locations and locations can be part of many regions)
- [x] Added YML file containing details of the regions (key, name and NOMIS location id's) to populate data (reworked from original Excel spreadsheet)
- [x] Added rake task to call importer with the YML file

### Why?

- The reference data for this is mastered in the back end as the source of truth. Working with a YML file is much simpler and avoids the need to add extra gems (e.g. Roo) to process spreadsheets. We can modify the YML file as needed in future should the regions change.
- Future work will expose a reference data endpoint to return the locations associated with each region
- This is needed for the front end allocations work to allow user to select region of interest

### Deployment risks (optional)

- Rake task `rails reference_data:create_regions` can be run safely as the data is not yet linked to any API endpoints
- Included YML file does not contain any sensitive data
