### PR TITLE
Fail fast and fix flakey test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,12 @@ jobs:
       - prepare_tests
 
       - run:
+          name: rubocop
+          command: bundle exec rubocop
+
+      - run:
           name: run tests
-          command: COVERAGE=1 bundle exec rake
+          command: COVERAGE=1 bundle exec rspec
 
       - *notify_slack
 

--- a/spec/services/regions/importer_spec.rb
+++ b/spec/services/regions/importer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Regions::Importer do
     it 'links to correct locations' do
       importer.call
 
-      expect(region1.locations.map(&:nomis_agency_id)).to match %w(FOO BAR)
+      expect(region1.locations.map(&:nomis_agency_id)).to match_array %w(FOO BAR)
     end
 
     it 'does not link to missing locations' do


### PR DESCRIPTION
### What?

- [x] fix flakey test to not care about order in array
- [x] run rubocop first in circle CI before tests

### Why?

Run rubocop before tests in circle build to fail fast, and fix flakey test because no one likes flakiness 