### PR TITLE
P4-1555 Enhance Allocation status

### DIFF
--- a/app/controllers/api/v1/allocation_events_controller.rb
+++ b/app/controllers/api/v1/allocation_events_controller.rb
@@ -9,7 +9,7 @@ module Api
       def create
         case event_name
         when 'cancel'
-          allocation.cancel_with_moves
+          allocation.cancel
 
           allocation.save!
           render json: fake_event_object, status: :created

--- a/app/controllers/api/v1/allocation_events_controller.rb
+++ b/app/controllers/api/v1/allocation_events_controller.rb
@@ -9,7 +9,7 @@ module Api
       def create
         case event_name
         when 'cancel'
-          allocation.cancel
+          allocation.cancel_with_moves
 
           allocation.save!
           render json: fake_event_object, status: :created

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -68,8 +68,10 @@ class Allocation < VersionedModel
   end
 
   def refresh_status_and_moves_count!
-    moves.not_cancelled.empty? || moves.not_cancelled.unfilled? ? unfill : fill
-    self.moves_count = moves.not_cancelled.count
+    current_moves = moves.not_cancelled
+
+    current_moves.unfilled? ? unfill : fill
+    self.moves_count = current_moves.count
 
     save!
   end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -49,6 +49,7 @@ class Allocation < VersionedModel
   validates :cancellation_reason, absence: true, unless: :cancelled?
 
   attribute :complex_cases, Types::JSONB.new(Allocation::ComplexCaseAnswers)
+  after_initialize :initialize_state
 
   def refresh_moves_count!
     self.moves_count = moves.not_cancelled.count
@@ -67,5 +68,15 @@ class Allocation < VersionedModel
     )
 
     save!
+  end
+
+  private
+
+  def state_machine
+    @state_machine ||= AllocationStateMachine.new(self)
+  end
+
+  def initialize_state
+    self.status = state_machine.current
   end
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -51,18 +51,18 @@ class Allocation < VersionedModel
   attribute :complex_cases, Types::JSONB.new(Allocation::ComplexCaseAnswers)
 
   after_initialize :initialize_state
-  delegate :fill, :unfill, to: :state_machine
+  delegate :fill, :unfill, :cancel, to: :state_machine
 
-  def cancel
+  def cancel_with_moves
     comment = 'Allocation was cancelled'
 
     assign_attributes(
-      status: ALLOCATION_STATUS_CANCELLED,
       cancellation_reason: CANCELLATION_REASON_OTHER,
       cancellation_reason_comment: comment,
       moves: moves.each { |move| move.cancel(comment: comment) },
       moves_count: 0,
     )
+    cancel
 
     save!
   end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -51,9 +51,9 @@ class Allocation < VersionedModel
   attribute :complex_cases, Types::JSONB.new(Allocation::ComplexCaseAnswers)
 
   after_initialize :initialize_state
-  delegate :fill, :unfill, :cancel, to: :state_machine
+  delegate :fill, :unfill, to: :state_machine
 
-  def cancel_with_moves
+  def cancel
     comment = 'Allocation was cancelled'
 
     assign_attributes(
@@ -62,7 +62,7 @@ class Allocation < VersionedModel
       moves: moves.each { |move| move.cancel(comment: comment) },
       moves_count: 0,
     )
-    cancel
+    state_machine.cancel
 
     save!
   end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -86,7 +86,9 @@ private
     if status.present?
       state_machine.restore!(status.to_sym)
     else
-      self.status = state_machine.current
+      # TODO: restore after data is backfilled on production
+      # self.status = state_machine.current
+      self.status = moves.not_cancelled.unfilled? ? :unfilled : :filled
     end
   end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -81,6 +81,10 @@ class Move < VersionedModel
     )
   end
 
+  def self.unfilled?
+    pluck(:profile_id).any?(&:nil?)
+  end
+
   def nomis_event_id=(event_id)
     nomis_event_ids << event_id
   end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -82,7 +82,7 @@ class Move < VersionedModel
   end
 
   def self.unfilled?
-    pluck(:profile_id).any?(&:nil?)
+    none? || exists?(profile_id: nil)
   end
 
   def nomis_event_id=(event_id)

--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -13,10 +13,11 @@ module Moves
       move.assign_attributes(attributes)
       # NB: rather than update directly, we need to detect whether the move status has changed before saving the record
       self.status_changed = move.status_changed?
+      profile_id_changed = move.profile_id_changed?
 
       move.transaction do
         move.save!
-        move.allocation&.refresh_moves_count! if status_changed
+        move.allocation&.refresh_status_and_moves_count! if status_changed || profile_id_changed
       end
     end
 

--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -13,11 +13,10 @@ module Moves
       move.assign_attributes(attributes)
       # NB: rather than update directly, we need to detect whether the move status has changed before saving the record
       self.status_changed = move.status_changed?
-      profile_id_changed = move.profile_id_changed?
 
       move.transaction do
         move.save!
-        move.allocation&.refresh_status_and_moves_count! if status_changed || profile_id_changed
+        move.allocation&.refresh_status_and_moves_count!
       end
     end
 

--- a/app/state_machines/allocation_state_machine.rb
+++ b/app/state_machines/allocation_state_machine.rb
@@ -1,8 +1,8 @@
 class AllocationStateMachine < FiniteMachine::Definition
   initial :unfilled
 
-  event :fill, unfilled: :filled
-  event :unfill, filled: :unfilled
+  event :fill, %i[unfilled filled] => :filled
+  event :unfill, %i[unfilled filled] => :unfilled
   event :cancel, %i[unfilled filled] => :cancelled
 
   terminal :cancelled

--- a/app/state_machines/allocation_state_machine.rb
+++ b/app/state_machines/allocation_state_machine.rb
@@ -1,9 +1,11 @@
 class AllocationStateMachine < FiniteMachine::Definition
   initial :unfilled
 
-  event :fill, %i[none unfilled filled] => :filled
-  event :unfill, %i[none unfilled filled] => :unfilled
-  event :cancel, %i[none unfilled filled] => :cancelled
+  event :fill, unfilled: :filled
+  event :unfill, filled: :unfilled
+  event :cancel, %i[unfilled filled] => :cancelled
+
+  terminal :cancelled
 
   on_enter do |event|
     target.status = event.to

--- a/app/state_machines/allocation_state_machine.rb
+++ b/app/state_machines/allocation_state_machine.rb
@@ -1,3 +1,10 @@
 class AllocationStateMachine < FiniteMachine::Definition
   initial :unfilled
+
+  event :fill, %i[none unfilled filled] => :filled
+  event :unfill, %i[none unfilled filled] => :unfilled
+
+  on_enter do |event|
+    target.status = event.to
+  end
 end

--- a/app/state_machines/allocation_state_machine.rb
+++ b/app/state_machines/allocation_state_machine.rb
@@ -3,6 +3,7 @@ class AllocationStateMachine < FiniteMachine::Definition
 
   event :fill, %i[none unfilled filled] => :filled
   event :unfill, %i[none unfilled filled] => :unfilled
+  event :cancel, %i[none unfilled filled] => :cancelled
 
   on_enter do |event|
     target.status = event.to

--- a/app/state_machines/allocation_state_machine.rb
+++ b/app/state_machines/allocation_state_machine.rb
@@ -1,0 +1,3 @@
+class AllocationStateMachine < FiniteMachine::Definition
+  initial :unfilled
+end

--- a/lib/tasks/refresh_allocation_data.rake
+++ b/lib/tasks/refresh_allocation_data.rake
@@ -1,0 +1,6 @@
+namespace :allocations do
+  desc 'Refresh allocation moves count and status'
+  task refresh_data: :environment do
+    Allocation.find_each(&:refresh_status_and_moves_count!)
+  end
+end

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -12,8 +12,6 @@ FactoryBot.define do
     moves_count { Faker::Number.non_zero_digit }
     complete_in_full { false }
 
-    after(:build) { |object| object.send(:initialize_state) }
-
     trait :unfilled do
       status { 'unfilled' }
     end

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -12,6 +12,8 @@ FactoryBot.define do
     moves_count { Faker::Number.non_zero_digit }
     complete_in_full { false }
 
+    after(:build) { |object| object.send(:initialize_state) }
+
     trait :unfilled do
       status { 'unfilled' }
     end

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -25,6 +25,13 @@ FactoryBot.define do
       cancellation_reason { 'other' }
     end
 
+    # TODO: remove when we no longer support nil statuses on allocations
+    trait :none do
+      before(:create) do |allocation|
+        allocation.assign_attributes(status: nil)
+      end
+    end
+
     trait :with_moves do
       moves_count { 1 }
       after(:create) do |allocation|

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -130,4 +130,12 @@ RSpec.describe Allocation do
       expect(allocation.reload.moves.pluck(:status)).to contain_exactly(Move::MOVE_STATUS_REQUESTED)
     end
   end
+
+  describe '#status' do
+    it 'sets the initial status to unfilled' do
+      allocation = create(:allocation)
+
+      expect(allocation).to be_unfilled
+    end
+  end
 end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Allocation do
       let!(:allocation) { create :allocation, moves: moves, moves_count: 1 }
 
       it 'updates the number of non cancelled moves' do
-        expect { allocation.refresh_status_and_moves_count! }.to change { allocation.moves_count }.from(1).to(3)
+        expect { allocation.refresh_status_and_moves_count! }.to change(allocation, :moves_count).from(1).to(3)
       end
     end
 

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -181,6 +181,12 @@ RSpec.describe Allocation do
       expect(allocation).to be_unfilled
     end
 
+    it 'sets the initial status to nil if set as none' do
+      allocation = create(:allocation, :none)
+
+      expect(allocation.status).to be_nil
+    end
+
     it 'restores the current status if it is set' do
       allocation = create(:allocation, :filled)
 
@@ -227,6 +233,27 @@ RSpec.describe Allocation do
 
       allocation.unfill
       expect(allocation).to be_unfilled
+    end
+
+    it 'updates the status from nil if it is filled' do
+      allocation = create(:allocation, :none)
+
+      allocation.fill
+      expect(allocation).to be_filled
+    end
+
+    it 'updates the status from nil if it is unfilled' do
+      allocation = create(:allocation, :none)
+
+      allocation.unfill
+      expect(allocation).to be_unfilled
+    end
+
+    it 'updates the status from nil if it is cancelled' do
+      allocation = create(:allocation, :none)
+
+      allocation.cancel
+      expect(allocation).to be_cancelled
     end
   end
 end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -182,72 +182,51 @@ RSpec.describe Allocation do
     end
 
     it 'restores the current status if it is set' do
-      allocation = create(:allocation, status: 'filled')
+      allocation = create(:allocation, :filled)
 
       expect(allocation).to be_filled
     end
 
     it 'updates the status from unfilled if it is filled' do
-      allocation = create(:allocation, status: 'unfilled')
+      allocation = create(:allocation, :unfilled)
 
       allocation.fill
       expect(allocation).to be_filled
     end
 
     it 'updates the status from unfilled if it is cancelled' do
-      allocation = create(:allocation, status: 'unfilled')
+      allocation = create(:allocation, :unfilled)
 
       allocation.cancel
       expect(allocation).to be_cancelled
     end
 
     it 'updates the status from filled if it is unfilled' do
-      allocation = create(:allocation, status: 'filled')
+      allocation = create(:allocation, :filled)
 
       allocation.unfill
       expect(allocation).to be_unfilled
     end
 
     it 'updates the status from filled if it is cancelled' do
-      allocation = create(:allocation, status: 'filled')
+      allocation = create(:allocation, :filled)
 
       allocation.cancel
       expect(allocation).to be_cancelled
     end
 
     it 'keeps the status filled if already set' do
-      allocation = create(:allocation, status: 'filled')
+      allocation = create(:allocation, :filled)
 
       allocation.fill
       expect(allocation).to be_filled
     end
 
     it 'keeps the status unfilled if already set' do
-      allocation = create(:allocation, status: 'unfilled')
+      allocation = create(:allocation, :unfilled)
 
       allocation.unfill
       expect(allocation).to be_unfilled
-    end
-
-    it 'updates the status from nil if it is filled' do
-      allocation = create(:allocation, status: nil)
-
-      allocation.fill
-      expect(allocation).to be_filled
-    end
-
-    it 'updates the status from nil if it is unfilled' do
-      allocation = create(:allocation, status: nil)
-
-      allocation.unfill
-      expect(allocation).to be_unfilled
-    end
-
-    it 'updates the status from nil if it is cancelled' do
-      allocation = create(:allocation, status: nil)
-
-      allocation.cancel
-      expect(allocation).to be_cancelled
     end
   end
 end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Allocation do
       let!(:allocation) { create :allocation, moves: moves, moves_count: 1 }
 
       it 'updates the number of non cancelled moves' do
-        expect { allocation.refresh_status_and_moves_count! }.to change { allocation.reload.moves_count }.from(1).to(3)
+        expect { allocation.refresh_status_and_moves_count! }.to change { allocation.moves_count }.from(1).to(3)
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe Allocation do
         allocation = create(:allocation, moves: moves + [cancelled_move])
 
         allocation.refresh_status_and_moves_count!
-        expect(allocation.reload).to be_unfilled
+        expect(allocation).to be_unfilled
       end
 
       it 'sets status to `unfilled` if not all uncancelled moves are associated to profiles' do
@@ -64,7 +64,7 @@ RSpec.describe Allocation do
         allocation = create(:allocation, moves: [move_without_profile, move_with_profile, cancelled_move])
 
         allocation.refresh_status_and_moves_count!
-        expect(allocation.reload).to be_unfilled
+        expect(allocation).to be_unfilled
       end
 
       it 'sets status to `filled` if all uncancelled moves are associated to profiles' do
@@ -74,7 +74,7 @@ RSpec.describe Allocation do
         allocation = create(:allocation, moves: moves + [cancelled_move])
 
         allocation.refresh_status_and_moves_count!
-        expect(allocation.reload).to be_filled
+        expect(allocation).to be_filled
       end
 
       it 'sets status to `unfilled` if all moves cancelled' do
@@ -83,7 +83,7 @@ RSpec.describe Allocation do
         allocation = create(:allocation, moves: [cancelled_move])
 
         allocation.refresh_status_and_moves_count!
-        expect(allocation.reload).to be_unfilled
+        expect(allocation).to be_unfilled
       end
     end
   end
@@ -115,45 +115,45 @@ RSpec.describe Allocation do
     let(:allocation) { create(:allocation, :with_moves, status: nil) }
 
     it 'changes the status of an allocation to cancelled' do
-      allocation.reload.cancel
+      allocation.cancel
 
       expect(allocation.status).to eq(described_class::ALLOCATION_STATUS_CANCELLED)
     end
 
     it 'changes the moves_count of allocation to 0' do
-      allocation.reload.cancel
+      allocation.cancel
 
       expect(allocation.moves_count).to eq(0)
     end
 
     it 'changes the status of all associated moves to cancelled' do
-      allocation.reload.cancel
+      allocation.cancel
 
       expect(allocation.moves.pluck(:status)).to contain_exactly(Move::MOVE_STATUS_CANCELLED)
     end
 
     it 'sets the cancellation reason to other' do
-      allocation.reload.cancel
+      allocation.cancel
 
       expect(allocation.cancellation_reason).to eq(described_class::CANCELLATION_REASON_OTHER)
     end
 
     it 'sets the cancellation reason comment to cancelled by allocation' do
-      allocation.reload.cancel
+      allocation.cancel
 
       expect(allocation.cancellation_reason_comment).to eq('Allocation was cancelled')
     end
 
     it 'sets the cancellation reason on moves to other' do
-      allocation.reload.cancel
+      allocation.cancel
 
       expect(allocation.moves.first.cancellation_reason).to eq(Move::CANCELLATION_REASON_OTHER)
     end
 
     it 'sets the cancellation reason comment on moves to cancelled by allocation' do
-      allocation.reload.cancel
+      allocation.cancel
 
-      expect(allocation.reload.moves.first.cancellation_reason_comment).to eq('Allocation was cancelled')
+      expect(allocation.moves.first.cancellation_reason_comment).to eq('Allocation was cancelled')
     end
 
     it 'throws validation error if allocation invalid' do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -111,47 +111,47 @@ RSpec.describe Allocation do
     end
   end
 
-  describe '#cancel_with_moves' do
+  describe '#cancel' do
     let(:allocation) { create(:allocation, :with_moves, status: nil) }
 
     it 'changes the status of an allocation to cancelled' do
-      allocation.reload.cancel_with_moves
+      allocation.reload.cancel
 
-      expect(allocation.reload.status).to eq(described_class::ALLOCATION_STATUS_CANCELLED)
+      expect(allocation.status).to eq(described_class::ALLOCATION_STATUS_CANCELLED)
     end
 
     it 'changes the moves_count of allocation to 0' do
-      allocation.reload.cancel_with_moves
+      allocation.reload.cancel
 
-      expect(allocation.reload.moves_count).to eq(0)
+      expect(allocation.moves_count).to eq(0)
     end
 
     it 'changes the status of all associated moves to cancelled' do
-      allocation.reload.cancel_with_moves
+      allocation.reload.cancel
 
-      expect(allocation.reload.moves.pluck(:status)).to contain_exactly(Move::MOVE_STATUS_CANCELLED)
+      expect(allocation.moves.pluck(:status)).to contain_exactly(Move::MOVE_STATUS_CANCELLED)
     end
 
     it 'sets the cancellation reason to other' do
-      allocation.reload.cancel_with_moves
+      allocation.reload.cancel
 
-      expect(allocation.reload.cancellation_reason).to eq(described_class::CANCELLATION_REASON_OTHER)
+      expect(allocation.cancellation_reason).to eq(described_class::CANCELLATION_REASON_OTHER)
     end
 
     it 'sets the cancellation reason comment to cancelled by allocation' do
-      allocation.reload.cancel_with_moves
+      allocation.reload.cancel
 
-      expect(allocation.reload.cancellation_reason_comment).to eq('Allocation was cancelled')
+      expect(allocation.cancellation_reason_comment).to eq('Allocation was cancelled')
     end
 
     it 'sets the cancellation reason on moves to other' do
-      allocation.reload.cancel_with_moves
+      allocation.reload.cancel
 
-      expect(allocation.reload.moves.first.cancellation_reason).to eq(Move::CANCELLATION_REASON_OTHER)
+      expect(allocation.moves.first.cancellation_reason).to eq(Move::CANCELLATION_REASON_OTHER)
     end
 
     it 'sets the cancellation reason comment on moves to cancelled by allocation' do
-      allocation.reload.cancel_with_moves
+      allocation.reload.cancel
 
       expect(allocation.reload.moves.first.cancellation_reason_comment).to eq('Allocation was cancelled')
     end
@@ -159,13 +159,13 @@ RSpec.describe Allocation do
     it 'throws validation error if allocation invalid' do
       allocation.from_location = nil
 
-      expect { allocation.cancel_with_moves }.to raise_error(ActiveRecord::RecordInvalid)
+      expect { allocation.cancel }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it 'does not update moves if allocation invalid' do
       allocation.from_location = nil
       begin
-        allocation.cancel_with_moves
+        allocation.cancel
       rescue StandardError
         ActiveRecord::RecordInvalid
       end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe Move do
       expect(described_class).not_to be_unfilled
     end
 
-    it 'returns false if no moves are present' do
+    it 'returns true if no moves are present' do
       expect(described_class).to be_unfilled
     end
   end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -394,6 +394,10 @@ RSpec.describe Move do
 
       expect(described_class).not_to be_unfilled
     end
+
+    it 'returns false if no moves are present' do
+      expect(described_class).to be_unfilled
+    end
   end
 
   context 'with versioning' do

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -375,6 +375,27 @@ RSpec.describe Move do
     end
   end
 
+  describe '.unfilled?' do
+    it 'returns true if there are no profiles linked to a move' do
+      create_list(:move, 2, profile: nil)
+
+      expect(described_class).to be_unfilled
+    end
+
+    it 'returns true if not all moves have profiles linked' do
+      create(:move, profile: nil)
+      create(:move)
+
+      expect(described_class).to be_unfilled
+    end
+
+    it 'returns false if all moves are associated to a profile' do
+      create_list(:move, 2)
+
+      expect(described_class).not_to be_unfilled
+    end
+  end
+
   context 'with versioning' do
     let(:move) { create(:move) }
 

--- a/spec/requests/api/v1/allocations_controller_create_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_create_spec.rb
@@ -125,6 +125,10 @@ RSpec.describe Api::V1::AllocationsController do
         expect(response_json.dig('data', 'attributes', 'complex_cases').first).to match complex_case1_attributes.stringify_keys
       end
 
+      it 'sets the correct status' do
+        expect(response_json.dig('data', 'attributes', 'status')).to eq(Allocation::ALLOCATION_STATUS_UNFILLED)
+      end
+
       context 'when omitting requested_by attribute' do
         let(:allocation_attributes) { attributes_for(:allocation).except(:requested_by) }
 

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Allocations::Finder do
 
   let!(:from_location) { create :location }
   let!(:to_location) { create :location }
-  let!(:allocation) { create :allocation, from_location: from_location, to_location: to_location }
+
+  let!(:allocation) { create :allocation, :none, from_location: from_location, to_location: to_location }
   let(:filter_params) { {} }
 
   describe 'filtering' do
@@ -127,7 +128,7 @@ RSpec.describe Allocations::Finder do
         let(:filter_params) { { status: 'unfilled,cancelled' } }
 
         it 'returns allocations matching status' do
-          expect(allocation_finder.call).to contain_exactly(allocation, unfilled_allocation, cancelled_allocation)
+          expect(allocation_finder.call).to contain_exactly(unfilled_allocation, cancelled_allocation)
         end
       end
 
@@ -136,6 +137,14 @@ RSpec.describe Allocations::Finder do
 
         it 'returns empty results set' do
           expect(allocation_finder.call).to be_empty
+        end
+      end
+
+      context 'with nil status' do
+        let(:filter_params) { { status: nil } }
+
+        it 'returns only allocations without a status' do
+          expect(allocation_finder.call).to contain_exactly(allocation)
         end
       end
     end

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Allocations::Finder do
 
   let!(:from_location) { create :location }
   let!(:to_location) { create :location }
-  let!(:allocation) { create :allocation, from_location: from_location, to_location: to_location, status: nil }
+  let!(:allocation) { create :allocation, from_location: from_location, to_location: to_location }
   let(:filter_params) { {} }
 
   describe 'filtering' do
@@ -127,7 +127,7 @@ RSpec.describe Allocations::Finder do
         let(:filter_params) { { status: 'unfilled,cancelled' } }
 
         it 'returns allocations matching status' do
-          expect(allocation_finder.call).to contain_exactly(unfilled_allocation, cancelled_allocation)
+          expect(allocation_finder.call).to contain_exactly(allocation, unfilled_allocation, cancelled_allocation)
         end
       end
 
@@ -136,14 +136,6 @@ RSpec.describe Allocations::Finder do
 
         it 'returns empty results set' do
           expect(allocation_finder.call).to be_empty
-        end
-      end
-
-      context 'with nil status' do
-        let(:filter_params) { { status: nil } }
-
-        it 'returns only allocations without a status' do
-          expect(allocation_finder.call).to contain_exactly(allocation)
         end
       end
     end

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Allocations::Finder do
 
   let!(:from_location) { create :location }
   let!(:to_location) { create :location }
-  let!(:allocation) { create :allocation, from_location: from_location, to_location: to_location }
+  let!(:allocation) { create :allocation, from_location: from_location, to_location: to_location, status: nil }
   let(:filter_params) { {} }
 
   describe 'filtering' do

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -81,15 +81,6 @@ RSpec.describe Moves::Updater do
       end
     end
 
-    context 'when status is not updated with an associated allocation' do
-      let!(:allocation) { create :allocation, moves_count: 5 }
-      let!(:move) { create :move, :requested, from_location: from_location, allocation: allocation }
-
-      it 'does not change allocation moves_count' do
-        expect { updater.call }.not_to change { allocation.reload.moves_count }
-      end
-    end
-
     context 'with allocation' do
       let(:person) { create(:person) }
 

--- a/spec/state_machines/allocation_state_machine_spec.rb
+++ b/spec/state_machines/allocation_state_machine_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AllocationStateMachine do
+  let(:machine) { described_class.new(target) }
+  let(:target) { build(:allocation) }
+  let(:initial_state) { :unfilled }
+
+  before { machine.restore!(initial_state) }
+
+  shared_examples 'state_machine target status' do |expected_status|
+    describe 'machine status' do
+      it { expect(machine.current).to eql expected_status }
+    end
+
+    describe 'target status' do
+      it { expect(target.status).to eql expected_status.to_s }
+    end
+  end
+
+  context 'when in the unfilled status' do
+    it_behaves_like 'state_machine target status', :unfilled
+  end
+end

--- a/spec/state_machines/allocation_state_machine_spec.rb
+++ b/spec/state_machines/allocation_state_machine_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AllocationStateMachine do
     end
   end
 
-  it { is_expected.to respond_to(:fill, :unfill) }
+  it { is_expected.to respond_to(:fill, :unfill, :cancel) }
 
   context 'when in the unfilled status' do
     it_behaves_like 'state_machine target status', :unfilled

--- a/spec/state_machines/allocation_state_machine_spec.rb
+++ b/spec/state_machines/allocation_state_machine_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe AllocationStateMachine do
 
       it_behaves_like 'state_machine target status', :unfilled
     end
+
+    context 'when the cancel event is fired' do
+      before { machine.cancel }
+
+      it_behaves_like 'state_machine target status', :cancelled
+    end
   end
 
   context 'when in the filled status' do
@@ -53,23 +59,53 @@ RSpec.describe AllocationStateMachine do
 
       it_behaves_like 'state_machine target status', :filled
     end
+
+    context 'when the cancel event is fired' do
+      before { machine.cancel }
+
+      it_behaves_like 'state_machine target status', :cancelled
+    end
   end
 
   context 'when in the none status' do
-    context 'when the fill event is fired' do
-      let(:initial_state) { :none }
+    let(:initial_state) { :none }
 
+    it_behaves_like 'state_machine target status', :none
+
+    context 'when the fill event is fired' do
       before { machine.fill }
 
       it_behaves_like 'state_machine target status', :filled
     end
 
     context 'when the unfill event is fired' do
-      let(:initial_state) { :none }
-
       before { machine.unfill }
 
       it_behaves_like 'state_machine target status', :unfilled
+    end
+
+    context 'when the cancel event is fired' do
+      before { machine.cancel }
+
+      it_behaves_like 'state_machine target status', :cancelled
+    end
+  end
+
+  context 'when in the cancelled status' do
+    let(:initial_state) { :cancelled }
+
+    it_behaves_like 'state_machine target status', :cancelled
+
+    context 'when the fill event is fired' do
+      before { machine.fill }
+
+      it_behaves_like 'state_machine target status', :cancelled
+    end
+
+    context 'when the unfill event is fired' do
+      before { machine.unfill }
+
+      it_behaves_like 'state_machine target status', :cancelled
     end
   end
 end

--- a/spec/state_machines/allocation_state_machine_spec.rb
+++ b/spec/state_machines/allocation_state_machine_spec.rb
@@ -67,30 +67,6 @@ RSpec.describe AllocationStateMachine do
     end
   end
 
-  context 'when in the none status' do
-    let(:initial_state) { :none }
-
-    it_behaves_like 'state_machine target status', :none
-
-    context 'when the fill event is fired' do
-      before { machine.fill }
-
-      it_behaves_like 'state_machine target status', :filled
-    end
-
-    context 'when the unfill event is fired' do
-      before { machine.unfill }
-
-      it_behaves_like 'state_machine target status', :unfilled
-    end
-
-    context 'when the cancel event is fired' do
-      before { machine.cancel }
-
-      it_behaves_like 'state_machine target status', :cancelled
-    end
-  end
-
   context 'when in the cancelled status' do
     let(:initial_state) { :cancelled }
 

--- a/spec/state_machines/allocation_state_machine_spec.rb
+++ b/spec/state_machines/allocation_state_machine_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AllocationStateMachine do
   let(:machine) { described_class.new(target) }
-  let(:target) { build(:allocation) }
+  let(:target) { Struct.new(:status).new(initial_state) }
   let(:initial_state) { :unfilled }
 
   before { machine.restore!(initial_state) }
@@ -15,11 +15,61 @@ RSpec.describe AllocationStateMachine do
     end
 
     describe 'target status' do
-      it { expect(target.status).to eql expected_status.to_s }
+      it { expect(target.status).to eql expected_status }
     end
   end
 
+  it { is_expected.to respond_to(:fill, :unfill) }
+
   context 'when in the unfilled status' do
     it_behaves_like 'state_machine target status', :unfilled
+
+    context 'when the fill event is fired' do
+      before { machine.fill }
+
+      it_behaves_like 'state_machine target status', :filled
+    end
+
+    context 'when the unfill event is fired' do
+      before { machine.unfill }
+
+      it_behaves_like 'state_machine target status', :unfilled
+    end
+  end
+
+  context 'when in the filled status' do
+    let(:initial_state) { :filled }
+
+    it_behaves_like 'state_machine target status', :filled
+
+    context 'when the unfill event is fired' do
+      before { machine.unfill }
+
+      it_behaves_like 'state_machine target status', :unfilled
+    end
+
+    context 'when the fill event is fired' do
+      before { machine.fill }
+
+      it_behaves_like 'state_machine target status', :filled
+    end
+  end
+
+  context 'when in the none status' do
+    context 'when the fill event is fired' do
+      let(:initial_state) { :none }
+
+      before { machine.fill }
+
+      it_behaves_like 'state_machine target status', :filled
+    end
+
+    context 'when the unfill event is fired' do
+      let(:initial_state) { :none }
+
+      before { machine.unfill }
+
+      it_behaves_like 'state_machine target status', :unfilled
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[P4-1555](https://dsdmoj.atlassian.net/browse/P4-1555)

### What?

I have added/removed/altered:

- [x] Added a state machine to allocation statuses
- [x] Updated move updater logic to include updating allocation status
- [x] Update existing allocation cancellation logic to use state machine cancellation

### Why?

To ensure that we update an allocation status with filled/unfilled correctly we need to update the status when a move is updated. When a move is linked/unlinked to a profile or when its status changes (all done through the PATCH endpoint for a move for now) a trigger to update the `moves_count` and the `status` is done. We are utilising a state machine for the allocation for all the different steps. 
- A status is filled if all **non cancelled moves** are associated with profiles
- A status is unfilled if no **non cancelled moves** are associated with profiles
- A status is unfilled if some **non cancelled moves** are associated with profiles
- A status is unfilled if all moves are cancelled

Since we have existing allocations with `nil` values in production, we are releasing the new statuses in stages. The first stage includes a rake task to be run when this is deployed. This ensures that all statuses will be updated. This deployment before running the rake task however still accepts `nil` statuses and won't break. The next step after the rake task is run on all environments is to add validations and restrictions.

### Deployment risks (optional)

- Appends different states of data to existing records in production
- Changes an api that is used in production

