### PR TITLE
P4-1579 Add new endpoint to explicitly reject a move

### DIFF
--- a/app/controllers/api/v1/move_events_controller.rb
+++ b/app/controllers/api/v1/move_events_controller.rb
@@ -9,6 +9,7 @@ module Api
       COMPLETE_PARAMS = [:type, attributes: %i[timestamp notes]].freeze
       LOCKOUT_PARAMS = [:type, attributes: %i[timestamp notes], relationships: { from_location: {} }].freeze
       REDIRECT_PARAMS = [:type, attributes: %i[timestamp notes], relationships: { to_location: {} }].freeze
+      REJECT_PARAMS = [:type, attributes: %i[timestamp rejection_reason cancellation_reason_comment]].freeze
       DEPRECATED_EVENT_PARAMS = [:type, attributes: %i[timestamp event_name notes], relationships: { to_location: {} }].freeze
 
       def cancel
@@ -32,6 +33,12 @@ module Api
       def redirects
         validate_params!(redirect_params, require_to_location: true)
         process_event(move, Event::REDIRECT, redirect_params)
+        render status: :no_content
+      end
+
+      def reject
+        validate_params!(reject_params)
+        process_event(move, Event::REJECT, reject_params)
         render status: :no_content
       end
 
@@ -95,6 +102,10 @@ module Api
 
       def redirect_params
         @redirect_params ||= params.require(:data).permit(REDIRECT_PARAMS).to_h
+      end
+
+      def reject_params
+        @reject_params ||= params.require(:data).permit(REJECT_PARAMS).to_h
       end
 
       def deprecated_event_params

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,7 @@ class Event < ApplicationRecord
     UNCOMPLETE = 'uncomplete'.freeze,
     REDIRECT = 'redirect'.freeze,
     LOCKOUT = 'lockout'.freeze,
+    REJECT = 'reject'.freeze,
   ].freeze
 
   belongs_to :eventable, polymorphic: true

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -32,6 +32,11 @@ class Move < VersionedModel
     CANCELLATION_REASON_OTHER = 'other',
   ].freeze
 
+  REJECTION_REASONS = [
+    REJECTION_REASON_NO_SPACE = 'no_space_at_receiving_prison',
+    REJECTION_REASON_NO_TRANSPORT = 'no_transport_available',
+  ].freeze
+
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location', optional: true
   belongs_to :profile, optional: true
@@ -62,6 +67,9 @@ class Move < VersionedModel
   validates :cancellation_reason, inclusion: { in: CANCELLATION_REASONS }, if: :cancelled?
   validates :cancellation_reason, absence: true, unless: :cancelled?
 
+  validates :rejection_reason, inclusion: { in: REJECTION_REASONS }, allow_nil: true, if: :rejected?
+  validates :rejection_reason, absence: true, unless: :rejected?
+
   validate :date_to_after_date_from
 
   before_validation :set_reference
@@ -83,6 +91,10 @@ class Move < VersionedModel
 
   def self.unfilled?
     none? || exists?(profile_id: nil)
+  end
+
+  def rejected?
+    cancellation_reason == CANCELLATION_REASON_REJECTED
   end
 
   def nomis_event_id=(event_id)

--- a/app/models/move_event.rb
+++ b/app/models/move_event.rb
@@ -1,6 +1,10 @@
 class MoveEvent < Event
   # NB: this class exposes a few methods specific to moves to the Event model
 
+  def rejection_reason
+    @rejection_reason ||= event_params.dig(:attributes, :rejection_reason)
+  end
+
   def cancellation_reason
     @cancellation_reason ||= event_params.dig(:attributes, :cancellation_reason)
   end

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -10,6 +10,7 @@ class MoveSerializer < ActiveModel::Serializer
              :date,
              :move_type,
              :additional_information,
+             :rejection_reason,
              :cancellation_reason,
              :cancellation_reason_comment,
              :move_agreed,

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -15,6 +15,11 @@ module EventLog
           move.status = Move::MOVE_STATUS_CANCELLED
           move.cancellation_reason = event.cancellation_reason
           move.cancellation_reason_comment = event.cancellation_reason_comment
+        when Event::REJECT
+          move.status = Move::MOVE_STATUS_CANCELLED
+          move.rejection_reason = event.rejection_reason
+          move.cancellation_reason = Move::CANCELLATION_REASON_REJECTED
+          move.cancellation_reason_comment = event.cancellation_reason_comment
         when Event::COMPLETE
           move.status = Move::MOVE_STATUS_COMPLETED
         when Event::LOCKOUT

--- a/app/services/move_events/params_validator.rb
+++ b/app/services/move_events/params_validator.rb
@@ -4,10 +4,11 @@ module MoveEvents
   class ParamsValidator
     include ActiveModel::Validations
 
-    attr_reader :timestamp, :type, :cancellation_reason
+    attr_reader :timestamp, :type, :cancellation_reason, :rejection_reason
 
-    validates :type, presence: true, inclusion: { in: %w[cancel complete lockouts redirects events] } # TODO: remove 'events' type once FE updated
+    validates :type, presence: true, inclusion: { in: %w[cancel complete lockouts redirects reject events] } # TODO: remove 'events' type once FE updated
     validates :cancellation_reason, inclusion: { in: Move::CANCELLATION_REASONS }, if: -> { type == 'cancel' }
+    validates :rejection_reason, inclusion: { in: Move::REJECTION_REASONS }, if: -> { type == 'reject' }
     validates_each :timestamp, presence: true do |record, attr, value|
       Time.iso8601(value)
     rescue ArgumentError
@@ -18,6 +19,7 @@ module MoveEvents
       @timestamp = params.dig(:attributes, :timestamp)
       @type = params[:type]
       @cancellation_reason = params.dig(:attributes, :cancellation_reason)
+      @rejection_reason = params.dig(:attributes, :rejection_reason)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
           post 'complete', controller: 'move_events'
           post 'lockouts', controller: 'move_events'
           post 'redirects', controller: 'move_events'
+          post 'reject', controller: 'move_events'
         end
       end
       namespace :reference do

--- a/db/migrate/20200605123822_add_rejection_reason_to_moves.rb
+++ b/db/migrate/20200605123822_add_rejection_reason_to_moves.rb
@@ -1,0 +1,5 @@
+class AddRejectionReasonToMoves < ActiveRecord::Migration[5.2]
+  def change
+    add_column :moves, :rejection_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_03_142002) do
+ActiveRecord::Schema.define(version: 2020_06_05_123822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -214,6 +214,7 @@ ActiveRecord::Schema.define(version: 2020_06_03_142002) do
     t.date "date_from"
     t.date "date_to"
     t.uuid "allocation_id"
+    t.string "rejection_reason"
     t.index ["allocation_id"], name: "index_moves_on_allocation_id"
     t.index ["created_at"], name: "index_moves_on_created_at"
     t.index ["date"], name: "index_moves_on_date"

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -45,6 +45,10 @@ FactoryBot.define do
       event_name { 'lockout' }
     end
 
+    trait :reject do
+      event_name { 'reject' }
+    end
+
     # NB: move_event factory inherits from the event factory
     factory :move_event, class: 'MoveEvent' do
       details do
@@ -75,6 +79,18 @@ FactoryBot.define do
             attributes: {
               cancellation_reason: nil,
               cancellation_reason_comment: 'this is a broken event',
+            },
+          } }
+        end
+      end
+
+      trait :reject do
+        event_name { 'reject' }
+        details do
+          { event_params: {
+            attributes: {
+              rejection_reason: 'no_transport_available',
+              cancellation_reason_comment: 'computer says no',
             },
           } }
         end

--- a/spec/requests/api/v1/move_events_controller_reject_spec.rb
+++ b/spec/requests/api/v1/move_events_controller_reject_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::MoveEventsController do
+  let(:response_json) { JSON.parse(response.body) }
+
+  describe 'POST /moves/:move_id/reject' do
+    let(:schema) { load_yaml_schema('post_move_events_responses.yaml') }
+
+    let(:supplier) { create(:supplier) }
+    let(:application) { create(:application, owner_id: supplier.id) }
+    let(:access_token) { create(:access_token, application: application).token }
+    let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
+    let(:content_type) { ApiController::CONTENT_TYPE }
+
+    let(:move) { create(:move) }
+    let(:move_id) { move.id }
+    let(:reject_params) do
+      {
+        data: {
+          type: 'reject',
+          attributes: {
+            timestamp: '2020-04-23T18:25:43.511Z',
+            rejection_reason: 'no_space_at_receiving_prison',
+            cancellation_reason_comment: 'no room on the broom',
+          },
+        },
+      }
+    end
+
+    before do
+      allow(Notifier).to receive(:prepare_notifications)
+      post "/api/v1/moves/#{move_id}/reject", params: reject_params, headers: headers, as: :json
+    end
+
+    context 'when successful' do
+      it_behaves_like 'an endpoint that responds with success 204'
+
+      it 'updates the move status' do
+        expect(move.reload.status).to eql('cancelled')
+      end
+
+      it 'updates the move cancellation_reason' do
+        expect(move.reload.cancellation_reason).to eql('rejected')
+      end
+
+      it 'updates the move cancellation_reason_comment' do
+        expect(move.reload.cancellation_reason_comment).to eql('no room on the broom')
+      end
+
+      it 'updates the move rejection_reason' do
+        expect(move.reload.rejection_reason).to eql('no_space_at_receiving_prison')
+      end
+
+      describe 'webhook and email notifications' do
+        it 'calls the notifier when updating a person' do
+          expect(Notifier).to have_received(:prepare_notifications).with(topic: move, action_name: 'update_status')
+        end
+      end
+    end
+
+    context 'with a bad request' do
+      let(:reject_params) { nil }
+
+      it_behaves_like 'an endpoint that responds with error 400'
+    end
+
+    context 'when not authorized' do
+      let(:access_token) { 'foo-bar' }
+      let(:detail_401) { 'Token expired or invalid' }
+
+      it_behaves_like 'an endpoint that responds with error 401'
+    end
+
+    context 'with a missing move_id' do
+      let(:move_id) { 'foo-bar' }
+      let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
+
+      it_behaves_like 'an endpoint that responds with error 404'
+    end
+
+    context 'with an invalid CONTENT_TYPE header' do
+      let(:content_type) { 'application/xml' }
+
+      it_behaves_like 'an endpoint that responds with error 415'
+    end
+
+    context 'with validation errors' do
+      context 'with a bad timestamp' do
+        let(:reject_params) { { data: { type: 'reject', attributes: { timestamp: 'Foo-Bar', rejection_reason: 'no_space_at_receiving_prison' } } } }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) { [{ 'title' => 'Invalid timestamp', 'detail' => 'Validation failed: Timestamp must be formatted as a valid ISO-8601 date-time' }] }
+        end
+      end
+
+      context 'with a bad event type' do
+        let(:reject_params) { { data: { type: 'Foo-bar', attributes: { timestamp: '2020-04-23T18:25:43.511Z', rejection_reason: 'no_space_at_receiving_prison' } } } }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) { [{ 'title' => 'Invalid type', 'detail' => 'Validation failed: Type is not included in the list' }] }
+        end
+      end
+
+      context 'with a bad rejection_reason' do
+        let(:reject_params) { { data: { type: 'reject', attributes: { timestamp: '2020-04-23T18:25:43.511Z', rejection_reason: 'Yo Momma' } } } }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) { [{ 'title' => 'Invalid rejection_reason', 'detail' => 'Validation failed: Rejection reason is not included in the list' }] }
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe MoveSerializer do
       expect(attributes[:move_type]).to eql move.move_type
     end
 
+    it 'contains a rejection_reason attribute' do
+      expect(attributes[:rejection_reason]).to eql move.rejection_reason
+    end
+
     it 'contains a date attribute' do
       expect(attributes[:date]).to eql move.date.iso8601
     end

--- a/spec/services/move_events/params_validator_spec.rb
+++ b/spec/services/move_events/params_validator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe MoveEvents::ParamsValidator do
   let(:timestamp) { '2020-04-29T22:45:59.000Z' }
   let(:type) { 'redirects' }
   let(:cancellation_reason) { 'supplier_declined_to_move' }
+  let(:rejection_reason) { 'no_transport_available' }
 
   context 'when valid' do
     it { is_expected.to be_valid }
@@ -31,6 +32,28 @@ RSpec.describe MoveEvents::ParamsValidator do
 
     context 'when missing' do
       before { params.delete(:cancellation_reason) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe 'rejection_reason' do
+    let(:type) { 'reject' }
+
+    context 'when invalid' do
+      let(:rejection_reason) { 'foo-bar' }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when nil' do
+      let(:rejection_reason) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when missing' do
+      before { params.delete(:rejection_reason) }
 
       it { is_expected.not_to be_valid }
     end

--- a/spec/swagger/definitions/hand_coded_paths_v1.yaml
+++ b/spec/swagger/definitions/hand_coded_paths_v1.yaml
@@ -813,6 +813,68 @@
           application/vnd.api+json:
             schema:
               $ref: error_responses.yaml#/422
+/moves/{move_id}/reject:
+  post:
+    summary: 'Rejects a move'
+    description: |
+      Rejecting a move will change the move status to `cancelled`, the move cancellation reason to `rejected` and update with the provided rejection reason.
+    tags:
+      - Moves
+    consumes:
+      - application/vnd.api+json
+    parameters:
+      - $ref: move_id_parameter.yaml#/MoveId
+      - $ref: idempotency_key_parameter.yaml#/IdempotencyKey
+      - $ref: content_type_parameter.yaml#/ContentType
+      - name: body
+        in: body
+        required: true
+        description: |
+          ### Rejecting a Move
+
+          Rejecting a move will change the move status to `cancelled`, the move cancellation reason to `rejected` and update with the provided rejection reason.
+        schema:
+          $ref: post_move_reject.yaml#/PostMoveReject
+    responses:
+      '204':
+        description: no content
+        content:
+      '400':
+        description: bad request
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/400
+      '401':
+        description: unauthorized
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/401
+      '404':
+        description: resource not found
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/404
+      '409':
+        description: conflict
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/409
+      '415':
+        description: invalid media type
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/415
+      '422':
+        description: unprocessable entity
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/422
 /moves/{move_id}/complete:
   post:
     summary: 'Completes a move'

--- a/swagger/v1/move_rejection_reason_attribute.yaml
+++ b/swagger/v1/move_rejection_reason_attribute.yaml
@@ -1,0 +1,7 @@
+MoveRejectionReason:
+  type: string
+  example: made_in_error
+  enum:
+  - no_space_at_receiving_prison
+  - no_transport_available
+  description: The reason the move has been rejected

--- a/swagger/v1/post_move_reject.yaml
+++ b/swagger/v1/post_move_reject.yaml
@@ -1,0 +1,24 @@
+PostMoveReject:
+  type: object
+  required:
+  - type
+  - attributes
+  properties:
+    type:
+      type: string
+      example: reject
+      enum:
+      - reject
+      description: The type of this object - always `reject`
+    attributes:
+      type: object
+      required:
+      - timestamp
+      - rejection_reason
+      properties:
+        timestamp:
+          $ref: timestamp_attribute.yaml#/Timestamp
+        rejection_reason:
+          $ref: move_rejection_reason_attribute.yaml#/MoveRejectionReason
+        cancellation_reason_comment:
+          $ref: move_cancellation_reason_comment_attribute.yaml#/MoveCancellationReasonComment


### PR DESCRIPTION
### Jira link

P4-1579

### What?

- [x] Adds a new endpoint `POST /moves/:move_id/reject`
- [x] Adds a new event type of `reject` and appropriate behaviour in event runner

### Why?

- This will be called when the OCA rejects a singleton move - they must specify a reason for rejecting the move, and optionally include a comment (which is stored in the existing cancellation_reason_comment attribute.
- It's currently possible to reject a move by calling the `PATCH /moves/:move_id` endpoint but we want to deprecate that approach and instead use distinct endpoints which change move status.
- This is a special case of cancelling a move so is worthy of it's own endpoint that requires a rejection reason to be specified.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Adds a new endpoint, doesn't affect existing production endpoints so minimal risk
