### PR TITLE
P4-1608 Reinstate support for null `move_agreed` attribute on move model

### DIFF
--- a/db/migrate/20200603142002_change_null_move_agreed.rb
+++ b/db/migrate/20200603142002_change_null_move_agreed.rb
@@ -1,0 +1,12 @@
+class ChangeNullMoveAgreed < ActiveRecord::Migration[5.2]
+  def up
+    change_column_null :moves, :move_agreed, true
+    change_column_default :moves, :move_agreed, nil
+  end
+
+  def down
+    Move.where(move_agreed: nil).update_all(move_agreed: false)
+    change_column_default :moves, :move_agreed, false
+    change_column_null :moves, :move_agreed, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_01_091307) do
+ActiveRecord::Schema.define(version: 2020_06_03_142002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -207,7 +207,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_091307) do
     t.text "cancellation_reason_comment"
     t.integer "nomis_event_ids", default: [], null: false, array: true
     t.uuid "profile_id"
-    t.boolean "move_agreed", default: false, null: false
+    t.boolean "move_agreed"
     t.string "move_agreed_by"
     t.uuid "prison_transfer_reason_id"
     t.text "reason_comment"

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -39,4 +39,9 @@ namespace :data_maintenance do
       move.update_attribute(:nomis_event_ids, [move.nomis_event_id])
     end
   end
+
+  desc 'fix incorrect move_agreed for all moves except prison transfers'
+  task fix_move_agreed_for_non_prison_transfers: :environment do
+    Move.where(move_agreed: false).where.not(move_type: 'prison_transfer').update_all(move_agreed: nil)
+  end
 end

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -99,6 +99,10 @@ RSpec.describe Api::V1::MovesController do
         expect(response_json).to eq resource_to_json
       end
 
+      it 'does not provide a default value for move_agreed' do
+        expect(response_json.dig('data', 'attributes', 'move_agreed')).to eq nil
+      end
+
       it 'sets the additional_information' do
         expect(response_json.dig('data', 'attributes', 'additional_information')).to match 'some more info'
       end

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -43,7 +43,9 @@ Move:
           - prison_transfer
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
-          type: boolean
+          oneOf:
+          - type: boolean
+          - type: 'null'
           example: 'true'
           description: Indicates if the moved has been agreed
         move_agreed_by:


### PR DESCRIPTION
### Jira link

P4-1608

### What?

- [x] Added a migration to reinstate support for `null` values on `move_agreed` within `moves`, and to remove the default `false` value
- [x] Added a spec to check explicitly that `move_agreed` can be omitted from the create move request and the value is persisted correctly with a `null` value
- [x] Added a data maintenance rake task to remove the incorrect default value of this attribute where it has not been explicitly set

### Why?

- `move_agreed` is not specified by the front end when creating a move initially, but the request succeeds because the model is automatically defaulting the attribute to false. This is incorrect behaviour (although was seemingly intentionally added in a migration previously):

```ruby
class MoveAgreedDefaultFalse < ActiveRecord::Migration[5.2]
  def up
    Move.update_all(move_agreed: false)
    change_column_default :moves, :move_agreed, false
    change_column_null :moves, :move_agreed, false
  end

  def down
    change_column_null :moves, :move_agreed, true
    change_column_default :moves, :move_agreed, nil
  end
end
```

- The `move_agreed` attribute is explicitly set later in the user journey when attaching a person/profile to the move - user should be prompted to explicitly answer this question. However if the value has already been defaulted to `false` then the user is not prompted. A value of `null` means that the question has never been answered and the user should be prompted.

- As a workaround in the front end the `move_type` is checked and if not a `prison_transfer` request the user is always prompted to answer the "move agreed" question, even if `move_agreed` is already false. This workaround breaks down now that we have introduced allocations and means that the user is being asked the question unnecessarily.

- Once this change is merged and the data has been corrected the front end can be updated to remove the above workaround and rely on the `move_agreed` value. Some coordination will be needed to make the production data fix immediately before deploying the corresponding front end.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Includes a data fix task - this must be run immediately prior to deploying the corresponding front end change that removes the workaround to ignore the current value of `move_agreed` (or possibly run after, which would be safe but potentially still annoy users by asking the question unnecessarily).
- Changes the behaviour slightly of an existing production api (i.e. when creating a move)