### PR TITLE
[P4-1497] Prepare includes

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -124,7 +124,6 @@ module Api
         @updater ||= Moves::Updater.new(move, update_move_params)
       end
 
-      # ["foo.bar", "baz.bim"]
       def include_params
         params.permit(:include)
       end

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -8,7 +8,8 @@ module Api
       def index
         moves = Moves::Finder.new(filter_params, current_ability, params[:sort] || {}).call
         # Excludes potentially many court hearing documents to reduce the request size. This was requested specifically by the frontend team.
-        paginate moves, include: MoveSerializer::INCLUDED_ATTRIBUTES.dup.except(:court_hearings), fields: MoveSerializer::INCLUDED_FIELDS
+        includes = MoveSerializer::INCLUDED_ATTRIBUTES.dup - %w[court_hearings]
+        paginate moves, include: includes, fields: MoveSerializer::INCLUDED_FIELDS
       end
 
       def show
@@ -121,6 +122,11 @@ module Api
 
       def updater
         @updater ||= Moves::Updater.new(move, update_move_params)
+      end
+
+      # ["foo.bar", "baz.bim"]
+      def include_params
+        params.permit(:include)
       end
     end
   end

--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -123,10 +123,6 @@ module Api
       def updater
         @updater ||= Moves::Updater.new(move, update_move_params)
       end
-
-      def include_params
-        params.permit(:include)
-      end
     end
   end
 end

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -19,9 +19,5 @@ class AllocationSerializer < ActiveModel::Serializer
   has_one :to_location
   has_many :moves
 
-  INCLUDED_ATTRIBUTES = {
-    from_location: [],
-    to_location: [],
-    moves: %i[person],
-  }.freeze
+  INCLUDED_ATTRIBUTES = %w[from_location to_location moves.person].freeze
 end

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -25,15 +25,16 @@ class MoveSerializer < ActiveModel::Serializer
   has_many :court_hearings, serializer: CourtHearingSerializer
   belongs_to :allocation, serializer: AllocationSerializer
 
-  INCLUDED_ATTRIBUTES = {
-    person: %i[ethnicity gender],
-    from_location: [],
-    to_location: [],
-    documents: [],
-    prison_transfer_reason: [],
-    court_hearings: [],
-    allocation: [],
-  }.freeze
+  INCLUDED_ATTRIBUTES = %w[
+    person.ethnicity
+    person.gender
+    from_location
+    to_location
+    documents
+    prison_transfer_reason
+    court_hearings
+    allocation
+  ].freeze
 
   INCLUDED_FIELDS = {
     allocation: %i[to_location from_location moves_count created_at],

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -16,7 +16,7 @@ class PersonSerializer < ActiveModel::Serializer
   has_one :ethnicity, serializer: EthnicitySerializer, if: -> { ethnicity.present? }
   has_one :gender, serializer: GenderSerializer
 
-  INCLUDED_DETAIL = %i[ethnicity gender].freeze
+  INCLUDED_DETAIL = %w[ethnicity gender].freeze
 
   def first_names
     object.latest_profile&.first_names


### PR DESCRIPTION
### Jira link

P4-1497

### What?

We are expecting includes to come from the query param in the following format:

`?include=gender,location,person.profile`

Which gets parsed by rails/rack as:

```ruby
"include" => [
  "gender",
  "location",
  "person.profile"
]
```

This format is supported by AMS in addition to the current format we're using.

This PR moves our current includes to the same format that comes from the query params to avoid doing things in more than one way and to simplify our setup.

### Why?

To simplify our setup
