### PR TITLE
Reduce CircleCI parallelism slightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ jobs:
 
   api_docs:
     executor: test-executor
-    parallelism: 8
+    parallelism: 2
     steps:
       - checkout
       - *attach-tmp-workspace
@@ -290,7 +290,7 @@ jobs:
 
   rspec_tests:
     executor: test-executor
-    parallelism: 8
+    parallelism: 4
     steps:
       - checkout
       - build-base


### PR DESCRIPTION
### What?

- [x] Reduced number of executors for rspec and swagger doc jobs

### Why?

- This seems to be too aggressive at present and ties up all of the build executors for a single workflow, leading to queued PR tests.
- The swagger docs job only runs a few specs so 2 executors should be enough for that.
For the main rspec tests it looks like a law of diminishing returns so 4 should be almost as fast as 8.
