### PR TITLE
Run api_jobs non-concurrently

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,7 @@ jobs:
 
   api_docs:
     executor: test-executor
-    parallelism: 2
+    parallelism: 1
     steps:
       - checkout
       - *attach-tmp-workspace


### PR DESCRIPTION

### What?

I have added/removed/altered:

- [ ] Reverted to run api_docs step non concurrently,

### Why?

I am doing this because:

-  as it was affecting the 'swagger.yml' generation, causing only part of the endpoint to be generated.

