### PR TITLE
Add new post /v2/person endpoint

### DIFF
--- a/app/controllers/api/v2/people_controller.rb
+++ b/app/controllers/api/v2/people_controller.rb
@@ -43,17 +43,17 @@ module Api
       end
 
       def person_attributes
+        person_params[:attributes].merge(ethnicity: ethnicity, gender: gender)
+      end
+
+      def ethnicity
         ethnicity_id = params.require(:data).dig(:relationships, :ethnicity, :data, :id)
-        gender_id = params.require(:data).dig(:relationships, :gender, :data, :id)
-
-        # Validate the existence of Ethnicity and Gender
         Ethnicity.find(ethnicity_id) if ethnicity_id
-        Gender.find(gender_id) if gender_id
+      end
 
-        person_params[:attributes].merge(
-          ethnicity_id: ethnicity_id,
-          gender_id: gender_id,
-        )
+      def gender
+        gender_id = params.require(:data).dig(:relationships, :gender, :data, :id)
+        Gender.find(gender_id) if gender_id
       end
     end
   end

--- a/app/controllers/api/v2/people_controller.rb
+++ b/app/controllers/api/v2/people_controller.rb
@@ -43,9 +43,16 @@ module Api
       end
 
       def person_attributes
+        ethnicity_id = params.require(:data).dig(:relationships, :ethnicity, :data, :id)
+        gender_id = params.require(:data).dig(:relationships, :gender, :data, :id)
+
+        # Validate the existence of Ethnicity and Gender
+        Ethnicity.find(ethnicity_id) if ethnicity_id
+        Gender.find(gender_id) if gender_id
+
         person_params[:attributes].merge(
-          ethnicity_id: params.require(:data).dig(:relationships, :ethnicity, :data, :id),
-          gender_id: params.require(:data).dig(:relationships, :gender, :data, :id),
+          ethnicity_id: ethnicity_id,
+          gender_id: gender_id,
         )
       end
     end

--- a/app/controllers/api/v2/people_controller.rb
+++ b/app/controllers/api/v2/people_controller.rb
@@ -6,7 +6,7 @@ module Api
       before_action :validate_include_params, only: %i[index create]
 
       def create
-        person = Person.create(new_person_attributes)
+        person = Person.create(person_attributes)
 
         render json: person, status: :created, include: included_relationships, serializer: ::V2::PersonSerializer
       end
@@ -44,7 +44,7 @@ module Api
         params.require(:data).permit(PERMITTED_PERSON_PARAMS).to_h
       end
 
-      def new_person_attributes
+      def person_attributes
         person_params[:attributes].merge(
           ethnicity_id: params.require(:data).dig(:relationships, :ethnicity, :data, :id),
           gender_id: params.require(:data).dig(:relationships, :gender, :data, :id),

--- a/app/controllers/api/v2/people_controller.rb
+++ b/app/controllers/api/v2/people_controller.rb
@@ -3,6 +3,14 @@
 module Api
   module V2
     class PeopleController < ApiController
+      before_action :validate_include_params, only: :index
+
+      def create
+        person = Person.last
+
+        render json: person, status: :created
+      end
+
       def index
         people = ::V2::People::Finder.new(filter_params).call
 

--- a/app/controllers/api/v2/people_controller.rb
+++ b/app/controllers/api/v2/people_controller.rb
@@ -3,8 +3,6 @@
 module Api
   module V2
     class PeopleController < ApiController
-      before_action :validate_include_params, only: %i[index create]
-
       def create
         person = Person.create(person_attributes)
 

--- a/app/controllers/api/v2/people_controller.rb
+++ b/app/controllers/api/v2/people_controller.rb
@@ -25,7 +25,6 @@ module Api
         first_names
         last_name
         date_of_birth
-        nomis_prison_number
         prison_number
         criminal_records_office
         police_national_computer

--- a/app/controllers/api/v2/people_controller.rb
+++ b/app/controllers/api/v2/people_controller.rb
@@ -25,6 +25,10 @@ module Api
         first_names
         last_name
         date_of_birth
+        nomis_prison_number
+        prison_number
+        criminal_records_office
+        police_national_computer
         gender_additional_information
       ].freeze
       PERMITTED_PERSON_PARAMS = [:type, attributes: PERSON_ATTRIBUTES, relationships: {}].freeze

--- a/app/controllers/api/v2/people_controller.rb
+++ b/app/controllers/api/v2/people_controller.rb
@@ -3,12 +3,12 @@
 module Api
   module V2
     class PeopleController < ApiController
-      before_action :validate_include_params, only: :index
+      before_action :validate_include_params, only: %i[index create]
 
       def create
         person = Person.create(new_person_attributes)
 
-        render json: person, status: :created, serializer: ::V2::PersonSerializer
+        render json: person, status: :created, include: included_relationships, serializer: ::V2::PersonSerializer
       end
 
       def index

--- a/app/serializers/v2/person_serializer.rb
+++ b/app/serializers/v2/person_serializer.rb
@@ -8,8 +8,7 @@ module V2
       :last_name,
       :date_of_birth,
       :gender_additional_information,
-      :nomis_prison_number,
-      :prison_number, # TODO: should we remove this?
+      :prison_number,
       :criminal_records_office,
       :police_national_computer,
     )

--- a/app/serializers/v2/person_serializer.rb
+++ b/app/serializers/v2/person_serializer.rb
@@ -9,7 +9,7 @@ module V2
       :date_of_birth,
       :gender_additional_information,
       :nomis_prison_number,
-      :prison_number,
+      :prison_number, # TODO: should we remove this?
       :criminal_records_office,
       :police_national_computer,
     )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
     end
 
     namespace :v2 do
-      resources :people, only: %i[index]
+      resources :people, only: %i[index create]
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -207,10 +207,10 @@ ActiveRecord::Schema.define(version: 2020_06_01_091307) do
     t.text "cancellation_reason_comment"
     t.integer "nomis_event_ids", default: [], null: false, array: true
     t.uuid "profile_id"
-    t.uuid "prison_transfer_reason_id"
-    t.text "reason_comment"
     t.boolean "move_agreed", default: false, null: false
     t.string "move_agreed_by"
+    t.uuid "prison_transfer_reason_id"
+    t.text "reason_comment"
     t.date "date_from"
     t.date "date_to"
     t.uuid "allocation_id"
@@ -416,7 +416,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_091307) do
   add_foreign_key "moves", "allocations"
   add_foreign_key "moves", "locations", column: "from_location_id", name: "fk_rails_moves_from_location_id"
   add_foreign_key "moves", "locations", column: "to_location_id", name: "fk_rails_moves_to_location_id"
-  add_foreign_key "moves", "people", name: "fk_rails_moves_person_id"
+  add_foreign_key "moves", "people"
   add_foreign_key "notifications", "notification_types"
   add_foreign_key "notifications", "subscriptions"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -207,10 +207,10 @@ ActiveRecord::Schema.define(version: 2020_06_01_091307) do
     t.text "cancellation_reason_comment"
     t.integer "nomis_event_ids", default: [], null: false, array: true
     t.uuid "profile_id"
-    t.boolean "move_agreed", default: false, null: false
-    t.string "move_agreed_by"
     t.uuid "prison_transfer_reason_id"
     t.text "reason_comment"
+    t.boolean "move_agreed", default: false, null: false
+    t.string "move_agreed_by"
     t.date "date_from"
     t.date "date_to"
     t.uuid "allocation_id"
@@ -416,7 +416,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_091307) do
   add_foreign_key "moves", "allocations"
   add_foreign_key "moves", "locations", column: "from_location_id", name: "fk_rails_moves_from_location_id"
   add_foreign_key "moves", "locations", column: "to_location_id", name: "fk_rails_moves_to_location_id"
-  add_foreign_key "moves", "people"
+  add_foreign_key "moves", "people", name: "fk_rails_moves_person_id"
   add_foreign_key "notifications", "notification_types"
   add_foreign_key "notifications", "subscriptions"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"

--- a/spec/requests/api/v1/people_controller_create_spec.rb
+++ b/spec/requests/api/v1/people_controller_create_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe Api::V1::PeopleController do
 
       it 'returns the correct data' do
         post '/api/v1/people', params: person_params, headers: headers, as: :json
+
         expect(response_json).to include_json(data: expected_data.merge(id: Person.last&.id))
       end
 

--- a/spec/requests/api/v2/people_controller_create_spec.rb
+++ b/spec/requests/api/v2/people_controller_create_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe Api::V2::PeopleController do
             first_names: 'Bob',
             last_name: 'Roberts',
             date_of_birth: Date.civil(1980, 1, 1),
-            nomis_prison_number: 'G3239GV',
-            prison_number: 'G3239GV', # TODO: should we remove this?
+            prison_number: 'G3239GV',
             criminal_records_office: 'CRO0111d',
             police_national_computer: 'AB/1234567',
             gender_additional_information: 'info about Bob',
@@ -56,8 +55,7 @@ RSpec.describe Api::V2::PeopleController do
             first_names: 'Bob',
             last_name: 'Roberts',
             date_of_birth: Date.civil(1980, 1, 1).iso8601,
-            nomis_prison_number: 'G3239GV',
-            prison_number: 'G3239GV', # TODO: should we remove this?
+            prison_number: 'G3239GV',
             criminal_records_office: 'CRO0111d',
             police_national_computer: 'AB/1234567',
             gender_additional_information: 'info about Bob',

--- a/spec/requests/api/v2/people_controller_create_spec.rb
+++ b/spec/requests/api/v2/people_controller_create_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Api::V2::PeopleController do
             first_names: 'Bob',
             last_name: 'Roberts',
             date_of_birth: Date.civil(1980, 1, 1),
+            nomis_prison_number: 'G3239GV',
+            prison_number: 'G3239GV', # TODO: should we remove this?
+            criminal_records_office: 'CRO0111d',
+            police_national_computer: 'AB/1234567',
             gender_additional_information: 'info about Bob',
           },
           relationships: {
@@ -52,6 +56,10 @@ RSpec.describe Api::V2::PeopleController do
             first_names: 'Bob',
             last_name: 'Roberts',
             date_of_birth: Date.civil(1980, 1, 1).iso8601,
+            nomis_prison_number: 'G3239GV',
+            prison_number: 'G3239GV', # TODO: should we remove this?
+            criminal_records_office: 'CRO0111d',
+            police_national_computer: 'AB/1234567',
             gender_additional_information: 'info about Bob',
           },
           relationships: {

--- a/spec/requests/api/v2/people_controller_create_spec.rb
+++ b/spec/requests/api/v2/people_controller_create_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V2::PeopleController do
           attributes: {
             first_names: 'Bob',
             last_name: 'Roberts',
-            date_of_birth: Date.civil(1980, 1, 1),
+            date_of_birth: Date.new(1980, 1, 1),
             prison_number: 'G3239GV',
             criminal_records_office: 'CRO0111d',
             police_national_computer: 'AB/1234567',
@@ -54,7 +54,7 @@ RSpec.describe Api::V2::PeopleController do
           attributes: {
             first_names: 'Bob',
             last_name: 'Roberts',
-            date_of_birth: Date.civil(1980, 1, 1).iso8601,
+            date_of_birth: Date.new(1980, 1, 1).iso8601,
             prison_number: 'G3239GV',
             criminal_records_office: 'CRO0111d',
             police_national_computer: 'AB/1234567',

--- a/spec/requests/api/v2/people_controller_create_spec.rb
+++ b/spec/requests/api/v2/people_controller_create_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Api::V2::PeopleController do
   describe 'POST /people' do
     let(:schema) { load_yaml_schema('post_people_responses.yaml', version: 'v2') }
 
-    let(:profile) { create :profile }
+    let(:ethnicity) { create :ethnicity }
+    let(:gender) { create :gender }
     let(:risk_type_1) { create :assessment_question, :risk }
     let(:risk_type_2) { create :assessment_question, :risk }
 
@@ -23,17 +24,19 @@ RSpec.describe Api::V2::PeopleController do
             first_names: 'Bob',
             last_name: 'Roberts',
             date_of_birth: Date.civil(1980, 1, 1),
-
-            identifiers: [
-              { identifier_type: 'police_national_computer', value: 'ABC123' },
-              { identifier_type: 'prison_number', value: 'XYZ987' },
-            ],
+            gender_additional_information: 'info about Bob',
           },
           relationships: {
             ethnicity: {
               data: {
-                id: profile.id,
-                type: 'profiles',
+                id: ethnicity.id,
+                type: 'ethnicities',
+              },
+            },
+            gender: {
+              data: {
+                id: gender.id,
+                type: 'genders',
               },
             },
           },
@@ -49,11 +52,7 @@ RSpec.describe Api::V2::PeopleController do
             first_names: 'Bob',
             last_name: 'Roberts',
             date_of_birth: Date.civil(1980, 1, 1).iso8601,
-
-            identifiers: [
-              { identifier_type: 'police_national_computer', value: 'ABC123' },
-              { identifier_type: 'prison_number', value: 'XYZ987' },
-            ],
+            gender_additional_information: 'info about Bob',
           },
           relationships: {
             gender: {
@@ -73,18 +72,7 @@ RSpec.describe Api::V2::PeopleController do
       end
 
       let(:expected_included) do
-        [
-          {
-            id: profile.id,
-            type: 'profiles',
-            attributes: {
-              assessment_answers: [
-                  { title: risk_type_1.title, assessment_question_id: risk_type_1.id },
-                  { title: risk_type_2.title, assessment_question_id: risk_type_2.id },
-              ],
-            },
-          },
-        ]
+        []
       end
 
       context 'with valid params' do
@@ -93,6 +81,94 @@ RSpec.describe Api::V2::PeopleController do
         it_behaves_like 'an endpoint that responds with success 201'
       end
 
+      it 'returns the correct data' do
+        post '/api/v2/people', params: person_params, headers: headers, as: :json
+        # expect(response_json).to include_json(data: expected_data.merge(id: Person.last.id))
+        #
+        expect(response_json).to include_json(data: expected_data.merge(id: Person.last.id))
+      end
+
+      it 'returns the correct included resources' do
+        post '/api/v1/people', params: person_params, headers: headers, as: :json
+
+        expect(response_json).to include_json(included: expected_included)
+      end
+
+      it 'creates a new person' do
+        expect {
+          post '/api/v1/people', params: person_params, headers: headers, as: :json
+        }.to change(Person, :count).by(1)
+      end
+
+      #   describe 'webhook and email notifications' do
+      #     before do
+      #       allow(Notifier).to receive(:prepare_notifications)
+      #       post '/api/v1/people', params: person_params, headers: headers, as: :json
+      #     end
+      #
+      #     it 'does NOT call the notifier when creating a person' do
+      #       expect(Notifier).not_to have_received(:prepare_notifications)
+      #     end
+      #   end
+      # end
+      #
+      # context 'with gender_additional_information' do
+      #   let(:gender_additional_information) { 'some additional info' }
+      #
+      #   it 'updates an existing person' do
+      #     post '/api/v1/people', params: person_params, headers: headers, as: :json
+      #     expect(Person.last.reload.latest_profile.gender_additional_information).to eq gender_additional_information
+      #   end
+      # end
+      #
+      # context 'with a bad request' do
+      #   before { post '/api/v1/people', params: {}, headers: headers, as: :json }
+      #
+      #   it_behaves_like 'an endpoint that responds with error 400'
+      # end
+      #
+      # context 'when not authorized', :with_invalid_auth_headers do
+      #   let(:detail_401) { 'Token expired or invalid' }
+      #   let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+      #   let(:content_type) { ApiController::CONTENT_TYPE }
+      #
+      #   before { post '/api/v1/people', params: person_params, headers: headers, as: :json }
+      #
+      #   it_behaves_like 'an endpoint that responds with error 401'
+      # end
+      #
+      # context 'with an invalid CONTENT_TYPE header' do
+      #   let(:content_type) { 'application/xml' }
+      #
+      #   before { post '/api/v1/people', params: person_params, headers: headers, as: :json }
+      #
+      #   it_behaves_like 'an endpoint that responds with error 415'
+      # end
+      #
+      # context 'with validation errors' do
+      #   let(:person_params) do
+      #     {
+      #       data: {
+      #         type: 'people',
+      #         attributes: { first_names: 'Bob' },
+      #       },
+      #     }
+      #   end
+      #
+      #   let(:errors_422) do
+      #     [
+      #       {
+      #         'title' => 'Unprocessable entity',
+      #         'detail' => "Last name can't be blank",
+      #         'source' => { 'pointer' => '/data/attributes/last_name' },
+      #         'code' => 'blank',
+      #       },
+      #     ]
+      #   end
+      #
+      #   before { post '/api/v1/people', params: person_params, headers: headers, as: :json }
+      #
+      #   it_behaves_like 'an endpoint that responds with error 422'
     end
   end
 end

--- a/spec/requests/api/v2/people_controller_create_spec.rb
+++ b/spec/requests/api/v2/people_controller_create_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V2::PeopleController do
+  let(:response_json) { JSON.parse(response.body) }
+  let(:access_token) { create(:access_token).token }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
+
+  describe 'POST /people' do
+    let(:schema) { load_yaml_schema('post_people_responses.yaml', version: 'v2') }
+
+    let(:profile) { create :profile }
+    let(:risk_type_1) { create :assessment_question, :risk }
+    let(:risk_type_2) { create :assessment_question, :risk }
+
+    let(:person_params) do
+      {
+        data: {
+          type: 'people',
+          attributes: {
+            first_names: 'Bob',
+            last_name: 'Roberts',
+            date_of_birth: Date.civil(1980, 1, 1),
+
+            identifiers: [
+              { identifier_type: 'police_national_computer', value: 'ABC123' },
+              { identifier_type: 'prison_number', value: 'XYZ987' },
+            ],
+          },
+          relationships: {
+            ethnicity: {
+              data: {
+                id: profile.id,
+                type: 'profiles',
+              },
+            },
+          },
+        },
+      }
+    end
+
+    context 'when successful' do
+      let(:expected_data) do
+        {
+          type: 'people',
+          attributes: {
+            first_names: 'Bob',
+            last_name: 'Roberts',
+            date_of_birth: Date.civil(1980, 1, 1).iso8601,
+
+            identifiers: [
+              { identifier_type: 'police_national_computer', value: 'ABC123' },
+              { identifier_type: 'prison_number', value: 'XYZ987' },
+            ],
+          },
+          relationships: {
+            gender: {
+              data: {
+                type: 'genders',
+                id: gender.id,
+              },
+            },
+            ethnicity: {
+              data: {
+                type: 'ethnicities',
+                id: ethnicity.id,
+              },
+            },
+          },
+        }
+      end
+
+      let(:expected_included) do
+        [
+          {
+            id: profile.id,
+            type: 'profiles',
+            attributes: {
+              assessment_answers: [
+                  { title: risk_type_1.title, assessment_question_id: risk_type_1.id },
+                  { title: risk_type_2.title, assessment_question_id: risk_type_2.id },
+              ],
+            },
+          },
+        ]
+      end
+
+      context 'with valid params' do
+        before { post '/api/v2/people', params: person_params, headers: headers, as: :json }
+
+        it_behaves_like 'an endpoint that responds with success 201'
+      end
+
+    end
+  end
+end

--- a/spec/requests/api/v2/people_controller_index_spec.rb
+++ b/spec/requests/api/v2/people_controller_index_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Api::V2::PeopleController do
         context 'when the include query param is empty' do
           let(:params) { { include: [] } }
 
-          it 'does not include any resource' do
+          it 'does not include any relationship' do
             expect(response_json).not_to include('included')
           end
         end
@@ -145,15 +145,15 @@ RSpec.describe Api::V2::PeopleController do
         context 'when include is nil' do
           let(:params) { { include: nil } }
 
-          it 'does not include any resource' do
+          it 'does not include any relationship' do
             expect(response_json).not_to include('included')
           end
         end
 
-        context 'when including the multiple query param' do
+        context 'when including multiple relationships' do
           let(:params) { { include: 'ethnicity,gender,profiles' } }
 
-          it 'returns the relevant ethnicity' do
+          it 'includes the relevant relationships' do
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
 
             expect(returned_types).to contain_exactly('ethnicities', 'genders', 'profiles')
@@ -161,13 +161,13 @@ RSpec.describe Api::V2::PeopleController do
         end
 
         context 'when including a non existing relationship in a query param' do
-          let(:params) { { include: 'gender,bar' } }
+          let(:params) { { include: 'gender,non-existent-relationship' } }
 
           it 'responds with error 400' do
             response_error = response_json['errors'].first
 
             expect(response_error['title']).to eq('Bad request')
-            expect(response_error['detail']).to include('["bar"] is not supported.')
+            expect(response_error['detail']).to include('["non-existent-relationship"] is not supported.')
           end
         end
       end

--- a/spec/requests/api/v2/people_controller_index_spec.rb
+++ b/spec/requests/api/v2/people_controller_index_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Api::V2::PeopleController do
             response_error = response_json['errors'].first
 
             expect(response_error['title']).to eq('Bad request')
-            expect(response_error['detail']).to include('["non-existent-relationship"] is not supported.')
+            expect(response_error['detail']).too include('["non-existent-relationship"] is not supported.')
           end
         end
       end

--- a/spec/requests/api/v2/people_controller_index_spec.rb
+++ b/spec/requests/api/v2/people_controller_index_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Api::V2::PeopleController do
             'last_name',
             'date_of_birth',
             'gender_additional_information',
-            'nomis_prison_number',
             'prison_number',
             'criminal_records_office',
             'police_national_computer',

--- a/spec/requests/api/v2/people_controller_index_spec.rb
+++ b/spec/requests/api/v2/people_controller_index_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Api::V2::PeopleController do
             response_error = response_json['errors'].first
 
             expect(response_error['title']).to eq('Bad request')
-            expect(response_error['detail']).too include('["non-existent-relationship"] is not supported.')
+            expect(response_error['detail']).to include('["non-existent-relationship"] is not supported.')
           end
         end
       end

--- a/swagger/v2/post_people_responses.yaml
+++ b/swagger/v2/post_people_responses.yaml
@@ -1,0 +1,52 @@
+'201':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: person.yaml#/Person
+'400':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError
+'404':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/ResourceNotFound
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnsupportedMediaType
+'422':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnprocessableEntity


### PR DESCRIPTION
### Jira link
https://dsdmoj.atlassian.net/browse/P4-1583

### What?
This PR adds the endpoint `/v2/people` to create a new person

### Why?
This is part of the planned set of the new endpoints.
This allows creating a person with more attributes, and it is from a profile (when you create a person, the profile is not created)

### Have you? (optional)
- [ ] Updated API docs if necessary

The Swagger Doc will be updated in the next PR: https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/507/files

### Deployment risks (optional)

Very low risk, since this is a new endpoint.