### PR TITLE
[P4-1435] Adds migration for extra person fields

### DIFF
--- a/db/migrate/20200526152251_adds_fields_to_people.rb
+++ b/db/migrate/20200526152251_adds_fields_to_people.rb
@@ -13,6 +13,5 @@ class AddsFieldsToPeople < ActiveRecord::Migration[5.2]
 
     add_reference :people, :ethnicity, type: :uuid
     add_reference :people, :gender, type: :uuid
-    add_reference :people, :nationality, type: :uuid
   end
 end

--- a/db/migrate/20200526152251_adds_fields_to_people.rb
+++ b/db/migrate/20200526152251_adds_fields_to_people.rb
@@ -13,5 +13,9 @@ class AddsFieldsToPeople < ActiveRecord::Migration[5.2]
 
     add_reference :people, :ethnicity, type: :uuid
     add_reference :people, :gender, type: :uuid
+
+    add_index :people, :prison_number
+    add_index :people, :criminal_records_office
+    add_index :people, :police_national_computer
   end
 end

--- a/db/migrate/20200526152251_adds_fields_to_people.rb
+++ b/db/migrate/20200526152251_adds_fields_to_people.rb
@@ -1,0 +1,18 @@
+class AddsFieldsToPeople < ActiveRecord::Migration[5.2]
+  def change
+    add_column :people, :prison_number, :string
+    add_column :people, :criminal_records_office, :string
+    add_column :people, :police_national_computer, :string
+
+    add_column :people, :first_names, :string
+    add_column :people, :last_name, :string
+    add_column :people, :date_of_birth, :date
+    add_column :people, :gender_additional_information, :string
+
+    add_column :people, :latest_nomis_booking_id, :string
+
+    add_reference :people, :ethnicity, type: :uuid
+    add_reference :people, :gender, type: :uuid
+    add_reference :people, :nationality, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,10 +326,13 @@ ActiveRecord::Schema.define(version: 2020_05_26_152251) do
     t.string "latest_nomis_booking_id"
     t.uuid "ethnicity_id"
     t.uuid "gender_id"
+    t.index ["criminal_records_office"], name: "index_people_on_criminal_records_office"
     t.index ["ethnicity_id"], name: "index_people_on_ethnicity_id"
     t.index ["gender_id"], name: "index_people_on_gender_id"
     t.index ["nationality_id"], name: "index_people_on_nationality_id"
     t.index ["nomis_prison_number"], name: "index_people_on_nomis_prison_number"
+    t.index ["police_national_computer"], name: "index_people_on_police_national_computer"
+    t.index ["prison_number"], name: "index_people_on_prison_number"
   end
 
   create_table "prison_transfer_reasons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_19_120027) do
+ActiveRecord::Schema.define(version: 2020_05_26_152251) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -315,6 +315,20 @@ ActiveRecord::Schema.define(version: 2020_05_19_120027) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "nomis_prison_number"
+    t.string "prison_number"
+    t.string "criminal_records_office"
+    t.string "police_national_computer"
+    t.string "first_names"
+    t.string "last_name"
+    t.date "date_of_birth"
+    t.string "gender_additional_information"
+    t.string "latest_nomis_booking_id"
+    t.uuid "ethnicity_id"
+    t.uuid "gender_id"
+    t.uuid "nationality_id"
+    t.index ["ethnicity_id"], name: "index_people_on_ethnicity_id"
+    t.index ["gender_id"], name: "index_people_on_gender_id"
+    t.index ["nationality_id"], name: "index_people_on_nationality_id"
     t.index ["nomis_prison_number"], name: "index_people_on_nomis_prison_number"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -315,7 +315,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_152251) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "nomis_prison_number"
-    t.uuid "nationality_id"
     t.string "prison_number"
     t.string "criminal_records_office"
     t.string "police_national_computer"
@@ -329,7 +328,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_152251) do
     t.index ["criminal_records_office"], name: "index_people_on_criminal_records_office"
     t.index ["ethnicity_id"], name: "index_people_on_ethnicity_id"
     t.index ["gender_id"], name: "index_people_on_gender_id"
-    t.index ["nationality_id"], name: "index_people_on_nationality_id"
     t.index ["nomis_prison_number"], name: "index_people_on_nomis_prison_number"
     t.index ["police_national_computer"], name: "index_people_on_police_national_computer"
     t.index ["prison_number"], name: "index_people_on_prison_number"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -315,6 +315,7 @@ ActiveRecord::Schema.define(version: 2020_05_26_152251) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "nomis_prison_number"
+    t.uuid "nationality_id"
     t.string "prison_number"
     t.string "criminal_records_office"
     t.string "police_national_computer"
@@ -325,7 +326,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_152251) do
     t.string "latest_nomis_booking_id"
     t.uuid "ethnicity_id"
     t.uuid "gender_id"
-    t.uuid "nationality_id"
     t.index ["ethnicity_id"], name: "index_people_on_ethnicity_id"
     t.index ["gender_id"], name: "index_people_on_gender_id"
     t.index ["nationality_id"], name: "index_people_on_nationality_id"


### PR DESCRIPTION
### Jira link

P4-1435

### What?

It makes way more sense to have relatively-infrequently changing `Profile` attributes on a `Person`.

A `Profile` is expected to change every `Move` potentially and a new one should be created for the `Move`.

The full list of `Profile` attributes are:

```ruby
    t.uuid "person_id", null: false
    t.string "last_name", null: false
    t.string "first_names", null: false
    t.date "date_of_birth"
    t.string "aliases", default: [], array: true
    t.uuid "gender_id"
    t.uuid "ethnicity_id"
    t.uuid "nationality_id"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
    t.jsonb "assessment_answers"
    t.jsonb "profile_identifiers"
    t.string "gender_additional_information"
    t.integer "latest_nomis_booking_id"
```

- [x] Migrates attributes
- [x] Splits out and promotes identifier attributes 

### Why?

A profile should contain frequently changing assessments and personal care needs and shouldn't be an audit trail of all changes to the person.
