### PR TITLE
P4-1428 Replicate review app database from main heroku API app

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,24 @@ bundle exec rails fake_data:recreate_all
 To create reference data (seed data) needed in production run the
 following rake tasks:
 
-```
-bundle exec rake reference_data:create_assessment_questions
-bundle exec rake reference_data:create_allocation_complex_cases
+```bash
+bundle exec rake reference_data:create_locations
 bundle exec rake reference_data:create_ethnicities
 bundle exec rake reference_data:create_genders
 bundle exec rake reference_data:create_identifier_types
-bundle exec rake reference_data:create_locations
+bundle exec rake reference_data:create_assessment_questions
+bundle exec rake reference_data:create_allocation_complex_cases
 bundle exec rake reference_data:create_nomis_alerts
 bundle exec rake reference_data:create_regions
 bundle exec rake reference_data:create_suppliers
+bundle exec rake reference_data:create_prison_transfer_reasons
+bundle exec rake reference_data:link_suppliers
+```
+
+Alternatively, **all** of the reference data can be created at once by running the combined rake task:
+
+```bash
+bundle exec rake reference_data:create_all
 ```
 
 Some of these tasks pull data from NOMIS and therefore require

--- a/app.json
+++ b/app.json
@@ -3,29 +3,61 @@
   "description": "",
   "repository": "https://github.com/ministryofjustice/hmpps-book-secure-move-api",
   "env": {
+	  "MASTER_DATABASE_URL": {
+      "description": "DATABASE_URL value from main API application deployed on Heroku",
+	    "required": true
+	  },
     "ENCRYPTOR_SALT": {
       "description": "Secret salt value for encryption/decryption",
-      "required": "true"
+      "required": true
     },
     "S3_ACCESS_KEY_ID": {
       "description": "Public access key for AWS S3 storage",
-      "required": "true"
+      "required": true
     },
     "S3_SECRET_ACCESS_KEY": {
       "description": "Private secrete access key for AWS S3 storage",
-      "required": "true"
+      "required": true
     },
     "S3_BUCKET_NAME": {
       "description": "Name of the storage bucket to use on AWS S3",
-      "required": "true"
+      "required": true
+    },
+    "NOMIS_SITE": {
+      "description": "Base URL for NOMIS API",
+      "required": true
+    },
+    "NOMIS_CLIENT_ID": {
+      "description": "User ID to authenticate with for NOMIS API",
+      "required": true
+    },
+    "NOMIS_CLIENT_SECRET": {
+      "description": "User secret to authenticate with for NOMIS API",
+      "required": true
+    },
+    "NOMIS_AUTH_SCHEME": {
+      "description": "Authentication scheme to use with NOMIS API",
+      "required": true
+    },
+    "NOMIS_API_PATH_PREFIX": {
+      "description": "Namespace for general NOMIS API endpoints",
+      "required": true
+    },
+    "NOMIS_AUTH_PATH_PREFIX": {
+      "description": "Namespace for authentication NOMIS API endpoints",
+      "required": true
     },
     "SERVE_API_DOCS": {
-      "value": "true"
+      "description": "Enable endpoints for static documentation",
+      "value": true
     },
     "HEROKU_DISABLE_AUTH": {
       "description": "Disable authentication on Heroku review apps if true",
-      "required": "true"
+      "required": true
     }
+  },
+  "scripts": {
+    "postdeploy": "pg_dump $MASTER_DATABASE_URL | psql $DATABASE_URL && bundle exec rails db:migrate"
   },
   "buildpacks": [
     {

--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -93,6 +93,21 @@ namespace :reference_data do
     puts_summary_of_relationships
   end
 
+  desc 'create all of the necessary reference data'
+  task create_all: :environment do
+    Rake::Task['reference_data:create_locations'].invoke
+    Rake::Task['reference_data:create_ethnicities'].invoke
+    Rake::Task['reference_data:create_genders'].invoke
+    Rake::Task['reference_data:create_identifier_types'].invoke
+    Rake::Task['reference_data:create_assessment_questions'].invoke
+    Rake::Task['reference_data:create_allocation_complex_cases'].invoke
+    Rake::Task['reference_data:create_nomis_alerts'].invoke
+    Rake::Task['reference_data:create_regions'].invoke
+    Rake::Task['reference_data:create_suppliers'].invoke
+    Rake::Task['reference_data:create_prison_transfer_reasons'].invoke
+    Rake::Task['reference_data:link_suppliers'].invoke
+  end
+
 private
 
   def have_locations_changed?(locations1, locations2)


### PR DESCRIPTION
### Jira link

P4-1428

### What?

I have added/removed/altered:

- [x] Added extra configuration setting placeholders in `app.json` so that these are populated for new review apps deployed to Heroku
- [x] Configured values within Heroku on the main app and for the pipeline for each of the new config settings (mostly around NOMIS - these point to the T3 environment)
- [x] Populated `MASTER_DATABASE_URL` in the pipeline so that review apps know where the database is located for the main app
- [x] Added a post deploy script to replicate the database content from the main app when a review app is deployed
- [x] Populated all of the relevant reference data on the main Heroku review app (via running all of the rake tasks)
- [x] Added a new combined rake task to setup all of the reference data at once `rails reference_data:create_all` (makes it easier to setup a new environment)

### Why?

- Heroku main API app now works as expected and contains reference data so the API endpoints work. Authentication is currently disabled on the Heroku review apps but enabled for the main app. This protects the known good "reference" data - we need to keep that clean and lightweight and use the disposable copies on review apps for testing.

- In the near future I'm hoping that we'll be able to run the end to end test suite against a deployed Heroku review app and get that passing. This would then allow stronger testing of any API changes to ensure that no regressions are introduced.