### PR TITLE
Surface allocation moves in move endpoint

### DIFF
--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -34,10 +34,11 @@ class MoveSerializer < ActiveModel::Serializer
     prison_transfer_reason
     court_hearings
     allocation
+    allocation.moves
   ].freeze
 
   INCLUDED_FIELDS = {
-    allocation: %i[to_location from_location moves_count created_at],
+    allocation: %i[to_location from_location moves_count moves created_at],
   }.freeze
 
   def person

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe MoveSerializer do
   describe 'allocations' do
     context 'with an allocation' do
       let(:adapter_options) do
-        { include: :allocation, fields: MoveSerializer::INCLUDED_FIELDS }
+        { include: %w[allocation.moves], fields: MoveSerializer::INCLUDED_FIELDS }
       end
       let(:move) { create(:move, :with_allocation) }
       let(:expected_json) do
@@ -155,6 +155,14 @@ RSpec.describe MoveSerializer do
                   type: 'locations',
                 },
               },
+              moves: {
+                data: [
+                  {
+                    id: move.id,
+                    type: 'moves',
+                  },
+                ],
+              },
             },
           },
         ]
@@ -166,6 +174,15 @@ RSpec.describe MoveSerializer do
 
       it 'contains an included allocation' do
         expect(result[:included]).to eq(expected_json)
+      end
+
+      context 'when allocation associated to multiple moves' do
+        let(:allocation) { create(:allocation, :with_moves, moves_count: 2) }
+        let(:move) { allocation.moves.first }
+
+        it 'contains an included allocation' do
+          expect(result[:included].map { |r| r[:type] }).to match_array(%w[allocations moves])
+        end
       end
     end
 


### PR DESCRIPTION
When a move is associated to an allocation we want to see all the included
moves as well. Surface those values in included fields and attributes. Please
note that because all moves are included in the main GET moves endpoint we
won't show those as included, and those only appear in the single GET move
requests

