### PR TITLE
[P4-1631] Bring back notification on release.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,10 @@ references:
       at: .
 
 executors:
+  basic-executor:
+    docker:
+      - image: cimg/base:2020.06
+
   cloud-platform-executor:
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
@@ -269,9 +273,14 @@ commands:
 
 jobs:
   notify_of_approval:
-    executor: cloud-platform-executor
+    executor: basic-executor
     steps:
       - *notify_slack_of_approval
+
+  notify_of_release:
+    executor: basic-executor
+    steps:
+      - *notify_slack_on_release_start
 
   setup_test_environment:
     executor: test-executor
@@ -374,6 +383,8 @@ workflows:
 
   test-build-deploy:
     jobs:
+      - notify_of_release:
+          <<: *only_deploy_tags
       - setup_test_environment:
           <<: *all_tags
       - api_docs:


### PR DESCRIPTION
### Jira link

P4-1631

### What?

I have added/removed/altered:

- [ ] Reinstated a notification that was going when building a docker images in the scope of a release to production.

### Why?

I am doing this because:

- This functionality was lost during the refractoring of the pipeline, as we no longer have a dedicated production build.

