### PR TITLE
P4-1441 Cancel allocations

### DIFF
--- a/app/controllers/api/v1/allocation_events_controller.rb
+++ b/app/controllers/api/v1/allocation_events_controller.rb
@@ -3,6 +3,7 @@
 module Api
   module V1
     class AllocationEventsController < ApiController
+      before_action :validate_params, only: :create
       after_action :send_move_notifications, only: :create
 
       def create
@@ -25,6 +26,10 @@ module Api
         :type,
         attributes: %i[timestamp event_name],
       ].freeze
+
+      def validate_params
+        AllocationEvents::ParamsValidator.new(event_params).validate!(action_name.to_sym)
+      end
 
       def event_params
         params.require(:data).permit(PERMITTED_EVENT_PARAMS).to_h

--- a/app/controllers/api/v1/allocation_events_controller.rb
+++ b/app/controllers/api/v1/allocation_events_controller.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class AllocationEventsController < ApiController
+      after_action :send_move_notifications, only: :create
+
+      def create
+        case event_name
+        when 'cancel'
+          allocation.cancel
+
+          allocation.save!
+          render json: fake_event_object, status: :created
+        else
+          render status: :bad_request, json: {
+            errors: [{ title: 'invalid event_name', detail: "#{event_name} is not supported" }],
+          }
+        end
+      end
+
+    private
+
+      PERMITTED_EVENT_PARAMS = [
+        :type,
+        attributes: %i[timestamp event_name],
+      ].freeze
+
+      def event_params
+        params.require(:data).permit(PERMITTED_EVENT_PARAMS).to_h
+      end
+
+      def allocation
+        @allocation ||= Allocation.find(params.require(:allocation_id))
+      end
+
+      def send_move_notifications
+        allocation.moves.each do |move|
+          Notifier.prepare_notifications(topic: move, action_name: 'update_status')
+        end
+      end
+
+      def event_name
+        @event_name ||= event_params.dig(:attributes, :event_name)
+      end
+
+      def timestamp
+        @timestamp ||= Time.zone.parse(event_params.dig(:attributes, :timestamp))
+      end
+
+      def fake_event_object
+        # NB: this is a temporarily implementation to simulate the creation of a new event
+        {
+          data: {
+            id: SecureRandom.uuid,
+            type: 'events',
+            attributes: {
+              event_name: event_name,
+              timestamp: timestamp,
+            },
+            relationships: {
+              allocation: {
+                data: {
+                  type: 'allocations',
+                  id: allocation.id,
+                },
+              },
+            },
+          },
+        }
+      end
+    end
+  end
+end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -23,6 +23,14 @@ class Allocation < VersionedModel
     cancelled: ALLOCATION_STATUS_CANCELLED,
   }
 
+  CANCELLATION_REASONS = [
+    MADE_IN_ERROR = 'made_in_error',
+    SUPPLIER_DECLINED_TO_MOVE = 'supplier_declined_to_move',
+    LACK_OF_SPACE = 'lack_of_space_at_receiving_establishment',
+    FAILED_TO_FILL_ALLOCATION = 'sending_establishment_failed_to_fill_allocation',
+    OTHER = 'other',
+  ].freeze
+
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location'
   has_many :moves, inverse_of: :allocation, dependent: :destroy
@@ -36,6 +44,9 @@ class Allocation < VersionedModel
 
   validates :moves_count, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :date, presence: true
+
+  validates :cancellation_reason, inclusion: { in: CANCELLATION_REASONS }, if: :cancelled?
+  validates :cancellation_reason, absence: true, unless: :cancelled?
 
   attribute :complex_cases, Types::JSONB.new(Allocation::ComplexCaseAnswers)
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Allocation < VersionedModel
+  ALLOCATION_STATUS_UNFILLED = 'unfilled'
+  ALLOCATION_STATUS_FILLED = 'filled'
+  ALLOCATION_STATUS_CANCELLED = 'cancelled'
+
   enum prisoner_category: {
     b: 'B',
     c: 'C',
@@ -10,6 +14,13 @@ class Allocation < VersionedModel
   enum sentence_length: {
     short: '16_or_less',
     long: 'more_than_16',
+  }
+
+  # TODO: implement statemachine, for now just allow an allocation to be cancelled
+  enum status: {
+    unfilled: ALLOCATION_STATUS_UNFILLED,
+    filled: ALLOCATION_STATUS_FILLED,
+    cancelled: ALLOCATION_STATUS_CANCELLED,
   }
 
   belongs_to :from_location, class_name: 'Location'

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -26,6 +26,7 @@ class Allocation < VersionedModel
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location'
   has_many :moves, inverse_of: :allocation, dependent: :destroy
+  has_many :events, as: :eventable, dependent: :destroy
 
   validates :from_location, presence: true
   validates :to_location, presence: true

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -57,8 +57,11 @@ class Move < VersionedModel
   validates :date, presence: true, unless: -> { proposed? || cancelled? }
   validates :date_from, presence: true, if: :proposed?
   validates :status, inclusion: { in: statuses }
-  validates :cancellation_reason, inclusion: { in: CANCELLATION_REASONS + Allocation::CANCELLATION_REASONS }, if: :cancelled?
+
+  # Ignoring cancellation reason validations when an allocation exists until we implement them on the FE
+  validates :cancellation_reason, inclusion: { in: CANCELLATION_REASONS + Allocation::CANCELLATION_REASONS }, if: -> { cancelled? && allocation.blank? }
   validates :cancellation_reason, absence: true, unless: :cancelled?
+
   validate :date_to_after_date_from
 
   before_validation :set_reference

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -57,7 +57,7 @@ class Move < VersionedModel
   validates :date, presence: true, unless: -> { proposed? || cancelled? }
   validates :date_from, presence: true, if: :proposed?
   validates :status, inclusion: { in: statuses }
-  validates :cancellation_reason, inclusion: { in: CANCELLATION_REASONS }, if: :cancelled?
+  validates :cancellation_reason, inclusion: { in: CANCELLATION_REASONS + Allocation::CANCELLATION_REASONS }, if: :cancelled?
   validates :cancellation_reason, absence: true, unless: :cancelled?
   validate :date_to_after_date_from
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -58,7 +58,7 @@ class Move < VersionedModel
   validates :date_from, presence: true, if: :proposed?
   validates :status, inclusion: { in: statuses }
 
-  validates :cancellation_reason, inclusion: { in: CANCELLATION_REASONS + Allocation::CANCELLATION_REASONS }, if: :cancelled?
+  validates :cancellation_reason, inclusion: { in: CANCELLATION_REASONS }, if: :cancelled?
   validates :cancellation_reason, absence: true, unless: :cancelled?
 
   validate :date_to_after_date_from

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class AllocationSerializer < ActiveModel::Serializer
-  attributes :moves_count, :date, :prisoner_category, :sentence_length, :complex_cases, :complete_in_full, :other_criteria, :status, :created_at, :updated_at
+  attributes :moves_count, :date, :prisoner_category, :sentence_length, :complex_cases, :complete_in_full,
+             :other_criteria, :status, :cancellation_reason, :cancellation_reason_comment, :created_at, :updated_at
 
   has_one :from_location
   has_one :to_location

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AllocationSerializer < ActiveModel::Serializer
-  attributes :moves_count, :date, :prisoner_category, :sentence_length, :complex_cases, :complete_in_full, :other_criteria, :created_at, :updated_at
+  attributes :moves_count, :date, :prisoner_category, :sentence_length, :complex_cases, :complete_in_full, :other_criteria, :status, :created_at, :updated_at
 
   has_one :from_location
   has_one :to_location

--- a/app/services/allocation_events/params_validator.rb
+++ b/app/services/allocation_events/params_validator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module AllocationEvents
+  class ParamsValidator
+    include ActiveModel::Validations
+
+    attr_reader :event_name, :timestamp
+
+    validates :event_name, inclusion: %w[cancel], presence: true
+    validates_each :timestamp, presence: true do |record, attr, value|
+      Time.iso8601(value)
+    rescue ArgumentError
+      record.errors.add(attr, 'must be formatted as a valid ISO-8601 date-time')
+    end
+
+    def initialize(params)
+      @event_name = params.dig(:attributes, :event_name)
+      @timestamp = params.dig(:attributes, :timestamp)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,10 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :allocations, only: %i[create index show]
+      resources :allocations, only: %i[create index show] do
+        resources :events, only: %i[create], controller: 'allocation_events'
+      end
+
       resources :documents, only: %i[create]
       resources :court_hearings, only: %i[create]
       resources :people, only: %i[index create update] do

--- a/db/migrate/20200514052159_add_status_to_allocations.rb
+++ b/db/migrate/20200514052159_add_status_to_allocations.rb
@@ -1,0 +1,5 @@
+class AddStatusToAllocations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :allocations, :status, :string
+  end
+end

--- a/db/migrate/20200514055112_add_cancellation_reason_and_comment_to_allocations.rb
+++ b/db/migrate/20200514055112_add_cancellation_reason_and_comment_to_allocations.rb
@@ -1,0 +1,6 @@
+class AddCancellationReasonAndCommentToAllocations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :allocations, :cancellation_reason, :string
+    add_column :allocations, :cancellation_reason_comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_11_150020) do
+ActiveRecord::Schema.define(version: 2020_05_14_052159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2020_05_11_150020) do
     t.text "other_criteria"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status"
     t.index ["date"], name: "index_allocations_on_date"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_14_052159) do
+ActiveRecord::Schema.define(version: 2020_05_14_055112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -56,6 +56,8 @@ ActiveRecord::Schema.define(version: 2020_05_14_052159) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "status"
+    t.string "cancellation_reason"
+    t.text "cancellation_reason_comment"
     t.index ["date"], name: "index_allocations_on_date"
   end
 

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe Allocation do
 
     it 'does not update moves if allocation invalid' do
       allocation.from_location = nil
-      allocation.cancel
-    rescue ActiveRecord::RecordInvalid
+      allocation.cancel rescue ActiveRecord::RecordInvalid
+
       expect(allocation.reload.moves.pluck(:status)).to contain_exactly(Move::MOVE_STATUS_REQUESTED)
     end
   end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -31,4 +31,27 @@ RSpec.describe Allocation do
       expect(allocation.versions.map(&:event)).to eq(%w[create])
     end
   end
+
+  describe 'cancellation_reason' do
+    context 'when the allocation is not cancelled' do
+      let(:allocation) { build(:allocation, status: nil) }
+
+      it { expect(allocation).to validate_absence_of(:cancellation_reason) }
+    end
+
+    context 'when the allocation is cancelled' do
+      let(:allocation) { build(:allocation, status: 'cancelled') }
+
+      it {
+        expect(allocation).to validate_inclusion_of(:cancellation_reason)
+          .in_array(%w[
+            made_in_error
+            supplier_declined_to_move
+            other
+            lack_of_space_at_receiving_establishment
+            sending_establishment_failed_to_fill_allocation
+          ])
+      }
+    end
+  end
 end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe Allocation do
   it { is_expected.to allow_value(nil).for(:sentence_length) }
   it { is_expected.to define_enum_for(:sentence_length).backed_by_column_of_type(:string) }
 
+  it { is_expected.to allow_value(nil).for(:status) }
+  it { is_expected.to define_enum_for(:status).backed_by_column_of_type(:string) }
+
   it { is_expected.to validate_presence_of(:moves_count) }
   it { is_expected.to validate_numericality_of(:moves_count) }
   it { is_expected.to validate_presence_of(:date) }

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Allocation do
     end
   end
 
-  xdescribe 'cancellation_reason' do
+  describe 'cancellation_reason' do
     context 'when the allocation is not cancelled' do
       let(:allocation) { build(:allocation, status: nil) }
 
@@ -68,6 +68,30 @@ RSpec.describe Allocation do
       allocation.reload.cancel
 
       expect(allocation.reload.moves.pluck(:status)).to contain_exactly(Move::MOVE_STATUS_CANCELLED)
+    end
+
+    it 'sets the cancellation reason to other' do
+      allocation.reload.cancel
+
+      expect(allocation.reload.cancellation_reason).to eq(described_class::CANCELLATION_REASON_OTHER)
+    end
+
+    it 'sets the cancellation reason comment to cancelled by allocation' do
+      allocation.reload.cancel
+
+      expect(allocation.reload.cancellation_reason_comment).to eq('Allocation was cancelled')
+    end
+
+    it 'sets the cancellation reason on moves to other' do
+      allocation.reload.cancel
+
+      expect(allocation.reload.moves.first.cancellation_reason).to eq(Move::CANCELLATION_REASON_OTHER)
+    end
+
+    it 'sets the cancellation reason comment on moves to cancelled by allocation' do
+      allocation.reload.cancel
+
+      expect(allocation.reload.moves.first.cancellation_reason_comment).to eq('Allocation was cancelled')
     end
 
     it 'throws validation error if allocation invalid' do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Allocation do
   it { is_expected.to belong_to(:to_location) }
 
   it { is_expected.to have_many(:moves) }
+  it { is_expected.to have_many(:events) }
 
   it { is_expected.to validate_presence_of(:from_location) }
   it { is_expected.to validate_presence_of(:to_location) }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -23,32 +23,19 @@ RSpec.describe Move do
     end
 
     context 'when the move is cancelled' do
-      context 'without an allocation' do
-        let(:move) { build(:move, status: 'cancelled') }
+      let(:move) { build(:move, status: 'cancelled') }
 
-        it {
-          expect(move).to validate_inclusion_of(:cancellation_reason)
-            .in_array(%w[
-              made_in_error
-              supplier_declined_to_move
-              rejected
-              other
-              lack_of_space_at_receiving_establishment
-              sending_establishment_failed_to_fill_allocation
-            ])
-        }
-      end
-
-      context 'with an allocation' do
-        let(:move) { create(:move, :with_allocation) }
-
-        it 'is valid with no cancellation reason' do
-          move.status = 'cancelled'
-          move.cancellation_reason = nil
-
-          expect(move).to be_valid
-        end
-      end
+      it {
+        expect(move).to validate_inclusion_of(:cancellation_reason)
+          .in_array(%w[
+            made_in_error
+            supplier_declined_to_move
+            rejected
+            other
+            lack_of_space_at_receiving_establishment
+            sending_establishment_failed_to_fill_allocation
+          ])
+      }
     end
   end
 
@@ -353,6 +340,40 @@ RSpec.describe Move do
 
         it { is_expected.to be true }
       end
+    end
+  end
+
+  describe '#cancel' do
+    let(:move) { build(:move) }
+
+    it 'sets the default cancellation_reason attribute to other' do
+      move.cancel
+
+      expect(move.cancellation_reason).to eq(described_class::CANCELLATION_REASON_OTHER)
+    end
+
+    it 'does not set the default cancellation_reason_comment attribute' do
+      move.cancel
+
+      expect(move.cancellation_reason_comment).to be_nil
+    end
+
+    it 'sets the cancellation_reason attribute' do
+      move.cancel(reason: described_class::CANCELLATION_REASON_MADE_IN_ERROR)
+
+      expect(move.cancellation_reason).to eq(described_class::CANCELLATION_REASON_MADE_IN_ERROR)
+    end
+
+    it 'sets the cancellation_reason_comment' do
+      move.cancel(comment: 'some comment')
+
+      expect(move.cancellation_reason_comment).to eq('some comment')
+    end
+
+    it 'sets the status to cancelled' do
+      move.cancel
+
+      expect(move.status).to eq('cancelled')
     end
   end
 

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -17,15 +17,25 @@ RSpec.describe Move do
 
   describe 'cancellation_reason' do
     context 'when the move is not cancelled' do
-      subject(:move) { build(:move, status: 'requested') }
+      let(:move) { build(:move, status: 'requested') }
 
-      it { is_expected.to validate_absence_of(:cancellation_reason) }
+      it { expect(move).to validate_absence_of(:cancellation_reason) }
     end
 
     context 'when the move is cancelled' do
-      subject(:move) { build(:move, status: 'cancelled') }
+      let(:move) { build(:move, status: 'cancelled') }
 
-      it { is_expected.to validate_inclusion_of(:cancellation_reason).in_array(%w[made_in_error supplier_declined_to_move rejected other]) }
+      it {
+        expect(move).to validate_inclusion_of(:cancellation_reason)
+          .in_array(%w[
+            made_in_error
+            supplier_declined_to_move
+            rejected
+            other
+            lack_of_space_at_receiving_establishment
+            sending_establishment_failed_to_fill_allocation
+          ])
+      }
     end
   end
 

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe Move do
             supplier_declined_to_move
             rejected
             other
-            lack_of_space_at_receiving_establishment
-            sending_establishment_failed_to_fill_allocation
           ])
       }
     end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -23,19 +23,32 @@ RSpec.describe Move do
     end
 
     context 'when the move is cancelled' do
-      let(:move) { build(:move, status: 'cancelled') }
+      context 'without an allocation' do
+        let(:move) { build(:move, status: 'cancelled') }
 
-      it {
-        expect(move).to validate_inclusion_of(:cancellation_reason)
-          .in_array(%w[
-            made_in_error
-            supplier_declined_to_move
-            rejected
-            other
-            lack_of_space_at_receiving_establishment
-            sending_establishment_failed_to_fill_allocation
-          ])
-      }
+        it {
+          expect(move).to validate_inclusion_of(:cancellation_reason)
+            .in_array(%w[
+              made_in_error
+              supplier_declined_to_move
+              rejected
+              other
+              lack_of_space_at_receiving_establishment
+              sending_establishment_failed_to_fill_allocation
+            ])
+        }
+      end
+
+      context 'with an allocation' do
+        let(:move) { create(:move, :with_allocation) }
+
+        it 'is valid with no cancellation reason' do
+          move.status = 'cancelled'
+          move.cancellation_reason = nil
+
+          expect(move).to be_valid
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v1/allocation_events_controller_create_spec.rb
+++ b/spec/requests/api/v1/allocation_events_controller_create_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::AllocationEventsController do
+  let(:response_json) { JSON.parse(response.body) }
+
+  describe 'POST /allocations/:allocation_id/events' do
+    let(:schema) { load_yaml_schema('post_allocation_events_responses.yaml') }
+
+    let(:supplier) { create(:supplier) }
+    let(:application) { create(:application, owner_id: supplier.id) }
+    let(:access_token) { create(:access_token, application: application).token }
+    let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
+    let(:content_type) { ApiController::CONTENT_TYPE }
+
+    let(:allocation) { create(:allocation, :with_moves) }
+    let(:move) { allocation.moves.first }
+    let(:allocation_id) { allocation.id }
+    let(:allocation_event_params) do
+      {
+        data: {
+          type: 'events',
+          attributes: {
+            timestamp: '2020-04-23T18:25:43.511Z',
+            event_name: 'cancel',
+          },
+        },
+      }
+    end
+
+    before do
+      allow(Notifier).to receive(:prepare_notifications)
+      post "/api/v1/allocations/#{allocation_id}/events", params: allocation_event_params, headers: headers, as: :json
+    end
+
+    describe 'Cancel event' do
+      context 'when successful' do
+        it_behaves_like 'an endpoint that responds with success 201'
+
+        it 'updates the allocation status' do
+          expect(allocation.reload.status).to eql('cancelled')
+        end
+
+        it 'updates the allocation moves status' do
+          expect(allocation.reload.moves.pluck(:status).uniq).to contain_exactly('cancelled')
+        end
+
+        describe 'webhook and email notifications' do
+          it 'calls the move notifier when updating the status' do
+            expect(Notifier).to have_received(:prepare_notifications).with(topic: move, action_name: 'update_status')
+          end
+        end
+      end
+    end
+
+    context 'with a bad request' do
+      let(:allocation_event_params) { nil }
+
+      it_behaves_like 'an endpoint that responds with error 400'
+    end
+
+    context 'when not authorized' do
+      let(:access_token) { 'foo-bar' }
+      let(:detail_401) { 'Token expired or invalid' }
+
+      it_behaves_like 'an endpoint that responds with error 401'
+    end
+
+    context 'with a missing allocation_id' do
+      let(:allocation_id) { 'foo-bar' }
+      let(:detail_404) { "Couldn't find Allocation with 'id'=foo-bar" }
+
+      it_behaves_like 'an endpoint that responds with error 404'
+
+      it 'does not call the move notifier' do
+        expect(Notifier).not_to have_received(:prepare_notifications)
+      end
+    end
+
+    context 'with an invalid CONTENT_TYPE header' do
+      let(:content_type) { 'application/xml' }
+
+      it_behaves_like 'an endpoint that responds with error 415'
+    end
+
+    context 'with validation errors' do
+      # TODO add validation tests once the Event model is finalised
+    end
+  end
+end

--- a/spec/serializers/allocation_serializer_spec.rb
+++ b/spec/serializers/allocation_serializer_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe AllocationSerializer do
 
     it 'contains a status attribute' do
       expect(attributes[:status]).to eql allocation.status
+
+    it 'contains a cancellation_reason attribute' do
+      expect(attributes[:cancellation_reason]).to eql allocation.cancellation_reason
+    end
+
+    it 'contains a cancellation_reason_comment attribute' do
+      expect(attributes[:cancellation_reason_comment]).to eql allocation.cancellation_reason_comment
     end
 
     it 'contains a created_at attribute' do

--- a/spec/serializers/allocation_serializer_spec.rb
+++ b/spec/serializers/allocation_serializer_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe AllocationSerializer do
 
     it 'contains a status attribute' do
       expect(attributes[:status]).to eql allocation.status
+    end
 
     it 'contains a cancellation_reason attribute' do
       expect(attributes[:cancellation_reason]).to eql allocation.cancellation_reason

--- a/spec/serializers/allocation_serializer_spec.rb
+++ b/spec/serializers/allocation_serializer_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe AllocationSerializer do
       expect(attributes[:other_criteria]).to eql allocation.other_criteria
     end
 
+    it 'contains a status attribute' do
+      expect(attributes[:status]).to eql allocation.status
+    end
+
     it 'contains a created_at attribute' do
       expect(attributes[:created_at]).to eql allocation.created_at.iso8601
     end

--- a/spec/services/allocation_events/params_validator_spec.rb
+++ b/spec/services/allocation_events/params_validator_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AllocationEvents::ParamsValidator do
+  subject(:params_validator) { described_class.new(params) }
+
+  let(:params) { { attributes: { event_name: event_name, timestamp: timestamp } } }
+  let(:event_name) { 'cancel' }
+  let(:timestamp) { '2020-04-29T22:45:59.000Z' }
+
+  context 'when valid' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'event_name' do
+    context 'when invalid' do
+      let(:event_name) { 'foo' }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when nil' do
+      let(:event_name) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when missing' do
+      before { params[:attributes].delete(:event_name) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe 'timestamp' do
+    context 'when invalid' do
+      let(:timestamp) { '1/2/20 8pm' }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when nil' do
+      let(:timestamp) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when missing' do
+      before { params[:attributes].delete(:timestamp) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/spec/swagger/definitions/hand_coded_paths.yaml
+++ b/spec/swagger/definitions/hand_coded_paths.yaml
@@ -130,6 +130,97 @@
           application/vnd.api+json:
             schema:
               $ref: post_allocations_responses.yaml#/422
+/allocations/{allocation_id}/events:
+  post:
+    summary: '[NOT YET IMPLEMENTED] Creates an allocation event'
+    description: |
+      ## [NOT YET IMPLEMENTED]
+
+      Creating an allocation event can change the underlying allocation's status or other attributes.
+
+      Use the `event_name` attribute to specify the type of event:
+
+      * `cancel` - cancel an allocation and associated moves
+    tags:
+    - Allocations
+    consumes:
+    - application/vnd.api+json
+    parameters:
+    - $ref: allocation_id_parameter.yaml#/AllocationId
+    - $ref: idempotency_key_parameter.yaml#/IdempotencyKey
+    - $ref: content_type_parameter.yaml#/ContentType
+    - name: body
+      in: body
+      required: true
+      description: |
+        ### Cancelling an Allocation
+
+        An allocation is cancelled by POSTing a `cancelled` event. Cancelling an allocation will change the allocation status to `cancelled`.
+        It will also cancel all associated moves with the allocation.
+
+        ```
+        {
+          "type": "events",
+          "attributes": {
+            "event_name": "cancel",
+            "timestamp": "2020-04-21T13:20:50.52Z"
+          }
+        }
+        ```
+        ---
+      schema:
+        $ref: post_allocation_event.yaml#/PostAllocationEvent
+    responses:
+      '201':
+        description: created
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: post_allocation_events_responses.yaml#/201
+        examples:
+          Cancel:
+            data:
+              id: 355b78b6-57da-4c52-9c41-29a90376c0d7
+              type: events
+              attributes:
+                event_name: cancel
+                timestamp: '2020-04-21T13:20:50.52Z'
+      '400':
+        description: bad request
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/400
+      '401':
+        description: unauthorized
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/401
+      '404':
+        description: resource not found
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/404
+      '409':
+        description: conflict
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/409
+      '415':
+        description: invalid media type
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/415
+      '422':
+        description: unprocessable entity
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/422
 /moves:
   get:
     summary: Returns a list of moves

--- a/swagger/v1/allocation.yaml
+++ b/swagger/v1/allocation.yaml
@@ -113,6 +113,23 @@ Allocation:
             - filled
             - cancelled
           description: Indicates the stage in it's lifecycle that this allocation is at
+        cancellation_reason:
+          oneOf:
+          - type: 'null'
+          - type: string
+            enum:
+            - made_in_error
+            - supplier_declined_to_move
+            - lack_of_space_at_receiving_establishment
+            - sending_establishment_failed_to_fill_allocation
+            - other
+          description: Reason the allocation has been cancelled
+        cancellation_reason_comment:
+          oneOf:
+          - type: string
+          - type: 'null'
+          description: In case 'other' is chosen as cancellation_reason, further details
+            can be specified
     relationships:
       type: object
       required:

--- a/swagger/v1/allocation.yaml
+++ b/swagger/v1/allocation.yaml
@@ -104,6 +104,15 @@ Allocation:
           - type: string
           - type: 'null'
           description: Additional information about the allocation
+        status:
+          oneOf:
+          - type: 'null'
+          - type: string
+            enum:
+            - unfilled
+            - filled
+            - cancelled
+          description: Indicates the stage in it's lifecycle that this allocation is at
     relationships:
       type: object
       required:

--- a/swagger/v1/allocation_event_name_attribute.yaml
+++ b/swagger/v1/allocation_event_name_attribute.yaml
@@ -1,0 +1,6 @@
+AllocationEventName:
+  type: string
+  example: cancel
+  enum:
+  - cancel
+  description: The type of this move event

--- a/swagger/v1/allocation_id_parameter.yaml
+++ b/swagger/v1/allocation_id_parameter.yaml
@@ -1,0 +1,9 @@
+AllocationId:
+  name: allocation_id
+  in: path
+  required: true
+  description: The ID of the allocation
+  schema:
+    type: string
+    format: uuid
+  example: 5b61f755-0fd7-4a91-b7a3-a33d751f985f

--- a/swagger/v1/get_allocation_event.yaml
+++ b/swagger/v1/get_allocation_event.yaml
@@ -1,0 +1,28 @@
+GetAllocationEvent:
+  type: object
+  required:
+  - id
+  - type
+  - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: 355b78b6-57da-4c52-9c41-29a90376c0d7
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: events
+      enum:
+      - events
+      description: The type of this object - always `events`
+    attributes:
+      type: object
+      required:
+      - event_name
+      - timestamp
+      properties:
+        event_name:
+          $ref: allocation_event_name_attribute.yaml#/AllocationEventName
+        timestamp:
+          $ref: timestamp_attribute.yaml#/Timestamp

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -102,8 +102,6 @@ Move:
             - made_in_error
             - supplier_declined_to_move
             - rejected
-            - lack_of_space_at_receiving_establishment
-            - sending_establishment_failed_to_fill_allocation
             - other
           - type: 'null'
           description: Reason the move has been cancelled

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -102,6 +102,8 @@ Move:
             - made_in_error
             - supplier_declined_to_move
             - rejected
+            - lack_of_space_at_receiving_establishment
+            - sending_establishment_failed_to_fill_allocation
             - other
           - type: 'null'
           description: Reason the move has been cancelled

--- a/swagger/v1/post_allocation_event.yaml
+++ b/swagger/v1/post_allocation_event.yaml
@@ -1,0 +1,22 @@
+PostAllocationEvent:
+  type: object
+  required:
+  - type
+  - attributes
+  properties:
+    type:
+      type: string
+      example: events
+      enum:
+      - events
+      description: The type of this object - always `events`
+    attributes:
+      type: object
+      required:
+      - event_name
+      - timestamp
+      properties:
+        event_name:
+          $ref: allocation_event_name_attribute.yaml#/AllocationEventName
+        timestamp:
+          $ref: timestamp_attribute.yaml#/Timestamp

--- a/swagger/v1/post_allocation_events_responses.yaml
+++ b/swagger/v1/post_allocation_events_responses.yaml
@@ -1,0 +1,19 @@
+'201':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: get_allocation_event.yaml#/GetAllocationEvent
+'400':
+  $ref: error_responses.yaml#/400
+'401':
+  $ref: error_responses.yaml#/401
+'404':
+  $ref: error_responses.yaml#/404
+'409':
+  $ref: error_responses.yaml#/409
+'415':
+  $ref: error_responses.yaml#/415
+'422':
+  $ref: error_responses.yaml#/422


### PR DESCRIPTION
### Jira link

[P4-1441](https://dsdmoj.atlassian.net/browse/P4-1441)

### What?

- Add a status to an allocation. An allocation can have 3 statuses: filled, unfilled and cancelled. We will now only implement cancelled
- Add events to allocation to allow for setting the status
- Add cancellation reason and comment to an allocation 
- Add allocation events create path
### Why?

To allow the cancellation of an allocation and the associated moves, add a new event endpoint which when set as cancelled will set the new "status" of allocation to cancelled as well as all moves.

The event endpoint is returning a fake response as it is still to be implemented in further work. 
I initially implemented cancellation reason but then it got de-scoped later on, so I kept the implementation to avoid having to redo this.


### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production
- Changes validation on cancellation reason move (to check with FE that empty cancellation reasons is ok)

