### PR TITLE
P4-1384 GET /reference/regions API endpoint

### DIFF
--- a/app/controllers/api/v1/reference/regions_controller.rb
+++ b/app/controllers/api/v1/reference/regions_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Reference
+      class RegionsController < ApiController
+        def index
+          render json: Region.all.includes(:locations)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/region_serializer.rb
+++ b/app/serializers/region_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RegionSerializer < ActiveModel::Serializer
+  attributes :key, :name, :created_at, :updated_at
+
+  has_many :locations
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,17 +9,16 @@ Rails.application.routes.draw do
   get "/docs/*id" => 'pages#show', as: :page, format: false
   get 'docs/', to: 'pages#show', id: 'overview'
 
-  get '/ping', to: 'status#ping', format: :json
   get '/health', to: 'status#health', format: :json
+  get '/ping', to: 'status#ping', format: :json
 
   namespace :api do
     namespace :v1 do
       resources :allocations, only: %i[create index show] do
         resources :events, only: %i[create], controller: 'allocation_events'
       end
-
-      resources :documents, only: %i[create]
       resources :court_hearings, only: %i[create]
+      resources :documents, only: %i[create]
       resources :people, only: %i[index create update] do
         get 'images', to: 'people#image'
         get 'court_cases', to: 'people#court_cases'
@@ -31,15 +30,16 @@ Rails.application.routes.draw do
         resources :journeys, only: %i[index show create update]
       end
       namespace :reference do
-        resources :locations, only: %i[index show]
         resources :allocation_complex_cases, only: :index
         resources :assessment_questions, only: :index
-        resources :genders, only: :index
         resources :ethnicities, only: :index
-        resources :nationalities, only: :index
+        resources :genders, only: :index
         resources :identifier_types, only: :index
-        resources :suppliers, only: %i[index show]
+        resources :locations, only: %i[index show]
+        resources :nationalities, only: :index
         resources :prison_transfer_reasons, only: %i[index]
+        resources :regions, only: :index
+        resources :suppliers, only: %i[index show]
       end
     end
   end

--- a/spec/factories/region.rb
+++ b/spec/factories/region.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :region do
+    sequence(:key) { |x| "key_#{x}" }
+    sequence(:name) { |x| "#{Faker::Address.state}_#{x}" }
+  end
+end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Region do
+  subject(:region) { build(:region) }
+
+  it { is_expected.to have_and_belong_to_many(:locations) }
+
+  it { is_expected.to validate_presence_of(:key) }
+  it { is_expected.to validate_presence_of(:name) }
+
+  it { is_expected.to validate_uniqueness_of(:key) }
+  it { is_expected.to validate_uniqueness_of(:name) }
+end

--- a/spec/requests/api/v1/reference/regions_controller_spec.rb
+++ b/spec/requests/api/v1/reference/regions_controller_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::Reference::RegionsController do
+  let!(:access_token) { create(:access_token).token }
+  let(:response_json) { JSON.parse(response.body) }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
+
+  describe 'GET /api/v1/reference/regions' do
+    let(:schema) { load_yaml_schema('get_regions_responses.yaml') }
+
+    let(:location) { create(:location) }
+    let!(:region1) { create(:region, locations: [location]) }
+    let!(:region2) { create(:region, locations: [location]) }
+
+    let(:data) do
+      [
+        {
+          type: 'regions',
+          attributes: {
+            key: region1.key,
+            name: region1.name,
+          },
+          relationships: {
+            locations: {
+              data: [
+                {
+                  id: location.id,
+                  type: 'locations',
+                },
+              ],
+            },
+          },
+        },
+        {
+          type: 'regions',
+          attributes: {
+            key: region2.key,
+            name: region2.name,
+          },
+          relationships: {
+            locations: {
+              data: [
+                {
+                  id: location.id,
+                  type: 'locations',
+                },
+              ],
+            },
+          },
+        },
+      ]
+    end
+
+    before do
+      get '/api/v1/reference/regions', headers: headers
+    end
+
+    context 'when successful' do
+      it_behaves_like 'an endpoint that responds with success 200'
+
+      it 'returns the correct data' do
+        expect(response_json).to include_json(data: data)
+      end
+    end
+
+    context 'when not authorized', :with_invalid_auth_headers do
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+      let(:content_type) { ApiController::CONTENT_TYPE }
+      let(:detail_401) { 'Token expired or invalid' }
+
+      it_behaves_like 'an endpoint that responds with error 401'
+    end
+
+    context 'with an invalid CONTENT_TYPE header' do
+      let(:content_type) { 'application/xml' }
+
+      it_behaves_like 'an endpoint that responds with error 415'
+    end
+  end
+end

--- a/spec/requests/api/v1/reference/regions_controller_spec.rb
+++ b/spec/requests/api/v1/reference/regions_controller_spec.rb
@@ -66,6 +66,41 @@ RSpec.describe Api::V1::Reference::RegionsController do
       end
     end
 
+    context 'with multiple locations' do
+      let(:location1) { create(:location) }
+      let(:location2) { create(:location) }
+      let(:location3) { create(:location) }
+      let!(:region1) { create(:region, locations: [location1, location2]) }
+      let!(:region2) { create(:region, locations: [location2, location3]) }
+
+      let(:expected_relationships) do
+        UnorderedArray(
+          {
+            relationships: {
+              locations: {
+                data: UnorderedArray(
+                  { id: location1.id, type: 'locations' },
+                  id: location2.id, type: 'locations',
+                ),
+              },
+            },
+          },
+          relationships: {
+            locations: {
+              data: UnorderedArray(
+                { id: location2.id, type: 'locations' },
+                id: location3.id, type: 'locations',
+              ),
+            },
+          },
+        )
+      end
+
+      it 'has correct relationships for each location' do
+        expect(response_json).to include_json(data: expected_relationships)
+      end
+    end
+
     context 'when not authorized', :with_invalid_auth_headers do
       let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
       let(:content_type) { ApiController::CONTENT_TYPE }

--- a/spec/serializers/region_serializer_spec.rb
+++ b/spec/serializers/region_serializer_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RegionSerializer do
+  subject(:serializer) { described_class.new(region) }
+
+  let(:region) { create(:region) }
+  let(:result) do
+    JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys
+  end
+  let(:result_data) { result[:data] }
+  let(:attributes) { result_data[:attributes] }
+
+  it 'contains a type property' do
+    expect(result_data[:type]).to eql 'regions'
+  end
+
+  it 'contains an id property' do
+    expect(result_data[:id]).to eql region.id
+  end
+
+  it 'contains a key attribute' do
+    expect(attributes[:key]).to eql region.key
+  end
+
+  it 'contains a name attribute' do
+    expect(attributes[:name]).to eql region.name
+  end
+
+  it 'contains a created_at attribute' do
+    expect(attributes[:created_at]).to eql region.created_at.iso8601
+  end
+
+  it 'contains an updated_at attribute' do
+    expect(attributes[:updated_at]).to eql region.updated_at.iso8601
+  end
+
+  describe 'locations' do
+    context 'with locations' do
+      let(:location) { create(:location) }
+      let(:region) { create(:region, locations: [location]) }
+
+      it 'contains a locations relationship' do
+        expect(result_data[:relationships][:locations][:data]).to contain_exactly(id: location.id, type: 'locations')
+      end
+
+      it 'does not contain an included location' do
+        expect(result[:included]).to be_nil
+      end
+    end
+
+    context 'without locations' do
+      it 'contains empty locations' do
+        expect(result_data[:relationships][:locations][:data]).to be_empty
+      end
+
+      it 'does not contain an included location' do
+        expect(result[:included]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/regions/importer_spec.rb
+++ b/spec/services/regions/importer_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Regions::Importer do
 
   context 'with one existing record' do
     before do
-      Region.create!(key: '1', name: 'First region')
+      create(:region, key: '1', name: 'First region')
     end
 
     it 'creates only the missing items' do
@@ -60,7 +60,7 @@ RSpec.describe Regions::Importer do
   end
 
   context 'with one existing record with the wrong name' do
-    let!(:existing) { Region.create!(key: '2A', name: 'Wrong', locations: [unlinked_location]) }
+    let!(:existing) { create(:region, key: '2A', name: 'Wrong', locations: [unlinked_location]) }
 
     it 'updates the title of the existing record' do
       importer.call

--- a/spec/support/json_schemas.rb
+++ b/spec/support/json_schemas.rb
@@ -4,7 +4,6 @@ RSpec.configure do |config|
   def load_schema(file_name)
     return unless File.file?("#{Rails.root}/swagger/v1/#{file_name}")
 
-    # schema = load_json_schema(file_name)
     schema = load_yaml_schema(file_name)
     JSON::Validator.add_schema(JSON::Schema.new(schema, file_name))
   end
@@ -17,12 +16,17 @@ RSpec.configure do |config|
 
   def load_yaml_schema(file_name)
     File.open("#{Rails.root}/swagger/v1/#{file_name}") do |file|
-      YAML.safe_load(file.read)
+      begin
+        YAML.safe_load(file.read)
+      rescue Psych::SyntaxError => e
+        # Include original filename in exception to make debugging a less cryptic affair
+        raise Psych::SyntaxError.new(file_name, e.line, e.column, e.offset, e.problem, e.context)
+      end
     end
   end
 
   config.before(:suite) do
-    # This runs *once* before the test suite starts to ensure that we can resolve all of the Swagger JSON definitions
+    # This runs *once* before the test suite starts to ensure that we can resolve all of the Swagger definitions
     Dir.glob('**/*.yaml', base: 'swagger/v1').each { |file_name| load_schema(file_name) }
   end
 end

--- a/spec/swagger/definitions/hand_coded_paths.yaml
+++ b/spec/swagger/definitions/hand_coded_paths.yaml
@@ -1550,6 +1550,35 @@
           application/vnd.api+json:
             schema:
               $ref: get_nationalities_responses.yaml#/415
+/reference/regions:
+  get:
+    summary: Returns a list of regions (location groups)
+    tags:
+    - Regions
+    - Locations
+    consumes:
+    - application/vnd.api+json
+    parameters:
+    - $ref: content_type_parameter.yaml#/ContentType
+    responses:
+      '200':
+        description: success
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: get_regions_responses.yaml#/200
+      '401':
+        description: unauthorized
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: get_regions_responses.yaml#/401
+      '415':
+        description: invalid media type
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: get_regions_responses.yaml#/415
 /reference/suppliers:
   get:
     summary: Returns the list of suppliers

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -153,6 +153,9 @@ RSpec.configure do |config|
           ProfileIdentifier: {
             "$ref": 'profile_identifier.yaml#/ProfileIdentifier',
           },
+          Region: {
+            "$ref": 'region.yaml#/Region',
+          },
           Supplier: {
             "$ref": 'supplier.yaml#/Supplier',
           },

--- a/swagger/v1/allocation.yaml
+++ b/swagger/v1/allocation.yaml
@@ -144,7 +144,7 @@ Allocation:
           description: The location (prison) that the people are being moved to
         moves:
           $ref: move_reference.yaml#/MoveReference
-          description: The moves associated with this Allocation
+          description: The moves associated with this allocation
         person:
           $ref: person_reference.yaml#/PersonReference
           description: The people being moved

--- a/swagger/v1/get_regions_responses.yaml
+++ b/swagger/v1/get_regions_responses.yaml
@@ -1,0 +1,27 @@
+'200':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      type: array
+      items:
+        $ref: region.yaml#/Region
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnsupportedMediaType
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError

--- a/swagger/v1/location_reference.yaml
+++ b/swagger/v1/location_reference.yaml
@@ -4,7 +4,9 @@ LocationReference:
   - data
   properties:
     data:
-      type: object
+      oneOf:
+      - type: object
+      - type: array
       required:
       - type
       - id
@@ -19,5 +21,4 @@ LocationReference:
           type: string
           format: uuid
           example: c3f9cc0c-0154-49ec-b01e-d60ded8e0ab1
-          description: The unique identifier (UUID) of the object that this reference
-            points to
+          description: The unique identifier (UUID) of the object that this reference points to

--- a/swagger/v1/move_reference.yaml
+++ b/swagger/v1/move_reference.yaml
@@ -22,5 +22,4 @@ MoveReference:
           type: string
           format: uuid
           example: 3561f372-9f1c-4e13-997e-b11e1647cce1
-          description: The unique identifier (UUID) of the object that this reference
-            points to
+          description: The unique identifier (UUID) of the object that this reference points to

--- a/swagger/v1/region.yaml
+++ b/swagger/v1/region.yaml
@@ -1,0 +1,50 @@
+Region:
+  type: object
+  required:
+  - id
+  - type
+  - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: 7cc9c528-3301-4d69-f200-69e482ce1ed8
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: regions
+      enum:
+      - regions
+      description: The type of this object - always `regions`
+    attributes:
+      type: object
+      required:
+      - key
+      - name
+      properties:
+        key:
+          type: string
+          example: 5A
+          description: Region key (reference number used internally)
+        name:
+          type: string
+          example: North Wales
+          description: Human readable label for this region
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of when the region was last created or updated
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp of when the region was created
+          readOnly: true
+    relationships:
+      type: object
+      required:
+      - locations
+      properties:
+        locations:
+          $ref: location_reference.yaml#/LocationReference
+          description: The locations associated with this region


### PR DESCRIPTION
### Jira link

P4-1384

### What?

- [x] New route, controller and serializer for GET /reference/regions
- [x] Rearranged routes in alphabetical order (makes it slightly easier to find them in the code)
- [x] Improved error reporting for invalid Swagger YAML files (now includes relevant filename to make tracking down issues easier)
- [x] Added specs and new region factory; refactored some existing specs to use factory
- [x] Updated swagger documentation

### Why?

- The front end work for allocations will soon allow user to choose a region to work with; this provides a list of locations that can then be used to scope the visible locations for the user, as well as filter the relevant list of prisons when creating an allocation.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- This is a new api endpoint, so no risk to production

