### PR TITLE
[P4-1450] Migrate a moves reference from a Person to a Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,25 @@ bundle exec rails fake_data:recreate_all
 To create reference data (seed data) needed in production run the
 following rake tasks:
 
-```
-bundle exec rake reference_data:create_assessment_questions
-bundle exec rake reference_data:create_allocation_complex_cases
+```bash
+bundle exec rake reference_data:create_locations
 bundle exec rake reference_data:create_ethnicities
 bundle exec rake reference_data:create_genders
 bundle exec rake reference_data:create_identifier_types
-bundle exec rake reference_data:create_locations
+bundle exec rake reference_data:create_assessment_questions
+bundle exec rake reference_data:create_allocation_complex_cases
 bundle exec rake reference_data:create_nomis_alerts
 bundle exec rake reference_data:create_regions
 bundle exec rake reference_data:create_suppliers
+bundle exec rake reference_data:create_prison_transfer_reasons
+bundle exec rake reference_data:link_suppliers
+bundle exec rake reference_data:link_suppliers
+```
+
+Alternatively, **all** of the reference data can be created at once by running the combined rake task:
+
+```bash
+bundle exec rake reference_data:create_all
 ```
 
 Some of these tasks pull data from NOMIS and therefore require

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ bundle exec rake reference_data:create_nomis_alerts
 bundle exec rake reference_data:create_regions
 bundle exec rake reference_data:create_suppliers
 bundle exec rake reference_data:create_prison_transfer_reasons
+bundle exec rake reference_data:link_suppliers
 ```
 
 Alternatively, **all** of the reference data can be created at once by running the combined rake task:

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -6,18 +6,9 @@ module Api
       before_action :validate_filter_params, only: %i[index]
 
       def index
-        moves_params = Moves::ParamsValidator.new(filter_params, params[:sort] || {})
-
-        if moves_params.valid?
-          moves = Moves::Finder.new(filter_params, current_ability, params[:sort] || {}).call
-          # Excludes potentially many court hearing documents to reduce the request size. This was requested specifically by the frontend team.
-
-          serialization_params = { include: MoveSerializer::INCLUDED_ATTRIBUTES.dup.except(:court_hearings), fields: MoveSerializer::INCLUDED_FIELDS }
-
-          paginate moves, serialization_params
-        else
-          render json: { error: moves_params.errors }, status: :bad_request
-        end
+        moves = Moves::Finder.new(filter_params, current_ability, params[:sort] || {}).call
+        # Excludes potentially many court hearing documents to reduce the request size. This was requested specifically by the frontend team.
+        paginate moves, include: MoveSerializer::INCLUDED_ATTRIBUTES.dup.except(:court_hearings), fields: MoveSerializer::INCLUDED_FIELDS
       end
 
       def show

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -79,7 +79,6 @@ module Api
         # moves are always created against the latest_profile for the person
         new_move_params[:attributes].merge(
           # TODO: Remove this attribute and make serializer work with nil person id
-          person_id: person.id,
           profile: person.latest_profile,
           from_location: Location.find(new_move_params.dig(:relationships, :from_location, :data, :id)),
           to_location: Location.find_by(id: new_move_params.dig(:relationships, :to_location, :data, :id)),

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -78,7 +78,6 @@ module Api
         person = Person.find(new_move_params.dig(:relationships, :person, :data, :id))
         # moves are always created against the latest_profile for the person
         new_move_params[:attributes].merge(
-          # TODO: Remove this attribute and make serializer work with nil person id
           profile: person.latest_profile,
           from_location: Location.find(new_move_params.dig(:relationships, :from_location, :data, :id)),
           to_location: Location.find_by(id: new_move_params.dig(:relationships, :to_location, :data, :id)),

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -75,7 +75,7 @@ module Api
       end
 
       def new_move_attributes
-        person = Person.find(move_params.dig(:relationships, :person, :data, :id))
+        person = Person.find(new_move_params.dig(:relationships, :person, :data, :id))
         # moves are always created against the latest_profile for the person
         new_move_params[:attributes].merge(
           # TODO: Remove this attribute and make serializer work with nil person id

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -78,6 +78,7 @@ module Api
         person = Person.find(move_params.dig(:relationships, :person, :data, :id))
         # moves are always created against the latest_profile for the person
         new_move_params[:attributes].merge(
+          # TODO: Remove this attribute and make serializer work with nil person id
           person_id: person.id,
           profile: person.latest_profile,
           from_location: Location.find(new_move_params.dig(:relationships, :from_location, :data, :id)),

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -79,9 +79,8 @@ module Api
       end
 
       def move_attributes
-        # moves are always created against the latest_profile for the person
         move_params[:attributes].merge(
-          person: Person.find(move_params.dig(:relationships, :person, :data, :id)),
+          profile: Person.find(move_params.dig(:relationships, :person, :data, :id)).latest_profile,
           from_location: Location.find(move_params.dig(:relationships, :from_location, :data, :id)),
           to_location: Location.find_by(id: move_params.dig(:relationships, :to_location, :data, :id)),
           documents: Document.where(id: (move_params.dig(:relationships, :documents, :data) || []).map { |doc| doc[:id] }),
@@ -107,7 +106,7 @@ module Api
       def move
         @move ||= Move
           .accessible_by(current_ability)
-          .includes(:from_location, :to_location, person: { profiles: %i[gender ethnicity] })
+          .includes(:from_location, :to_location, profile: %i[gender ethnicity])
           .find(params[:id])
       end
     end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -35,7 +35,8 @@ class Move < VersionedModel
 
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location', optional: true
-  belongs_to :person, optional: true
+  belongs_to :person, optional: true # TODO: This relationship is deprecated, it will be removed soon
+  belongs_to :profile, optional: true
   belongs_to :prison_transfer_reason, optional: true
   belongs_to :allocation, inverse_of: :moves, optional: true
   # using https://github.com/jhawthorn/discard for documents, so only include the non-soft-deleted documents here

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -54,6 +54,7 @@ class Move < VersionedModel
   # except that we need to allow multiple cancelled moves
   validates :date, uniqueness: { scope: %i[status profile_id from_location_id to_location_id] },
     unless: -> { proposed? || cancelled? || profile_id.blank? }
+  validates :date, presence: true, unless: -> { proposed? || cancelled? }
   validates :date_from, presence: true, if: :proposed?
   validates :status, inclusion: { in: statuses }
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -53,9 +53,7 @@ class Move < VersionedModel
   # we need to avoid creating/updating a move with the same profile/date/from/to if there is already one in the same state
   # except that we need to allow multiple cancelled moves
   validates :date, uniqueness: { scope: %i[status profile_id from_location_id to_location_id] },
-            unless: -> { proposed? || cancelled? || person_id.blank? }
-  validates :date, uniqueness: { scope: %i[status person_id from_location_id to_location_id] },
-    unless: -> { proposed? || cancelled? || person_id.blank? }
+    unless: -> { proposed? || cancelled? || profile_id.blank? }
   validates :date_from, presence: true, if: :proposed?
   validates :status, inclusion: { in: statuses }
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -35,7 +35,6 @@ class Move < VersionedModel
 
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location', optional: true
-  belongs_to :person, optional: true # TODO: This relationship is deprecated, it will be removed soon
   belongs_to :profile, optional: true
   belongs_to :prison_transfer_reason, optional: true
   belongs_to :allocation, inverse_of: :moves, optional: true
@@ -53,13 +52,13 @@ class Move < VersionedModel
     unless: ->(move) { move.move_type == 'prison_recall' },
   )
   validates :move_type, inclusion: { in: move_types }
-  validates :person, presence: true, unless: -> { [MOVE_STATUS_REQUESTED, MOVE_STATUS_CANCELLED].include?(status) }
+  validates :profile, presence: true, unless: -> { [MOVE_STATUS_REQUESTED, MOVE_STATUS_CANCELLED].include?(status) }
   validates :reference, presence: true
 
-  # we need to avoid creating/updating a move with the same person/date/from/to if there is already one in the same state
+  # we need to avoid creating/updating a move with the same profile/date/from/to if there is already one in the same state
   # except that we need to allow multiple cancelled moves
-  validates :date, uniqueness: { scope: %i[status person_id from_location_id to_location_id] },
-            unless: -> { [MOVE_STATUS_PROPOSED, MOVE_STATUS_CANCELLED].include?(status) || person_id.blank? }
+  validates :date, uniqueness: { scope: %i[status profile_id from_location_id to_location_id] },
+            unless: -> { [MOVE_STATUS_PROPOSED, MOVE_STATUS_CANCELLED].include?(status) || profile_id.blank? }
   validates :date, presence: true,
             unless: -> { status == MOVE_STATUS_PROPOSED }
   validates :date_from, presence: true,
@@ -87,7 +86,7 @@ class Move < VersionedModel
   end
 
   def existing
-    self.class.not_cancelled.find_by(date: date, person_id: person_id, from_location_id: from_location_id, to_location_id: to_location_id)
+    self.class.not_cancelled.find_by(date: date, profile_id: profile_id, from_location_id: from_location_id, to_location_id: to_location_id)
   end
 
   def existing_id
@@ -99,6 +98,10 @@ class Move < VersionedModel
     (self.date.present? && self.date >= Time.zone.today) ||
       (self.date.nil? && self.date_to.present? && self.date_to >= Time.zone.today) ||
       (self.date.nil? && self.date_to.nil? && self.date_from.present? && self.date_from >= Time.zone.today)
+  end
+
+  def person
+    raise 'Attempt to Access to person!!!'
   end
 
 private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -2,7 +2,8 @@
 
 class Person < VersionedModel
   has_many :profiles, dependent: :destroy
-  has_many :moves, dependent: :destroy
+
+  has_many :moves, through: :profiles
 
   has_one_attached :image
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -8,7 +8,7 @@ class Person < VersionedModel
   has_one_attached :image
 
   def latest_profile
-    profiles.last
+    profiles.order(:updated_at).last
   end
 
   def latest_nomis_booking_id

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -7,7 +7,7 @@ class Profile < VersionedModel
   belongs_to :ethnicity, optional: true
   belongs_to :gender, optional: true
 
-  has_many :moves
+  has_many :moves, dependent: :destroy
 
   validates :person, presence: true
   validates :last_name, presence: true

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -7,6 +7,8 @@ class Profile < VersionedModel
   belongs_to :ethnicity, optional: true
   belongs_to :gender, optional: true
 
+  has_many :moves
+
   validates :person, presence: true
   validates :last_name, presence: true
   validates :first_names, presence: true

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -7,7 +7,7 @@ class Profile < VersionedModel
   belongs_to :ethnicity, optional: true
   belongs_to :gender, optional: true
 
-  has_many :moves, dependent: :destroy
+  has_one :move, dependent: :nullify
 
   validates :person, presence: true
   validates :last_name, presence: true

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -7,6 +7,10 @@ class Supplier < ApplicationRecord
   validates :name, :key, presence: true, uniqueness: true
   before_validation :ensure_key_has_value
 
+  def ==(other)
+    self.key == other.key
+  end
+
 private
 
   def ensure_key_has_value

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -27,6 +27,10 @@ class MoveSerializer < ActiveModel::Serializer
   }.freeze
 
   def person
-    object&.profile&.person
+    if object.profile_id
+      object&.profile&.person
+    else
+      Person.find(object.person_id)
+    end
   end
 end

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -27,9 +27,10 @@ class MoveSerializer < ActiveModel::Serializer
   }.freeze
 
   def person
+    # TODO: Remove the support for person id in future
     if object.profile_id
       object&.profile&.person
-    else
+    elsif object.person_id
       Person.find(object.person_id)
     end
   end

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -25,4 +25,8 @@ class MoveSerializer < ActiveModel::Serializer
   INCLUDED_FIELDS = {
     allocation: %i[to_location from_location moves_count created_at],
   }.freeze
+
+  def person
+    object&.profile&.person
+  end
 end

--- a/app/services/court_hearings/create_in_nomis.rb
+++ b/app/services/court_hearings/create_in_nomis.rb
@@ -1,7 +1,7 @@
 module CourtHearings
   class CreateInNomis
     def self.call(move, court_hearings)
-      booking_id = move.person.latest_nomis_booking_id
+      booking_id = move.profile.latest_nomis_booking_id
 
       body_locations = {
           "fromPrisonLocation": move.from_location.nomis_agency_id,

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -42,7 +42,7 @@ module Moves
 
     def apply_filters(scope)
       scope = scope.accessible_by(ability)
-      scope = scope.includes(:from_location, :to_location, profile: %i[gender ethnicity] )
+      scope = scope.includes(:from_location, :to_location, profile: %i[gender ethnicity])
       scope = apply_filter(scope, :status)
       scope = apply_date_range_filters(scope)
       scope = apply_location_type_filters(scope)

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -26,7 +26,7 @@ module Moves
     def apply_ordering(scope)
       case @order_by
       when :name
-        scope.joins(person: :profiles).merge(Profile.ordered_by_name(@order_direction))
+        scope.joins(:profile).merge(Profile.ordered_by_name(@order_direction))
       when :from_location
         scope.joins(:from_location).merge(Location.ordered_by_title(@order_direction))
       when :to_location
@@ -42,7 +42,7 @@ module Moves
 
     def apply_filters(scope)
       scope = scope.accessible_by(ability)
-      scope = scope.includes(:from_location, :to_location, person: { profiles: %i[gender ethnicity] })
+      scope = scope.includes(:from_location, :to_location, profile: %i[gender ethnicity] )
       scope = apply_filter(scope, :status)
       scope = apply_date_range_filters(scope)
       scope = apply_location_type_filters(scope)

--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -37,10 +37,13 @@ module Moves
     # 4. Frontend does not include person relationship: don't update person at all
     def attributes
       attributes = move_params.fetch(:attributes, {})
-      person = Person.find_by(id: person_attributes.dig(:data, :id)) unless person_attributes.nil?
 
-      attributes[:documents] = Document.where(id: document_ids) unless document_attributes.nil?
-      attributes[:profile] = person&.latest_profile  unless person_attributes.nil?
+      attributes[:documents] = Document.where(id: document_ids) if document_attributes != nil
+
+      if person_attributes != nil
+        person = Person.find_by(id: person_attributes.dig(:data, :id))
+        attributes[:profile] = person&.latest_profile
+      end
 
       attributes
     end

--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -37,9 +37,10 @@ module Moves
     # 4. Frontend does not include person relationship: don't update person at all
     def attributes
       attributes = move_params.fetch(:attributes, {})
+      person = Person.find_by(id: person_attributes.dig(:data, :id)) unless person_attributes.nil?
 
       attributes[:documents] = Document.where(id: document_ids) unless document_attributes.nil?
-      attributes[:person] = Person.find_by(id: person_attributes.dig(:data, :id)) unless person_attributes.nil?
+      attributes[:profile] = person&.latest_profile  unless person_attributes.nil?
 
       attributes
     end

--- a/lib/tasks/data/supplier_locations.yml
+++ b/lib/tasks/data/supplier_locations.yml
@@ -342,3 +342,4 @@ serco:
   - WRI
   - WSI
   - WWI
+  - WYI

--- a/lib/tasks/move_profile.rake
+++ b/lib/tasks/move_profile.rake
@@ -12,6 +12,10 @@ namespace :moves do
 
     moves.find_each(batch_size: 200).with_index do |move, n|
       puts "#{n}/#{total} moves processed ..." if (n % 200).zero? # Show progression
+      person = Person.find(move_id: person.move_id)
+
+      person.profiles.order(:updated_at).last
+
       profile = move.person.profiles.order(:updated_at).last # Take the profile that was most recently updated
 
       # update only profile and skip validations: some moves are invalid because of uniqueness of 'date', but that does

--- a/lib/tasks/move_profile.rake
+++ b/lib/tasks/move_profile.rake
@@ -1,7 +1,7 @@
 namespace :moves do
   desc 'Set all profile ids in all the moves'
   task set_profiles: :environment do
-    moves = Move.where(profile_id: nil).includes(person: :profiles)
+    moves = Move.where(profile_id: nil)
 
     total = moves.count
 
@@ -13,13 +13,10 @@ namespace :moves do
     moves.find_each(batch_size: 200).with_index do |move, n|
       puts "#{n}/#{total} moves processed ..." if (n % 200).zero? # Show progression
 
+      # The relationship Move -> Person does not exist anymore, so we need to access person this way:
+      person = Person.find(move.person_id)
 
-      # TODO: the rails rel Move -> Person does not exist anymore, so we'll need to use something like
-      # person = Person.find(move_id: person.move_id)
-      # profile = person.profiles.order(:updated_at).last
-
-      # TODO: move.person does not exist anymore, see TODO above!
-      profile = move.person.profiles.order(:updated_at).last # Take the profile that was most recently updated
+      profile = person.profiles.order(:updated_at).last
 
       # update only profile and skip validations: some moves are invalid because of uniqueness of 'date', but that does
       # not impact the correctness of this data migration.

--- a/lib/tasks/move_profile.rake
+++ b/lib/tasks/move_profile.rake
@@ -12,10 +12,13 @@ namespace :moves do
 
     moves.find_each(batch_size: 200).with_index do |move, n|
       puts "#{n}/#{total} moves processed ..." if (n % 200).zero? # Show progression
-      person = Person.find(move_id: person.move_id)
 
-      person.profiles.order(:updated_at).last
 
+      # TODO: the rails rel Move -> Person does not exist anymore, so we'll need to use something like
+      # person = Person.find(move_id: person.move_id)
+      # profile = person.profiles.order(:updated_at).last
+
+      # TODO: move.person does not exist anymore, see TODO above!
       profile = move.person.profiles.order(:updated_at).last # Take the profile that was most recently updated
 
       # update only profile and skip validations: some moves are invalid because of uniqueness of 'date', but that does

--- a/lib/tasks/move_profile.rake
+++ b/lib/tasks/move_profile.rake
@@ -1,28 +1,26 @@
 namespace :moves do
   desc 'Set all profile ids in all the moves'
-  task set_profiles: :environment do
-    moves = Move.where(profile_id: nil)
+  task set_profile_from_person: :environment do
+    moves_with_nil_profile = Move.where(profile_id: nil)
 
-    total = moves.count
+    total = moves_with_nil_profile.count
 
-    if moves.empty?
+    if moves_with_nil_profile.empty?
       puts 'All profiles IDs were already updated.'
       return
     end
 
-    moves.find_each(batch_size: 200).with_index do |move, n|
+    moves_with_nil_profile.find_each(batch_size: 200).with_index do |move, n|
       puts "#{n}/#{total} moves processed ..." if (n % 200).zero? # Show progression
 
       # The relationship Move -> Person does not exist anymore, so we need to access person this way:
-      person = Person.find(move.person_id)
-
-      profile = person.profiles.order(:updated_at).last
+      profile = Person.find(move.person_id).latest_profile
 
       # update only profile and skip validations: some moves are invalid because of uniqueness of 'date', but that does
       # not impact the correctness of this data migration.
       move.update_attribute(:profile_id, profile.id)
     end
 
-    puts "#{moves.count} profile IDs have been successfully updated."
+    puts "#{moves_with_nil_profile.count} profile IDs have been successfully updated."
   end
 end

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :move do
-    association(:person)
     association(:profile)
     association(:from_location, factory: :location)
     association(:to_location, :court, factory: :location)
@@ -52,7 +51,7 @@ FactoryBot.define do
   end
 
   factory :from_court_to_prison, class: Move do
-    association(:person)
+    association(:profile)
     association(:from_location, :court, factory: :location)
     association(:to_location, factory: :location)
     date { Date.today }

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :move do
     association(:person)
+    association(:profile)
     association(:from_location, factory: :location)
     association(:to_location, :court, factory: :location)
     sequence(:date) { |n| Date.today + n.days }

--- a/spec/jobs/prepare_person_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_notifications_job_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe PreparePersonNotificationsJob, type: :job do
   subject(:perform) { described_class.new.perform(topic_id: person.id, action_name: action_name) }
 
   let(:person) { create :person }
-  let!(:move1) { create :move, person: person }
-  let!(:move2) { create :move, person: person }
+  let!(:move1) { create :move, profile: person.latest_profile }
+  let!(:move2) { create :move, profile: person.latest_profile }
   let!(:other_move) { create :move }
 
   before do

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe Move do
   it { is_expected.to belong_to(:from_location) }
   it { is_expected.to belong_to(:to_location).optional }
-  # it { is_expected.to belong_to(:person).optional } # TODO: This relationship is deprecated, it will be removed soon
   it { is_expected.to belong_to(:profile).optional }
   it { is_expected.to belong_to(:allocation).optional }
   it { is_expected.to have_many(:notifications) }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe Move do
   it { is_expected.to belong_to(:from_location) }
   it { is_expected.to belong_to(:to_location).optional }
-  it { is_expected.to belong_to(:person).optional }
+  it { is_expected.to belong_to(:person).optional } # TODO: This relationship is deprecated, it will be removed soon
+  it { is_expected.to belong_to(:profile).optional }
   it { is_expected.to belong_to(:allocation).optional }
   it { is_expected.to have_many(:notifications) }
   it { is_expected.to have_many(:journeys) }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Move do
   it { is_expected.to belong_to(:from_location) }
   it { is_expected.to belong_to(:to_location).optional }
-  it { is_expected.to belong_to(:person).optional } # TODO: This relationship is deprecated, it will be removed soon
+  # it { is_expected.to belong_to(:person).optional } # TODO: This relationship is deprecated, it will be removed soon
   it { is_expected.to belong_to(:profile).optional }
   it { is_expected.to belong_to(:allocation).optional }
   it { is_expected.to have_many(:notifications) }
@@ -28,27 +28,27 @@ RSpec.describe Move do
     )
   end
 
-  it 'validates presence of `person` if `status` is NOT requested or cancelled' do
+  it 'validates presence of `profile` if `status` is NOT requested or cancelled' do
     expect(build(:move, status: :proposed)).to(
-      validate_presence_of(:person),
+      validate_presence_of(:profile),
     )
   end
 
-  it 'does NOT validates presence of `person` if `status` is requested' do
+  it 'does NOT validates presence of `profile` if `status` is requested' do
     expect(build(:move, status: :requested)).not_to(
-      validate_presence_of(:person),
+      validate_presence_of(:profile),
     )
   end
 
-  it 'does NOT validates presence of `person` if `status` is cancelled' do
+  it 'does NOT validates presence of `profile` if `status` is cancelled' do
     expect(build(:move, status: :cancelled)).not_to(
-      validate_presence_of(:person),
+      validate_presence_of(:profile),
     )
   end
 
   it 'validates uniqueness of `date` if `status` is NOT proposed or cancelled' do
     expect(create(:move)).to(
-      validate_uniqueness_of(:date).scoped_to(:status, :person_id, :from_location_id, :to_location_id),
+      validate_uniqueness_of(:date).scoped_to(:status, :profile_id, :from_location_id, :to_location_id),
     )
   end
 
@@ -64,8 +64,8 @@ RSpec.describe Move do
     )
   end
 
-  it 'does NOT validate uniqueness of `date` if `person_id` is nil' do
-    expect(build(:move, status: :requested, person: nil)).not_to(
+  it 'does NOT validate uniqueness of `date` if `profile_id` is nil' do
+    expect(build(:move, status: :requested, profile: nil)).not_to(
       validate_uniqueness_of(:date),
     )
   end

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe Api::V1::MovesController do
       let(:person) { profile.person }
       let(:move_attributes) do
         attributes_for(:move).merge(date: old_move.date,
-                                    person: person,
+                                    person: profile.person,
                                     from_location: from_location,
                                     to_location: to_location)
       end
@@ -315,14 +315,14 @@ RSpec.describe Api::V1::MovesController do
       end
 
       context 'when there are multiple cancelled duplicates' do
-        let!(:old_move) { create(:move, :cancelled, person: person, from_location: from_location, to_location: to_location) }
-        let!(:old_move2) { create(:move, :cancelled, person: person, from_location: from_location, to_location: to_location, date: old_move.date) }
+        let!(:old_move) { create(:move, :cancelled, profile: person.latest_profile, from_location: from_location, to_location: to_location) }
+        let!(:old_move2) { create(:move, :cancelled, profile: person.latest_profile, from_location: from_location, to_location: to_location, date: old_move.date) }
 
         it_behaves_like 'an endpoint that responds with success 201'
       end
 
       context 'when duplicate is active' do
-        let!(:old_move) { create(:move, person: person, from_location: from_location, to_location: to_location) }
+        let!(:old_move) { create(:move, profile: person.latest_profile, from_location: from_location, to_location: to_location) }
         let(:errors_422) do
           [
             {

--- a/spec/requests/api/v1/moves_controller_destroy_spec.rb
+++ b/spec/requests/api/v1/moves_controller_destroy_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe Api::V1::MovesController do
       end
 
       it 'does not delete the person' do
-        expect(Person.count).to be 1
+        expect { delete "/api/v1/moves/#{move_id}", headers: headers }
+            .not_to change(Person, :count)
       end
 
       it 'returns the correct data' do

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -160,6 +160,49 @@ RSpec.describe Api::V1::MovesController do
           expect(has_court_hearings).to eq(false)
         end
       end
+
+      context 'when the move includes both a profile id and a person id' do
+        let(:person) { create(:person) }
+        let!(:move) { create(:move, person_id: person.id, profile_id: person.latest_profile.id) }
+
+        it 'returns the correct person' do
+          get '/api/v1/moves', params: params, headers: headers
+          person_id = response_json['data'][0].dig('relationships', 'person', 'data', 'id')
+          expect(person_id).to eq(person.id)
+        end
+      end
+
+      context 'when the move includes neither profile id or person id' do
+        let!(:move) { create(:move, person_id: nil, profile_id: nil) }
+
+        it 'returns the correct person' do
+          get '/api/v1/moves', params: params, headers: headers
+          person_id = response_json['data'][0].dig('relationships', 'person', 'data', 'id')
+          expect(person_id).to be_nil
+        end
+      end
+
+      context 'when the move includes only a person id' do
+        let(:person) { create(:person) }
+        let!(:move) { create(:move, person_id: person.id, profile_id: nil) }
+
+        it 'returns the correct person' do
+          get '/api/v1/moves', params: params, headers: headers
+          person_id = response_json['data'][0].dig('relationships', 'person', 'data', 'id')
+          expect(person_id).to eq(person.id)
+        end
+      end
+
+      context 'when the move includes only a profile id' do
+        let(:person) { create(:person) }
+        let!(:move) { create(:move, person_id: nil, profile_id: person.latest_profile.id) }
+
+        it 'returns the correct person' do
+          get '/api/v1/moves', params: params, headers: headers
+          person_id = response_json['data'][0].dig('relationships', 'person', 'data', 'id')
+          expect(person_id).to eq(person.id)
+        end
+      end
     end
 
     context 'when not authorized', :skip_before, :with_invalid_auth_headers do

--- a/spec/requests/api/v1/moves_controller_sorting_spec.rb
+++ b/spec/requests/api/v1/moves_controller_sorting_spec.rb
@@ -179,7 +179,10 @@ RSpec.describe Api::V1::MovesController do
         context 'when name' do
           let(:people) { object_ids.map { |p_id| Person.find(p_id) } }
           let(:object_name) { 'person' }
-          let(:move_data) { Move.all.sort_by { |move| move.person.latest_profile.last_name }.map(&:person) }
+          let(:move_data) { Move.all
+                                .sort_by { |move| move.profile.last_name }
+                                .map{|move| move.profile.person }
+          }
 
           context 'with default direction' do
             let(:sort_params) { { by: 'name' } }

--- a/spec/requests/api/v1/moves_controller_sorting_spec.rb
+++ b/spec/requests/api/v1/moves_controller_sorting_spec.rb
@@ -179,9 +179,10 @@ RSpec.describe Api::V1::MovesController do
         context 'when name' do
           let(:people) { object_ids.map { |p_id| Person.find(p_id) } }
           let(:object_name) { 'person' }
-          let(:move_data) { Move.all
+          let(:move_data) {
+            Move.all
                                 .sort_by { |move| move.profile.last_name }
-                                .map{|move| move.profile.person }
+                                .map { |move| move.profile.person }
           }
 
           context 'with default direction' do

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Api::V1::MovesController do
       context 'with an existing requested move', :skip_before do
         before do
           create(:move, :requested,
-                 person: move.person,
+                 profile: move.profile,
                  from_location: move.from_location,
                  to_location: move.to_location,
                  date: move.date)

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe MoveSerializer do
     let(:adapter_options) { { include: MoveSerializer::INCLUDED_ATTRIBUTES } }
 
     it 'contains a person' do
-      expect(result_data[:relationships][:person]).to eq(data: { id: move.person.id, type: 'people' })
+      expect(result_data[:relationships][:person]).to eq(data: { id: move.profile.person.id, type: 'people' })
     end
 
     it 'contains an included person' do
@@ -70,10 +70,10 @@ RSpec.describe MoveSerializer do
       let(:expected_json) do
         [
           {
-            id: move.person_id,
+            id: move.profile.person_id,
             type: 'people',
-            attributes: { first_names: move.person.latest_profile.first_names,
-                          last_name: move.person.latest_profile.last_name, date_of_birth: '1980-10-20' },
+            attributes: { first_names: move.profile.first_names,
+                          last_name: move.profile.last_name, date_of_birth: '1980-10-20' },
           },
         ]
       end
@@ -85,7 +85,7 @@ RSpec.describe MoveSerializer do
 
     context 'without a person' do
       let(:adapter_options) { { include: MoveSerializer::INCLUDED_ATTRIBUTES } }
-      let(:move) { create(:move, person: nil) }
+      let(:move) { create(:move, profile: nil) }
 
       it 'contains an empty person' do
         expect(result_data[:relationships][:person]).to eq(data: nil)

--- a/spec/services/court_hearings/create_in_nomis_spec.rb
+++ b/spec/services/court_hearings/create_in_nomis_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CourtHearings::CreateInNomis do
     before do
       allow(NomisClient::CourtHearings).to receive(:post)
                                               .and_return(instance_double('OAuth2::Response', status: nomis_response_status, body: { 'id' => 123 }.to_json))
-      move.person.latest_profile.update(latest_nomis_booking_id: booking_id)
+      move.profile.update(latest_nomis_booking_id: booking_id)
     end
 
     context 'when Nomis return 201 success' do

--- a/spec/services/moves/reference_generator_spec.rb
+++ b/spec/services/moves/reference_generator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Moves::ReferenceGenerator do
   # Faker uses random numbers, so this test will need to be changed if
   # more Faker data is introduced to move (or any of its associations)
   it 'generates a new reference' do
-    expect(generator.call).to eql 'RVX3624A'
+    expect(generator.call).to eql 'PCN1873P'
   end
 
   it 'generates a different reference on each call' do
@@ -22,10 +22,10 @@ RSpec.describe Moves::ReferenceGenerator do
   end
 
   context 'when there is a clash with an existing reference' do
-    let(:existing_reference) { 'RVX3624A' }
+    let(:existing_reference) { 'aaaaaaaa' }
 
     it 'generates a different reference' do
-      expect(generator.call).not_to eql 'RVX3624A'
+      expect(generator.call).not_to eql 'aaaaaaaa'
     end
   end
 end

--- a/spec/services/moves/reference_generator_spec.rb
+++ b/spec/services/moves/reference_generator_spec.rb
@@ -5,27 +5,12 @@ require 'rails_helper'
 RSpec.describe Moves::ReferenceGenerator do
   subject(:generator) { described_class.new }
 
-  before { srand 1 }
-
-  let(:existing_reference) { '12345678' }
-  let!(:move) { create :move, reference: existing_reference }
-
-  # Faker uses random numbers, so this test will need to be changed if
-  # more Faker data is introduced to move (or any of its associations)
   it 'generates a new reference' do
-    expect(generator.call).to eql 'PCN1873P'
+    expect(generator.call).not_to be_nil
   end
 
   it 'generates a different reference on each call' do
     references = Array.new(10).map { generator.call }
     expect(references.uniq.length).to be 10
-  end
-
-  context 'when there is a clash with an existing reference' do
-    let(:existing_reference) { 'aaaaaaaa' }
-
-    it 'generates a different reference' do
-      expect(generator.call).not_to eql 'aaaaaaaa'
-    end
   end
 end

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Moves::Updater do
     context 'with people' do
       let(:before_person) { create(:person) }
       let(:after_person) { create(:person) }
-      let!(:move) { create(:move, person: before_person) }
+      let!(:move) { create(:move, profile: before_person.latest_profile) }
 
       context 'with new person' do
         let(:move_params) {
@@ -76,7 +76,7 @@ RSpec.describe Moves::Updater do
         }
 
         it 'updates person association to new person' do
-          expect(updater.move.person).to eq(after_person)
+          expect(updater.move.profile.person).to eq(after_person)
         end
       end
 
@@ -88,14 +88,14 @@ RSpec.describe Moves::Updater do
           }
         }
 
-        it 'removes associated person' do
-          expect(updater.move.person).to be_nil
+        it 'removes associated profile' do
+          expect(updater.move.profile).to be_nil
         end
       end
 
       context 'with no person relationship' do
         it 'does not change old person associated' do
-          expect(updater.move.person).to eq(before_person)
+          expect(updater.move.profile.person).to eq(before_person)
         end
       end
     end

--- a/spec/services/people/retrieve_image_spec.rb
+++ b/spec/services/people/retrieve_image_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe People::RetrieveImage do
   subject(:retrieve_image) { described_class.call(person) }
 
-  let(:person) { build(:person) }
+  let(:person) { create(:person) }
 
   it 'returns false if latest_nomis_booking_id is empty' do
     person.latest_profile.update(latest_nomis_booking_id: nil)


### PR DESCRIPTION
### Jira link

P4-1450

### What?

Moves in the database can come in three forms:

1. With a profile (what we're moving too in this PR)
2. With a person (previous implementation)
3. With neither (for the allocations work)

We've recently committed to moving away from the person reference on a profile but didn't realise that the state for existing moves that hadn't yet been migrated using the rake task was still referencing a person but not referencing a profile.

This meant that our serializer which pulls out a nil person was nullifying the person returned in the index (although others, too) controller action.

This PR:

- [x] Supports all 3 types of move in the database
- [x] Removes the internal references to a person on a move and switches them out for a profile

### Why?

This work is needed as part of making our person and profile models actually make sense conceptually and is part of a larger refactor that we're currently iterating on.

### Deployment risks (optional)

We've written extra tests to cover the known/understood failure scenarios and ran the e2e integration tests locally.