### PR TITLE
P4-1432 Allow relationships to be surfaced in Serializers even if missing

### DIFF
--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -22,8 +22,8 @@ class MoveSerializer < ActiveModel::Serializer
   has_one :profile, serializer: ProfileSerializer # <- TODO: update the serializer
 
   has_one :from_location, serializer: LocationSerializer
-  has_one :to_location, serializer: LocationSerializer, if: -> { object.to_location.present? }
-  has_one :prison_transfer_reason, serializer: PrisonTransferReasonSerializer, if: -> { object.prison_transfer_reason.present? }
+  has_one :to_location, serializer: LocationSerializer
+  has_one :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
   has_many :documents, serializer: DocumentSerializer
   has_many :court_hearings, serializer: CourtHearingSerializer
   belongs_to :allocation, serializer: AllocationSerializer

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -11,7 +11,7 @@ class PersonSerializer < ActiveModel::Serializer
     :gender_additional_information,
   )
 
-  has_one :ethnicity, serializer: EthnicitySerializer, if: -> { ethnicity.present? }
+  has_one :ethnicity, serializer: EthnicitySerializer
   has_one :gender, serializer: GenderSerializer
 
   SUPPORTED_RELATIONSHIPS = %w[ethnicity gender].freeze

--- a/spec/requests/api/v1/moves_controller_create_spec.rb
+++ b/spec/requests/api/v1/moves_controller_create_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::V1::MovesController do
         relationships: {
           person: { data: { type: 'people', id: person.id } },
           from_location: { data: { type: 'locations', id: from_location.id } },
-          to_location: to_location ? { data: { type: 'locations', id: to_location.id } } : nil,
+          to_location: to_location ? { data: { type: 'locations', id: to_location.id } } : { data: nil },
           documents: { data: [{ type: 'documents', id: document.id }] },
           prison_transfer_reason: { data: { type: 'prison_transfer_reasons', id: reason.id } },
         },

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -129,6 +129,25 @@ RSpec.describe MoveSerializer do
     it 'contains an included from and to location' do
       expect(result[:included]).to(include_json(expected_json))
     end
+
+    context 'without a to_location' do
+      let(:adapter_options) do
+        {
+          include: {
+            to_location: %I[location_type title],
+          },
+        }
+      end
+      let(:move) { create(:move, :prison_recall) }
+
+      it 'contains empty location' do
+        expect(result_data[:relationships][:to_location][:data]).to be_nil
+      end
+
+      it 'does not contain an included location' do
+        expect(result[:included]).to be_nil
+      end
+    end
   end
 
   describe 'allocations' do
@@ -182,6 +201,43 @@ RSpec.describe MoveSerializer do
 
       it 'does not contain an included allocation' do
         expect(result[:included].map { |r| r[:type] }).to match_array(%w[locations locations ethnicities genders people profiles])
+      end
+    end
+  end
+
+  describe 'prison_transfer_reason' do
+    let(:adapter_options) do
+      {
+        include: {
+          prison_transfer_reason: %I[title],
+        },
+      }
+    end
+    let(:move) { create(:move, :prison_transfer) }
+
+    let(:expected_json) do
+      [
+        {
+          id: move.prison_transfer_reason.id,
+          type: 'prison_transfer_reasons',
+          attributes: { title: move.prison_transfer_reason.title },
+        },
+      ]
+    end
+
+    it 'contains an included prison_transfer_reason' do
+      expect(result[:included]).to(include_json(expected_json))
+    end
+
+    context 'without a prison_transfer_reason' do
+      let(:move) { create(:move, prison_transfer_reason: nil) }
+
+      it 'contains empty prison_transfer_reason' do
+        expect(result_data[:relationships][:prison_transfer_reason][:data]).to be_nil
+      end
+
+      it 'does not contain an included prison_transfer_reason' do
+        expect(result[:included]).to be_nil
       end
     end
   end

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -106,16 +106,16 @@ RSpec.describe PersonSerializer do
 
   describe 'ethnicity' do
     let(:adapter_options) { { include: { ethnicity: %I[key title description] } } }
-    let(:ethnicity) { person.latest_profile&.ethnicity }
+    let(:ethnicity) { person.latest_profile.ethnicity }
     let(:expected_json) do
       [
         {
-          id: ethnicity&.id,
+          id: ethnicity.id,
           type: 'ethnicities',
           attributes: {
-            key: ethnicity&.key,
-            title: ethnicity&.title,
-            description: ethnicity&.description,
+            key: ethnicity.key,
+            title: ethnicity.title,
+            description: ethnicity.description,
           },
         },
       ]
@@ -123,6 +123,18 @@ RSpec.describe PersonSerializer do
 
     it 'contains an included ethnicity' do
       expect(result[:included]).to(include_json(expected_json))
+    end
+
+    context 'without an ethnicity' do
+      let(:person) { create(:person_without_profiles) }
+
+      it 'contains empty ethnicity' do
+        expect(result[:data][:relationships][:ethnicity][:data]).to be_nil
+      end
+
+      it 'does not contain an included ethnicity' do
+        expect(result[:included]).to be_nil
+      end
     end
   end
 

--- a/swagger/v1/ethnicity_reference.yaml
+++ b/swagger/v1/ethnicity_reference.yaml
@@ -4,7 +4,9 @@ EthnicityReference:
   - data
   properties:
     data:
-      type: object
+      oneOf:
+      - type: object
+      - type: 'null'
       required:
       - id
       - type

--- a/swagger/v1/location_reference.yaml
+++ b/swagger/v1/location_reference.yaml
@@ -7,6 +7,7 @@ LocationReference:
       oneOf:
       - type: object
       - type: array
+      - type: 'null'
       required:
       - type
       - id

--- a/swagger/v1/prison_transfer_reason_reference.yaml
+++ b/swagger/v1/prison_transfer_reason_reference.yaml
@@ -4,7 +4,9 @@ PrisonTransferReasonReference:
   - data
   properties:
     data:
-      type: object
+      oneOf:
+      - type: object
+      - type: 'null'
       required:
       - type
       - id


### PR DESCRIPTION
### Jira link

[P4-1432](https://dsdmoj.atlassian.net/browse/P4-1432)

### What?

- [x] Removed checks for hiding missing relationships in Move Serializer
- [x] Removed checks for hiding missing relationships in Person Serializer

### Why?

To adhere to the JSON:API [specs](https://jsonapi.org/format/#document-resource-object-linkage) regarding relationships linkage where an empty relationship should be represented as:
- null for empty to-one relationships.
- an empty array ([]) for empty to-many relationships.

Allow relationships to be surfaced in serializers even if missing.
 
### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

