### PR TITLE
Remove NodeJS buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -61,9 +61,6 @@
   },
   "buildpacks": [
     {
-      "url": "heroku/nodejs"
-    },
-    {
       "url": "heroku/ruby"
     }
   ]


### PR DESCRIPTION
### What?

- [x] Removed the nodejs buildpack entirely from Heroku pipeline.

### Why?

- Heroku is throwing errors about this now as we don't have a `package.json` file at root level

```
-----> App not compatible with buildpack: https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/nodejs.tgz

 !     ERROR: Application not supported by 'heroku/nodejs' buildpack
 !
 !     The 'heroku/nodejs' buildpack is set on this application, but was
 !     unable to detect a Node.js codebase.
 !
 !     A Node.js app on Heroku requires a 'package.json' at the root of
 !     the directory structure.
 !
 !     If you are trying to deploy a Node.js application, ensure that this
 !     file is present at the top level directory. This directory has the
 !     following files:
 !
 !     adr/
 !     app/
 !     app.json
 !     bin/
 !     CHANGELOG.md
 !     config/
 !     config.ru
 !     db/
 !     docker-compose.yml
 !     Dockerfile
 !     docs/
 !     Gemfile
 !     Gemfile.lock
 !     lib/
 !     log/
 !     public/
 !     Rakefile
 !     README.md
 !     run.sh
 !     spec/
 !     storage/
 !     swagger/
 !     tmp/
 !     vendor/
 !
 !     If you are trying to deploy an application written in another
 !     language, you need to change the list of buildpacks set on your
 !     Heroku app using the 'heroku buildpacks' command.
 !
 !     For more information, refer to the following documentation:
 !     https://devcenter.heroku.com/articles/buildpacks
 !     https://devcenter.heroku.com/articles/nodejs-support#activation
       More info: https://devcenter.heroku.com/articles/buildpacks#detection-failure
 !     Push failed
```

- This **was** working so presumably either the buildpack changed or `package.json` got removed. Deployment works fine without this, however.