### PR TITLE
[P4-1435] Fixes fields on a person

### DIFF
--- a/app/services/person_populator.rb
+++ b/app/services/person_populator.rb
@@ -20,7 +20,6 @@ private
     last_name
     date_of_birth
     gender_additional_information
-    latest_nomis_booking_id
     ethnicity_id
     gender_id
   ].freeze

--- a/db/migrate/20200529085159_fix_fields_on_person.rb
+++ b/db/migrate/20200529085159_fix_fields_on_person.rb
@@ -1,0 +1,10 @@
+class FixFieldsOnPerson < ActiveRecord::Migration[5.2]
+  def change
+    add_column :people, :last_synced_with_nomis, :datetime
+    add_column :profiles, :last_synced_with_nomis, :datetime
+
+    # This field will be used to populate latest profile information and
+    # is relevant to the latest version of a profile, only
+    remove_column :people, :latest_nomis_booking_id, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_152251) do
+ActiveRecord::Schema.define(version: 2020_05_29_085159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -322,9 +322,9 @@ ActiveRecord::Schema.define(version: 2020_05_26_152251) do
     t.string "last_name"
     t.date "date_of_birth"
     t.string "gender_additional_information"
-    t.string "latest_nomis_booking_id"
     t.uuid "ethnicity_id"
     t.uuid "gender_id"
+    t.datetime "last_synced_with_nomis"
     t.index ["criminal_records_office"], name: "index_people_on_criminal_records_office"
     t.index ["ethnicity_id"], name: "index_people_on_ethnicity_id"
     t.index ["gender_id"], name: "index_people_on_gender_id"
@@ -355,6 +355,7 @@ ActiveRecord::Schema.define(version: 2020_05_26_152251) do
     t.jsonb "profile_identifiers"
     t.string "gender_additional_information"
     t.integer "latest_nomis_booking_id"
+    t.datetime "last_synced_with_nomis"
   end
 
   create_table "regions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
### Jira link

P4-1435

### What?

- Adds `last_synced_with_nomis` to **People**
- Adds `last_synced_with_nomis` to **Profile**
- Removes `latest_nomis_booking_id` from **People**

### Why?

After talking we realised it would be valuable to have some audit
information for when a person and profile were last synced
with Nomis.

The booking id should exist on the latest profile because it changes
each time a person receives a new booking in a prison from Nomis