### PR TITLE
P4-1525 Improve validation of `moves_count` when creating an allocation

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -22,7 +22,7 @@ class Allocation < VersionedModel
   validates :prisoner_category, inclusion: { in: prisoner_categories }, allow_nil: true
   validates :sentence_length, inclusion: { in: sentence_lengths }, allow_nil: true
 
-  validates :moves_count, presence: true
+  validates :moves_count, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :date, presence: true
 
   attribute :complex_cases, Types::JSONB.new(Allocation::ComplexCaseAnswers)

--- a/app/services/allocations/creator.rb
+++ b/app/services/allocations/creator.rb
@@ -11,32 +11,27 @@ module Allocations
 
     def call
       self.allocation = Allocation.new(attributes)
+      allocation.moves = moves if allocation.valid?
 
       allocation.save!
     end
 
   private
 
-    def date
-      @date ||= allocation_params.dig(:attributes, :date)
-    end
-
     def from_location
-      @from_location ||= Location.find(allocation_params.dig(:relationships, :from_location, :data, :id))
+      Location.find(allocation_params.dig(:relationships, :from_location, :data, :id))
     end
 
     def to_location
-      @to_location ||= Location.find(allocation_params.dig(:relationships, :to_location, :data, :id))
+      Location.find(allocation_params.dig(:relationships, :to_location, :data, :id))
     end
 
     def moves
-      return [] unless date
-
-      Array.new(allocation_params.dig(:attributes, :moves_count)) {
+      Array.new(allocation.moves_count) {
         Move.new(
-          from_location: from_location,
-          to_location: to_location,
-          date: date,
+          from_location: allocation.from_location,
+          to_location: allocation.to_location,
+          date: allocation.date,
         )
       }
     end
@@ -46,7 +41,6 @@ module Allocations
         from_location: from_location,
         to_location: to_location,
         complex_cases: Allocation::ComplexCaseAnswers.new(complex_case_params),
-        moves: moves,
       )
     end
   end

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
 
     prisoner_category { Allocation.prisoner_categories.values.sample }
     sentence_length { Allocation.sentence_lengths.values.sample }
-    moves_count { Faker::Number.digit }
+    moves_count { Faker::Number.non_zero_digit }
     complete_in_full { false }
 
     trait :with_moves do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Allocation do
   it { is_expected.to define_enum_for(:sentence_length).backed_by_column_of_type(:string) }
 
   it { is_expected.to validate_presence_of(:moves_count) }
+  it { is_expected.to validate_numericality_of(:moves_count) }
   it { is_expected.to validate_presence_of(:date) }
 
   context 'with versioning' do

--- a/spec/requests/api/v1/allocations_controller_create_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_create_spec.rb
@@ -269,5 +269,39 @@ RSpec.describe Api::V1::AllocationsController do
         end
       end
     end
+
+    context 'with incorrect moves_count type' do
+      let(:moves_count) { '27.5' }
+
+      let(:errors_422) do
+        [
+          {
+            'title' => 'Unprocessable entity',
+            'detail' => 'Moves count must be an integer',
+            'source' => { 'pointer' => '/data/attributes/moves_count' },
+            'code' => 'not_an_integer',
+          },
+        ]
+      end
+
+      it_behaves_like 'an endpoint that responds with error 422'
+    end
+
+    context 'with zero moves_count' do
+      let(:moves_count) { 0 }
+
+      let(:errors_422) do
+        [
+          {
+            'title' => 'Unprocessable entity',
+            'detail' => 'Moves count must be greater than 0',
+            'source' => { 'pointer' => '/data/attributes/moves_count' },
+            'code' => 'greater_than',
+          },
+        ]
+      end
+
+      it_behaves_like 'an endpoint that responds with error 422'
+    end
   end
 end


### PR DESCRIPTION
### Jira link

P4-1525

### What?

- [x] Improved validation of `moves_count` attribute within `Allocation` model. This now rejects zero, negative or non integer values.
- [x] Extended request spec coverage when creating an allocation to check additional validation errors
- [x] Refactored `Allocation::Creator` slightly to ensure that allocation is valid before creating associated moves

### Why?

- This was previously throwing an error when creating an allocation passing `moves_count` as a string value. This blew up within the `Allocations::Creator` service but didn't get caught as a validation error. It turns out Rails is extremely forgiving and will automatically convert string to integer values within the `Allocation` model; the problem was that the creator then used the raw params passed in rather than the allocation attributes. The same code was also relying solely on the presence of a `date` param to determine validity prior to creating associated moves.
- Refactored implementation means that moves are explicitly created after confirming that the allocation is valid, and to use the allocation attributes to build the moves rather than the params. This also allows cleaning up some of the private methods in the same class as we don't need to memoize location lookups, or explicitly check for date param (this is now delegated to the allocation validation rules).
- This resolves an observed failure when creating allocations on staging environment causing a number of Sentry exceptions to be thrown. This change will allow a `moves_count` value of e.g. `"2"` (as a string) to work as expected, even though this strictly speaking violates the JSONAPI specification for the endpoint. The extra "friendliness" provided by Rails models offers this for free and avoids the need to change the front end immediately - ideally the front end should pass `moves_count` as an integer.

### Deployment risks (optional)

- Fixes an api that is deployed to production, but not currently used by real users

