### PR TITLE
Adds strong migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'rails', '~> 5.2.3'
 gem 'sassc-rails'
 gem 'sentry-raven'
 gem 'sidekiq'
+gem 'strong_migrations', '~> 0.6.8'
 gem 'tty-prompt'
 gem 'validate_url', '~> 1.0.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,6 +355,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    strong_migrations (0.6.8)
+      activerecord (>= 5)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -439,6 +441,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  strong_migrations (~> 0.6.8)
   timecop
   tty-prompt
   validate_url (~> 1.0.8)

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,18 @@
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20200521122241
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

Adds strong_migrations to our project.

This gem is essentially a linter for migrations - are they dangerous, are they slow, are they known wrong ways of doing stuff, etc.

It ignores our existing migrations and makes it so that all future migrations explode when a principle is breached.

### Why?

- Pedagogical - we learn some of the principles around safer migrations by exposure to failures
- Process - we get better at thinking more about how migrations are going to affect our production systems
- Safety - we cause fewer outages/exceptions and catch things earlier