### PR TITLE
Improve ci workflow by removing api_docs job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,17 +228,6 @@ jobs:
           name: run tests
           command: COVERAGE=1 bundle exec rspec
 
-      - *notify_slack_on_failure
-
-  api_docs:
-    <<: *app_containers
-    steps:
-      - prepare_tests
-
-      - run:
-          name: generate swagger documentation
-          command: bundle exec rspec spec/swagger spec/requests --format Rswag::Specs::SwaggerFormatter --order defined
-
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,34 +14,34 @@ aliases:
   - &notify_slack_on_release_start
     slack/notify:
       channel: $BUILD_NOTIFICATIONS_CHANNEL_ID
-      title: 'API is being prepared for release :building_construction:'
-      title_link: 'https://github.com/ministryofjustice/hmpps-book-secure-move-api/blob/master/CHANGELOG.md'
+      title: "API is being prepared for release :building_construction:"
+      title_link: "https://github.com/ministryofjustice/hmpps-book-secure-move-api/blob/master/CHANGELOG.md"
       message: A new release was created by ${CIRCLE_USERNAME}
       footer: Click the title to view the changes
       include_project_field: false
       include_job_number_field: false
       include_visit_job_action: false
-      color: '#1d70b8'
+      color: "#1d70b8"
       mentions: here
   - &notify_slack_of_approval
     slack/approval:
       channel: $BUILD_NOTIFICATIONS_CHANNEL_ID
-      message: 'API release *requires your approval* before it can be deployed :eyes:'
+      message: "API release *requires your approval* before it can be deployed :eyes:"
       include_project_field: false
       include_job_number_field: false
-      color: '#912b88'
+      color: "#912b88"
       mentions: $BUILD_NOTIFICATIONS_MENTION_ID
   - &notify_slack_on_release_end
     slack/notify:
       channel: $BUILD_NOTIFICATIONS_CHANNEL_ID
-      title: 'API has been deployed :rocket:'
+      title: "API has been deployed :rocket:"
       title_link: https://github.com/ministryofjustice/hmpps-book-secure-move-api/releases
       message: This release was successfully deployed to production
       footer: Click the title to view the release notes
       include_project_field: false
       include_job_number_field: false
       include_visit_job_action: false
-      color: '#28a197'
+      color: "#28a197"
       mentions: here
   - &all_tags
     filters:
@@ -55,8 +55,8 @@ aliases:
     filters:
       branches:
         only:
-        - master
-        - dev-auth-from-docs
+          - master
+          - dev-auth-from-docs
   - &only_deploy_tags
     filters:
       tags:


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

Simplifies our circle ci workflow by removing the completely unnecessary extra job for generating the docs.

Docs get generated when we run the suite with bundle exec rspec.

I diffed the output swagger.yml for `bundle exec rspec` and `bundle exec rspec spec/swagger spec/requests --format Rswag::Specs::SwaggerFormatter --order defined` and we get the same result.

### Why?

We won't see a benefit in `wall time` but we will reduce arbitrary noise around CI workflows.