### PR TITLE
Clearer last_name sorting test

### DIFF
--- a/spec/requests/api/v1/moves_controller_sorting_spec.rb
+++ b/spec/requests/api/v1/moves_controller_sorting_spec.rb
@@ -16,10 +16,15 @@ RSpec.describe Api::V1::MovesController do
     let(:location3) { create :location, title: 'LOCATION3' }
     let(:location4) { create :location, title: 'location4' }
 
-    let!(:move1) { create :move, to_location: location1 }
-    let!(:move2) { create :move, :prison_transfer, to_location: location2 }
-    let!(:move3) { create :move, :prison_transfer, to_location: location3 }
-    let!(:move4) { create :move, to_location: location4 }
+    let(:profile1) { create :profile, last_name: 'PROFILE1' }
+    let(:profile2) { create :profile, last_name: 'profile2' }
+    let(:profile3) { create :profile, last_name: 'PROFILE3' }
+    let(:profile4) { create :profile, last_name: 'profile4' }
+
+    let!(:move1) { create :move, profile: profile1, to_location: location1 }
+    let!(:move2) { create :move, :prison_transfer, profile: profile2, to_location: location2 }
+    let!(:move3) { create :move, :prison_transfer, profile: profile3, to_location: location3 }
+    let!(:move4) { create :move, profile: profile4, to_location: location4 }
 
     before do
       next if RSpec.current_example.metadata[:skip_before]
@@ -192,27 +197,22 @@ RSpec.describe Api::V1::MovesController do
         end
 
         context 'when name' do
-          let(:people) { object_ids.map { |p_id| Person.find(p_id) } }
           let(:object_name) { 'person' }
-          let(:move_data) {
-            Move.all
-                                .sort_by { |move| move.profile.last_name }
-                                .map { |move| move.profile.person }
-          }
+          let(:last_names) { object_ids.map { |person_id| Person.find(person_id).latest_profile.last_name } }
 
           context 'with default direction' do
             let(:sort_params) { { by: 'name' } }
 
-            it 'sorts by to location' do
-              expect(people).to eq(move_data)
+            it 'sorts by to last_name (ascending, case sensitive)' do
+              expect(last_names).to eq(%w[PROFILE1 PROFILE3 profile2 profile4])
             end
           end
 
           context 'with reverse direction' do
             let(:sort_params) { { by: 'name', direction: 'desc' } }
 
-            it 'sorts by to location' do
-              expect(people).to eq(move_data.reverse)
+            it 'sorts by last_name (descending, case sensitive)' do
+              expect(last_names).to eq(%w[profile4 profile2 PROFILE3 PROFILE1])
             end
           end
         end


### PR DESCRIPTION
### Clearer last_name sorting test

### What?

I have added/removed/altered:

- [X] made last_names explicit

### Why?

I am doing this because:
- the test `rspec ./spec/requests/api/v1/moves_controller_sorting_spec.rb:214` fails occasionally without good reasons 🤔 