### PR TITLE
[P4-1563] Improve docker image size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+vendor
 
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ config/application_insights.toml
 
 # Ignore auto generated data diagram
 erd.pdf
+
+# Ignore local data directory for docker-compose
+.data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM ruby:2.6.6-alpine as build-stage
 
 ENV RAILS_ENV=production
-ENV BUNDLE_APP_CONFIG="app/.bundle"
+ENV BUNDLE_WITHOUT="development:test"
+ENV BUNDLE_FROZEN="true"
 
 WORKDIR /app
-
-RUN apk add git build-base tzdata postgresql-dev
+RUN apk --update add git build-base postgresql-dev
 
 COPY . /app
 RUN gem update bundler --no-document
-RUN bundle install --without="development test"  --jobs 4 --retry 3
+RUN bundle install --jobs 4 --retry 3 \
+     && rm -rf /usr/local/bundle/cache/*.gem \
+     && find /usr/local/bundle/gems/ -name "*.c" -delete \
+     && find /usr/local/bundle/gems/ -name "*.o" -delete
 
 ############### End of Build step ###############
 FROM ruby:2.6.6-alpine
@@ -26,22 +29,18 @@ ENV APP_GIT_COMMIT ${APP_GIT_COMMIT}
 ENV APPUID 1000
 
 ENV RAILS_ENV production
-ENV BUNDLE_APP_CONFIG="app/.bundle"
 
 ENV PUMA_PORT 3000
 EXPOSE $PUMA_PORT
 
 RUN addgroup -g $APPUID -S appgroup && \
-    adduser -u $APPUID -S appuser -G appgroup
+    adduser -u $APPUID -S appuser -G appgroup -h /app
 
-RUN apk add tzdata postgresql-dev
+RUN apk add --no-cache tzdata postgresql-dev
 
 WORKDIR /app
-COPY --from=build-stage /usr/local/bundle /usr/local/bundle
-COPY --from=build-stage /app /app
-
-RUN  chown -R appuser:appgroup /app  && \
-     chown -R appuser:appgroup /home/appuser
+COPY --chown=appuser:appgroup --from=build-stage /app /app
+COPY --chown=appuser:appgroup --from=build-stage /usr/local/bundle /usr/local/bundle
 
 USER $APPUID
 ENTRYPOINT ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV BUNDLE_WITHOUT="development:test"
 ENV BUNDLE_FROZEN="true"
 
 WORKDIR /app
-RUN apk --update add git build-base postgresql-dev
+RUN apk --update --no-cache add git build-base postgresql-dev
 
 COPY . /app
 RUN gem update bundler --no-document
@@ -36,7 +36,7 @@ EXPOSE $PUMA_PORT
 RUN addgroup -g $APPUID -S appgroup && \
     adduser -u $APPUID -S appuser -G appgroup -h /app
 
-RUN apk add --no-cache tzdata postgresql-dev
+RUN apk add --update --no-cache tzdata postgresql-dev
 
 WORKDIR /app
 COPY --chown=appuser:appgroup --from=build-stage /app /app

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ docker-compose up -d
 docker-compose logs -f
 ```
 
+You can force rebuilding the container with:
+```
+docker-compose build
+```
+
+
 You should be able to see the swagger documentation pointing your browser to
 
 ```

--- a/README.md
+++ b/README.md
@@ -153,3 +153,36 @@ CircleCI, find the build that you want to deploy and click the
 `test-build-deploy` link. This should take you to the workflow graph for
 that build where you can click the `hold_production` step to kick off
 the production deploy.
+
+
+## Running in docker-compose locally.
+
+You can run the build container locally using docker-compose.
+
+```bash
+# start the docker-compose stack in the background.
+docker-compose up -d
+
+# You can follow the logs by doing
+docker-compose logs -f
+```
+
+You should be able to see the swagger documentation pointing your browser to
+
+```
+http://localhost:3000/api-docs/index.html
+```
+
+If your database is fresh or was reset, you need to generate new application client credentials.
+You can do this by running the respecive rake task inside the compose stack.
+
+```bash
+docker exec -it hmpps-book-secure-move-api_web_1 bundle exec rake auth:create_client_application NAME=test
+```
+
+The docker-compose stack also exposes the Postgres port to the host, so you can update the reference data with:
+
+```
+$ export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/hmpps-book-secure-move-api
+$ bundle exec rake reference_data:create_all
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,38 @@ version: '3'
 services:
   db:
     image: postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+    - './.data/postgres:/var/lib/postgresql/data'
+    ports:
+    - 5432:5432
+  s3:
+    image: localstack/localstack:latest
+    ports:
+      - '4563-4599:4563-4599'
+      - '8055:8080'
+    environment:
+      - DEBUG=0
+      - LOCALSTACK_SERVICES=s3
+      - DATA_DIR=/tmp/localstack/data
+    volumes:
+      - './.data/localstack:/tmp/localstack'
+      - '/var/run/docker.sock:/var/run/docker.sock'
   web:
     build: .
     environment:
-      - DATABASE_URL=postgresql://postgres@db/hmpps-book-secure-move-api
+      - DATABASE_URL=postgresql://postgres:postgres@db/hmpps-book-secure-move-api
       - SECRET_KEY_BASE=h463472fhaa91f4a277002e9652f86f330e636358e2090d86ab4a4f06845ege1
       - SERVE_API_DOCS=true
+      - AWS_ACCESS_KEY_ID=fakeid
+      - AWS_SECRET_ACCESS_KEY=fakesecret
+      - S3_BUCKET_NAME=apibook-a-secure-move-documents-s3-bucket
+      - S3_BACKEND=http://s3:4572
+      - ENCRYPTOR_SALT=saltnpepper
     ports:
       - "3000:3000"
     depends_on:
       - db
+      - s3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,3 @@
-# Simplify running the application inside a container locally.
-# Usage: `docker-compose up`
-#
-# Do not use docker-compose in production environments.
-#
 version: '3'
 
 services:
@@ -29,6 +24,8 @@ services:
       - '/var/run/docker.sock:/var/run/docker.sock'
   web:
     build: .
+    env_file:
+      - ./.env
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db/hmpps-book-secure-move-api
       - SECRET_KEY_BASE=h463472fhaa91f4a277002e9652f86f330e636358e2090d86ab4a4f06845ege1
@@ -37,7 +34,6 @@ services:
       - AWS_SECRET_ACCESS_KEY=fakesecret
       - S3_BUCKET_NAME=apibook-a-secure-move-documents-s3-bucket
       - S3_BACKEND=http://s3:4572
-      - ENCRYPTOR_SALT=saltnpepper
     ports:
       - "3000:3000"
     depends_on:

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Sadly toml files don't support inline expansion of environment variables
 bundle exec erb config/application_insights.erb >config/application_insights.toml


### PR DESCRIPTION
### Jira link

P4-1563

### What?

I have added/removed/altered:

- [x] Used alpine ruby as the base image
- [x] Installed minimum set of OS packages to satisfy dependencies.

### Why?

I am doing this because:

- The current docker image is too big ~1.6GB, which takes a longer than desirable to download, delaying pod start.
- Reduces the CVE footprint by not having a full ubuntu/OS distro running in the container


### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- This PR does not change anything on the application resources or ruby/gem version. It changes however the underling OS and uses different implementation of some system libraries, which might have an impact on natively built gems.  This is considered to be very low risk as alpine is generally used in production for a number of workloads, including ruby, node, java, etc. 

The current test suites don't validate a running image, so testing was done by manually poking some API endpoints.


![image](https://user-images.githubusercontent.com/5406688/83259426-edd92080-a1af-11ea-9e8c-fab732a37955.png)


