### PR TITLE
Handle missing attributes when patching a moves documents

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -93,7 +93,7 @@ module Api
       def patch_move_attributes
         document_ids = (patch_move_params.dig(:relationships, :documents, :data) || []).map { |doc| doc[:id] }
 
-        attributes = patch_move_params[:attributes]
+        attributes = patch_move_params.fetch(:attributes, {})
 
         return attributes if document_ids.blank?
 

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -173,9 +173,9 @@ RSpec.describe Api::V1::MovesController do
             end
 
             it 'updates the moves documents' do
-              expect(move.reload.documents).to eq(before_documents)
+              expect(move.reload.documents).to match_array(before_documents)
               do_patch
-              expect(move.reload.documents).to eq(after_documents)
+              expect(move.reload.documents).to match_array(after_documents)
             end
 
             it 'does not affect other relationships' do

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -162,6 +162,34 @@ RSpec.describe Api::V1::MovesController do
               response_json.dig('data', 'relationships', 'documents', 'data').map { |document| document['id'] },
             ).to eq(after_documents.pluck(:id))
           end
+
+          context 'when there are no attributes in the patch' do
+            let(:move_params) do
+              documents = after_documents.map { |d| { id: d.id, type: 'documents' } }
+              {
+                type: 'moves',
+                relationships: { documents: { data: documents } },
+              }
+            end
+
+            it 'updates the moves documents' do
+              expect(move.reload.documents).to eq(before_documents)
+              do_patch
+              expect(move.reload.documents).to eq(after_documents)
+            end
+
+            it 'does not affect other relationships' do
+              expect { do_patch }.not_to change { move.reload.from_location }
+            end
+
+            it 'returns the updated documents in the response body' do
+              do_patch
+
+              expect(
+                response_json.dig('data', 'relationships', 'documents', 'data').map { |document| document['id'] },
+              ).to eq(after_documents.pluck(:id))
+            end
+          end
         end
 
         context 'when cancelling a move' do

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Api::V1::MovesController do
             ).to eq(after_documents.pluck(:id))
           end
 
-          context 'when there are no attributes in the patch' do
+          context 'when there are no attributes in the params' do
             let(:move_params) do
               documents = after_documents.map { |d| { id: d.id, type: 'documents' } }
               {

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Api::V1::MovesController do
 
               expect(
                 response_json.dig('data', 'relationships', 'documents', 'data').map { |document| document['id'] },
-              ).to eq(after_documents.pluck(:id))
+              ).to match_array(after_documents.pluck(:id))
             end
           end
         end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

Adds support for patching a move without any attribute changes (i.e. only the documents)

### Why?

This is a genuine use case of this api.

