### PR TITLE
[P4-1185] Updates default fallback question for building personal care need

### DIFF
--- a/app/services/personal_care_needs/importer.rb
+++ b/app/services/personal_care_needs/importer.rb
@@ -6,7 +6,7 @@ module PersonalCareNeeds
 
     QUESTION_KEY_PREGNANT = 'pregnant'
     QUESTION_KEY_SPECIAL_VEHICLE = 'special_vehicle'
-    QUESTION_KEY_FALLBACK = 'pregnant'
+    QUESTION_KEY_FALLBACK = 'health_issue'
 
     DOMAIN_PHYSICAL = 'PHY'
     DOMAIN_DISABILITY = 'DISAB'

--- a/spec/services/moves/import_people_spec.rb
+++ b/spec/services/moves/import_people_spec.rb
@@ -27,16 +27,16 @@ RSpec.describe Moves::ImportPeople do
      { prison_number: prisoner_two.nomis_prison_number, first_name: 'Bob' }]
   end
   let(:personal_care_needs_response) do
-    [{ offender_no: prisoner_one.nomis_prison_number, problem_type: 'MATSTAT', problem_code: 'ACCU9' },
-     { offender_no: prisoner_two.nomis_prison_number, problem_type: 'MATSTAT', problem_code: 'ACCU9' },
-     { offender_no: prisoner_two.nomis_prison_number, problem_type: 'MATSTAT', problem_code: 'ACCU4' }]
+    [{ offender_no: prisoner_one.nomis_prison_number, problem_type: 'FOO', problem_code: 'AA' },
+     { offender_no: prisoner_two.nomis_prison_number, problem_type: 'FOO', problem_code: 'BAC' },
+     { offender_no: prisoner_two.nomis_prison_number, problem_type: 'FOO', problem_code: 'TTG' }]
   end
 
   before do
     allow(NomisClient::People).to receive(:get).and_return(prison_numbers_response)
     allow(NomisClient::Alerts).to receive(:get).and_return(alerts_response)
     allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return(personal_care_needs_response)
-    # create fallback questions for PersonalCareNeeds importer and Alerts importer
+
     create(:assessment_question, :care_needs_fallback)
     create(:assessment_question, :alerts_fallback)
   end

--- a/spec/services/personal_care_needs/importer_spec.rb
+++ b/spec/services/personal_care_needs/importer_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe PersonalCareNeeds::Importer do
       },
     ]
   end
-  let(:problem_code) { 'ACCU9' }
+  let(:problem_code) { 'BRK' }
 
-  let!(:default_question) { create(:assessment_question, key: :pregnant, title: 'Pregnant', category: 'health') }
+  let!(:default_question) { create(:assessment_question, :care_needs_fallback) }
 
   let!(:assessment_question) { create(:assessment_question, key: :special_vehicle, title: 'Requires special vehicle', category: 'health') }
 
@@ -44,7 +44,7 @@ RSpec.describe PersonalCareNeeds::Importer do
 
       expect(profile.assessment_answers.first.as_json).to include(
         category: default_question.category,
-        key: default_question.key,
+        key: 'health_issue',
         nomis_alert_code: problem_code,
         nomis_alert_type_description: 'Unknown',
       )


### PR DESCRIPTION
### Jira link

P4-1185

### What?

The initial implementation of the AssessmentAnswer documents for personal care needs was only for female prisons where the person might be pregnant.

This updates the default question to be more appropriate for a wider gamut of people we might move.

### Why?

This is principally a UX change that will make using our service make more sense.

