### PR TITLE
Adds support for allocation.moves.person.{gender,ethnicity}

### DIFF
--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -19,5 +19,5 @@ class AllocationSerializer < ActiveModel::Serializer
   has_one :to_location
   has_many :moves
 
-  SUPPORTED_RELATIONSHIPS = %w[from_location to_location moves.person].freeze
+  SUPPORTED_RELATIONSHIPS = %w[from_location to_location moves.person moves.person.gender moves.person.ethnicity ].freeze
 end

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -19,5 +19,5 @@ class AllocationSerializer < ActiveModel::Serializer
   has_one :to_location
   has_many :moves
 
-  SUPPORTED_RELATIONSHIPS = %w[from_location to_location moves.person moves.person.gender moves.person.ethnicity ].freeze
+  SUPPORTED_RELATIONSHIPS = %w[from_location to_location moves.person moves.person.gender moves.person.ethnicity].freeze
 end

--- a/spec/requests/api/v1/allocations_controller_index_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_index_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Api::V1::AllocationsController do
 
           it 'returns the default includes' do
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
-            expect(returned_types).to contain_exactly('people', 'moves', 'locations')
+            expect(returned_types).to contain_exactly('people', 'moves', 'locations', 'genders', 'ethnicities')
           end
         end
 
@@ -217,7 +217,7 @@ RSpec.describe Api::V1::AllocationsController do
               'errors' => [
                 {
                   'title' => 'Bad request',
-                  'detail' => '["foo.bar"] is not supported. Valid values are: ["from_location", "to_location", "moves", "moves.person"]',
+                  'detail' => '["foo.bar"] is not supported. Valid values are: ["from_location", "to_location", "moves", "moves.person", "moves.person.gender", "moves.person.ethnicity"]',
                 },
               ],
             }
@@ -243,7 +243,7 @@ RSpec.describe Api::V1::AllocationsController do
 
           it 'returns the default includes' do
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
-            expect(returned_types).to contain_exactly('people', 'moves', 'locations')
+            expect(returned_types).to contain_exactly('people', 'moves', 'locations', 'genders', 'ethnicities')
           end
         end
       end

--- a/spec/serializers/allocation_serializer_spec.rb
+++ b/spec/serializers/allocation_serializer_spec.rb
@@ -116,32 +116,30 @@ RSpec.describe AllocationSerializer do
   end
 
   describe 'moves' do
-    context 'with a move' do
-      let(:adapter_options) do
-        { include: AllocationSerializer::SUPPORTED_RELATIONSHIPS }
-      end
-      let(:allocation) { create(:allocation, :with_moves) }
-      let(:move) { allocation.moves.first }
+    let(:adapter_options) do
+      { include: AllocationSerializer::SUPPORTED_RELATIONSHIPS }
+    end
+    let(:allocation) { create(:allocation, :with_moves) }
+    let(:move) { allocation.moves.first }
 
-      it 'contains a moves relationship' do
-        expect(result_data[:relationships][:moves][:data]).to contain_exactly(id: move.id, type: 'moves')
-      end
-
-      it 'contains an included move and person' do
-        expect(result[:included].map { |r| r[:type] }).to match_array(%w[people moves locations locations])
-      end
+    it 'contains a moves relationship' do
+      expect(result_data[:relationships][:moves][:data]).to contain_exactly(id: move.id, type: 'moves')
     end
 
-    context 'without a move' do
-      let(:adapter_options) { { include: AllocationSerializer::SUPPORTED_RELATIONSHIPS } }
+    it 'contains an included move and person' do
+      expect(result[:included].map { |r| r[:type] }).to match_array(%w[people moves locations locations genders ethnicities])
+    end
+  end
 
-      it 'contains empty moves' do
-        expect(result_data[:relationships][:moves][:data]).to be_empty
-      end
+  context 'without a move' do
+    let(:adapter_options) { { include: AllocationSerializer::SUPPORTED_RELATIONSHIPS } }
 
-      it 'does not contain an included allocation' do
-        expect(result[:included].map { |r| r[:type] }).to match_array(%w[locations locations])
-      end
+    it 'contains empty moves' do
+      expect(result_data[:relationships][:moves][:data]).to be_empty
+    end
+
+    it 'does not contain an included allocation' do
+      expect(result[:included].map { |r| r[:type] }).to match_array(%w[locations locations])
     end
   end
 end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

- [x] Support `moves.person.gender` and `moves.person.ethnicity` in `AllocationSerializer`

### Why?

This was an afterthought and needed by the frontend