### PR TITLE
[P4-1617] Support explicit and implicit nested chains for includes

### DIFF
--- a/app/services/include_params_validator.rb
+++ b/app/services/include_params_validator.rb
@@ -6,7 +6,7 @@ class IncludeParamsValidator
   attr_reader :relationships, :supported_relationships
 
   validates_each :relationships, allow_blank: true do |record, _attr, values|
-    unsupported_values = values - record.formatted_supported_relationships
+    unsupported_values = values - record.splatted_supported_relationships
 
     unless unsupported_values.empty?
       record.errors.add 'Bad request', "#{unsupported_values} is not supported. Valid values are: #{record.supported_relationships}"
@@ -29,17 +29,17 @@ class IncludeParamsValidator
   #
   # To reflect this behaviour in the validation we need to support all variations
   # of nested chains by preformatting them in this validator.
-  def formatted_supported_relationships
-    formatted_supported_relationships = Set.new
+  def splatted_supported_relationships
+    splatted_supported_relationships = Set.new
 
     supported_relationships.each do |chain|
       split_chain = chain.split('.')
       split_chain.each_with_index do |_, index|
-        formatted_supported_relationships << split_chain[0..index].join('.')
+        splatted_supported_relationships << split_chain[0..index].join('.')
       end
     end
 
-    formatted_supported_relationships.to_a
+    splatted_supported_relationships.to_a
   end
 
   class ValidationError < StandardError

--- a/app/services/include_params_validator.rb
+++ b/app/services/include_params_validator.rb
@@ -6,7 +6,7 @@ class IncludeParamsValidator
   attr_reader :relationships, :supported_relationships
 
   validates_each :relationships, allow_blank: true do |record, _attr, values|
-    unsupported_values = values - record.supported_relationships
+    unsupported_values = values - record.formatted_supported_relationships
 
     unless unsupported_values.empty?
       record.errors.add 'Bad request', "#{unsupported_values} is not supported. Valid values are: #{record.supported_relationships}"
@@ -20,6 +20,26 @@ class IncludeParamsValidator
 
   def fully_validate!
     raise ValidationError, self if invalid?
+  end
+
+  # Active Model Serializers return all members of a nested chain
+  #
+  # For example:
+  #   'foo.bar.baz' is equivalent to ['foo', 'foo.bar', 'foo.bar.baz']
+  #
+  # To reflect this behaviour in the validation we need to support all variations
+  # of nested chains by preformatting them in this validator.
+  def formatted_supported_relationships
+    formatted_supported_relationships = Set.new
+
+    supported_relationships.each do |chain|
+      split_chain = chain.split('.')
+      split_chain.each_with_index do |_, index|
+        formatted_supported_relationships << split_chain[0..index].join('.')
+      end
+    end
+
+    formatted_supported_relationships.to_a
   end
 
   class ValidationError < StandardError

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Api::V1::MovesController do
       end
 
       describe 'included relationships' do
-        let!(:moves) { create_list(:move, 1, profile: create(:profile, person: create(:person, ethnicity: create(:ethnicity)))) }
+        let!(:moves) { create_list(:move, 1) }
         let!(:court_hearing) { create(:court_hearing, move: moves.first) }
 
         before do
@@ -151,7 +151,7 @@ RSpec.describe Api::V1::MovesController do
         end
 
         context 'when including the include query param' do
-          let(:query_params) { '?include=profile,person.ethnicity' }
+          let(:query_params) { '?include=profile' }
 
           it 'includes the requested includes in the response' do
             returned_types = response_json['included'].map { |r| r['type'] }.uniq

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Api::V1::MovesController do
       end
 
       describe 'included relationships' do
-        let!(:moves) { create_list(:move, 1) }
+        let!(:moves) { create_list(:move, 1, profile: create(:profile, person: create(:person, ethnicity: create(:ethnicity)))) }
         let!(:court_hearing) { create(:court_hearing, move: moves.first) }
 
         before do
@@ -151,9 +151,10 @@ RSpec.describe Api::V1::MovesController do
         end
 
         context 'when including the include query param' do
-          let(:query_params) { '?include=profile' }
+          let(:query_params) { '?include=profile,person.ethnicity' }
 
           it 'includes the requested includes in the response' do
+            binding.pry
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
             expect(returned_types).to contain_exactly('profiles')
           end

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -154,7 +154,6 @@ RSpec.describe Api::V1::MovesController do
           let(:query_params) { '?include=profile,person.ethnicity' }
 
           it 'includes the requested includes in the response' do
-            binding.pry
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
             expect(returned_types).to contain_exactly('profiles')
           end

--- a/spec/services/include_params_validator_spec.rb
+++ b/spec/services/include_params_validator_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe IncludeParamsValidator do
   subject(:params_validator) { described_class.new(relationships, supported_relationships) }
 
-  let(:supported_relationships) { %w[ethnicity gender bar] }
+  let(:supported_relationships) { %w[ethnicity gender bar person.profiles.flibble] }
 
   describe '#valid?' do
     context 'with supported relationships' do
@@ -15,14 +15,12 @@ RSpec.describe IncludeParamsValidator do
     end
 
     context 'with explicit unnested relationships' do
-      let(:supported_relationships) { %w[ethnicity gender person.profiles.flibble] }
       let(:relationships) { %w[person person.profiles] }
 
       it { is_expected.to be_valid }
     end
 
     context 'with implicit unnested relationships' do
-      let(:supported_relationships) { %w[ethnicity gender person.profiles.flibble] }
       let(:relationships) { %w[person.profiles.flibble] }
 
       it { is_expected.to be_valid }

--- a/spec/services/include_params_validator_spec.rb
+++ b/spec/services/include_params_validator_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe IncludeParamsValidator do
       it { is_expected.to be_valid }
     end
 
+    context 'with invalid unnested relationships' do
+      let(:relationships) { %w[profiles] }
+
+      it { is_expected.not_to be_valid }
+    end
+
     context 'with unsupported relationships' do
       let(:relationships) { %w[foo] }
 

--- a/spec/services/include_params_validator_spec.rb
+++ b/spec/services/include_params_validator_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe IncludeParamsValidator do
       it { is_expected.to be_valid }
     end
 
+    context 'with implicit unnested relationships' do
+      let(:supported_relationships) { %w[ethnicity gender person.profiles.flibble] }
+      let(:relationships) { %w[person.profiles.flibble] }
+
+      it { is_expected.to be_valid }
+    end
+
     context 'with unsupported relationships' do
       let(:relationships) { %w[foo] }
 

--- a/spec/services/include_params_validator_spec.rb
+++ b/spec/services/include_params_validator_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe IncludeParamsValidator do
       it { is_expected.to be_valid }
     end
 
+    context 'with explicit unnested relationships' do
+      let(:supported_relationships) { %w[ethnicity gender person.profiles.flibble] }
+      let(:relationships) { %w[person person.profiles] }
+
+      it { is_expected.to be_valid }
+    end
+
     context 'with unsupported relationships' do
       let(:relationships) { %w[foo] }
 


### PR DESCRIPTION

### Jira link

P4-1617

### What?

Jira link: https://dsdmoj.atlassian.net/browse/P4-1617

We've added a generic validator, see:

https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/530

This validator shares a supported relationships list with Active Model
Serializers.

AMS supports implicit and explicit forms of include query param chains
and we want our validator to support both to match this.

For example:
  'foo.bar.baz' is equivalent to ['foo', 'foo.bar', 'foo.bar.baz'] in
  AMS and ['foo.bar.baz'] in our validator

### Why?

- Makes our api more flexible and consistent

