### PR TITLE
P4-1380 Add support for sorting on GET /allocations endpoint

### DIFF
--- a/app/controllers/api/v1/allocations_controller.rb
+++ b/app/controllers/api/v1/allocations_controller.rb
@@ -6,9 +6,9 @@ module Api
       after_action :send_move_notifications, only: :create
 
       def index
-        allocations_params = Allocations::ParamsValidator.new(filter_params)
+        allocations_params = Allocations::ParamsValidator.new(filter_params, sort_params)
         if allocations_params.valid?
-          allocations = Allocations::Finder.new(filter_params).call
+          allocations = Allocations::Finder.new(filter_params, sort_params).call
           paginate allocations, include: included_relationships
         else
           render_allocation({ error: allocations_params.errors }, :bad_request)
@@ -30,6 +30,7 @@ module Api
     private
 
       PERMITTED_FILTER_PARAMS = %i[date_from date_to locations from_locations to_locations status].freeze
+      PERMITTED_SORT_PARAMS = %i[by direction].freeze
 
       PERMITTED_ALLOCATION_PARAMS = [
         :type,
@@ -39,8 +40,12 @@ module Api
 
       PERMITTED_COMPLEX_CASE_PARAMS = %i[key title answer allocation_complex_case_id].freeze
 
+      def sort_params
+        @sort_params ||= params.fetch(:sort, {}).permit(PERMITTED_SORT_PARAMS).to_h
+      end
+
       def filter_params
-        params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h
+        @filter_params ||= params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h
       end
 
       def allocation_params

--- a/app/services/allocations/params_validator.rb
+++ b/app/services/allocations/params_validator.rb
@@ -4,7 +4,7 @@ module Allocations
   class ParamsValidator
     include ActiveModel::Validations
 
-    attr_reader :date_from, :date_to, :locations, :from_locations, :to_locations
+    attr_reader :date_from, :date_to, :locations, :from_locations, :to_locations, :sort_by, :sort_direction
 
     validates_each :date_from, :date_to, allow_nil: true do |record, attr, value|
       Date.strptime(value, '%Y-%m-%d')
@@ -16,12 +16,20 @@ module Allocations
       record.errors.add attr, 'may not be used in combination with `from_locations` or `to_locations` filters.' if record.from_locations.present? || record.to_locations.present?
     end
 
-    def initialize(filter_params)
+    validates :sort_direction, inclusion: %w[asc desc], allow_nil: true
+    validates :sort_by,
+              inclusion: %w[from_location to_location moves_count date],
+              allow_nil: true
+
+    def initialize(filter_params, sort_params)
       @date_from = filter_params[:date_from]
       @date_to = filter_params[:date_to]
       @locations = filter_params[:locations]
       @from_locations = filter_params[:from_locations]
       @to_locations = filter_params[:to_locations]
+
+      @sort_by = sort_params[:by]
+      @sort_direction = sort_params[:direction]
     end
   end
 end

--- a/spec/services/allocations/params_validator_spec.rb
+++ b/spec/services/allocations/params_validator_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Allocations::ParamsValidator do
-  subject(:params_validator) { described_class.new(filter_params) }
+  subject(:params_validator) { described_class.new(filter_params, sort_params) }
 
   let(:filter_params) { { date_from: date_from, date_to: date_to } }
+  let(:sort_params) { { by: 'date', direction: 'asc' } }
   let(:good_date) { '2019-05-05' }
   let(:date_from) { good_date }
   let(:date_to) { good_date }
@@ -64,6 +65,24 @@ RSpec.describe Allocations::ParamsValidator do
 
   context 'with from_locations, to_locations and locations' do
     let(:filter_params) { { from_locations: 'foo', to_locations: 'bar', locations: 'baz' } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'without sort details' do
+    let(:sort_params) { {} }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with invalid sort direction' do
+    let(:sort_params) { { direction: 'foo' } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with invalid sort by' do
+    let(:sort_params) { { by: 'foo' } }
 
     it { is_expected.not_to be_valid }
   end

--- a/spec/swagger/definitions/hand_coded_paths.yaml
+++ b/spec/swagger/definitions/hand_coded_paths.yaml
@@ -71,6 +71,28 @@
           - filled
           - unfilled
           - cancelled
+    - name: sort[by]
+      description: field to sort results by
+      in: query
+      style: form
+      explode: false
+      schema:
+        type: string
+        enum:
+        - from_location
+        - to_location
+        - date
+        - moves_count
+    - name: sort[direction]
+      description: direction to sort by
+      in: query
+      style: form
+      explode: false
+      schema:
+        type: string
+        enum:
+        - asc
+        - desc
     - $ref: pagination_parameters.yaml#/Page
     - $ref: pagination_parameters.yaml#/PerPage
     responses:


### PR DESCRIPTION

### Jira link

P4-1380

### What?

- [x] `GET /allocations` endpoint now accepts additional `sort[by]` and `sort[direction]` parameters
- [x] Extended Allocations::ParamsValidator services to accept and validate both of these parameters
- [x] Extended Allocations::Finder service to accept new parameters and order results accordingly

### Why?

- This is required to support sorting allocation results in the front end
- Both of the new parameters are optional and named with the same convention as `GET /moves` endpoint
- If neither are specified the default sort order is descending date (i.e. most recent allocations first) which matches the existing behaviour prior to this PR

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes a production api, but only if additional parameters are specified. The new parameters are optional so this is backwards compatible with the existing front end and can be deployed first.