### PR TITLE
P4-1474 Add support for optional `requested_by` attribute in allocation model

### DIFF
--- a/app/controllers/api/v1/allocations_controller.rb
+++ b/app/controllers/api/v1/allocations_controller.rb
@@ -33,7 +33,7 @@ module Api
 
       PERMITTED_ALLOCATION_PARAMS = [
         :type,
-        attributes: %i[date prisoner_category sentence_length moves_count complete_in_full other_criteria],
+        attributes: %i[date prisoner_category sentence_length moves_count complete_in_full other_criteria requested_by],
         relationships: {},
       ].freeze
 

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AllocationSerializer < ActiveModel::Serializer
-  attributes :moves_count, :date, :prisoner_category, :sentence_length, :complex_cases, :complete_in_full,
+  attributes :moves_count, :date, :prisoner_category, :sentence_length, :complex_cases, :complete_in_full, :requested_by,
              :other_criteria, :status, :cancellation_reason, :cancellation_reason_comment, :created_at, :updated_at
 
   has_one :from_location

--- a/db/migrate/20200519120027_add_requested_by_to_allocations.rb
+++ b/db/migrate/20200519120027_add_requested_by_to_allocations.rb
@@ -1,0 +1,5 @@
+class AddRequestedByToAllocations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :allocations, :requested_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_14_055112) do
+ActiveRecord::Schema.define(version: 2020_05_19_120027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2020_05_14_055112) do
     t.string "status"
     t.string "cancellation_reason"
     t.text "cancellation_reason_comment"
+    t.string "requested_by"
     t.index ["date"], name: "index_allocations_on_date"
   end
 

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
 
     prisoner_category { Allocation.prisoner_categories.values.sample }
     sentence_length { Allocation.sentence_lengths.values.sample }
+    requested_by { Faker::Name.name }
     moves_count { Faker::Number.non_zero_digit }
     complete_in_full { false }
 

--- a/spec/requests/api/v1/allocations_controller_create_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_create_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Api::V1::AllocationsController do
         prisoner_category: :b,
         sentence_length: :short,
         other_criteria: 'curly hair',
+        requested_by: 'Iama Requestor',
         complete_in_full: true,
         complex_cases: complex_cases_attributes,
       }
@@ -122,6 +123,14 @@ RSpec.describe Api::V1::AllocationsController do
 
       it 'sets the correct complex_cases attributes' do
         expect(response_json.dig('data', 'attributes', 'complex_cases').first).to match complex_case1_attributes.stringify_keys
+      end
+
+      context 'when omitting requested_by attribute' do
+        let(:allocation_attributes) { attributes_for(:allocation).except(:requested_by) }
+
+        it 'creates an allocation without requested_by' do
+          expect(allocation.requested_by).to be_nil
+        end
       end
 
       context 'when specifying nil complex_cases attribute' do

--- a/spec/serializers/allocation_serializer_spec.rb
+++ b/spec/serializers/allocation_serializer_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe AllocationSerializer do
       expect(attributes[:other_criteria]).to eql allocation.other_criteria
     end
 
+    it 'contains a requested_by attribute' do
+      expect(attributes[:requested_by]).to eql allocation.requested_by
+    end
+
     it 'contains a status attribute' do
       expect(attributes[:status]).to eql allocation.status
     end

--- a/swagger/v1/allocation.yaml
+++ b/swagger/v1/allocation.yaml
@@ -84,6 +84,11 @@ Allocation:
           type: boolean
           example: 'true'
           description: Indicates if allocation must be completed (i.e. populated with prisoners) in full
+        requested_by:
+          oneOf:
+          - type: 'null'
+          - type: string
+          description: Name of the person requesting this allocation
         updated_at:
           type: string
           format: date-time


### PR DESCRIPTION


### Jira link

P4-1474

### What?

- [x] Database migration to add new optional `requested_by` string column to allocations
- [x] Include new attribute when creating and returning an allocation
- [x] Update specs and documentation accordingly

### Why?

- This may be passed by the front end when creating an allocation, and should contain the name of the user within PMU creating the allocation.
- The attribute is optional and may be omitted entirely from the JSON request payload so that this change can be merged ahead of the front end implementation to include this new field.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api (in a non breaking way) that is used in production

