### PR TITLE
Fix output for set_profile_from_person rake

### DIFF
--- a/lib/tasks/move_profile.rake
+++ b/lib/tasks/move_profile.rake
@@ -21,6 +21,6 @@ namespace :moves do
       move.update_attribute(:profile_id, profile.id)
     end
 
-    puts "#{moves_with_nil_profile.count} profile IDs have been successfully updated."
+    puts "#{total} profile IDs have been successfully updated."
   end
 end


### PR DESCRIPTION
### What?
This is a small but valuable fix.

This PR fixes the output of the number of total profiles that has been updated in the set_profile_from_person data migration.
