### PR TITLE
P4-1650 Add an explicit endpoint to approve a move

### DIFF
--- a/app/controllers/api/v1/move_events_controller.rb
+++ b/app/controllers/api/v1/move_events_controller.rb
@@ -9,6 +9,7 @@ module Api
       COMPLETE_PARAMS = [:type, attributes: %i[timestamp notes]].freeze
       LOCKOUT_PARAMS = [:type, attributes: %i[timestamp notes], relationships: { from_location: {} }].freeze
       REDIRECT_PARAMS = [:type, attributes: %i[timestamp notes], relationships: { to_location: {} }].freeze
+      APPROVE_PARAMS = [:type, attributes: %i[timestamp date]].freeze
       REJECT_PARAMS = [:type, attributes: %i[timestamp rejection_reason cancellation_reason_comment]].freeze
 
       def cancel
@@ -32,6 +33,12 @@ module Api
       def redirects
         validate_params!(redirect_params, require_to_location: true)
         process_event(move, Event::REDIRECT, redirect_params)
+        render status: :no_content
+      end
+
+      def approve
+        validate_params!(approve_params)
+        process_event(move, Event::APPROVE, approve_params)
         render status: :no_content
       end
 
@@ -67,6 +74,10 @@ module Api
 
       def redirect_params
         @redirect_params ||= params.require(:data).permit(REDIRECT_PARAMS).to_h
+      end
+
+      def approve_params
+        @approve_params ||= params.require(:data).permit(APPROVE_PARAMS).to_h
       end
 
       def reject_params

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,7 @@ class Event < ApplicationRecord
     UNCOMPLETE = 'uncomplete'.freeze,
     REDIRECT = 'redirect'.freeze,
     LOCKOUT = 'lockout'.freeze,
+    APPROVE = 'approve'.freeze,
     REJECT = 'reject'.freeze,
   ].freeze
 

--- a/app/models/move_event.rb
+++ b/app/models/move_event.rb
@@ -1,6 +1,10 @@
 class MoveEvent < Event
   # NB: this class exposes a few methods specific to moves to the Event model
 
+  def date
+    @date ||= event_params.dig(:attributes, :date)
+  end
+
   def rejection_reason
     @rejection_reason ||= event_params.dig(:attributes, :rejection_reason)
   end

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -15,6 +15,9 @@ module EventLog
           move.status = Move::MOVE_STATUS_CANCELLED
           move.cancellation_reason = event.cancellation_reason
           move.cancellation_reason_comment = event.cancellation_reason_comment
+        when Event::APPROVE
+          move.status = Move::MOVE_STATUS_REQUESTED
+          move.date = event.date
         when Event::REJECT
           move.status = Move::MOVE_STATUS_CANCELLED
           move.rejection_reason = event.rejection_reason

--- a/app/services/move_events/params_validator.rb
+++ b/app/services/move_events/params_validator.rb
@@ -4,12 +4,22 @@ module MoveEvents
   class ParamsValidator
     include ActiveModel::Validations
 
-    attr_reader :timestamp, :type, :cancellation_reason, :rejection_reason
+    attr_reader :timestamp, :type, :date, :cancellation_reason, :rejection_reason
 
-    validates :type, presence: true, inclusion: { in: %w[cancel complete lockouts redirects reject] }
+    validates :type, presence: true, inclusion: { in: %w[cancel complete lockouts redirects approve reject] }
     validates :cancellation_reason, inclusion: { in: Move::CANCELLATION_REASONS }, if: -> { type == 'cancel' }
     validates :rejection_reason, inclusion: { in: Move::REJECTION_REASONS }, if: -> { type == 'reject' }
-    validates_each :timestamp, presence: true do |record, attr, value|
+
+    validates :date, presence: true, if: -> { type == 'approve' }
+    validates :timestamp, presence: true
+
+    validates_each :date, allow_nil: true do |record, attr, value|
+      Date.strptime(value, '%Y-%m-%d')
+    rescue ArgumentError
+      record.errors.add attr, 'is not a valid date.'
+    end
+
+    validates_each :timestamp, allow_nil: true do |record, attr, value|
       Time.iso8601(value)
     rescue ArgumentError
       record.errors.add(attr, 'must be formatted as a valid ISO-8601 date-time')
@@ -18,6 +28,7 @@ module MoveEvents
     def initialize(params)
       @timestamp = params.dig(:attributes, :timestamp)
       @type = params[:type]
+      @date = params.dig(:attributes, :date)
       @cancellation_reason = params.dig(:attributes, :cancellation_reason)
       @rejection_reason = params.dig(:attributes, :rejection_reason)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
           post 'complete', controller: 'move_events'
           post 'lockouts', controller: 'move_events'
           post 'redirects', controller: 'move_events'
+          post 'approve', controller: 'move_events'
           post 'reject', controller: 'move_events'
         end
       end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -45,6 +45,10 @@ FactoryBot.define do
       event_name { 'lockout' }
     end
 
+    trait :approve do
+      event_name { 'approve' }
+    end
+
     trait :reject do
       event_name { 'reject' }
     end
@@ -79,6 +83,17 @@ FactoryBot.define do
             attributes: {
               cancellation_reason: nil,
               cancellation_reason_comment: 'this is a broken event',
+            },
+          } }
+        end
+      end
+
+      trait :approve do
+        event_name { 'approve' }
+        details do
+          { event_params: {
+            attributes: {
+              date: Date.tomorrow,
             },
           } }
         end

--- a/spec/requests/api/v1/move_events_controller_approve_spec.rb
+++ b/spec/requests/api/v1/move_events_controller_approve_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::MoveEventsController do
+  let(:response_json) { JSON.parse(response.body) }
+
+  describe 'POST /moves/:move_id/approve' do
+    let(:schema) { load_yaml_schema('post_move_events_responses.yaml') }
+
+    let(:supplier) { create(:supplier) }
+    let(:application) { create(:application, owner_id: supplier.id) }
+    let(:access_token) { create(:access_token, application: application).token }
+    let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
+    let(:content_type) { ApiController::CONTENT_TYPE }
+
+    let(:move) { create(:move, :proposed) }
+    let(:approved_date) { move.date + 1.day }
+    let(:move_id) { move.id }
+    let(:approve_params) do
+      {
+        data: {
+          type: 'approve',
+          attributes: {
+            timestamp: '2020-04-23T18:25:43.511Z',
+            date: approved_date,
+          },
+        },
+      }
+    end
+
+    before do
+      allow(Notifier).to receive(:prepare_notifications)
+      post "/api/v1/moves/#{move_id}/approve", params: approve_params, headers: headers, as: :json
+    end
+
+    context 'when successful' do
+      it_behaves_like 'an endpoint that responds with success 204'
+
+      it 'updates the move status' do
+        expect(move.reload.status).to eql('requested')
+      end
+
+      it 'updates the move date' do
+        expect(move.reload.date).to eql(approved_date)
+      end
+
+      describe 'webhook and email notifications' do
+        it 'calls the notifier' do
+          expect(Notifier).to have_received(:prepare_notifications).with(topic: move, action_name: 'update_status')
+        end
+      end
+    end
+
+    context 'with a bad request' do
+      let(:approve_params) { nil }
+
+      it_behaves_like 'an endpoint that responds with error 400'
+    end
+
+    context 'when not authorized' do
+      let(:access_token) { 'foo-bar' }
+      let(:detail_401) { 'Token expired or invalid' }
+
+      it_behaves_like 'an endpoint that responds with error 401'
+    end
+
+    context 'with a missing move_id' do
+      let(:move_id) { 'foo-bar' }
+      let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
+
+      it_behaves_like 'an endpoint that responds with error 404'
+    end
+
+    context 'with an invalid CONTENT_TYPE header' do
+      let(:content_type) { 'application/xml' }
+
+      it_behaves_like 'an endpoint that responds with error 415'
+    end
+
+    context 'with validation errors' do
+      context 'with a bad timestamp' do
+        let(:approve_params) { { data: { type: 'approve', attributes: { timestamp: 'Foo-Bar', date: approved_date } } } }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) { [{ 'title' => 'Invalid timestamp', 'detail' => 'Validation failed: Timestamp must be formatted as a valid ISO-8601 date-time' }] }
+        end
+      end
+
+      context 'with a bad date' do
+        let(:approve_params) { { data: { type: 'approve', attributes: { timestamp: '2020-04-23T18:25:43.511Z', date: 'Foo-Bar' } } } }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) { [{ 'title' => 'Invalid date', 'detail' => 'Validation failed: Date is not a valid date.' }] }
+        end
+      end
+
+      context 'with a missing date' do
+        let(:approve_params) { { data: { type: 'approve', attributes: { timestamp: '2020-04-23T18:25:43.511Z' } } } }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) { [{ 'title' => 'Invalid date', 'detail' => "Validation failed: Date can't be blank" }] }
+        end
+      end
+
+      context 'with a bad event type' do
+        let(:approve_params) { { data: { type: 'Foo-bar', attributes: { timestamp: '2020-04-23T18:25:43.511Z', date: approved_date } } } }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) { [{ 'title' => 'Invalid type', 'detail' => 'Validation failed: Type is not included in the list' }] }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/event_log/move_runner_spec.rb
+++ b/spec/services/event_log/move_runner_spec.rb
@@ -114,6 +114,34 @@ RSpec.describe EventLog::MoveRunner do
     end
   end
 
+  context 'when event_name=approve' do
+    let!(:event) { create(:move_event, :approve, eventable: move) }
+
+    context 'when the move is proposed' do
+      let!(:move) { create(:move, :proposed, date: Date.today) }
+
+      it 'updates the move status to requested' do
+        expect { runner.call }.to change(move, :status).from('proposed').to('requested')
+      end
+
+      it 'updates the move date' do
+        expect { runner.call }.to change(move, :date).from(Date.today).to(Date.tomorrow)
+      end
+
+      it_behaves_like 'it calls the Notifier with an update_status action_name'
+    end
+
+    context 'when the move is already requested' do
+      let!(:move) { create(:move, :requested, date: Date.tomorrow) }
+
+      it_behaves_like 'it does not call the Notifier'
+
+      it 'does not change the move status' do
+        expect { runner.call }.not_to change(move, :status).from('requested')
+      end
+    end
+  end
+
   context 'when event_name=reject' do
     let!(:event) { create(:move_event, :reject, eventable: move) }
 

--- a/spec/services/move_events/params_validator_spec.rb
+++ b/spec/services/move_events/params_validator_spec.rb
@@ -5,18 +5,23 @@ require 'rails_helper'
 RSpec.describe MoveEvents::ParamsValidator do
   subject(:params_validator) { described_class.new(params) }
 
-  let(:params) { { type: type, attributes: { timestamp: timestamp } } }
+  let(:attributes) { { timestamp: timestamp } }
+  let(:params) { { type: type, attributes: attributes } }
   let(:timestamp) { '2020-04-29T22:45:59.000Z' }
   let(:type) { 'redirects' }
-  let(:cancellation_reason) { 'supplier_declined_to_move' }
-  let(:rejection_reason) { 'no_transport_available' }
 
   context 'when valid' do
     it { is_expected.to be_valid }
   end
 
   describe 'cancellation_reason' do
+    let(:attributes) { { timestamp: timestamp, cancellation_reason: cancellation_reason } }
+    let(:cancellation_reason) { 'supplier_declined_to_move' }
     let(:type) { 'cancel' }
+
+    context 'when valid' do
+      it { is_expected.to be_valid }
+    end
 
     context 'when invalid' do
       let(:cancellation_reason) { 'foo-bar' }
@@ -31,14 +36,20 @@ RSpec.describe MoveEvents::ParamsValidator do
     end
 
     context 'when missing' do
-      before { params.delete(:cancellation_reason) }
+      before { attributes.delete(:cancellation_reason) }
 
       it { is_expected.not_to be_valid }
     end
   end
 
   describe 'rejection_reason' do
+    let(:attributes) { { timestamp: timestamp, rejection_reason: rejection_reason } }
+    let(:rejection_reason) { 'no_transport_available' }
     let(:type) { 'reject' }
+
+    context 'when valid' do
+      it { is_expected.to be_valid }
+    end
 
     context 'when invalid' do
       let(:rejection_reason) { 'foo-bar' }
@@ -53,7 +64,35 @@ RSpec.describe MoveEvents::ParamsValidator do
     end
 
     context 'when missing' do
-      before { params.delete(:rejection_reason) }
+      before { attributes.delete(:rejection_reason) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe 'date' do
+    let(:attributes) { { timestamp: timestamp, date: date } }
+    let(:date) { '2020-06-10' }
+    let(:type) { 'approve' }
+
+    context 'when valid' do
+      it { is_expected.to be_valid }
+    end
+
+    context 'when invalid' do
+      let(:date) { 'foo' }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when nil' do
+      let(:date) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when missing' do
+      before { attributes.delete(:date) }
 
       it { is_expected.not_to be_valid }
     end

--- a/spec/swagger/definitions/hand_coded_paths_v1.yaml
+++ b/spec/swagger/definitions/hand_coded_paths_v1.yaml
@@ -638,6 +638,68 @@
           application/vnd.api+json:
             schema:
               $ref: error_responses.yaml#/422
+/moves/{move_id}/approve:
+  post:
+    summary: 'Approves a move'
+    description: |
+      Approving a move will change the move status to `requested` and update with the provided move date.
+    tags:
+      - Moves
+    consumes:
+      - application/vnd.api+json
+    parameters:
+      - $ref: move_id_parameter.yaml#/MoveId
+      - $ref: idempotency_key_parameter.yaml#/IdempotencyKey
+      - $ref: content_type_parameter.yaml#/ContentType
+      - name: body
+        in: body
+        required: true
+        description: |
+          ### Approving a Move
+
+          Approving a move will change the move status to `requested` and update with the provided move date.
+        schema:
+          $ref: post_move_approve.yaml#/PostMoveApprove
+    responses:
+      '204':
+        description: no content
+        content:
+      '400':
+        description: bad request
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/400
+      '401':
+        description: unauthorized
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/401
+      '404':
+        description: resource not found
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/404
+      '409':
+        description: conflict
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/409
+      '415':
+        description: invalid media type
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/415
+      '422':
+        description: unprocessable entity
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: error_responses.yaml#/422
 /moves/{move_id}/reject:
   post:
     summary: 'Rejects a move'

--- a/swagger/v1/post_move_approve.yaml
+++ b/swagger/v1/post_move_approve.yaml
@@ -1,0 +1,25 @@
+PostMoveReject:
+  type: object
+  required:
+  - type
+  - attributes
+  properties:
+    type:
+      type: string
+      example: approve
+      enum:
+      - approve
+      description: The type of this object - always `approve`
+    attributes:
+      type: object
+      required:
+      - timestamp
+      - date
+      properties:
+        timestamp:
+          $ref: timestamp_attribute.yaml#/Timestamp
+        date:
+          type: string
+          format: date
+          example: '2020-05-17'
+          description: Date on which the move is scheduled


### PR DESCRIPTION
P4-1650

### What?

- [x] Adds a new route to `POST /moves/:id/approve`
- [x] Adds a new `approve` event type including `date` attribute
- [x] Adds support for `approve` in the move runner service
- [x] Adds validation for date parameter within move events

### Why?

- Currently the front end is PATCHING a proposed move and changing the status to `requested` and updating the move date.
- We want to move away from this approach and have dedicated endpoints which explicitly change move status and ensure the relevant related attributes are correctly specified.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Introduces a new API so minimal production risk
