### PR TITLE
Hugely speed up linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - "db/**/*"
     - "bin/**/*"
     - "config/**/*"
+    - "tmp/**/*"
 
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

Our rails app generates a whole bunch of unparseable files that rubocop
opens (see `lsof`) from the tmp/ directory

Most of these files are just bootsnap/spring cache-related and
unnecessary/untouched by us during development.

This adds about 12 seconds to the time it takes to run rubocop:

```bash
# before
time rubocop
________________________________________________________
Executed in   14.62 secs   fish           external
   usr time   12.59 secs  120.00 micros   12.59 secs
   sys time    0.94 secs  612.00 micros    0.94 secs

# after
time rubocop
________________________________________________________
Executed in    2.12 secs   fish           external
   usr time    1.74 secs  127.00 micros    1.74 secs
   sys time    0.39 secs  577.00 micros    0.39 secs
```

This should shave 12 seconds off of each test run in CI, too 🎉 

### Why?

I was fed up with how slow rubocop was and a fed up Will is an unproductive will 🙂 
