### PR TITLE
[P4-1435] Updates `PersonSerializer` to use `Person` attributes

### DIFF
--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -11,40 +11,44 @@ class PersonSerializer < ActiveModel::Serializer
     :gender_additional_information,
   )
 
-  has_one :ethnicity, serializer: EthnicitySerializer, if: -> { ethnicity.present? }
+  has_one :ethnicity, serializer: EthnicitySerializer
   has_one :gender, serializer: GenderSerializer
 
   INCLUDED_DETAIL = %w[ethnicity gender].freeze
 
-  def first_names
-    object.latest_profile&.first_names
-  end
-
-  def last_name
-    object.latest_profile&.last_name
-  end
-
-  def date_of_birth
-    object.latest_profile&.date_of_birth
-  end
-
-  def ethnicity
-    object.latest_profile&.ethnicity
-  end
-
-  def gender
-    object.latest_profile&.gender
-  end
-
-  def gender_additional_information
-    object.latest_profile&.gender_additional_information
-  end
-
+  # TODO: AssessmentAnswers in V2 world need moving to the ProfileSerializer
   def assessment_answers
     object.latest_profile&.assessment_answers || []
   end
 
   def identifiers
-    object.latest_profile&.profile_identifiers || []
+    [police_national_computer, prison_number, criminal_records_office].compact
+  end
+
+  def police_national_computer
+    if object.police_national_computer.present?
+      {
+        value: object.police_national_computer,
+        identifier_type: 'police_national_computer',
+      }
+    end
+  end
+
+  def prison_number
+    if object.prison_number.present?
+      {
+        value: object.prison_number,
+        identifier_type: 'prison_number',
+      }
+    end
+  end
+
+  def criminal_records_office
+    if object.criminal_records_office.present?
+      {
+        value: object.criminal_records_office,
+        identifier_type: 'criminal_records_office',
+      }
+    end
   end
 end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -14,18 +14,27 @@ FactoryBot.define do
     sequence(:police_national_computer) { |seq| sprintf('AB/%07d', seq) }
     sequence(:prison_number)            { |seq| sprintf('D%04dZZ', seq) }
     sequence(:criminal_records_office)  { |seq| sprintf('CRO/%05d', seq) }
-
-    trait :nomis_synced do
-      sequence(:nomis_prison_number) do |seq|
-        number = seq / 26 + 1000
-        letter = ('A'..'Z').to_a[seq % 26]
-        "T#{number}T#{letter}"
-      end
-    end
   end
 
   factory :person_without_profiles, class: 'Person' do
+    association(:ethnicity)
+    association(:gender)
+
+    date_of_birth { Date.new(1980, 10, 20) }
+
+    sequence(:police_national_computer) { |seq| sprintf('AB/%07d', seq) }
+    sequence(:prison_number)            { |seq| sprintf('D%04dZZ', seq) }
+    sequence(:criminal_records_office)  { |seq| sprintf('CRO/%05d', seq) }
+
     first_names { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
+  end
+
+  trait :nomis_synced do
+    sequence(:nomis_prison_number) do |seq|
+      number = seq / 26 + 1000
+      letter = ('A'..'Z').to_a[seq % 26]
+      "T#{number}T#{letter}"
+    end
   end
 end

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe MoveSerializer do
           {
             id: move.profile.person_id,
             type: 'people',
-            attributes: { first_names: move.profile.first_names,
-                          last_name: move.profile.last_name,
+            attributes: { first_names: move.profile.person.first_names,
+                          last_name: move.profile.person.last_name,
                           date_of_birth: '1980-10-20' },
           },
         ]

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PersonSerializer do
 
   let(:person) { create :person }
   let(:adapter_options) { {} }
+
   let(:result) do
     JSON.parse(ActiveModelSerializers::Adapter.create(serializer, adapter_options).to_json).deep_symbolize_keys
   end
@@ -20,11 +21,11 @@ RSpec.describe PersonSerializer do
   end
 
   it 'contains a first_names attribute' do
-    expect(result[:data][:attributes][:first_names]).to eql person.latest_profile.first_names
+    expect(result[:data][:attributes][:first_names]).to eql person.first_names
   end
 
   it 'contains a last_name attribute' do
-    expect(result[:data][:attributes][:last_name]).to eql person.latest_profile.last_name
+    expect(result[:data][:attributes][:last_name]).to eql person.last_name
   end
 
   describe '#assessment_answers' do
@@ -94,28 +95,25 @@ RSpec.describe PersonSerializer do
     end
 
     before do
-      profile = person.latest_profile
-      profile.profile_identifiers = profile_identifiers
-      profile.save!
+      person.update(criminal_records_office: nil, police_national_computer: 'ABC123456', prison_number: 'XYZ123456')
     end
 
     it 'contains two identifiers' do
-      expect(result[:data][:attributes][:identifiers]).to eql profile_identifiers
+      expect(result[:data][:attributes][:identifiers]).to match_array profile_identifiers
     end
   end
 
   describe 'ethnicity' do
     let(:adapter_options) { { include: { ethnicity: %I[key title description] } } }
-    let(:ethnicity) { person.latest_profile&.ethnicity }
     let(:expected_json) do
       [
         {
-          id: ethnicity&.id,
+          id: person.ethnicity&.id,
           type: 'ethnicities',
           attributes: {
-            key: ethnicity&.key,
-            title: ethnicity&.title,
-            description: ethnicity&.description,
+            key: person.ethnicity&.key,
+            title: person.ethnicity&.title,
+            description: person.ethnicity&.description,
           },
         },
       ]
@@ -128,20 +126,19 @@ RSpec.describe PersonSerializer do
 
   describe 'gender' do
     before do
-      person.latest_profile.update(gender_additional_information: gender_additional_information)
+      person.update(gender_additional_information: gender_additional_information)
     end
 
     let(:adapter_options) { { include: { gender: %I[title description] } } }
-    let(:gender) { person.latest_profile&.gender }
     let(:gender_additional_information) { 'more info about the person' }
     let(:expected_json) do
       [
         {
-          id: gender&.id,
+          id: person.gender&.id,
           type: 'genders',
           attributes: {
-            title: gender&.title,
-            description: gender&.description,
+            title: person.gender&.title,
+            description: person.gender&.description,
           },
         },
       ]


### PR DESCRIPTION
### Jira link

P4-1435

### What?

We've updated a `Person` to include a bunch of attributes that were
previously on the profile.

This change makes it so that these attributes are now available to
clients of the api via the `PersonSerializer`

- [x] Consume [new](https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/493) attributes in `PersonSerializer`
- [x] Fix broken factory to reflect move to using `Person` for these attributes

### Why?

Beyond cleanup, this is the final step in having our apis use `Person` attributes instead of `Profile` attributes in the `PeopleController`

This change **does not affect what the frontend receives** and is transparent.