### PR TITLE
Revert "Merge pull request #486"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     discard (1.1.0)
       activerecord (>= 4.2, < 7)
     docile (1.3.2)
-    doorkeeper (5.4.0)
+    doorkeeper (5.1.1)
       railties (>= 5)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)


### PR DESCRIPTION
This reverts commit 77aa6d4f358354a1ab4c48ff35c7e3928807e826, reversing
changes made to 7a312279d07b8db0f48e01f1a07f5f5dcfd16185.

There seems to be some issue with the gem that was updated and active record.
We are reverting this change for now and will investigate further. 


