### PR TITLE
P4-1428 Allow disabling API authentication for local dev and heroku review apps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ CORS_ALLOWED_ORIGINS=api.bookasecuremove.service.justice.gov.uk
 GOVUK_NOTIFY_ENABLED=false
 GOVUK_NOTIFY_API_KEY='Add gov.uk notify key here'
 GOVUK_NOTIFY_TEMPLATE_ID=8f2e5473-15f2-4db8-a2de-153f26a0524c
+
+# Completely disable API authentication for local development if true.
+DEV_DISABLE_AUTH=false

--- a/app.json
+++ b/app.json
@@ -23,7 +23,8 @@
       "value": "true"
     },
     "HEROKU_DISABLE_AUTH": {
-      "value": "true"
+      "description": "Disable authentication on Heroku review apps if true",
+      "required": "true"
     }
   },
   "buildpacks": [

--- a/app.json
+++ b/app.json
@@ -21,6 +21,9 @@
     },
     "SERVE_API_DOCS": {
       "value": "true"
+    },
+    "HEROKU_DISABLE_AUTH": {
+      "value": "true"
     }
   },
   "buildpacks": [

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApiController < ApplicationController
-  before_action :doorkeeper_authorize!
+  before_action :doorkeeper_authorize!, if: :authentication_enabled?
   before_action :restrict_request_content_type
   before_action :set_content_type
   before_action :set_paper_trail_whodunnit
@@ -21,10 +21,20 @@ class ApiController < ApplicationController
   end
 
   def user_for_paper_trail
+    return unless authentication_enabled?
+
     current_user.owner_id
   end
 
 private
+
+  def authentication_enabled?
+    return false if Rails.env.development? && ENV['DEV_DISABLE_AUTH'] =~ /true/i
+
+    return false if Rails.env.production? && ENV['HEROKU_DISABLE_AUTH'] =~ /true/i
+
+    true
+  end
 
   def doorkeeper_unauthorized_render_options(*)
     {


### PR DESCRIPTION
### Jira link

P4-1428

### What?

- [x] Adds support for `HEROKU_DISABLE_AUTH` environment variable to be used on Heroku environments only
- [x] Adds support for `DEV_DISABLE_AUTH` environment variable to be used for local development environments only

### Why?

During local development, the API authentication (and in particular the oauth timeout) is pretty irksome, meaning workarounds (e.g. Postman utility scripts) are needed to continually refresh the token. In most case we just want to test the API without worrying about which supplier invoked the API call.

Similarly for Heroku review apps, these would be much easier to use against front end if we didn't have to worry about generating oauth API credentials and communicating these to the front end team. Instead, with this change front end devs will be able to simply specify the API URL for the deployed review app and everything should work within the API as intended.

There are some caveats to this:
1. Clearly setting an environment variable in production mode that bypasses authentication is dangerous. So we must never do that. In an effort to make it less likely that someone would set this variable locally for some reason and possibly accidentally commit a `.env` file with this set, I've split the `HEROKU` env variable out and there is no need to ever set this locally which mitigates some of the risk. It's instead automatically set for all future Heroku review apps that get deployed.

2. Normally the `current_user` method returns a `Supplier` instance representing the supplier that owns the oauth token used for authentication. This in turn is then used to associate paper trail changes with a specific user id. I don't think the simple implementation of returning `nil` instead when auth is disabled breaks anything currently, but if we wish to do other things with `current_user` this may need improving in future. One option would be to return an arbitrary supplier e.g. `Supplier.last`.

3. This is kind of hard to test with a spec as it relies on `Rails.env` not being `test` and also having specific environment variables set. Open to suggestions on that, but the code is perhaps simple enough to live with this limitation.

### Have you? (optional)

- [x] Added `DEV_DISABLE_AUTH` to `.env.example` for local development use
- [x] Added `HEROKU_DISABLE_AUTH` to review app settings in `app.json` so this gets set automatically for new Heroku review apps

### Deployment risks (optional)

- No risk so long as the `HEROKU_DISABLE_AUTH` variable does not get set in production (i.e. on non Heroku environments). I'm hoping the naming is explicit enough to indicate that.