### PR TITLE
Reduce number of fixtures created for pagination tests

### DIFF
--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     trait :with_moves do
       after(:create) do |location, _|
-        create_list :move, 10, from_location: location
+        create_list :move, 2, from_location: location
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,3 +89,7 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+Kaminari.configure do |config|
+  config.default_per_page = 5
+end

--- a/spec/requests/api/v1/allocations_controller_index_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_index_spec.rb
@@ -137,27 +137,7 @@ RSpec.describe Api::V1::AllocationsController do
           }
         end
 
-        it 'paginates 5 results per page' do
-          expect(response_json['data'].size).to eq 5
-        end
-
-        it 'returns 1 result on the second page', skip_before: true do
-          get '/api/v1/allocations?page=2', headers: headers
-
-          expect(response_json['data'].size).to eq 1
-        end
-
-        it 'allows setting a different page size', skip_before: true do
-          get '/api/v1/allocations?per_page=1', headers: headers
-
-          expect(response_json['data'].size).to eq 1
-        end
-
-        it 'provides meta data with pagination', skip_before: true do
-          get '/api/v1/allocations', headers: headers
-
-          expect(response_json['meta']['pagination']).to include_json(meta_pagination)
-        end
+        it_behaves_like 'an endpoint that paginates resources'
       end
 
       describe 'validating dates before running queries' do

--- a/spec/requests/api/v1/allocations_controller_index_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_index_spec.rb
@@ -122,13 +122,13 @@ RSpec.describe Api::V1::AllocationsController do
       end
 
       describe 'paginating results' do
-        let!(:allocations) { create_list :allocation, 21 }
+        let!(:allocations) { create_list :allocation, 6 }
 
         let(:meta_pagination) do
           {
-            per_page: 20,
+            per_page: 5,
             total_pages: 2,
-            total_objects: 21,
+            total_objects: 6,
             links: {
               first: '/api/v1/allocations?page=1',
               last: '/api/v1/allocations?page=2',
@@ -137,8 +137,8 @@ RSpec.describe Api::V1::AllocationsController do
           }
         end
 
-        it 'paginates 20 results per page' do
-          expect(response_json['data'].size).to eq 20
+        it 'paginates 5 results per page' do
+          expect(response_json['data'].size).to eq 5
         end
 
         it 'returns 1 result on the second page', skip_before: true do
@@ -148,9 +148,9 @@ RSpec.describe Api::V1::AllocationsController do
         end
 
         it 'allows setting a different page size', skip_before: true do
-          get '/api/v1/allocations?per_page=15', headers: headers
+          get '/api/v1/allocations?per_page=1', headers: headers
 
-          expect(response_json['data'].size).to eq 15
+          expect(response_json['data'].size).to eq 1
         end
 
         it 'provides meta data with pagination', skip_before: true do

--- a/spec/requests/api/v1/journeys_controller_index_spec.rb
+++ b/spec/requests/api/v1/journeys_controller_index_spec.rb
@@ -24,9 +24,10 @@ RSpec.describe Api::V1::JourneysController do
     let(:page) { 1 }
     let(:per_page) { 5 }
     let(:url) { "/api/v1/moves/#{move.id}/journeys" }
+    let(:params) { {} }
 
     before do
-      get url, headers: headers, as: :json
+      get url, params: params, headers: headers
     end
 
     context 'when successful' do
@@ -47,31 +48,8 @@ RSpec.describe Api::V1::JourneysController do
       describe 'paginating results' do
         let(:url) { "/api/v1/moves/#{move.id}/journeys?page=#{page}&per_page=#{per_page}" }
         let(:intermediate_journeys_count) { 4 }
-
-        describe 'page size' do
-          subject { response_json['data'].size }
-
-          context 'when page=1' do
-            let(:page) { 1 }
-
-            it { is_expected.to be(5) }
-          end
-
-          context 'when page=2' do
-            let(:page) { 2 }
-
-            it { is_expected.to be(1) }
-          end
-
-          context 'when per_page=15' do
-            let(:per_page) { 1 }
-
-            it { is_expected.to be(1) }
-          end
-        end
-
-        it 'provides meta data with pagination' do
-          expect(response_json['meta']['pagination']).to include_json(
+        let(:meta_pagination) do
+          {
             per_page: 5,
             total_pages: 2,
             total_objects: 6,
@@ -80,8 +58,10 @@ RSpec.describe Api::V1::JourneysController do
               last: "/api/v1/moves/#{move.id}/journeys?page=2&per_page=#{per_page}",
               next: "/api/v1/moves/#{move.id}/journeys?page=2&per_page=#{per_page}",
             },
-          )
+          }
         end
+
+        it_behaves_like 'an endpoint that paginates resources'
       end
     end
 

--- a/spec/requests/api/v1/journeys_controller_index_spec.rb
+++ b/spec/requests/api/v1/journeys_controller_index_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Api::V1::JourneysController do
 
     let(:intermediate_journeys_count) { 1 }
     let(:page) { 1 }
-    let(:per_page) { 20 }
+    let(:per_page) { 5 }
     let(:url) { "/api/v1/moves/#{move.id}/journeys" }
 
     before do
@@ -46,7 +46,7 @@ RSpec.describe Api::V1::JourneysController do
 
       describe 'paginating results' do
         let(:url) { "/api/v1/moves/#{move.id}/journeys?page=#{page}&per_page=#{per_page}" }
-        let(:intermediate_journeys_count) { 19 }
+        let(:intermediate_journeys_count) { 4 }
 
         describe 'page size' do
           subject { response_json['data'].size }
@@ -54,7 +54,7 @@ RSpec.describe Api::V1::JourneysController do
           context 'when page=1' do
             let(:page) { 1 }
 
-            it { is_expected.to be(20) }
+            it { is_expected.to be(5) }
           end
 
           context 'when page=2' do
@@ -64,17 +64,17 @@ RSpec.describe Api::V1::JourneysController do
           end
 
           context 'when per_page=15' do
-            let(:per_page) { 15 }
+            let(:per_page) { 1 }
 
-            it { is_expected.to be(15) }
+            it { is_expected.to be(1) }
           end
         end
 
         it 'provides meta data with pagination' do
           expect(response_json['meta']['pagination']).to include_json(
-            per_page: 20,
+            per_page: 5,
             total_pages: 2,
-            total_objects: 21,
+            total_objects: 6,
             links: {
               first: "/api/v1/moves/#{move.id}/journeys?page=1&per_page=#{per_page}",
               last: "/api/v1/moves/#{move.id}/journeys?page=2&per_page=#{per_page}",

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -92,13 +92,13 @@ RSpec.describe Api::V1::MovesController do
       end
 
       describe 'paginating results' do
-        let!(:moves) { create_list :move, 21 }
+        let!(:moves) { create_list :move, 6 }
 
         let(:meta_pagination) do
           {
-            per_page: 20,
+            per_page: 5,
             total_pages: 2,
-            total_objects: 21,
+            total_objects: 6,
             links: {
               first: '/api/v1/moves?page=1',
               last: '/api/v1/moves?page=2',
@@ -107,10 +107,10 @@ RSpec.describe Api::V1::MovesController do
           }
         end
 
-        it 'paginates 20 results per page as default' do
+        it 'paginates 5 results per page as default' do
           get_moves
 
-          expect(response_json['data'].size).to eq 20
+          expect(response_json['data'].size).to eq 5
         end
 
         it 'returns 1 result on the second page'  do
@@ -120,9 +120,9 @@ RSpec.describe Api::V1::MovesController do
         end
 
         it 'allows setting a different page size' do
-          get '/api/v1/moves?per_page=15', headers: headers
+          get '/api/v1/moves?per_page=1', headers: headers
 
-          expect(response_json['data'].size).to eq 15
+          expect(response_json['data'].size).to eq 1
         end
 
         it 'provides meta data with pagination' do

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -107,29 +107,9 @@ RSpec.describe Api::V1::MovesController do
           }
         end
 
-        it 'paginates 5 results per page as default' do
-          get_moves
+        before { get_moves }
 
-          expect(response_json['data'].size).to eq 5
-        end
-
-        it 'returns 1 result on the second page'  do
-          get '/api/v1/moves?page=2', headers: headers
-
-          expect(response_json['data'].size).to eq 1
-        end
-
-        it 'allows setting a different page size' do
-          get '/api/v1/moves?per_page=1', headers: headers
-
-          expect(response_json['data'].size).to eq 1
-        end
-
-        it 'provides meta data with pagination' do
-          get_moves
-
-          expect(response_json['meta']['pagination']).to include_json(meta_pagination)
-        end
+        it_behaves_like 'an endpoint that paginates resources'
       end
 
       describe 'validating dates before running queries' do

--- a/spec/requests/api/v1/moves_controller_role_access_spec.rb
+++ b/spec/requests/api/v1/moves_controller_role_access_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Api::V1::MovesController do
       end
 
       it 'returns the right number of moves' do
-        expect(response_json['data'].size).to be 10
+        expect(response_json['data'].size).to be 2
       end
     end
   end

--- a/spec/requests/api/v1/reference/locations_controller_spec.rb
+++ b/spec/requests/api/v1/reference/locations_controller_spec.rb
@@ -86,37 +86,9 @@ RSpec.describe Api::V1::Reference::LocationsController do
         }
       end
 
-      context 'with no pagination parameters' do
-        before { get '/api/v1/reference/locations', headers: headers }
+      before { get '/api/v1/reference/locations', params: params, headers: headers }
 
-        it 'paginates 5 results per page' do
-          expect(response_json['data'].size).to eq 5
-        end
-
-        it 'provides meta data with pagination' do
-          expect(response_json['meta']['pagination']).to include_json(meta_pagination)
-        end
-      end
-
-      context 'with page parameter' do
-        let(:params) { { page: 2 } }
-
-        before { get '/api/v1/reference/locations', params: params, headers: headers }
-
-        it 'returns 1 result on the second page' do
-          expect(response_json['data'].size).to eq 1
-        end
-      end
-
-      context 'with per_page parameter' do
-        let(:params) { { per_page: 2 } }
-
-        before { get '/api/v1/reference/locations', params: params, headers: headers }
-
-        it 'allows setting a different page size' do
-          expect(response_json['data'].size).to eq 2
-        end
-      end
+      it_behaves_like 'an endpoint that paginates resources'
     end
 
     describe 'filters' do

--- a/spec/requests/api/v1/reference/locations_controller_spec.rb
+++ b/spec/requests/api/v1/reference/locations_controller_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe Api::V1::Reference::LocationsController do
     end
 
     describe 'pagination' do
-      let!(:prisons) { create_list :location, 11 }
-      let!(:courts) { create_list :location, 10, :court }
+      let!(:prisons) { create_list :location, 4 }
+      let!(:courts) { create_list :location, 2, :court }
       let(:meta_pagination) do
         {
-          per_page: 20,
+          per_page: 5,
           total_pages: 2,
-          total_objects: 21,
+          total_objects: 6,
           links: {
             first: '/api/v1/reference/locations?page=1',
             last: '/api/v1/reference/locations?page=2',
@@ -89,8 +89,8 @@ RSpec.describe Api::V1::Reference::LocationsController do
       context 'with no pagination parameters' do
         before { get '/api/v1/reference/locations', headers: headers }
 
-        it 'paginates 20 results per page' do
-          expect(response_json['data'].size).to eq 20
+        it 'paginates 5 results per page' do
+          expect(response_json['data'].size).to eq 5
         end
 
         it 'provides meta data with pagination' do
@@ -109,12 +109,12 @@ RSpec.describe Api::V1::Reference::LocationsController do
       end
 
       context 'with per_page parameter' do
-        let(:params) { { per_page: 15 } }
+        let(:params) { { per_page: 2 } }
 
         before { get '/api/v1/reference/locations', params: params, headers: headers }
 
         it 'allows setting a different page size' do
-          expect(response_json['data'].size).to eq 15
+          expect(response_json['data'].size).to eq 2
         end
       end
     end

--- a/spec/requests/api/v2/people_controller_index_spec.rb
+++ b/spec/requests/api/v2/people_controller_index_spec.rb
@@ -109,13 +109,13 @@ RSpec.describe Api::V2::PeopleController do
       end
 
       describe 'paginating results' do
-        let!(:people) { create_list :person, 21 }
+        let!(:people) { create_list :person, 6 }
 
         let(:meta_pagination) do
           {
-            per_page: 20,
+            per_page: 5,
             total_pages: 2,
-            total_objects: 21,
+            total_objects: 6,
             links: {
               first: '/api/v2/people?page=1',
               last: '/api/v2/people?page=2',
@@ -124,10 +124,10 @@ RSpec.describe Api::V2::PeopleController do
           }
         end
 
-        it 'paginates 20 results per page' do
+        it 'paginates 5 results per page' do
           get '/api/v2/people?page=1', headers: headers
 
-          expect(response_json['data'].size).to eq 20
+          expect(response_json['data'].size).to eq 5
         end
 
         it 'returns 1 result on the second page' do
@@ -137,9 +137,9 @@ RSpec.describe Api::V2::PeopleController do
         end
 
         it 'allows setting a different page size' do
-          get '/api/v2/people?per_page=15', headers: headers
+          get '/api/v2/people?per_page=2', headers: headers
 
-          expect(response_json['data'].size).to eq 15
+          expect(response_json['data'].size).to eq 2
         end
 
         it 'provides meta data with pagination' do

--- a/spec/requests/api/v2/people_controller_index_spec.rb
+++ b/spec/requests/api/v2/people_controller_index_spec.rb
@@ -124,29 +124,9 @@ RSpec.describe Api::V2::PeopleController do
           }
         end
 
-        it 'paginates 5 results per page' do
-          get '/api/v2/people?page=1', headers: headers
+        before { get '/api/v2/people', params: params, headers: headers }
 
-          expect(response_json['data'].size).to eq 5
-        end
-
-        it 'returns 1 result on the second page' do
-          get '/api/v2/people?page=2', headers: headers
-
-          expect(response_json['data'].size).to eq 1
-        end
-
-        it 'allows setting a different page size' do
-          get '/api/v2/people?per_page=2', headers: headers
-
-          expect(response_json['data'].size).to eq 2
-        end
-
-        it 'provides meta data with pagination' do
-          get '/api/v2/people', headers: headers
-
-          expect(response_json['meta']['pagination']).to include_json(meta_pagination)
-        end
+        it_behaves_like 'an endpoint that paginates resources'
       end
 
       describe 'included relationships' do

--- a/spec/support/with_pagination.rb
+++ b/spec/support/with_pagination.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an endpoint that paginates resources' do
+  context 'with no pagination parameters' do
+    it 'paginates 5 results per page' do
+      expect(response_json['data'].size).to eq 5
+    end
+
+    it 'provides meta data with pagination' do
+      expect(response_json['meta']['pagination']).to include_json(meta_pagination)
+    end
+  end
+
+  context 'with page parameter' do
+    let(:params) { { page: 2 } }
+
+    it 'returns 1 result on the second page' do
+      expect(response_json['data'].size).to eq 1
+    end
+  end
+
+  context 'with per_page parameter' do
+    let(:params) { { per_page: 2 } }
+
+    it 'allows setting a different page size' do
+      expect(response_json['data'].size).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
Set a different Kaminari page default in tests. Where previously it equated to 20, set it to 5 instead and amend tests to create less fixtures. 

Also move pagination tests to a shared example.