### PR TITLE
P4-1582 Allow profiles to be associated to moves on POST/PATCH endpoints

### DIFF
--- a/app/controllers/api/v1/moves_controller.rb
+++ b/app/controllers/api/v1/moves_controller.rb
@@ -98,11 +98,11 @@ module Api
       end
 
       def profile_or_person_latest_profile
-        person_id = new_move_params.dig(:relationships, :person, :data, :id)
-        # moves are always created against the latest_profile for the person if profile not provided
-        return Person.find(person_id).latest_profile if person_id
+        profile_id = new_move_params.dig(:relationships, :profile, :data, :id)
+        return Profile.find(profile_id) if profile_id
 
-        Profile.find(new_move_params.dig(:relationships, :profile, :data, :id))
+        # moves are always created against the latest_profile for the person if profile not provided
+        Person.find(new_move_params.dig(:relationships, :person, :data, :id)).latest_profile
       end
 
       def update_move_params

--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -30,6 +30,10 @@ module Moves
       move_params.dig(:relationships, :person)
     end
 
+    def profile_attributes
+      move_params.dig(:relationships, :profile)
+    end
+
     def document_ids
       document_attributes.map { |doc| doc[:id] }
     end
@@ -43,10 +47,13 @@ module Moves
 
       attributes[:documents] = Document.where(id: document_ids) unless document_attributes.nil?
 
+      # TODO: to be removed once move profile migration complete
       unless person_attributes.nil?
         person = Person.find_by(id: person_attributes.dig(:data, :id))
         attributes[:profile] = person&.latest_profile
       end
+
+      attributes[:profile] = Profile.find_by(id: profile_attributes.dig(:data, :id)) if profile_attributes.present?
 
       attributes
     end

--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -48,7 +48,7 @@ module Moves
       attributes[:documents] = Document.where(id: document_ids) unless document_attributes.nil?
 
       # TODO: to be removed once move profile migration complete
-      unless person_attributes.nil?
+      if person_attributes.present? && profile_attributes.nil?
         person = Person.find_by(id: person_attributes.dig(:data, :id))
         attributes[:profile] = person&.latest_profile
       end

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -272,6 +272,39 @@ RSpec.describe Api::V1::MovesController do
           expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'prison_recall'
         end
       end
+
+      context 'with a profile relationship' do
+        let(:profile) { create(:profile) }
+        let(:data) do
+          {
+            type: 'moves',
+            attributes: move_attributes,
+            relationships: {
+              profile: { data: { type: 'profiles', id: profile.id } },
+              from_location: { data: { type: 'locations', id: from_location.id } },
+              to_location: to_location ? { data: { type: 'locations', id: to_location.id } } : nil,
+              documents: { data: [{ type: 'documents', id: document.id }] },
+              prison_transfer_reason: { data: { type: 'prison_transfer_reasons', id: reason.id } },
+            },
+          }
+        end
+
+        it 'associates the profile with the newly created move' do
+          expect(move.profile).to eq(profile)
+        end
+
+        it 'returns the profile in the response' do
+          expected_response = { 'type' => 'profiles', 'id' => profile.id }
+
+          expect(response_json.dig('data', 'relationships', 'profile', 'data')).to eq(expected_response)
+        end
+
+        it 'returns the profile person in the response' do
+          expected_response = { 'type' => 'people', 'id' => profile.person.id }
+
+          expect(response_json.dig('data', 'relationships', 'person', 'data')).to eq(expected_response)
+        end
+      end
     end
 
     context 'with a bad request' do

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -305,6 +305,37 @@ RSpec.describe Api::V1::MovesController do
           expect(response_json.dig('data', 'relationships', 'person', 'data')).to eq(expected_response)
         end
       end
+
+      # TODO: Remove when people/profiles migration is completed
+      context 'with a profile and person relationship' do
+        let(:person) { create(:person) }
+        let(:profile) { create(:profile) }
+
+        let(:data) do
+          {
+            type: 'moves',
+            attributes: move_attributes,
+            relationships: {
+              profile: { data: { type: 'profiles', id: profile.id } },
+              person: { data: { type: 'people', id: person.id } },
+              from_location: { data: { type: 'locations', id: from_location.id } },
+              to_location: to_location ? { data: { type: 'locations', id: to_location.id } } : nil,
+              documents: { data: [{ type: 'documents', id: document.id }] },
+              prison_transfer_reason: { data: { type: 'prison_transfer_reasons', id: reason.id } },
+            },
+          }
+        end
+
+        it 'favours the profile passed in with the newly created move' do
+          expect(move.profile).to eq(profile)
+        end
+
+        it 'returns the profile person in the response' do
+          expected_response = { 'type' => 'people', 'id' => profile.person.id }
+
+          expect(response_json.dig('data', 'relationships', 'person', 'data')).to eq(expected_response)
+        end
+      end
     end
 
     context 'with a bad request' do

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Api::V1::MovesController do
             expect { do_patch }.not_to change { move.reload.from_location }
           end
 
-          it 'returns the updated documents in the response body' do
+          it 'returns the updated person in the response body' do
             expect(
               response_json.dig('data', 'relationships', 'person', 'data', 'id'),
             ).to eq(after_person.id)
@@ -283,6 +283,66 @@ RSpec.describe Api::V1::MovesController do
 
             it 'does nothing to person on move' do
               expect(move.reload.profile.person).to eq(before_person)
+            end
+          end
+        end
+
+        context 'when changing a moves profile' do
+          let(:after_profile) { create(:profile) }
+          let(:move_params) do
+            {
+              type: 'moves',
+              attributes: {
+                status: 'requested',
+              },
+              relationships: { profile: { data: { id: after_profile.id, type: 'profiles' } } },
+            }
+          end
+
+          it 'updates the moves profile' do
+            expect(move.reload.profile).to eq(after_profile)
+          end
+
+          it 'does not affect other relationships', :skip_before do
+            expect { do_patch }.not_to change { move.reload.from_location }
+          end
+
+          it 'returns the updated profile in the response body' do
+            expect(
+              response_json.dig('data', 'relationships', 'profile', 'data', 'id'),
+            ).to eq(after_profile.id)
+          end
+
+          context 'when profile is nil' do
+            let(:move_params) do
+              {
+                type: 'moves',
+                attributes: {
+                  status: 'requested',
+                },
+                relationships: { profile: { data: nil } },
+              }
+            end
+
+            it 'unlinks profile from the move' do
+              expect(move.reload.profile).to be_nil
+            end
+          end
+
+          context 'when there is no relationship defined' do
+            let(:before_profile) { create(:profile) }
+            let!(:move) { create :move, :proposed, move_type: 'prison_recall', from_location: from_location, profile: before_profile }
+            let(:move_params) do
+              {
+                type: 'moves',
+                attributes: {
+                  status: 'requested',
+                },
+              }
+            end
+
+            it 'does nothing to profile on move' do
+              expect(move.reload.profile).to eq(before_profile)
             end
           end
         end
@@ -489,6 +549,42 @@ RSpec.describe Api::V1::MovesController do
                   status: 'requested',
                 },
                 relationships: { person: { data: nil } },
+              }
+            end
+
+            it 'updates the allocation status to unfilled' do
+              expect(move.reload.allocation).to be_unfilled
+            end
+          end
+
+          context 'when linking a profile' do
+            let!(:move) { create :move, :with_allocation, profile: nil }
+            let(:profile) { create(:profile) }
+            let(:move_params) do
+              {
+                type: 'moves',
+                attributes: {
+                  status: 'requested',
+                },
+                relationships: { profile: { data: { id: profile.id, type: 'profiles' } } },
+              }
+            end
+
+            it 'updates the allocation status to filled' do
+              expect(move.reload.allocation).to be_filled
+            end
+          end
+
+          context 'when unlinking a profile' do
+            let(:profile) { create(:profile) }
+            let!(:move) { create :move, :with_allocation, profile: profile }
+            let(:move_params) do
+              {
+                type: 'moves',
+                attributes: {
+                  status: 'requested',
+                },
+                relationships: { profile: { data: nil } },
               }
             end
 

--- a/spec/requests/api/v1/moves_controller_update_spec.rb
+++ b/spec/requests/api/v1/moves_controller_update_spec.rb
@@ -347,6 +347,35 @@ RSpec.describe Api::V1::MovesController do
           end
         end
 
+        # TODO: Remove when people/profiles migration is completed
+        context 'when changing a moves profile and person' do
+          let(:person) { create(:person) }
+          let(:profile) { create(:profile) }
+
+          let(:move_params) do
+            {
+              type: 'moves',
+              attributes: {
+                status: 'requested',
+              },
+              relationships: {
+                profile: { data: { id: profile.id, type: 'profiles' } },
+                person: { data: { id: person.id, type: 'people' } },
+              },
+            }
+          end
+
+          it 'updates the moves profile as the default' do
+            expect(move.reload.profile).to eq(profile)
+          end
+
+          it 'returns the profile person in the response' do
+            expected_response = { 'type' => 'people', 'id' => profile.person.id }
+
+            expect(response_json.dig('data', 'relationships', 'person', 'data')).to eq(expected_response)
+          end
+        end
+
         context 'when cancelling a move' do
           let(:move_params) do
             {

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -119,6 +119,9 @@ Move:
         person:
           $ref: person_reference.yaml#/PersonReference
           description: The person being moved
+        profile:
+          $ref: profile_reference.yaml#/ProfileReference
+          description: The profile for the person being moved
         from_location:
           $ref: location_reference.yaml#/LocationReference
           description: The location that the person is being moved from

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -119,9 +119,6 @@ Move:
         person:
           $ref: person_reference.yaml#/PersonReference
           description: The person being moved
-        profile:
-          $ref: profile_reference.yaml#/ProfileReference
-          description: The profile for the person being moved
         from_location:
           $ref: location_reference.yaml#/LocationReference
           description: The location that the person is being moved from


### PR DESCRIPTION
### Jira link

[P4-1582](https://dsdmoj.atlassian.net/browse/P4-1582)

### What?

I have added/removed/altered:

- [x] Added support for setting a profile in POST move endpoint
- [x] Added support for setting a profile in PATCH move endpoint

### Why?

Allow a move to be created or updated by either passing in a profile id or person id (where latest profile will be associated to a move) in relationships. The profile will take precedence unless a person id is passed in on creation. It will also take precedence with validation errors. On updates the ability has been added to either unlink an existing profile or update it to a new one. 

After migration of profiles/people is complete on moves, all person setting logic is to be cleaned up.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

