### PR TITLE
P4-1495 Add Profile v2 POST endpoint

### DIFF
--- a/app/controllers/api/v2/profiles_controller.rb
+++ b/app/controllers/api/v2/profiles_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class ProfilesController < ApiController
+      def create
+        profile = person.profiles.create(profile_attributes)
+        render json: profile, status: :created, serializer: ::V2::ProfileSerializer
+      end
+
+    private
+
+      PROFILE_ATTRIBUTES = [
+        :type,
+        attributes: [
+          assessment_answers: [
+            %i[
+              key
+              date
+              expiry_data
+              category
+              title
+              comments
+              assessment_question_id
+              nomis_alert_type
+              nomis_alert_type_description
+              nomis_alert_code
+              nomis_alert_description
+              created_at
+              expires_at
+              imported_from_nomis
+            ],
+          ],
+        ],
+      ].freeze
+
+      def profile_params
+        params.require(:data).permit(PROFILE_ATTRIBUTES).to_h
+      end
+
+      def profile_attributes
+        # TODO: will be removed once we remove first name and last name from profiles
+        profile_params[:attributes].merge(first_names: person.first_names, last_name: person.last_name)
+      end
+
+      def person
+        @person ||= Person.find(params.require(:person_id))
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/profiles_controller.rb
+++ b/app/controllers/api/v2/profiles_controller.rb
@@ -5,7 +5,7 @@ module Api
     class ProfilesController < ApiController
       def create
         profile = person.profiles.create(profile_attributes)
-        render json: profile, status: :created, serializer: ::V2::ProfileSerializer
+        render json: profile, status: :created, include: included_relationships, serializer: ::V2::ProfileSerializer
       end
 
     private
@@ -45,6 +45,10 @@ module Api
 
       def person
         @person ||= Person.find(params.require(:person_id))
+      end
+
+      def supported_relationships
+        ::V2::ProfileSerializer::SUPPORTED_RELATIONSHIPS
       end
     end
   end

--- a/app/serializers/v2/profile_serializer.rb
+++ b/app/serializers/v2/profile_serializer.rb
@@ -3,9 +3,7 @@
 module V2
   class ProfileSerializer < ActiveModel::Serializer
     attributes(
-      :id,
       :assessment_answers,
-      :latest_nomis_booking_id,
     )
   end
 end

--- a/app/serializers/v2/profile_serializer.rb
+++ b/app/serializers/v2/profile_serializer.rb
@@ -5,5 +5,9 @@ module V2
     attributes(
       :assessment_answers,
     )
+
+    belongs_to :person, serializer: PersonSerializer
+
+    SUPPORTED_RELATIONSHIPS = %w[person].freeze
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,9 @@ Rails.application.routes.draw do
     end
 
     namespace :v2 do
-      resources :people, only: %i[index create]
+      resources :people, only: %i[index create] do
+        resources :profiles, only: %i[create]
+      end
     end
   end
 end

--- a/spec/requests/api/v2/profiles_controller_create_spec.rb
+++ b/spec/requests/api/v2/profiles_controller_create_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V2::ProfilesController do
+  let(:response_json) { JSON.parse(response.body) }
+  let(:access_token) { create(:access_token).token }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
+  let(:person) { create(:person_without_profiles) }
+  let(:risk_type_1) { create :assessment_question, :risk }
+  let(:risk_type_2) { create :assessment_question, :risk }
+
+  describe 'POST /v2/people/:id/profiles' do
+    let(:schema) { load_yaml_schema('post_profile_responses.yaml', version: 'v2') }
+
+    let(:profile_params) do
+      {
+        data: {
+          type: 'profiles',
+          attributes: {
+            assessment_answers: [
+              { title: risk_type_1.title, assessment_question_id: risk_type_1.id },
+              { title: risk_type_2.title, assessment_question_id: risk_type_2.id },
+            ],
+          },
+        },
+      }
+    end
+
+    let(:expected_data) do
+      {
+        type: 'profiles',
+        attributes: {
+          assessment_answers: [
+            { title: risk_type_1.title, assessment_question_id: risk_type_1.id },
+            { title: risk_type_2.title, assessment_question_id: risk_type_2.id },
+          ],
+        },
+      }
+    end
+
+    context 'with valid params' do
+      before { post "/api/v2/people/#{person.id}/profiles", params: profile_params, headers: headers, as: :json }
+
+      it_behaves_like 'an endpoint that responds with success 201'
+
+      it 'returns the correct data' do
+        expect(response_json['data']).to include_json(expected_data)
+      end
+
+      it 'creates a new profile' do
+        expect {
+          post "/api/v2/people/#{person.id}/profiles", params: profile_params, headers: headers, as: :json
+        }.to change(Profile, :count).by(1)
+      end
+    end
+
+    context 'with a person associated to multiple profiles' do
+      it 'maintains previous profiles associated to the person' do
+        person = create(:person)
+
+        expect {
+          post "/api/v2/people/#{person.id}/profiles", params: profile_params, headers: headers, as: :json
+        }.to change(Profile, :count).from(1).to(2)
+      end
+    end
+
+    context 'with a bad request' do
+      before { post "/api/v2/people/#{person.id}/profiles", params: {}, headers: headers, as: :json }
+
+      it_behaves_like 'an endpoint that responds with error 400'
+    end
+
+    context 'when not authorized', :with_invalid_auth_headers do
+      let(:detail_401) { 'Token expired or invalid' }
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
+      let(:content_type) { ApiController::CONTENT_TYPE }
+
+      before { post "/api/v2/people/#{person.id}/profiles", params: profile_params, headers: headers, as: :json }
+
+      it_behaves_like 'an endpoint that responds with error 401'
+    end
+
+    context 'with an invalid CONTENT_TYPE header' do
+      let(:content_type) { 'application/xml' }
+
+      before { post "/api/v2/people/#{person.id}/profiles", params: profile_params, headers: headers, as: :json }
+
+      it_behaves_like 'an endpoint that responds with error 415'
+    end
+  end
+end

--- a/spec/serializers/v2/profile_serializer_spec.rb
+++ b/spec/serializers/v2/profile_serializer_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe V2::ProfileSerializer do
     expect(result[:data][:id]).to eql profile.id
   end
 
-  it 'contains latest_nomis_booking_id' do
-    expect(result[:data][:attributes][:latest_nomis_booking_id]).to eql profile.latest_nomis_booking_id
-  end
-
   describe '#assessment_answers' do
     let(:risk_alert_type) { create :assessment_question, :risk }
     let(:health_alert_type) { create :assessment_question, :health }

--- a/swagger/v2/post_profile_responses.yaml
+++ b/swagger/v2/post_profile_responses.yaml
@@ -4,7 +4,7 @@
   - data
   properties:
     data:
-      $ref: profile.yaml#/Profile
+      $ref: '../v2/profile.yaml#/Profile'
 '400':
   type: object
   required:
@@ -13,7 +13,7 @@
     errors:
       type: array
       items:
-        $ref: errors.yaml#/BadRequest
+        $ref: '../v1/errors.yaml#/BadRequest'
 '401':
   type: object
   required:
@@ -22,7 +22,7 @@
     errors:
       type: array
       items:
-        $ref: errors.yaml#/NotAuthorisedError
+        $ref: '../v1/errors.yaml#/NotAuthorisedError'
 '404':
   type: object
   required:
@@ -31,7 +31,7 @@
     errors:
       type: array
       items:
-        $ref: errors.yaml#/ResourceNotFound
+        $ref: '../v1/errors.yaml#/ResourceNotFound'
 '415':
   type: object
   required:
@@ -40,7 +40,7 @@
     errors:
       type: array
       items:
-        $ref: errors.yaml#/UnsupportedMediaType
+        $ref: '../v1/errors.yaml#/UnsupportedMediaType'
 '422':
   type: object
   required:
@@ -49,4 +49,4 @@
     errors:
       type: array
       items:
-        $ref: errors.yaml#/UnprocessableEntity
+        $ref: '../v1/errors.yaml#/UnprocessableEntity'

--- a/swagger/v2/post_profile_responses.yaml
+++ b/swagger/v2/post_profile_responses.yaml
@@ -1,0 +1,52 @@
+'201':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: profile.yaml#/Profile
+'400':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError
+'404':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/ResourceNotFound
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnsupportedMediaType
+'422':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnprocessableEntity

--- a/swagger/v2/profile.yaml
+++ b/swagger/v2/profile.yaml
@@ -28,12 +28,3 @@ Profile:
           description:
             Collection of court information, risk and alerts that escorts
             need to be aware of for safety, security and other reasons
-    relationships:
-      type: object
-      properties:
-        gender:
-          $ref: "../v1/gender_reference.yaml#/GenderReference"
-          description: Profile's gender
-        ethnicity:
-          $ref: "../v1/ethnicity_reference.yaml#/EthnicityReference"
-          description: Profile's ethnicity


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-1495

### Jira link

[P4-1495](https://dsdmoj.atlassian.net/browse/P4-1495)
### What?

I have added/removed/altered:

- [x] Add new nested endpoint for creating a V2 profile

### Why?

To migrate to the new structure of person/profile, allow the new profile to be created under a new V2 endpoint `people/:id/profiles` which will accept only the assessment answers, and return the created profile. There is some legacy logic around validating existing first/last names on the profile, so for now we are maintaining those until migration is complete

### Have you? (optional)

- [ ] Updated API docs if necessary	
