### PR TITLE
Remove rubocop-rspec from lock file as it's been removed from our gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,7 +432,6 @@ DEPENDENCIES
   rswag-specs
   rswag-ui
   rubocop-govuk
-  rubocop-rspec
   sassc-rails
   sentry-raven
   shoulda-matchers


### PR DESCRIPTION
Remove rubocop-rspec from lock file as it's been removed from our gems