### PR TITLE
Allocation `moves_count` now includes only non cancelled moves

### DIFF
--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -14,8 +14,10 @@ module Moves
       # NB: rather than update directly, we need to detect whether the move status has changed before saving the record
       self.status_changed = move.status_changed?
 
-      move.save!
-      move.allocation&.refresh_moves_count! if status_changed
+      move.transaction do
+        move.save!
+        move.allocation&.refresh_moves_count! if status_changed
+      end
     end
 
   private

--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -15,6 +15,7 @@ module Moves
       self.status_changed = move.status_changed?
 
       move.save!
+      move.allocation&.refresh_moves_count! if status_changed
     end
 
   private

--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -209,7 +209,7 @@ namespace :fake_data do
         to_location: prisons.sample,
         prisoner_category: Allocation.prisoner_categories.values.sample,
         sentence_length: Allocation.sentence_lengths.values.sample,
-        moves_count: Faker::Number.digit,
+        moves_count: Faker::Number.non_zero_digit,
         complete_in_full: Faker::Boolean.boolean,
         complex_cases: fake_complex_case_answers,
       )

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe Allocation do
     end
   end
 
+  describe '#refresh_moves_count!' do
+    let(:cancelled_move) { create :move, :cancelled }
+    let(:proposed_move) { create :move, :proposed }
+    let(:requested_move) { create :move, :requested }
+    let(:completed_move) { create :move, :completed }
+    let(:moves) { [cancelled_move, proposed_move, requested_move, completed_move] }
+    let!(:allocation) { create :allocation, moves: moves, moves_count: 1 }
+
+    it 'updates the number of non cancelled moves' do
+      expect { allocation.refresh_moves_count! }.to change { allocation.reload.moves_count }.from(1).to(3)
+    end
+  end
+
   describe 'cancellation_reason' do
     context 'when the allocation is not cancelled' do
       let(:allocation) { build(:allocation, status: nil) }
@@ -62,6 +75,12 @@ RSpec.describe Allocation do
       allocation.reload.cancel
 
       expect(allocation.reload.status).to eq(described_class::ALLOCATION_STATUS_CANCELLED)
+    end
+
+    it 'changes the moves_count of allocation to 0' do
+      allocation.reload.cancel
+
+      expect(allocation.reload.moves_count).to eq(0)
     end
 
     it 'changes the status of all associated moves to cancelled' do

--- a/spec/requests/api/v1/allocation_events_controller_create_spec.rb
+++ b/spec/requests/api/v1/allocation_events_controller_create_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Api::V1::AllocationEventsController do
           expect(allocation.reload.status).to eql('cancelled')
         end
 
+        it 'updates the allocation moves_count' do
+          expect(allocation.reload.moves_count).to eq(0)
+        end
+
         it 'updates the allocation moves status' do
           expect(allocation.reload.moves.pluck(:status).uniq).to contain_exactly('cancelled')
         end

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -288,6 +288,25 @@ RSpec.describe Api::V1::MovesController do
         end
 
         context 'when cancelling a move' do
+          let(:move_params) do
+            {
+              type: 'moves',
+              attributes: {
+                status: 'cancelled',
+                cancellation_reason: 'other',
+              },
+            }
+          end
+
+          context 'with an associated allocation' do
+            let!(:allocation) { create :allocation, moves_count: 1 }
+            let!(:move) { create :move, :requested, from_location: from_location, allocation: allocation }
+
+            it 'updates the allocation moves_count' do
+              expect(allocation.reload.moves_count).to eq(0)
+            end
+          end
+
           context 'when the supplier has a webhook subscription', :skip_before do
             let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
             let!(:notification_type_webhook) { create(:notification_type, :webhook) }

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe Moves::Updater do
       end
     end
 
+    context 'when status is not updated with an associated allocation' do
+      let!(:allocation) { create :allocation, moves_count: 5 }
+      let!(:move) { create :move, :requested, from_location: from_location, allocation: allocation }
+
+      it 'does not change allocation moves_count' do
+        expect { updater.call }.not_to change { allocation.reload.moves_count }
+      end
+    end
+
     context 'with people' do
       let(:before_person) { create(:person) }
       let(:after_person) { create(:person) }

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Moves::Updater do
   let(:date_from) { Date.yesterday }
   let(:date_to) { Date.tomorrow }
   let(:status) { 'requested' }
+  let(:cancellation_reason) { nil }
 
   let(:move_params) do
     {
@@ -18,7 +19,7 @@ RSpec.describe Moves::Updater do
       attributes: {
         status: status,
         additional_information: 'some more info',
-        cancellation_reason: nil,
+        cancellation_reason: cancellation_reason,
         cancellation_reason_comment: nil,
         move_type: 'court_appearance',
         move_agreed: true,
@@ -29,14 +30,9 @@ RSpec.describe Moves::Updater do
     }
   end
 
-  before do
-    next if RSpec.current_example.metadata[:skip_before]
-
-    updater.call
-  end
-
   context 'with valid params' do
     it 'updates the correct attributes on an existing move' do
+      updater.call
       expect(updater.move).to have_attributes(
         status: 'requested',
         additional_information: 'some more info',
@@ -48,9 +44,31 @@ RSpec.describe Moves::Updater do
       )
     end
 
-    context 'when status updated' do
+    context 'when status changes without an associated allocation' do
       it 'sets `status_updated` to `true`' do
+        updater.call
         expect(updater.status_changed).to be_truthy
+      end
+    end
+
+    context 'when status changes to cancelled with an associated allocation' do
+      let!(:allocation) { create :allocation, moves_count: 5 }
+      let!(:move) { create :move, :requested, from_location: from_location, allocation: allocation }
+
+      let(:cancellation_reason) { 'other' }
+      let(:status) { 'cancelled' }
+
+      it 'corrects allocation moves_count' do
+        expect { updater.call }.to change { allocation.reload.moves_count }.from(5).to(0)
+      end
+    end
+
+    context 'when status changes to non cancelled with an associated allocation' do
+      let!(:allocation) { create :allocation, moves_count: 5 }
+      let!(:move) { create :move, :cancelled, from_location: from_location, allocation: allocation }
+
+      it 'corrects allocation moves_count' do
+        expect { updater.call }.to change { allocation.reload.moves_count }.from(5).to(1)
       end
     end
 
@@ -58,6 +76,7 @@ RSpec.describe Moves::Updater do
       let(:status) { 'proposed' }
 
       it 'sets `status_updated` to `false`' do
+        updater.call
         expect(updater.status_changed).to be_falsey
       end
     end
@@ -76,7 +95,7 @@ RSpec.describe Moves::Updater do
         end
 
         it 'updates person association to new person' do
-          expect(updater.move.profile.person).to eq(after_person)
+          expect { updater.call }.to change { move.reload.profile.person }.from(before_person).to(after_person)
         end
       end
 
@@ -89,13 +108,13 @@ RSpec.describe Moves::Updater do
         end
 
         it 'removes associated profile' do
-          expect(updater.move.profile).to be_nil
+          expect { updater.call }.to change { move.reload.profile }.to(nil)
         end
       end
 
       context 'with no person relationship' do
         it 'does not change old person associated' do
-          expect(updater.move.profile.person).to eq(before_person)
+          expect { updater.call }.not_to change { move.reload.profile.person }
         end
       end
     end
@@ -112,6 +131,7 @@ RSpec.describe Moves::Updater do
         end
 
         it 'updates documents association to new documents' do
+          updater.call
           expect(updater.move.documents).to match_array(after_documents)
         end
       end
@@ -125,6 +145,7 @@ RSpec.describe Moves::Updater do
         end
 
         it 'unsets associated documents' do
+          updater.call
           expect(updater.move.documents).to be_empty
         end
       end
@@ -138,12 +159,14 @@ RSpec.describe Moves::Updater do
         end
 
         it 'does nothing to existing documents' do
+          updater.call
           expect(updater.move.documents).to match_array(before_documents)
         end
       end
 
       context 'with no document relationship' do
         it 'does nothing to existing documents' do
+          updater.call
           expect(updater.move.documents).to match_array(before_documents)
         end
       end
@@ -153,7 +176,7 @@ RSpec.describe Moves::Updater do
   context 'with invalid input params' do
     let(:status) { 'wrong status' }
 
-    it 'raises an error', :skip_before do
+    it 'raises an error' do
       expect { updater.call }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end

--- a/swagger/v1/allocation.yaml
+++ b/swagger/v1/allocation.yaml
@@ -25,7 +25,7 @@ Allocation:
         moves_count:
           type: integer
           example: 5
-          description: The number of prisoners to move in this allocation
+          description: The number of prisoners to move in this allocation. This must be set when creating an allocation. When retrieving an allocation this will reflect the number of associated non-cancelled moves (i.e. cancelled moves are excluded from this count).
         prisoner_category:
           oneOf:
           - type: string


### PR DESCRIPTION
### Jira link

P4-1554

### What?

- [x] Updated validation on allocation `moves_count` (now only applies on `:create`)
- [x] Updated allocation `cancel` method to correct `moves_count` to 0
- [x] Updated `Moves::Updater` service to correct associated allocation `moves_count`
- [x] Refactored existing `Moves::Updater` specs to remove `:skip_before` tag

### Why?

- Allocation `moves_count` attribute should always reflect the number of associated non-cancelled moves. This can then be used reliably for the front end dashboard stats. Note that this PR does **not** change the allocation moves relationship, which still includes cancelled moves.
- When the allocation is first created, the `moves_count` attribute is used to create a number of associated moves with `requested` status, so the `moves_count` attribute on the allocation is correct at that point. Subsequently, the allocation cannot be changed but may be cancelled. Additionally the associated moves may be changed - notably to amend their status.
- If the allocation is cancelled completely, the `moves_count` should be set to zero as all of the associated moves are now cancelled.
- If a move associated to an allocation changes status (via the `Moves::Updater` service) then the allocation `moves_count` is now updated to count only non cancelled moves.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- This changes the behaviour of `moves_count` attribute within a production API, but actually corrects the existing incorrect behaviour.