### PR TITLE
[P4-1567] Fix create_client_application rake task

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     discard (1.1.0)
       activerecord (>= 4.2, < 7)
     docile (1.3.2)
-    doorkeeper (5.1.1)
+    doorkeeper (5.4.0)
       railties (>= 5)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-1567

### What?

I've bumped the version of the doorkeeper gem to the latest stable version.

### Why?

The locked version of the Gem seems to have been bumped up automatically to the next minimal version that satisfied a dependency, but that particular version was causing a rake task to fail.
As suggested by  @martyn-w, bumping it to the latest stable version fixes the problem.

Changing this Gem version did not had adverse effects on the outcome of the tests or on the generation of client application IDs

