### PR TITLE
Reinstate default includes for GET allocations endpoint

### DIFF
--- a/app/controllers/api/v1/allocations_controller.rb
+++ b/app/controllers/api/v1/allocations_controller.rb
@@ -9,7 +9,7 @@ module Api
         allocations_params = Allocations::ParamsValidator.new(filter_params, sort_params)
         if allocations_params.valid?
           allocations = Allocations::Finder.new(filter_params, sort_params).call
-          paginate allocations, include: minimum_relationships
+          paginate allocations, include: included_relationships
         else
           render_allocation({ error: allocations_params.errors }, :bad_request)
         end
@@ -75,12 +75,6 @@ module Api
         creator.allocation.moves.each do |move|
           Notifier.prepare_notifications(topic: move, action_name: 'create')
         end
-      end
-
-      def minimum_relationships
-        # FIXME: Validate the include param but then ignore and override to return only minimal relations
-        IncludeParamHandler.new(params).call
-        AllocationSerializer::MINIMUM_RELATIONSHIPS
       end
 
       def included_relationships

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -19,6 +19,5 @@ class AllocationSerializer < ActiveModel::Serializer
   has_one :to_location
   has_many :moves
 
-  MINIMUM_RELATIONSHIPS = %w[from_location to_location moves.person].freeze
   SUPPORTED_RELATIONSHIPS = %w[from_location to_location moves.person moves.person.gender moves.person.ethnicity].freeze
 end

--- a/spec/requests/api/v1/allocations_controller_index_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_index_spec.rb
@@ -204,7 +204,6 @@ RSpec.describe Api::V1::AllocationsController do
           let(:query_params) { '?include=from_location' }
 
           it 'returns the valid provided includes' do
-            pending 'Temporarily disabled until endpoint performance can be improved'
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
             expect(returned_types).to contain_exactly('locations')
           end
@@ -234,7 +233,6 @@ RSpec.describe Api::V1::AllocationsController do
           let(:query_params) { '?include=' }
 
           it 'returns none of the includes' do
-            pending 'Temporarily disabled until endpoint performance can be improved'
             returned_types = response_json['included']
             expect(returned_types).to be_nil
           end

--- a/spec/requests/api/v1/allocations_controller_index_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_index_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Api::V1::AllocationsController do
 
           it 'returns the default minimum includes' do
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
-            expect(returned_types).to contain_exactly('people', 'moves', 'locations')
+            expect(returned_types).to contain_exactly('people', 'moves', 'locations', 'ethnicities', 'genders')
           end
         end
 
@@ -243,7 +243,7 @@ RSpec.describe Api::V1::AllocationsController do
 
           it 'returns the default minimum includes' do
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
-            expect(returned_types).to contain_exactly('people', 'moves', 'locations')
+            expect(returned_types).to contain_exactly('people', 'moves', 'locations', 'ethnicities', 'genders')
           end
         end
       end


### PR DESCRIPTION
### What?

- [x] Restore previous GET /allocations support for includes parameter
- [x] Restore previous GET /allocations default includes when includes parameter not included
- [x] Reinstate previous broken specs that were marked as pending temporarily

### Why?

- The previous change was made as part of an attempted hotfix yesterday. We observed slow performance on the `GET /allocations` endpoint and assumed this was due to returning additional relationships that were recently added.
- The original change made did not improve the observed performance on staging environment (which was caused by another bug returning all documents for a move without a profile)
- Reverting this change does not impact the current performance baseline against staging data (tested locally)

#### Before this PR:

```
[active_model_serializers] Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::JsonApi (1234.66ms)
Completed 200 OK in 1464ms (Views: 1261.5ms | ActiveRecord: 134.0ms | Allocations: 1066401)
```

#### After this PR:

```
[active_model_serializers] Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::JsonApi (1218.58ms)
Completed 200 OK in 1335ms (Views: 1174.8ms | ActiveRecord: 116.4ms | Allocations: 1055574)
```

### Deployment risks (optional)

- Reverts production api to previous behaviour; this behaviour was present for a few days prior to the unrelated document bug being introduced so is safe to reinstate. Tested against a local copy of staging data and performance of the endpoint with no filters specified remains the same with this change.
