### PR TITLE
P4-1561 Add support for filtering GET /allocations by status

### DIFF
--- a/app/controllers/api/v1/allocations_controller.rb
+++ b/app/controllers/api/v1/allocations_controller.rb
@@ -29,7 +29,7 @@ module Api
 
     private
 
-      PERMITTED_FILTER_PARAMS = %i[date_from date_to locations from_locations to_locations].freeze
+      PERMITTED_FILTER_PARAMS = %i[date_from date_to locations from_locations to_locations status].freeze
 
       PERMITTED_ALLOCATION_PARAMS = [
         :type,

--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -19,7 +19,7 @@ module Allocations
       scope.order(date: :desc)
     end
 
-    def location_id_params(name)
+    def split_params(name)
       filter_params[name].split(',')
     end
 
@@ -27,6 +27,7 @@ module Allocations
       scope = scope.includes(from_location: :suppliers, to_location: :suppliers)
       scope = apply_date_range_filters(scope)
       scope = apply_location_filters(scope)
+      scope = apply_status_filters(scope)
       scope
     end
 
@@ -37,9 +38,14 @@ module Allocations
     end
 
     def apply_location_filters(scope)
-      scope = scope.where(from_location_id: location_id_params(:from_locations)) if filter_params.key?(:from_locations)
-      scope = scope.where(to_location_id: location_id_params(:to_locations)) if filter_params.key?(:to_locations)
-      scope = scope.where(from_location_id: location_id_params(:locations)).or(scope.where(to_location_id: location_id_params(:locations))) if filter_params.key?(:locations)
+      scope = scope.where(from_location_id: split_params(:from_locations)) if filter_params.key?(:from_locations)
+      scope = scope.where(to_location_id: split_params(:to_locations)) if filter_params.key?(:to_locations)
+      scope = scope.where(from_location_id: split_params(:locations)).or(scope.where(to_location_id: split_params(:locations))) if filter_params.key?(:locations)
+      scope
+    end
+
+    def apply_status_filters(scope)
+      scope = scope.where(status: split_params(:status)) if filter_params.key?(:status)
       scope
     end
   end

--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -20,7 +20,7 @@ module Allocations
     end
 
     def split_params(name)
-      filter_params[name].split(',')
+      filter_params[name]&.split(',')
     end
 
     def apply_filters(scope)

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -12,6 +12,17 @@ FactoryBot.define do
     moves_count { Faker::Number.non_zero_digit }
     complete_in_full { false }
 
+    trait :unfilled do
+      status { 'unfilled' }
+    end
+    trait :filled do
+      status { 'filled' }
+    end
+    trait :cancelled do
+      status { 'cancelled' }
+      cancellation_reason { 'other' }
+    end
+
     trait :with_moves do
       moves_count { 1 }
       after(:create) do |allocation|

--- a/spec/requests/api/v1/allocations_controller_index_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_index_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::AllocationsController do
   describe 'GET /allocations' do
     let(:schema) { load_yaml_schema('get_allocations_responses.yaml') }
 
-    let!(:allocations) { create_list :allocation, 21 }
+    let!(:allocations) { create_list :allocation, 2 }
     let(:params) { {} }
 
     before do
@@ -69,7 +69,25 @@ RSpec.describe Api::V1::AllocationsController do
         end
       end
 
+      describe 'filtering results by status' do
+        let(:unfilled_allocation) { create :allocation, :unfilled }
+        let(:filled_allocation) { create :allocation, :filled }
+        let(:cancelled_allocation) { create :allocation, :cancelled }
+        let!(:allocations) { [unfilled_allocation, filled_allocation, cancelled_allocation] }
+        let(:params) { { filter: { status: 'cancelled' } } }
+
+        it 'filters the results' do
+          expect(response_json['data'].size).to be 1
+        end
+
+        it 'returns the allocation that matches the filter' do
+          expect(response_json).to include_json(data: [{ id: cancelled_allocation.id }])
+        end
+      end
+
       describe 'paginating results' do
+        let!(:allocations) { create_list :allocation, 21 }
+
         let(:meta_pagination) do
           {
             per_page: 20,

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe Allocations::Finder do
           expect(allocation_finder.call).to be_empty
         end
       end
+
+      context 'with nil status' do
+        let(:filter_params) { { status: nil } }
+
+        it 'returns only allocations without a status' do
+          expect(allocation_finder.call).to contain_exactly(allocation)
+        end
+      end
     end
   end
 end

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Allocations::Finder do
       let(:filter_params) { { from_locations: from_location.id } }
 
       it 'returns allocations matching specified from_location' do
-        expect(allocation_finder.call).to match_array [allocation]
+        expect(allocation_finder.call).to contain_exactly(allocation)
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Allocations::Finder do
       let(:filter_params) { { to_locations: to_location.id } }
 
       it 'returns allocations matching specified to_location' do
-        expect(allocation_finder.call).to match_array [allocation]
+        expect(allocation_finder.call).to contain_exactly(allocation)
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe Allocations::Finder do
       let(:filter_params) { { from_locations: from_location.id, to_locations: to_location.id } }
 
       it 'returns allocations matching specified from_location and to_location' do
-        expect(allocation_finder.call).to match_array [allocation]
+        expect(allocation_finder.call).to contain_exactly(allocation)
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Allocations::Finder do
       let(:filter_params) { { locations: shared_location.id } }
 
       it 'returns allocations matching specified from_location or to_location' do
-        expect(allocation_finder.call).to match_array [allocation, other_allocation]
+        expect(allocation_finder.call).to contain_exactly(allocation, other_allocation)
       end
     end
 
@@ -86,7 +86,7 @@ RSpec.describe Allocations::Finder do
       let(:filter_params) { { from_locations: [from_location.id, other_location.id] } }
 
       it 'returns allocations matching either specified from_location' do
-        expect(allocation_finder.call).to match_array [allocation, other_allocation]
+        expect(allocation_finder.call).to contain_exactly(allocation, other_allocation)
       end
     end
 
@@ -96,7 +96,7 @@ RSpec.describe Allocations::Finder do
       let(:filter_params) { { to_locations: [to_location.id, other_location.id] } }
 
       it 'returns allocations matching either specified to_location' do
-        expect(allocation_finder.call).to match_array [allocation, other_allocation]
+        expect(allocation_finder.call).to contain_exactly(allocation, other_allocation)
       end
     end
 
@@ -106,7 +106,37 @@ RSpec.describe Allocations::Finder do
       let(:filter_params) { { locations: [from_location.id, other_location.id] } }
 
       it 'returns allocations matching either specified from_location or to_location' do
-        expect(allocation_finder.call).to match_array [allocation, other_allocation]
+        expect(allocation_finder.call).to contain_exactly(allocation, other_allocation)
+      end
+    end
+
+    describe 'by status' do
+      let!(:unfilled_allocation) { create :allocation, :unfilled, from_location: from_location, to_location: to_location }
+      let!(:filled_allocation) { create :allocation, :filled, from_location: from_location, to_location: to_location }
+      let!(:cancelled_allocation) { create :allocation, :cancelled, from_location: from_location, to_location: to_location }
+
+      context 'with matching status' do
+        let(:filter_params) { { status: 'filled' } }
+
+        it 'returns allocations matching status' do
+          expect(allocation_finder.call).to contain_exactly(filled_allocation)
+        end
+      end
+
+      context 'with multiple statuses' do
+        let(:filter_params) { { status: 'unfilled,cancelled' } }
+
+        it 'returns allocations matching status' do
+          expect(allocation_finder.call).to contain_exactly(unfilled_allocation, cancelled_allocation)
+        end
+      end
+
+      context 'with mis-matching status' do
+        let(:filter_params) { { status: 'foo' } }
+
+        it 'returns empty results set' do
+          expect(allocation_finder.call).to be_empty
+        end
       end
     end
   end

--- a/spec/swagger/definitions/hand_coded_paths.yaml
+++ b/spec/swagger/definitions/hand_coded_paths.yaml
@@ -59,6 +59,18 @@
         type: string
       example: '02cf0c8e-bf28-4e36-bf08-1e15fefa279b,0351fc23-5b8c-409e-aa87-1f7c4adb1ed6'
       format: uuid
+    - name: filter[status]
+      in: query
+      explode: false
+      description: Filters results to only include allocations with the given statuses
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+          - filled
+          - unfilled
+          - cancelled
     - $ref: pagination_parameters.yaml#/Page
     - $ref: pagination_parameters.yaml#/PerPage
     responses:


### PR DESCRIPTION
### Jira link

P4-1561

### What?

- [x] Add new filter by `status` within `GET /allocations` endpoint. This allows filtering results by each of the allocation statuses, with support for multiple statuses. If omitted all results are returned as before.

### Why?

- This supports front end work to exclude cancelled allocations in certain circumstances.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production, but in a non destructive way. Behaviour is unchanged if new filter parameter is not specified, so is backwards compatible.

