### PR TITLE
P4-1530 Allow person to be updated on a move

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -28,13 +28,10 @@ module Api
       def update
         raise ActiveRecord::ReadOnlyRecord, 'Can\'t change moves coming from Nomis' if move.from_nomis?
 
-        # NB: rather than update directly, we need to detect whether the move status has changed before saving the record
-        move.assign_attributes(update_move_attributes)
-        status_changed = move.status_changed?
-        move.save!
+        updater.call
 
-        Notifier.prepare_notifications(topic: move, action_name: status_changed ? 'update_status' : 'update')
-        render_move(move, :ok)
+        Notifier.prepare_notifications(topic: updater.move, action_name: updater.status_changed ? 'update_status' : 'update')
+        render_move(updater.move, :ok)
       end
 
       def destroy
@@ -93,18 +90,6 @@ module Api
         params.require(:data).permit(PERMITTED_UPDATE_MOVE_PARAMS).to_h
       end
 
-      # 1. Frontend specifies empty docs: update documents to be empty
-      # 2. Frontend does not include document relationship: don't update documents at all
-      def update_move_attributes
-        attributes = update_move_params.fetch(:attributes, {})
-        document_ids = update_move_params.dig(:relationships, :documents, :data)
-
-        return attributes if document_ids.nil?
-
-        document_ids = document_ids.map { |doc| doc[:id] }
-        attributes.merge(documents: Document.where(id: document_ids))
-      end
-
       def render_move(move, status)
         render json: move, status: status, include: MoveSerializer::INCLUDED_ATTRIBUTES, fields: MoveSerializer::INCLUDED_FIELDS
       end
@@ -114,6 +99,10 @@ module Api
           .accessible_by(current_ability)
           .includes(:from_location, :to_location, person: { profiles: %i[gender ethnicity] })
           .find(params[:id])
+      end
+
+      def updater
+        @updater ||= Moves::Updater.new(move, update_move_params)
       end
     end
   end

--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Moves
+  class Updater
+    attr_accessor :move_params, :move, :status_changed
+
+    def initialize(move, move_params)
+      self.move = move
+      self.move_params = move_params
+    end
+
+    def call
+      move.assign_attributes(attributes)
+      # NB: rather than update directly, we need to detect whether the move status has changed before saving the record
+      self.status_changed = move.status_changed?
+
+      move.save!
+    end
+
+  private
+
+    def document_attributes
+      @document_attributes ||= move_params.dig(:relationships, :documents, :data)
+    end
+
+    def person_attributes
+      move_params.dig(:relationships, :person)
+    end
+
+    def document_ids
+      document_attributes.map { |doc| doc[:id] }
+    end
+
+    # 1. Frontend specifies empty docs: update documents to be empty
+    # 2. Frontend does not include document relationship: don't update documents at all
+    # 3. Frontend specifies empty person: update person to be nil
+    # 4. Frontend does not include person relationship: don't update person at all
+    def attributes
+      attributes = move_params.fetch(:attributes, {})
+
+      attributes[:documents] = Document.where(id: document_ids) unless document_attributes.nil?
+      attributes[:person] = Person.find_by(id: person_attributes.dig(:data, :id)) unless person_attributes.nil?
+
+      attributes
+    end
+  end
+end

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moves::Updater do
+  subject(:updater) { described_class.new(move, move_params) }
+
+  let(:before_documents) { create_list(:document, 2) }
+  let!(:from_location) { create :location }
+  let!(:move) { create :move, :proposed, move_type: 'prison_recall', from_location: from_location, documents: before_documents }
+  let(:date_from) { Date.yesterday }
+  let(:date_to) { Date.tomorrow }
+  let(:status) { 'requested' }
+
+  let(:move_params) do
+    {
+      type: 'moves',
+      attributes: {
+        status: status,
+        additional_information: 'some more info',
+        cancellation_reason: nil,
+        cancellation_reason_comment: nil,
+        move_type: 'court_appearance',
+        move_agreed: true,
+        move_agreed_by: 'Fred Bloggs',
+        date_from: date_from,
+        date_to: date_to,
+      },
+    }
+  end
+
+  before do
+    next if RSpec.current_example.metadata[:skip_before]
+
+    updater.call
+  end
+
+  context 'with valid params' do
+    it 'updates the correct attributes on an existing move' do
+      expect(updater.move).to have_attributes(
+        status: 'requested',
+        additional_information: 'some more info',
+        move_type: 'court_appearance',
+        move_agreed: true,
+        move_agreed_by: 'Fred Bloggs',
+        date_from: date_from,
+        date_to: date_to,
+      )
+    end
+
+    context 'when status updated' do
+      it 'sets `status_updated` to `true`' do
+        expect(updater.status_changed).to be_truthy
+      end
+    end
+
+    context 'when status is not updated' do
+      let(:status) { 'proposed' }
+
+      it 'sets `status_updated` to `false`' do
+        expect(updater.status_changed).to be_falsey
+      end
+    end
+
+    context 'with people' do
+      let(:before_person) { create(:person) }
+      let(:after_person) { create(:person) }
+      let!(:move) { create(:move, person: before_person) }
+
+      context 'with new person' do
+        let(:move_params) {
+          {
+            type: 'moves',
+            relationships: { person: { data: { id: after_person.id, type: 'people' } } },
+          }
+        }
+
+        it 'updates person association to new person' do
+          expect(updater.move.person).to eq(after_person)
+        end
+      end
+
+      context 'with empty person data' do
+        let(:move_params) {
+          {
+            type: 'moves',
+            relationships: { person: { data: nil } },
+          }
+        }
+
+        it 'removes associated person' do
+          expect(updater.move.person).to be_nil
+        end
+      end
+
+      context 'with no person relationship' do
+        it 'does not change old person associated' do
+          expect(updater.move.person).to eq(before_person)
+        end
+      end
+    end
+
+    context 'with documents' do
+      context 'with new documents' do
+        let(:after_documents) { create_list(:document, 2) }
+        let(:move_params) do
+          documents = after_documents.map { |d| { id: d.id, type: 'documents' } }
+          {
+            type: 'moves',
+            relationships: { documents: { data: documents } },
+          }
+        end
+
+        it 'updates documents association to new documents' do
+          expect(updater.move.documents).to match_array(after_documents)
+        end
+      end
+
+      context 'with empty documents' do
+        let(:move_params) {
+          {
+            type: 'moves',
+            relationships: { documents: { data: [] } },
+          }
+        }
+
+        it 'unsets associated documents' do
+          expect(updater.move.documents).to be_empty
+        end
+      end
+
+      context 'with nil documents' do
+        let(:move_params) {
+          {
+            type: 'moves',
+            relationships: { documents: { data: nil } },
+          }
+        }
+
+        it 'does nothing to existing documents' do
+          expect(updater.move.documents).to match_array(before_documents)
+        end
+      end
+
+      context 'with no document relationship' do
+        it 'does nothing to existing documents' do
+          expect(updater.move.documents).to match_array(before_documents)
+        end
+      end
+    end
+  end
+
+  context 'with invalid input params' do
+    let(:status) { 'wrong status' }
+
+    it 'raises an error', :skip_before do
+      expect { updater.call }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-1530

### Jira link

[P4-1530](https://dsdmoj.atlassian.net/browse/P4-1530)

### What?

* Move update logic to service
* Allow a person to be updated on a move
* If no person relationship is set on a move do not update the association
* If nil data is set on a move param remove any associated person

### Why?

To allow a person to be associated to a move on the allocation workflow, amend the PATCH endpoint to accept a person relationship to link/unlink people to that move

### Have you? (optional)

- [ ] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

