### PR TITLE
P4-1560 Add allocation filter to moves endpoint

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -45,7 +45,7 @@ module Api
     private
 
       PERMITTED_FILTER_PARAMS = %i[
-        date_from date_to created_at_from created_at_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason
+        date_from date_to created_at_from created_at_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason has_relationship_to_allocation
       ].freeze
       PERMITTED_NEW_MOVE_PARAMS = [
         :type,

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -89,8 +89,8 @@ module Moves
     def apply_allocation_relationship_filters(scope)
       return scope unless filter_params.key?(:has_relationship_to_allocation)
 
-      scope = scope.where.not(allocation: nil) if filter_params[:has_relationship_to_allocation] == 'true'
-      scope = scope.where(allocation: nil) if filter_params[:has_relationship_to_allocation] == 'false'
+      scope = scope.where.not(allocation_id: nil) if filter_params[:has_relationship_to_allocation] == 'true'
+      scope = scope.where(allocation_id: nil) if filter_params[:has_relationship_to_allocation] == 'false'
       scope
     end
   end

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -45,6 +45,7 @@ module Moves
       scope = scope.includes(:from_location, :to_location, profile: %i[gender ethnicity])
       scope = apply_date_range_filters(scope)
       scope = apply_location_type_filters(scope)
+      scope = apply_allocation_relationship_filters(scope)
       scope = apply_filter(scope, :from_location_id)
       scope = apply_filter(scope, :to_location_id)
       scope = apply_filter(scope, :status)
@@ -83,6 +84,14 @@ module Moves
       return scope unless filter_params.key?(:supplier_id)
 
       scope.served_by(filter_params[:supplier_id])
+    end
+
+    def apply_allocation_relationship_filters(scope)
+      return scope unless filter_params.key?(:has_relationship_to_allocation)
+
+      scope = scope.where.not(allocation: nil) if filter_params[:has_relationship_to_allocation] == 'true'
+      scope = scope.where(allocation: nil) if filter_params[:has_relationship_to_allocation] == 'false'
+      scope
     end
   end
 end

--- a/spec/requests/api/v1/moves_controller_filter_spec.rb
+++ b/spec/requests/api/v1/moves_controller_filter_spec.rb
@@ -143,6 +143,36 @@ RSpec.describe Api::V1::MovesController do
       end
     end
 
+    describe 'by has_relationship_to_allocation' do
+      let(:filter_params) { { filter: { has_relationship_to_allocation: filter_value } } }
+      let(:move_with_allocation) { create(:move, :with_allocation) }
+      let(:move_without_allocation) { create(:move) }
+
+      context 'when set to true' do
+        let(:expected_moves) { Move.where(id: move_with_allocation.id) }
+        let(:unexpected_moves) { Move.where(id: move_without_allocation.id) }
+        let(:filter_value) { true }
+
+        it_behaves_like 'it returns the correct moves'
+      end
+
+      context 'when set to false' do
+        let(:expected_moves) { Move.where(id: move_without_allocation.id) }
+        let(:unexpected_moves) { Move.where(id: move_with_allocation.id) }
+        let(:filter_value) { false }
+
+        it_behaves_like 'it returns the correct moves'
+      end
+
+      context 'when set to incorrect type' do
+        let(:expected_moves) { Move.where(id: [move_without_allocation.id, move_with_allocation.id]) }
+        let(:unexpected_moves) { Move.none }
+        let(:filter_value) { 'some-value' }
+
+        it_behaves_like 'it returns the correct moves'
+      end
+    end
+
     describe 'by cancellation_reason' do
       let(:filter_params) { { filter: { cancellation_reason: cancellation_reason } } }
       let(:made_in_error_moves) { create_list :move, 3, :cancelled_made_in_error }

--- a/spec/requests/api/v1/moves_controller_filter_spec.rb
+++ b/spec/requests/api/v1/moves_controller_filter_spec.rb
@@ -171,6 +171,22 @@ RSpec.describe Api::V1::MovesController do
 
         it_behaves_like 'it returns the correct moves'
       end
+
+      context 'when set to empty value' do
+        let(:expected_moves) { Move.where(id: [move_without_allocation.id, move_with_allocation.id]) }
+        let(:unexpected_moves) { Move.none }
+        let(:filter_value) { nil }
+
+        it_behaves_like 'it returns the correct moves'
+      end
+
+      context 'when filter not set' do
+        let(:expected_moves) { Move.where(id: [move_without_allocation.id, move_with_allocation.id]) }
+        let(:unexpected_moves) { Move.none }
+        let(:filter_params) { {} }
+
+        it_behaves_like 'it returns the correct moves'
+      end
     end
 
     describe 'by cancellation_reason' do

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -16,10 +16,11 @@ RSpec.describe Moves::Finder do
       let!(:proposed_move) { create :move, :proposed }
       let!(:cancelled_supplier_declined_to_move) { create :move, :cancelled_supplier_declined_to_move }
       let!(:completed_move) { create :move, :completed }
+      let!(:move_with_allocation) { create(:move, :with_allocation) }
       let(:filter_params) { {} }
 
       it 'returns all moves' do
-        expect(results).to match_array [move, proposed_move, cancelled_supplier_declined_to_move, completed_move]
+        expect(results).to match_array [move, proposed_move, cancelled_supplier_declined_to_move, completed_move, move_with_allocation]
       end
     end
 
@@ -206,6 +207,35 @@ RSpec.describe Moves::Finder do
 
         it 'returns empty results set' do
           expect(results).to be_empty
+        end
+      end
+    end
+
+    describe 'by has_relationship_to_allocation' do
+      let!(:move_with_allocation) { create(:move, :with_allocation) }
+      let!(:move_without_allocation) { create(:move) }
+
+      context 'with wrong type passed to has_relationship_to_allocation filter' do
+        let(:filter_params) { { has_relationship_to_allocation: Random.uuid } }
+
+        it 'returns all moves' do
+          expect(results).to contain_exactly(move_with_allocation, move_without_allocation)
+        end
+      end
+
+      context 'with has_relationship_to_allocation set as `false`' do
+        let(:filter_params) { { has_relationship_to_allocation: 'false' } }
+
+        it 'returns only moves without allocations' do
+          expect(results).to contain_exactly(move_without_allocation)
+        end
+      end
+
+      context 'with has_relationship_to_allocation set as `true`' do
+        let(:filter_params) { { has_relationship_to_allocation: 'true' } }
+
+        it 'returns only moves with allocations' do
+          expect(results).to contain_exactly(move_with_allocation)
         end
       end
     end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -223,6 +223,14 @@ RSpec.describe Moves::Finder do
         end
       end
 
+      context 'with has_relationship_to_allocation set as `nil`' do
+        let(:filter_params) { { has_relationship_to_allocation: nil } }
+
+        it 'returns all moves' do
+          expect(results).to contain_exactly(move_with_allocation, move_without_allocation)
+        end
+      end
+
       context 'with has_relationship_to_allocation set as `false`' do
         let(:filter_params) { { has_relationship_to_allocation: 'false' } }
 

--- a/spec/swagger/definitions/hand_coded_paths.yaml
+++ b/spec/swagger/definitions/hand_coded_paths.yaml
@@ -320,6 +320,13 @@
         items:
           type: string
           format: uuid
+    - name: filter[has_relationship_to_allocation]
+      in: query
+      explode: false
+      description: Filters results to either exclude or include moves associated to an allocation
+      schema:
+        type: boolean
+        example: true
     - name: sort[by]
       description: field to sort results by
       in: query

--- a/spec/swagger/definitions/hand_coded_paths.yaml
+++ b/spec/swagger/definitions/hand_coded_paths.yaml
@@ -323,7 +323,7 @@
     - name: filter[has_relationship_to_allocation]
       in: query
       explode: false
-      description: Filters results to either exclude or include moves associated to an allocation
+      description: Filters results to either exclude or include moves associated to an allocation optionally
       schema:
         type: boolean
         example: true


### PR DESCRIPTION
To filter on moves with an allocation association, add a new filter
to either return all moves with an allocation if set to true, or to exclude
all moves associated to an allocation if set to false

### Jira link

P4- todo: create ticket 🥚 🐔 
https://dsdmoj.atlassian.net/browse/P4-1560
### What?

I have added/removed/altered:

- [x] Added a new filter to the moves endpoint

### Why?

To filter on moves with an allocation association, add a new filter
to either return all moves with an allocation if set to true, or to exclude
all moves associated to an allocation if set to false

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

