### PR TITLE
Simplify/Speed up serializer specs

### DIFF
--- a/spec/serializers/allocation_complex_case_serializer_spec.rb
+++ b/spec/serializers/allocation_complex_case_serializer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AllocationComplexCaseSerializer do
   subject(:serializer) { described_class.new(allocation_complex_case) }
 
   let(:allocation_complex_case) { create :allocation_complex_case }
-  let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
 
   it 'contains a type property' do
     expect(result[:data][:type]).to eql 'allocation_complex_cases'

--- a/spec/serializers/assessment_question_serializer_spec.rb
+++ b/spec/serializers/assessment_question_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AssessmentQuestionSerializer do
 
   let(:disabled_at) { Time.new(2019, 1, 1) }
   let(:assessment_question) { create :assessment_question, disabled_at: disabled_at }
-  let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
 
   it 'contains a type property' do
     expect(result[:data][:type]).to eql 'assessment_questions'
@@ -30,6 +30,6 @@ RSpec.describe AssessmentQuestionSerializer do
   end
 
   it 'contains a disabled_at attribute' do
-    expect(Time.parse(result[:data][:attributes][:disabled_at])).to eql disabled_at
+    expect(result[:data][:attributes][:disabled_at]).to eql disabled_at
   end
 end

--- a/spec/serializers/document_serializer_spec.rb
+++ b/spec/serializers/document_serializer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DocumentSerializer do
   subject(:serializer) { described_class.new(document) }
 
   let(:document) { create :document }
-  let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
 
   it 'contains a type property' do
     expect(result[:data][:type]).to eql 'documents'
@@ -17,7 +17,7 @@ RSpec.describe DocumentSerializer do
   end
 
   it 'contains a `filename` attribute' do
-    expect(result[:data][:attributes][:filename]).to eql 'file-sample_100kB.doc'
+    expect(result[:data][:attributes][:filename].to_s).to eql 'file-sample_100kB.doc'
   end
 
   it 'contains a `filesize` attribute' do

--- a/spec/serializers/ethnicity_serializer_spec.rb
+++ b/spec/serializers/ethnicity_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EthnicitySerializer do
 
   let(:disabled_at) { Time.new(2019, 1, 1) }
   let(:ethnicity) { create :ethnicity, disabled_at: disabled_at }
-  let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
 
   it 'contains a type property' do
     expect(result[:data][:type]).to eql 'ethnicities'
@@ -34,6 +34,6 @@ RSpec.describe EthnicitySerializer do
   end
 
   it 'contains a disabled_at attribute' do
-    expect(Time.parse(result[:data][:attributes][:disabled_at])).to eql disabled_at
+    expect(result[:data][:attributes][:disabled_at]).to eql disabled_at
   end
 end

--- a/spec/serializers/gender_serializer_spec.rb
+++ b/spec/serializers/gender_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GenderSerializer do
 
   let(:disabled_at) { Time.new(2019, 1, 1) }
   let(:gender) { create :gender, disabled_at: disabled_at }
-  let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
 
   it 'contains a type property' do
     expect(result[:data][:type]).to eql 'genders'
@@ -30,6 +30,6 @@ RSpec.describe GenderSerializer do
   end
 
   it 'contains a disabled_at attribute' do
-    expect(Time.parse(result[:data][:attributes][:disabled_at])).to eql disabled_at
+    expect(result[:data][:attributes][:disabled_at]).to eql disabled_at
   end
 end

--- a/spec/serializers/identifier_type_serializer_spec.rb
+++ b/spec/serializers/identifier_type_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IdentifierTypeSerializer do
 
   let(:disabled_at) { Time.new(2019, 1, 1) }
   let(:identifier_type) { create :identifier_type, disabled_at: disabled_at }
-  let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
 
   it 'contains a type property' do
     expect(result[:data][:type]).to eql 'identifier_types'
@@ -26,6 +26,6 @@ RSpec.describe IdentifierTypeSerializer do
   end
 
   it 'contains a disabled_at attribute' do
-    expect(Time.parse(result[:data][:attributes][:disabled_at])).to eql disabled_at
+    expect(result[:data][:attributes][:disabled_at]).to eql disabled_at
   end
 end

--- a/spec/serializers/location_serializer_spec.rb
+++ b/spec/serializers/location_serializer_spec.rb
@@ -8,21 +8,9 @@ RSpec.describe LocationSerializer do
   let(:disabled_at) { Time.new(2019, 1, 1) }
   let(:supplier) { create(:supplier) }
   let(:location) { create :location, disabled_at: disabled_at, suppliers: [supplier] }
-  let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
   let(:result_data) { result[:data] }
   let(:attributes) { result_data[:attributes] }
-
-  let(:expected_suppliers) do
-    [
-      {
-        created_at: supplier.created_at.xmlschema,
-        id: supplier.id,
-        key: supplier.key,
-        name: supplier.name,
-        updated_at: supplier.updated_at.xmlschema,
-      },
-    ]
-  end
 
   it 'contains a type property' do
     expect(result_data[:type]).to eql 'locations'
@@ -53,10 +41,10 @@ RSpec.describe LocationSerializer do
   end
 
   it 'contains a disabled_at attribute' do
-    expect(Time.parse(attributes[:disabled_at])).to eql disabled_at
+    expect(attributes[:disabled_at]).to eql disabled_at
   end
 
   it 'contains a suppliers attribute' do
-    expect(attributes[:suppliers]).to eq(expected_suppliers)
+    expect(attributes[:suppliers].to_a).to eq([supplier])
   end
 end

--- a/spec/serializers/nationality_serializer_spec.rb
+++ b/spec/serializers/nationality_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe NationalitySerializer do
 
   let(:disabled_at) { Time.new(2019, 1, 1) }
   let(:nationality) { create :nationality, disabled_at: disabled_at }
-  let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
 
   it 'contains a type property' do
     expect(result[:data][:type]).to eql 'nationalities'
@@ -26,6 +26,6 @@ RSpec.describe NationalitySerializer do
   end
 
   it 'contains a disabled_at attribute' do
-    expect(Time.parse(result[:data][:attributes][:disabled_at])).to eql disabled_at
+    expect(result[:data][:attributes][:disabled_at]).to eql disabled_at
   end
 end

--- a/spec/serializers/prison_transfer_reason_serializer_spec.rb
+++ b/spec/serializers/prison_transfer_reason_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PrisonTransferReasonSerializer do
 
   let(:disabled_at) { Time.new(2019, 1, 1) }
   let(:reason) { create :prison_transfer_reason, disabled_at: disabled_at }
-  let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
 
   it 'contains a type property' do
     expect(result[:data][:type]).to eql 'prison_transfer_reasons'
@@ -26,6 +26,6 @@ RSpec.describe PrisonTransferReasonSerializer do
   end
 
   it 'contains a `disabled_at` attribute' do
-    expect(Time.parse(result[:data][:attributes][:disabled_at])).to eql disabled_at
+    expect(result[:data][:attributes][:disabled_at]).to eql disabled_at
   end
 end


### PR DESCRIPTION
### Jira link

### What?
We can directly use the 
`serializable_hash` of the serializer 
instead of `.to_json` + `JSON.parse`

(We know already that the Json parser works)

### Why?

It's shorter and faster
