### PR TITLE
tweak connection pool and sidekiq concurrency

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,7 @@ default: &default
   adapter: postgresql
   username: <%= ENV["DB_USERNAME"] %>
   host: localhost
+  pool: <%= ENV['DB_POOL'] || ENV['RAILS_MAX_THREADS'] || 6 %>
 
 development:
   <<: *default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,7 +4,7 @@
 # pick it up automatically.
 ---
 :verbose: false
-:concurrency: 10
+:concurrency: <%= ENV['SIDEKIQ_PROCESSES'] || ENV['RAILS_MAX_THREADS'] || 3 %>
 :timeout: 25
 
 :queues:


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [X] specify db pools, rails threads and sidekiq concurrency from env vars


### Why?

I am doing this because:

- we get repeated database errors "ActiveRecord::ConnectionTimeoutError: could not obtain a connection from the pool within 5.000 seconds (waited 5.000 seconds); all pool..."

- this should ensure the pool size is always larger than that required to service requests.

### Deployment risks (optional)

- potentially a bit risky - but should be ok 🤞 

Related PR: https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy/pull/63