### PR TITLE
Spin up reference data for deployed heroku review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,29 +3,61 @@
   "description": "",
   "repository": "https://github.com/ministryofjustice/hmpps-book-secure-move-api",
   "env": {
+	  "MASTER_DATABASE_URL": {
+      "description": "DATABASE_URL value from main API application deployed on Heroku",
+	    "required": true
+	  },
     "ENCRYPTOR_SALT": {
       "description": "Secret salt value for encryption/decryption",
-      "required": "true"
+      "required": true
     },
     "S3_ACCESS_KEY_ID": {
       "description": "Public access key for AWS S3 storage",
-      "required": "true"
+      "required": true
     },
     "S3_SECRET_ACCESS_KEY": {
       "description": "Private secrete access key for AWS S3 storage",
-      "required": "true"
+      "required": true
     },
     "S3_BUCKET_NAME": {
       "description": "Name of the storage bucket to use on AWS S3",
-      "required": "true"
+      "required": true
+    },
+    "NOMIS_SITE": {
+      "description": "Base URL for NOMIS API",
+      "required": true
+    },
+    "NOMIS_CLIENT_ID": {
+      "description": "User ID to authenticate with for NOMIS API",
+      "required": true
+    },
+    "NOMIS_CLIENT_SECRET": {
+      "description": "User secret to authenticate with for NOMIS API",
+      "required": true
+    },
+    "NOMIS_AUTH_SCHEME": {
+      "description": "Authentication scheme to use with NOMIS API",
+      "required": true
+    },
+    "NOMIS_API_PATH_PREFIX": {
+      "description": "Namespace for general NOMIS API endpoints",
+      "required": true
+    },
+    "NOMIS_AUTH_PATH_PREFIX": {
+      "description": "Namespace for authentication NOMIS API endpoints",
+      "required": true
     },
     "SERVE_API_DOCS": {
-      "value": "true"
+      "description": "Enable endpoints for static documentation",
+      "value": true
     },
     "HEROKU_DISABLE_AUTH": {
       "description": "Disable authentication on Heroku review apps if true",
-      "required": "true"
+      "required": true
     }
+  },
+  "scripts": {
+    "postdeploy": "pg_dump $MASTER_DATABASE_URL | psql $DATABASE_URL && bundle exec rails db:migrate"
   },
   "buildpacks": [
     {

--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -93,6 +93,21 @@ namespace :reference_data do
     puts_summary_of_relationships
   end
 
+  desc 'create all of the necessary reference data'
+  task create_all: :environment do
+    Rake::Task['reference_data:create_locations'].invoke
+    Rake::Task['reference_data:create_ethnicities'].invoke
+    Rake::Task['reference_data:create_genders'].invoke
+    Rake::Task['reference_data:create_identifier_types'].invoke
+    Rake::Task['reference_data:create_assessment_questions'].invoke
+    Rake::Task['reference_data:create_allocation_complex_cases'].invoke
+    Rake::Task['reference_data:create_nomis_alerts'].invoke
+    Rake::Task['reference_data:create_regions'].invoke
+    Rake::Task['reference_data:create_suppliers'].invoke
+    Rake::Task['reference_data:create_prison_transfer_reasons'].invoke
+    Rake::Task['reference_data:link_suppliers'].invoke
+  end
+
 private
 
   def have_locations_changed?(locations1, locations2)


### PR DESCRIPTION
This should provide enough to get the endpoints working, now that the auth has been disabled on heroku review apps.

### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [ ] Added foo in bar
- [ ] Removed baz

### Why?

I am doing this because:

-
-
-

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

