### PR TITLE
P4-1462 Hard code default sort order for GET /allocations endpoint

### DIFF
--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -9,10 +9,15 @@ module Allocations
     end
 
     def call
-      apply_filters(Allocation)
+      scope = apply_filters(Allocation)
+      apply_ordering(scope)
     end
 
   private
+
+    def apply_ordering(scope)
+      scope.order(date: :desc)
+    end
 
     def location_id_params(name)
       filter_params[name].split(',')

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Allocations::Finder do
       let!(:allocation_5_days_future) { create(:allocation, date: allocation.date + 5.days) }
       let(:filter_params) { { date_from: allocation.date.to_s, date_to: (allocation.date + 5.days).to_s } }
 
-      it 'returns allocations matching date range' do
-        expect(allocation_finder.call).to match_array [allocation, allocation_5_days_future]
+      it 'returns allocations matching date range sorted by descending date' do
+        expect(allocation_finder.call).to eq [allocation_5_days_future, allocation]
       end
     end
 


### PR DESCRIPTION
### Jira link

P4-1462

### What?

- [x] Added a placeholder ordering method in the corresponding finder service

### Why?

- In future stories this will be expanded to allow the front end to specify a sort order, but for now we just need to apply a sensible default sort order, showing the most recent planned allocations (by date) first.

### Deployment risks (optional)

- Amends the behaviour of the API, but it's still not used in production
