### PR TITLE
P4-1562 add proposed journey state

### DIFF
--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -26,6 +26,8 @@ class Journey < ApplicationRecord
   has_many :events, as: :eventable, dependent: :destroy # NB: polymorphic association
 
   enum states: {
+    proposed: 'proposed',
+    rejected: 'rejected',
     in_progress: 'in_progress',
     completed: 'completed',
     cancelled: 'cancelled',
@@ -41,7 +43,7 @@ class Journey < ApplicationRecord
 
   scope :default_order, -> { order(client_timestamp: :asc) }
 
-  delegate :complete, :uncomplete, :cancel, :uncancel, to: :state_machine
+  delegate :start, :reject, :complete, :uncomplete, :cancel, :uncancel, to: :state_machine
 
   after_initialize :initialize_state # NB there is an equivalent after(:build) callback used by FactoryBot in the journeys factory
 

--- a/app/state_machines/journey_state_machine.rb
+++ b/app/state_machines/journey_state_machine.rb
@@ -1,8 +1,12 @@
 class JourneyStateMachine < FiniteMachine::Definition
-  initial :in_progress
+  initial :proposed
+
+  event :start, proposed: :in_progress
+  event :reject, proposed: :rejected
 
   event :complete, in_progress: :completed
   event :uncomplete, completed: :in_progress
+
   event :cancel, in_progress: :cancelled
   event :uncancel, cancelled: :in_progress
 

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Journey, type: :model do
 
   shared_examples 'model is synchronised with state_machine for events and initialization' do
     context 'when nil state' do
-      it_behaves_like 'model is synchronised with state_machine', :in_progress
+      it_behaves_like 'model is synchronised with state_machine', :proposed
     end
 
     context 'when specified state' do
@@ -47,9 +47,9 @@ RSpec.describe Journey, type: :model do
     end
 
     context 'when the state changes with an event' do
-      before { journey.cancel }
+      before { journey.start }
 
-      it_behaves_like 'model is synchronised with state_machine', :cancelled
+      it_behaves_like 'model is synchronised with state_machine', :in_progress
     end
 
     context 'when the model state is manually updated outside of the state_machine' do

--- a/spec/requests/api/v1/journeys_controller_create_spec.rb
+++ b/spec/requests/api/v1/journeys_controller_create_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Api::V1::JourneysController do
           "type": 'journeys',
           "attributes": {
             "billable": false,
-            "state": 'in_progress',
+            "state": 'proposed',
             "timestamp": '2020-05-04T09:00:00+01:00',
             "vehicle": { "id": '12345678ABC', "registration": 'AB12 CDE' },
           },

--- a/spec/requests/api/v1/journeys_controller_show_spec.rb
+++ b/spec/requests/api/v1/journeys_controller_show_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Api::V1::JourneysController do
           "type": 'journeys',
           "attributes": {
             "billable": false,
-            "state": 'in_progress',
+            "state": 'proposed',
             "timestamp": '2020-05-04T09:00:00+01:00',
             "vehicle": {
               "id": '12345678ABC',

--- a/spec/serializers/journey_serializer_spec.rb
+++ b/spec/serializers/journey_serializer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe JourneySerializer do
   end
 
   it 'contains a `state` attribute' do
-    expect(result[:data][:attributes][:state]).to eql 'in_progress'
+    expect(result[:data][:attributes][:state]).to eql 'proposed'
   end
 
   it 'contains a `timestamp` attribute' do

--- a/spec/state_machines/journey_state_machine_spec.rb
+++ b/spec/state_machines/journey_state_machine_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe JourneyStateMachine do
   let(:machine) { described_class.new(target) }
   let(:target) { Struct.new(:state).new(initial_state) } # NB: the target is not updated until an event fires
-  let(:initial_state) { :in_progress }
+  let(:initial_state) { :proposed }
 
   before { machine.restore!(initial_state) }
 
@@ -19,9 +19,27 @@ RSpec.describe JourneyStateMachine do
     end
   end
 
-  it { is_expected.to respond_to(:cancel, :uncancel, :complete, :uncomplete, :restore!, :current) }
+  it { is_expected.to respond_to(:start, :reject, :cancel, :uncancel, :complete, :uncomplete, :restore!, :current) }
+
+  context 'when in the proposed state' do
+    it_behaves_like 'state_machine target state', :proposed
+
+    context 'when the start event is fired' do
+      before { machine.start }
+
+      it_behaves_like 'state_machine target state', :in_progress
+    end
+
+    context 'when the reject event is fired' do
+      before { machine.reject }
+
+      it_behaves_like 'state_machine target state', :rejected
+    end
+  end
 
   context 'when in the in_progress state' do
+    let(:initial_state) { :in_progress }
+
     it_behaves_like 'state_machine target state', :in_progress
 
     context 'when the complete event is fired' do

--- a/swagger/v1/get_journey.yaml
+++ b/swagger/v1/get_journey.yaml
@@ -33,11 +33,12 @@ GetJourney:
           type: string
           enum:
           - proposed
+          - rejected
           - in_progress
           - cancelled
           - completed
           example: in_progress
-          description: the state of the journey (proposed / in_progress / cancelled / completed)
+          description: the state of the journey (proposed / rejected / in_progress / cancelled / completed)
         vehicle:
           type: object
           properties:

--- a/swagger/v1/get_journey.yaml
+++ b/swagger/v1/get_journey.yaml
@@ -32,11 +32,12 @@ GetJourney:
         state:
           type: string
           enum:
+          - proposed
           - in_progress
           - cancelled
           - completed
           example: in_progress
-          description: the state of the journey (in_progress / cancelled / completed)
+          description: the state of the journey (proposed / in_progress / cancelled / completed)
         vehicle:
           type: object
           properties:

--- a/swagger/v1/journey_event_name_attribute.yaml
+++ b/swagger/v1/journey_event_name_attribute.yaml
@@ -2,9 +2,10 @@ JourneyEventName:
   type: string
   example: complete
   enum:
+  - start
+  - reject
   - complete
   - uncomplete
   - cancel
   - uncancel
-  description: The type of this journey event - either `complete`, `uncomplete`, `cancel`
-    or `uncancel`
+  description: The type of this journey event - either `start`, `reject`, `complete`, `uncomplete`, `cancel` or `uncancel`


### PR DESCRIPTION
### Jira link

[P4-1562](https://dsdmoj.atlassian.net/browse/P4-1562)

### What?

I have added/removed/altered:

- [x] Added `proposed` initial journey state
- [x] Added `start` and `reject` journey events

### Why?

I am doing this because:
- suppliers have requested this state

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- minimal - not currently being used
