### PR TITLE
P4-1398 Surface associated moves in allocations

### DIFF
--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -5,6 +5,11 @@ class AllocationSerializer < ActiveModel::Serializer
 
   has_one :from_location
   has_one :to_location
+  has_many :moves
 
-  INCLUDED_ATTRIBUTES = %i[from_location to_location].freeze
+  INCLUDED_ATTRIBUTES = {
+    from_location: [],
+    to_location: [],
+    moves: %i[person],
+  }.freeze
 end

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -10,5 +10,20 @@ FactoryBot.define do
     sentence_length { Allocation.sentence_lengths.values.sample }
     moves_count { Faker::Number.digit }
     complete_in_full { false }
+
+    trait :with_moves do
+      moves_count { 1 }
+      after(:create) do |allocation|
+        create_list(
+          :move,
+          allocation.moves_count,
+          from_location: allocation.from_location,
+          to_location: allocation.to_location,
+          date: allocation.date,
+          status: 'requested',
+          allocation: allocation,
+        )
+      end
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,6 +80,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+  config.include RSpec::JsonExpectations::Matchers
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/api/v1/allocations_controller_create_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_create_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Api::V1::AllocationsController do
 
   let(:response_json) { JSON.parse(response.body) }
   let(:resource_to_json) do
-    JSON.parse(ActionController::Base.render(json: allocation, include: AllocationSerializer::INCLUDED_ATTRIBUTES))
+    resource = JSON.parse(ActionController::Base.render(json: allocation, include: AllocationSerializer::INCLUDED_ATTRIBUTES))
+    resource['data']['relationships']['moves']['data'] = UnorderedArray(*resource.dig('data', 'relationships', 'moves', 'data'))
+    resource['included'] = UnorderedArray(*resource['included'])
+    resource
   end
 
   describe 'POST /allocations' do
@@ -110,7 +113,7 @@ RSpec.describe Api::V1::AllocationsController do
       end
 
       it 'returns the correct data' do
-        expect(response_json).to eq resource_to_json
+        expect(response_json).to include_json resource_to_json
       end
 
       it 'sets the correct number of complex_cases' do

--- a/spec/serializers/allocation_serializer_spec.rb
+++ b/spec/serializers/allocation_serializer_spec.rb
@@ -99,4 +99,34 @@ RSpec.describe AllocationSerializer do
       expect(result[:included]).to(include_json(expected_json))
     end
   end
+
+  describe 'moves' do
+    context 'with a move' do
+      let(:adapter_options) {
+        { include: AllocationSerializer::INCLUDED_ATTRIBUTES }
+      }
+      let(:allocation) { create(:allocation, :with_moves) }
+      let(:move) { allocation.moves.first }
+
+      it 'contains a moves relationship' do
+        expect(result_data[:relationships][:moves][:data]).to contain_exactly(id: move.id, type: 'moves')
+      end
+
+      it 'contains an included move and person' do
+        expect(result[:included].map { |r| r[:type] }).to match_array(%w[people moves locations locations])
+      end
+    end
+
+    context 'without a move' do
+      let(:adapter_options) { { include: AllocationSerializer::INCLUDED_ATTRIBUTES } }
+
+      it 'contains empty moves' do
+        expect(result_data[:relationships][:moves][:data]).to be_empty
+      end
+
+      it 'does not contain an included allocation' do
+        expect(result[:included].map { |r| r[:type] }).to match_array(%w[locations locations])
+      end
+    end
+  end
 end

--- a/swagger/v1/allocation.yaml
+++ b/swagger/v1/allocation.yaml
@@ -116,3 +116,9 @@ Allocation:
         to_location:
           $ref: location_reference.yaml#/LocationReference
           description: The location (prison) that the people are being moved to
+        moves:
+          $ref: move_reference.yaml#/MoveReference
+          description: The moves associated with this Allocation
+        person:
+          $ref: person_reference.yaml#/PersonReference
+          description: The people being moved

--- a/swagger/v1/get_allocations_responses.yaml
+++ b/swagger/v1/get_allocations_responses.yaml
@@ -12,6 +12,8 @@
       items:
         anyOf:
         - $ref: location.yaml#/Location
+        - $ref: move.yaml#/Move
+        - $ref: person.yaml#/Person
     links:
       $ref: pagination_links.yaml#/PaginationLinks
     meta:

--- a/swagger/v1/move_reference.yaml
+++ b/swagger/v1/move_reference.yaml
@@ -7,6 +7,7 @@ MoveReference:
       oneOf:
       - type: object
       - type: 'null'
+      - type: array
       required:
       - id
       - type


### PR DESCRIPTION
### Jira link

[P4-1398](https://dsdmoj.atlassian.net/browse/P4-1398)

### What?

- [x] Added moves `relationship` and `includes` in allocation serializer

### Why?

We would like to surface moves in the allocation endpoints. Moves should also surface people in `includes` if there are any associated with them.

There are two issues I'd like to address in the current implementation:
1) We are including a circular dependency in the `moves` include response where it will also surface the allocation in the relationship.
2) Inferring moves count rather than including an extra attribute

### Have you? (optional)

- [x] Updated API docs if necessary
### Deployment risks (optional)

- Changes an api that is used in production

