### PR TITLE
Add recent rake tasks for reference data to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,13 @@ following rake tasks:
 
 ```
 bundle exec rake reference_data:create_assessment_questions
+bundle exec rake reference_data:create_allocation_complex_cases
 bundle exec rake reference_data:create_ethnicities
 bundle exec rake reference_data:create_genders
 bundle exec rake reference_data:create_identifier_types
 bundle exec rake reference_data:create_locations
 bundle exec rake reference_data:create_nomis_alerts
+bundle exec rake reference_data:create_regions
 bundle exec rake reference_data:create_suppliers
 ```
 


### PR DESCRIPTION
### Why?

I missed this when previously adding these tasks, didn't realise they were documented in the README too.