### PR TITLE
Return supplier on locations for moves

### DIFF
--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -32,7 +32,9 @@ class MoveSerializer < ActiveModel::Serializer
     person.ethnicity
     person.gender
     from_location
+    from_location.suppliers
     to_location
+    to_location.suppliers
     documents
     prison_transfer_reason
     court_hearings

--- a/app/services/include_params_validator.rb
+++ b/app/services/include_params_validator.rb
@@ -9,7 +9,7 @@ class IncludeParamsValidator
     unsupported_values = values - record.splatted_supported_relationships
 
     unless unsupported_values.empty?
-      record.errors.add 'Bad request', "#{unsupported_values} is not supported. Valid values are: #{record.supported_relationships}"
+      record.errors.add 'Bad request', "#{unsupported_values} is not supported. Valid values are: #{record.splatted_supported_relationships}"
     end
   end
 

--- a/spec/requests/api/v1/allocations_controller_index_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_index_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Api::V1::AllocationsController do
               'errors' => [
                 {
                   'title' => 'Bad request',
-                  'detail' => '["foo.bar"] is not supported. Valid values are: ["from_location", "to_location", "moves.person"]',
+                  'detail' => '["foo.bar"] is not supported. Valid values are: ["from_location", "to_location", "moves", "moves.person"]',
                 },
               ],
             }

--- a/spec/requests/api/v1/moves_controller_index_spec.rb
+++ b/spec/requests/api/v1/moves_controller_index_spec.rb
@@ -134,8 +134,19 @@ RSpec.describe Api::V1::MovesController do
       end
 
       describe 'included relationships' do
-        let!(:moves) { create_list(:move, 1) }
+        let!(:moves) do
+          create_list(
+            :move,
+            1,
+            from_location: from_location,
+            to_location: to_location,
+          )
+        end
+
         let!(:court_hearing) { create(:court_hearing, move: moves.first) }
+
+        let(:to_location) { create(:location, suppliers: [supplier]) }
+        let(:from_location) { create(:location, suppliers: [supplier]) }
 
         before do
           get "/api/v1/moves#{query_params}", params: params, headers: headers
@@ -146,7 +157,7 @@ RSpec.describe Api::V1::MovesController do
 
           it 'returns the default includes' do
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
-            expect(returned_types).to contain_exactly('ethnicities', 'genders', 'locations', 'people', 'profiles')
+            expect(returned_types).to contain_exactly('ethnicities', 'genders', 'locations', 'people', 'profiles', 'suppliers')
           end
         end
 

--- a/spec/services/include_params_validator_spec.rb
+++ b/spec/services/include_params_validator_spec.rb
@@ -68,10 +68,23 @@ RSpec.describe IncludeParamsValidator do
 
     context 'when not valid' do
       let(:relationships) { %w[foo] }
+      let(:expected_message) do
+        {
+          "Bad request": [
+            '["foo"] is not supported. Valid values are: ["ethnicity", "gender", "bar", "person", "person.profiles", "person.profiles.flibble"]',
+          ],
+        }
+      end
 
       it 'propagates a custom validation error' do
         expect { params_validator.fully_validate! }
           .to raise_error(described_class::ValidationError)
+      end
+
+      it 'propagates the correct validation error messages' do
+        params_validator.fully_validate!
+      rescue described_class::ValidationError => e
+        expect(e.errors.messages).to eq(expected_message)
       end
     end
   end

--- a/swagger/v1/get_moves_responses.yaml
+++ b/swagger/v1/get_moves_responses.yaml
@@ -1,7 +1,7 @@
-'200':
+"200":
   type: object
   required:
-  - data
+    - data
   properties:
     data:
       type: array
@@ -11,12 +11,13 @@
       type: array
       items:
         anyOf:
-        - $ref: location.yaml#/Location
-        - $ref: person.yaml#/Person
-        - $ref: gender.yaml#/Gender
-        - $ref: ethnicity.yaml#/Ethnicity
-        - $ref: allocation.yaml#/Allocation
-        - $ref: profile.yaml#/Profile
+          - $ref: location.yaml#/Location
+          - $ref: person.yaml#/Person
+          - $ref: gender.yaml#/Gender
+          - $ref: ethnicity.yaml#/Ethnicity
+          - $ref: allocation.yaml#/Allocation
+          - $ref: profile.yaml#/Profile
+          - $ref: supplier.yaml#/Supplier
     links:
       $ref: pagination_links.yaml#/PaginationLinks
     meta:
@@ -24,37 +25,37 @@
       properties:
         pagination:
           $ref: pagination.yaml#/Pagination
-'400':
+"400":
   type: object
   required:
-  - errors
+    - errors
   properties:
     errors:
       type: array
       items:
         $ref: errors.yaml#/BadRequest
-'401':
+"401":
   type: object
   required:
-  - errors
+    - errors
   properties:
     errors:
       type: array
       items:
         $ref: errors.yaml#/NotAuthorisedError
-'415':
+"415":
   type: object
   required:
-  - errors
+    - errors
   properties:
     errors:
       type: array
       items:
         $ref: errors.yaml#/UnsupportedMediaType
-'422':
+"422":
   type: object
   required:
-  - errors
+    - errors
   properties:
     errors:
       type: array


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

- [x] Adds support for explicit support includes
- [x] Adds support for returning suppliers on a from and to location in a move 

### Why?

To clarify supported relationships for the frontend/suppliers
To support the way moves are being consumed by the frontend