### PR TITLE
[P4-1510] Support `person` in include validator

### DIFF
--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -29,6 +29,7 @@ class MoveSerializer < ActiveModel::Serializer
 
   SUPPORTED_RELATIONSHIPS = %w[
     profile
+    person
     person.ethnicity
     person.gender
     from_location

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Api::V1::MovesController do
         end
 
         it 'includes profile in the response' do
-          get '/api/v1/moves?include=profile,person.gender', params: params, headers: headers
+          get '/api/v1/moves?include=profile,person,person.gender', params: params, headers: headers
 
           profiles = response_json['included'].filter { |e| e['type'] == 'profiles' }
 

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Api::V1::MovesController do
         end
 
         it 'includes profile in the response' do
-          get '/api/v1/moves?include=profile', params: params, headers: headers
+          get '/api/v1/moves?include=profile,person.gender', params: params, headers: headers
 
           profiles = response_json['included'].filter { |e| e['type'] == 'profiles' }
 


### PR DESCRIPTION
### Jira link

P4-1510

### What?

Active Model Serializers (AMS) automagically returns a root object
when given the following `.` (dot) separated format include query `person.gender`.

This meant that we never needed to add `person` to our static include
list.

The validator we added does not support root objects implicitly and requires us to be explicit.

Since both the validator and AMS depend on the same list this means we
need to make sure we're supporting the explicit form for included
documents when doing validations.


### Why?

To prevent the frontend experience unexpected validation failures when they explicitly request a `person` in their include query.

