### PR TITLE
Setup API V2 Swagger docs

### DIFF
--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -7,4 +7,5 @@ Rswag::Ui.configure do |c|
   # then the list below should correspond to the relative paths for those endpoints
 
   c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'PECS4 API V1 Docs'
+  c.swagger_endpoint '/api-docs/v2/swagger.yaml', 'PECS4 API V2 Docs'
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -166,6 +166,150 @@ RSpec.configure do |config|
       },
       paths: load_swagger_yaml('hand_coded_paths.yaml'),
     },
+
+    'v2/swagger.yaml' => {
+        basePath: '/api/v2',
+        openapi: '3.0.1',
+        info: {
+            title: 'PECS4 API V2 Docs',
+            version: 'v2',
+            description: 'Book A Secure Move supplier and frontend API.',
+        },
+        consumes: [
+            'application/vnd.api+json',
+        ],
+        servers: [
+            {
+                url: 'http://localhost:3000/api/v2',
+                description: 'Local development (localhost)',
+            },
+            {
+                url: 'https://hmpps-book-secure-move-api-dev.apps.live-1.cloud-platform.service.justice.gov.uk/api/v2',
+                description: 'Dev API',
+            },
+            {
+                url: 'https://hmpps-book-secure-move-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/api/v2',
+                description: 'Staging API',
+            },
+            {
+                url: 'https://hmpps-book-secure-move-api-preprod.apps.live-1.cloud-platform.service.justice.gov.uk/api/v2',
+                description: 'PreProd API',
+            },
+            {
+                url: 'https://api.bookasecuremove.service.justice.gov.uk/api/v2',
+                description: 'Production API',
+            },
+        ],
+        security: [
+            {
+                oauth2: [],
+            },
+        ],
+        components: {
+            securitySchemes: {
+                oauth2: {
+                    type: :oauth2,
+                    flows: {
+                        clientCredentials: {
+                            authorizationUrl: '/oauth/authorize',
+                            tokenUrl: '/oauth/token/',
+                            scopes: {},
+                        },
+                    },
+                },
+            },
+            schemas: {
+                Allocation: {
+                    "$ref": 'allocation.yaml#/Allocation',
+                },
+                AllocationReference: {
+                    "$ref": 'allocation_reference.yaml#/AllocationReference',
+                },
+                AllocationComplexCase: {
+                    "$ref": 'allocation_complex_case.yaml#/AllocationComplexCase',
+                },
+                AllocationComplexCaseAnswer: {
+                    "$ref": 'allocation_complex_case_answer.yaml#/AllocationComplexCaseAnswer',
+                },
+                AssessmentAnswer: {
+                    "$ref": 'assessment_answer.yaml#/AssessmentAnswer',
+                },
+                AssessmentQuestion: {
+                    "$ref": 'assessment_question.yaml#/AssessmentQuestion',
+                },
+                CourtCase: {
+                    "$ref": 'court_case.yaml#/CourtCase',
+                },
+                CourtHearing: {
+                    "$ref": 'court_hearing.yaml#/CourtHearing',
+                },
+                CourtHearingReference: {
+                    "$ref": 'court_hearing_reference.yaml#/CourtHearingReference',
+                },
+                Document: {
+                    "$ref": 'document.yaml#/Document',
+                },
+                Ethnicity: {
+                    "$ref": 'ethnicity.yaml#/Ethnicity',
+                },
+                Gender: {
+                    "$ref": 'gender.yaml#/Gender',
+                },
+                Journey: {
+                    "$ref": 'get_journey.yaml#/GetJourney',
+                },
+                JourneyEvent: {
+                    "$ref": 'get_journey_event.yaml#/GetJourneyEvent',
+                },
+                Location: {
+                    "$ref": 'location.yaml#/Location',
+                },
+                LocationReference: {
+                    "$ref": 'location_reference.yaml#/LocationReference',
+                },
+                Move: {
+                    "$ref": 'move.yaml#/Move',
+                },
+                MoveEvent: {
+                    "$ref": 'get_move_event.yaml#/GetMoveEvent',
+                },
+                MoveReference: {
+                    "$ref": 'move_reference.yaml#/MoveReference',
+                },
+                Nationality: {
+                    "$ref": 'nationality.yaml#/Nationality',
+                },
+                Pagination: {
+                    "$ref": 'pagination.yaml#/Pagination',
+                },
+                PaginationLinks: {
+                    "$ref": 'pagination_links.yaml#/PaginationLinks',
+                },
+                Person: {
+                    "$ref": 'person.yaml#/Person',
+                },
+                PersonReference: {
+                    "$ref": 'person_reference.yaml#/PersonReference',
+                },
+                PrisonTransferReason: {
+                    "$ref": 'prison_transfer_reason.yaml#/PrisonTransferReason',
+                },
+                ProfileIdentifier: {
+                    "$ref": 'profile_identifier.yaml#/ProfileIdentifier',
+                },
+                Region: {
+                    "$ref": 'region.yaml#/Region',
+                },
+                Supplier: {
+                    "$ref": 'supplier.yaml#/Supplier',
+                },
+                TimetableEntry: {
+                    "$ref": 'timetable_entry.yaml#/TimetableEntry',
+                },
+            },
+        },
+        paths: load_swagger_yaml('hand_coded_paths.yaml'),
+    },
   }
 
   # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.

--- a/swagger/v2/get_people_responses.yaml
+++ b/swagger/v2/get_people_responses.yaml
@@ -1,0 +1,49 @@
+'200':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      type: array
+      items:
+        $ref: person.yaml#/Person
+    included:
+      type: array
+      items:
+        anyOf:
+        - $ref: ../v1/gender.yaml#/Gender
+        - $ref: ../v1/ethnicity.yaml#/Ethnicity
+    links:
+      $ref: ../v1/pagination_links.yaml#/PaginationLinks
+    meta:
+      type: object
+      properties:
+        pagination:
+          $ref: ../v1/pagination.yaml#/Pagination
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: ../v1/errors.yaml#/UnsupportedMediaType
+'400':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: ../v1/errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: ../v1/errors.yaml#/NotAuthorisedError

--- a/swagger/v2/person.yaml
+++ b/swagger/v2/person.yaml
@@ -1,0 +1,71 @@
+Person:
+  type: object
+  required:
+  - id
+  - type
+  - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: 88089bbd-8719-4192-b309-f9db9105d3e1
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: people
+      enum:
+      - people
+      description: The type of this object - always `people`
+    attributes:
+      type: object
+      required:
+      - first_names
+      - last_name
+      properties:
+        first_names:
+          type: string
+          example: Bob
+          description: Person's first names
+        last_name:
+          type: string
+          example: Roberts
+          description: Person's surname
+        date_of_birth:
+          type: string
+          format: date
+          example: '1965-10-24'
+          description: Person's date of birth in ISO 8601 format
+        image_url:
+          type: string
+          format: uri
+          example: http://localhost:3000/api/v1/people/88089bbd-8719-4192-b309-f9db9105d3e1/image.jpg
+          description: URI pointing to the image of the person
+          readOnly: true
+        assessment_answers:
+          type: array
+          items:
+            $ref: ../v1/assessment_answer.yaml#/AssessmentAnswer
+          description: Collection of court information, risk and alerts that escorts
+            need to be aware of for safety, security and other reasons
+        identifiers:
+          type: array
+          items:
+            $ref: ../v1/profile_identifier.yaml#/ProfileIdentifier
+          description: Collection of identifiers used to identify the person. Different
+            services have various id schemes such police criminal records number,
+            prison number etc. We may need to record several of these.
+        gender_additional_information:
+          oneOf:
+          - type: string
+          - type: 'null'
+          description: Supporting information for detainees of certain genders to
+            capture any relevant transport information
+    relationships:
+      type: object
+      properties:
+        gender:
+          $ref: ../v1/gender_reference.yaml#/GenderReference
+          description: Person's gender
+        ethnicity:
+          $ref: ../v1/ethnicity_reference.yaml#/EthnicityReference
+          description: Person's ethnicity

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -1,0 +1,225 @@
+---
+basePath: "/api/v2"
+openapi: 3.0.1
+info:
+  title: PECS4 API V1 Docs
+  version: v2
+  description: Book A Secure Move supplier and frontend API.
+consumes:
+- application/vnd.api+json
+servers:
+- url: http://localhost:3000/api/v2
+  description: Local development (localhost)
+- url: https://hmpps-book-secure-move-api-dev.apps.live-1.cloud-platform.service.justice.gov.uk/api/v2
+  description: Dev API
+- url: https://hmpps-book-secure-move-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/api/v2
+  description: Staging API
+- url: https://hmpps-book-secure-move-api-preprod.apps.live-1.cloud-platform.service.justice.gov.uk/api/v2
+  description: PreProd API
+- url: https://api.bookasecuremove.service.justice.gov.uk/api/v2
+  description: Production API
+security:
+- oauth2: []
+components:
+  securitySchemes:
+    oauth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          authorizationUrl: "/oauth/authorize"
+          tokenUrl: "/oauth/token/"
+          scopes: {}
+  schemas:
+    Ethnicity:
+      "$ref": ethnicity.yaml#/Ethnicity
+    Gender:
+      "$ref": gender.yaml#/Gender
+    Person:
+      "$ref": person.yaml#/Person
+
+paths:
+  "/people":
+    get:
+      summary: Returns a list of people
+      tags:
+        - People
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": ../v1/content_type_parameter.yaml#/ContentType
+        - name: include
+          in: query
+          description:
+          schema:
+            type: string
+            enum:
+              - profiles
+              - profiles.gender
+              - profiles.ethnicity
+              - profiles.court_hearings
+              - gender
+              - ethnicity
+        - name: filter[police_national_computer_number]
+          in: query
+          description: Filters results to only include people identified by that police_national_computer_number.
+            Either filter[police_national_computer] or filter[prison_number] or both
+            filters are required.
+          schema:
+            type: string
+            example: 07/1435713R
+          format: string
+          required: false
+        - name: filter[prison_number]
+          in: query
+          description: Filters results to only include people identified by that prison_number.
+            Either filter[police_national_computer_number] or filter[prison_number]
+            or both filters are required.
+          schema:
+            type: string
+            example: G1234UT
+          format: string
+          required: false
+        - "$ref": ../v1/pagination_parameters.yaml#/Page
+        - "$ref": ../v1/pagination_parameters.yaml#/PerPage
+      responses:
+        '200':
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": get_people_responses.yaml#/200
+        '400':
+          description: bad request (for example no filter has been provided)
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": get_people_responses.yaml#/400
+        '401':
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": get_people_responses.yaml#/401
+        '415':
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": get_people_responses.yaml#/415
+        '503':
+          description: forbidden (for example attempt to filter or include on an invalid
+            attribute)
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": get_people_responses.yaml#/503
+    post:
+      summary: Creates a new person
+      tags:
+        - People
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: The person object to be created
+          schema:
+            "$ref": person.yaml#/Person
+      responses:
+        '201':
+          description: created
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": post_people_responses.yaml#/201
+        '400':
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": post_people_responses.yaml#/400
+        '401':
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": post_people_responses.yaml#/401
+        '404':
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": post_people_responses.yaml#/404
+        '415':
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": post_people_responses.yaml#/415
+        '422':
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": post_people_responses.yaml#/422
+    "/people/{person_id}":
+      patch:
+        summary: Update an existing person. You can optionally update any relationships
+          (gender, ethnicity, profiles).
+        tags:
+          - People
+        consumes:
+          - application/vnd.api+json
+        parameters:
+          - name: person_id
+            in: path
+            required: true
+            description: The ID of the person
+            schema:
+              type: string
+            format: uuid
+            example: 00525ecb-7316-492a-aae2-f69334b2a155
+          - name: body
+            in: body
+            required: true
+            description: The person object to be updated
+            schema:
+              "$ref": person.yaml#/Person
+        responses:
+          '200':
+            description: updated
+            content:
+              application/vnd.api+json:
+                schema:
+                  "$ref": put_people_responses.yaml#/201
+          '400':
+            description: bad request
+            content:
+              application/vnd.api+json:
+                schema:
+                  "$ref": put_people_responses.yaml#/400
+          '401':
+            description: unauthorized
+            content:
+              application/vnd.api+json:
+                schema:
+                  "$ref": put_people_responses.yaml#/401
+          '404':
+            description: resource not found
+            content:
+              application/vnd.api+json:
+                schema:
+                  "$ref": put_people_responses.yaml#/404
+          '415':
+            description: invalid media type
+            content:
+              application/vnd.api+json:
+                schema:
+                  "$ref": put_people_responses.yaml#/415
+          '422':
+            description: unprocessable entity
+            content:
+              application/vnd.api+json:
+                schema:
+                  "$ref": put_people_responses.yaml#/422


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-1493

### What?
This is part of the "Create the first V2 endpoint: get /v2/people"

The goal of this is to set up the first doc example that uses API V2.

The doc itself could be not fully correct, but that is not the point, it will be 100% correct in the coming PR when the endpoint /v2/people is present.

### Why?

I am doing this because:
Setup the swagger for the V2 is exemplary for other endpoints.
This first Docs is like a placeholder for the coming V2 endpoints.
