### PR TITLE
[P4-1502] Adds support for query includes in PeopleController

### DIFF
--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -13,7 +13,7 @@ module Api
 
         people = People::Finder.new(filter_params).call
 
-        paginate people, include: PersonSerializer::INCLUDED_DETAIL
+        paginate people, include: included_relationships
       end
 
       def create
@@ -119,7 +119,7 @@ module Api
       end
 
       def render_person(person, status)
-        render json: person, status: status, include: PersonSerializer::INCLUDED_DETAIL
+        render json: person, status: status, include: included_relationships
       end
 
       def person_params
@@ -154,6 +154,10 @@ module Api
       def validate_nomis_profile
         profile_validator = People::NomisProfileValidator.new(person.latest_profile)
         profile_validator.validate!
+      end
+
+      def included_relationships
+        IncludeParamHandler.new(params).call || PersonSerializer::SUPPORTED_RELATIONSHIPS
       end
     end
   end

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -14,7 +14,7 @@ class PersonSerializer < ActiveModel::Serializer
   has_one :ethnicity, serializer: EthnicitySerializer, if: -> { ethnicity.present? }
   has_one :gender, serializer: GenderSerializer
 
-  INCLUDED_DETAIL = %w[ethnicity gender].freeze
+  SUPPORTED_RELATIONSHIPS = %w[ethnicity gender].freeze
 
   def first_names
     object.latest_profile&.first_names

--- a/spec/requests/api/v1/people_controller_index_spec.rb
+++ b/spec/requests/api/v1/people_controller_index_spec.rb
@@ -10,42 +10,39 @@ RSpec.describe Api::V1::PeopleController do
 
   describe 'GET /people' do
     let(:prison_number) { 'G5033UT' }
+    let(:params) { { filter: { police_national_computer: 'AB/1234567' }, access_token: token.token } }
 
-    describe 'filtering the results' do
-      let(:params) { { filter: { police_national_computer: 'AB/1234567' }, access_token: token.token } }
+    context 'when called with police_national_computer filter' do
+      let!(:people) { create_list :person, 5, :nomis_synced }
 
-      context 'when called with police_national_computer filter' do
-        let!(:people) { create_list :person, 5, :nomis_synced }
-
-        before do
-          get '/api/v1/people', headers: headers, params: params
-        end
-
-        it_behaves_like 'an endpoint that responds with success 200'
-
-        it 'returns the correct data' do
-          expect(response_json['data'].size).to eq(5)
-        end
-      end
-
-      context 'with no ethnicity' do
-        let!(:person) { create(:profile, ethnicity: nil).person }
-
-        before do
-          get '/api/v1/people', headers: headers, params: params
-        end
-
-        it_behaves_like 'an endpoint that responds with success 200'
-      end
-
-      it 'delegates the query execution to People::Finder with correct filter', skip_before: true do
-        people_finder = instance_double('People::Finder', call: Person.all)
-        allow(People::Finder).to receive(:new).and_return(people_finder)
-
+      before do
         get '/api/v1/people', headers: headers, params: params
-
-        expect(People::Finder).to have_received(:new).with(police_national_computer: 'AB/1234567')
       end
+
+      it_behaves_like 'an endpoint that responds with success 200'
+
+      it 'returns the correct data' do
+        expect(response_json['data'].size).to eq(5)
+      end
+    end
+
+    context 'with no ethnicity' do
+      let!(:person) { create(:profile, ethnicity: nil).person }
+
+      before do
+        get '/api/v1/people', headers: headers, params: params
+      end
+
+      it_behaves_like 'an endpoint that responds with success 200'
+    end
+
+    it 'delegates the query execution to People::Finder with correct filter', skip_before: true do
+      people_finder = instance_double('People::Finder', call: Person.all)
+      allow(People::Finder).to receive(:new).and_return(people_finder)
+
+      get '/api/v1/people', headers: headers, params: params
+
+      expect(People::Finder).to have_received(:new).with(police_national_computer: 'AB/1234567')
     end
 
     context 'when the filter prison_number is used' do
@@ -57,12 +54,56 @@ RSpec.describe Api::V1::PeopleController do
       before do
         allow(People::Finder).to receive(:new).and_return(people_finder)
         allow(Moves::ImportPeople).to receive(:new).with([prison_number])
-                                                   .and_return(instance_double('Moves::ImportPeople', call: nil))
+          .and_return(instance_double('Moves::ImportPeople', call: nil))
         get '/api/v1/people', headers: headers, params: params
       end
 
       it 'requests data from NOMIS' do
         expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'included relationships', :skip_before do
+      let!(:people) { create_list :person, 2 }
+
+      before do
+        get "/api/v1/people#{query_params}", headers: headers, params: params
+      end
+
+      context 'when not including the include query param' do
+        let(:query_params) { '' }
+
+        it 'returns the default includes' do
+          returned_types = response_json['included'].map { |r| r['type'] }.uniq
+          expect(returned_types).to contain_exactly('ethnicities', 'genders')
+        end
+      end
+
+      context 'when including the include query param' do
+        let(:query_params) { '?include=foo.bar,gender' }
+
+        it 'returns the valid provided includes' do
+          returned_types = response_json['included'].map { |r| r['type'] }.uniq
+          expect(returned_types).to contain_exactly('genders')
+        end
+      end
+
+      context 'when including an empty include query param' do
+        let(:query_params) { '?include=' }
+
+        it 'returns none of the includes' do
+          returned_types = response_json['included']
+          expect(returned_types).to be_nil
+        end
+      end
+
+      context 'when including a nil include query param' do
+        let(:query_params) { '?include' }
+
+        it 'returns the default includes' do
+          returned_types = response_json['included'].map { |r| r['type'] }.uniq
+          expect(returned_types).to contain_exactly('ethnicities', 'genders')
+        end
       end
     end
   end


### PR DESCRIPTION
### Jira link

P4-1502

### What?

Support query includes params in PeopleController

### Why?

Reduce query burden on backend api and be consistent with json:api standards.

Docs are getting updated for all endpoints at the end.