### PR TITLE
P4-1466 Surface an allocation associated to a move

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -8,7 +8,7 @@ module Api
         if moves_params.valid?
           moves = Moves::Finder.new(filter_params, current_ability, params[:sort] || {}).call
           # Excludes potentially many court hearing documents to reduce the request size. This was requested specifically by the frontend team.
-          paginate moves, include: MoveSerializer::INCLUDED_ATTRIBUTES.dup.except(:court_hearings)
+          paginate moves, include: MoveSerializer::INCLUDED_ATTRIBUTES.dup.except(:court_hearings), fields: MoveSerializer::INCLUDED_FIELDS
         else
           render json: { error: moves_params.errors }, status: :bad_request
         end
@@ -101,7 +101,7 @@ module Api
       end
 
       def render_move(move, status)
-        render json: move, status: status, include: MoveSerializer::INCLUDED_ATTRIBUTES
+        render json: move, status: status, include: MoveSerializer::INCLUDED_ATTRIBUTES, fields: MoveSerializer::INCLUDED_FIELDS
       end
 
       def move

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -10,13 +10,19 @@ class MoveSerializer < ActiveModel::Serializer
   has_one :prison_transfer_reason, serializer: PrisonTransferReasonSerializer, if: -> { object.prison_transfer_reason.present? }
   has_many :documents, serializer: DocumentSerializer
   has_many :court_hearings, serializer: CourtHearingSerializer
+  belongs_to :allocation, serializer: AllocationSerializer
 
   INCLUDED_ATTRIBUTES = {
-    person: %i[first_names last_name date_of_birth assessment_answers indentifiers ethnicity gender reason_comment],
-    from_location: %i[location_type description],
-    to_location: %i[location_type description],
-    documents: %i[url filename filesize content_type],
-    prison_transfer_reason: %i[key title],
+    person: %i[ethnicity gender],
+    from_location: [],
+    to_location: [],
+    documents: [],
+    prison_transfer_reason: [],
     court_hearings: [],
+    allocation: [],
+  }.freeze
+
+  INCLUDED_FIELDS = {
+    allocation: %i[to_location from_location moves_count created_at],
   }.freeze
 end

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -36,6 +36,18 @@ FactoryBot.define do
     trait :with_transfer_reason do
       association :prison_transfer_reason
     end
+
+    trait :with_allocation do
+      after(:create) do |move|
+        create(
+          :allocation,
+          from_location: move.from_location,
+          to_location: move.to_location,
+          date: move.date,
+          moves: [move],
+        )
+      end
+    end
   end
 
   factory :from_court_to_prison, class: Move do

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -78,6 +78,9 @@ RSpec.configure do |config|
           Allocation: {
             "$ref": 'allocation.yaml#/Allocation',
           },
+          AllocationReference: {
+            "$ref": 'allocation_reference.yaml#/AllocationReference',
+          },
           AllocationComplexCase: {
             "$ref": 'allocation_complex_case.yaml#/AllocationComplexCase',
           },

--- a/swagger/v1/allocation_reference.yaml
+++ b/swagger/v1/allocation_reference.yaml
@@ -1,0 +1,25 @@
+AllocationReference:
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      oneOf:
+      - type: object
+      - type: 'null'
+      required:
+      - id
+      - type
+      properties:
+        type:
+          type: string
+          example: allocations
+          enum:
+          - allocations
+          description: The type of this object - always `allocations`
+        id:
+          type: string
+          format: uuid
+          example: 3561f372-9f1c-4e13-997e-b11e1647cce1
+          description: The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v1/get_moves_responses.yaml
+++ b/swagger/v1/get_moves_responses.yaml
@@ -15,6 +15,7 @@
         - $ref: person.yaml#/Person
         - $ref: gender.yaml#/Gender
         - $ref: ethnicity.yaml#/Ethnicity
+        - $ref: allocation.yaml#/Allocation
     links:
       $ref: pagination_links.yaml#/PaginationLinks
     meta:

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -134,3 +134,6 @@ Move:
           $ref: court_hearing_reference.yaml#/CourtHearingReference
           description: A court hearing generated when creating a move. May have corresponding
             hearing in Nomis backend (see nomis fields).
+        allocation:
+          $ref: allocation_reference.yaml#/AllocationReference
+          description: The allocation associated with this move


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-1466

### Jira link

[P4-1466](https://dsdmoj.atlassian.net/browse/P4-1466)

### What?

- [x] Add an allocation to the moves serializer
- [x] Fix bug in moves serializer regarding included objects vs fields (this will be deprecated when @willfish picks up moving to params specifying what should be included)

### Why?

We would like to surface allocations if they are associated with a move on the moves and move get endpoints. These allocations should appear as a relationship, as well as in detail in the  included section
I also fixed bug in the move serializer where we aren't utilising the correct format for only including fields vs objects. These need to be separated. The `include` key will handle what objects we expect to return, while the `fields` key determines which fields we only want to return per object. After speaking to Dom, we would like to start limiting fields as we go rather to not break current included objects. We are now only limiting allocations, but all other objects will have all their attributes returned otherwise. 

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

