### PR TITLE
Fix flaky specs

### DIFF
--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -146,9 +146,9 @@ RSpec.describe Api::V1::MovesController do
           end
 
           it 'updates the moves documents' do
-            expect(move.reload.documents).to eq(before_documents)
+            expect(move.reload.documents).to match_array(before_documents)
             do_patch
-            expect(move.reload.documents).to eq(after_documents)
+            expect(move.reload.documents).to match_array(after_documents)
           end
 
           it 'does not affect other relationships' do
@@ -160,7 +160,7 @@ RSpec.describe Api::V1::MovesController do
 
             expect(
               response_json.dig('data', 'relationships', 'documents', 'data').map { |document| document['id'] },
-            ).to match(after_documents.pluck(:id))
+            ).to match_array(after_documents.pluck(:id))
           end
         end
 

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Api::V1::MovesController do
 
             expect(
               response_json.dig('data', 'relationships', 'documents', 'data').map { |document| document['id'] },
-            ).to eq(after_documents.pluck(:id))
+            ).to match(after_documents.pluck(:id))
           end
         end
 


### PR DESCRIPTION
This sometimes fails for me but I found a seed (65033) that reliably reproduced the problem. Looks to just be (incorrectly) expecting documents to be returned in a specific order rather than just checking for the correct documents.