### PR TITLE
Removes dead references

### DIFF
--- a/swagger/v1/identifier_type.yaml
+++ b/swagger/v1/identifier_type.yaml
@@ -1,9 +1,9 @@
 IdentifierType:
   type: object
   required:
-  - id
-  - type
-  - attributes
+    - id
+    - type
+    - attributes
   properties:
     id:
       type: string
@@ -13,22 +13,20 @@ IdentifierType:
       type: string
       example: identifier_types
       enum:
-      - identifier_types
+        - identifier_types
       description: The type of this object - always `identifier_types`
     attributes:
       type: object
       required:
-      - title
+        - title
       properties:
         key:
           type: string
           example: police_national_computer
           enum:
-          - police_national_computer
-          - criminal_records_office
-          - prison_number
-          - niche_reference
-          - athena_reference
+            - police_national_computer
+            - criminal_records_office
+            - prison_number
           description: The unique string key (alias of `id`)
         title:
           type: string
@@ -36,12 +34,13 @@ IdentifierType:
           description: The human readable label for this identifier type
         description:
           oneOf:
-          - type: string
-          - type: 'null'
+            - type: string
+            - type: "null"
           description: The human readable description for this identifier type (optional)
         disabled_at:
           type: String
           format: date-time
-          example: '2017-07-21T17:32:28Z'
-          description: The date-time at which a value was disabled, in ISO-8601 format,
+          example: "2017-07-21T17:32:28Z"
+          description:
+            The date-time at which a value was disabled, in ISO-8601 format,
             or null if it is enabled

--- a/swagger/v1/profile_identifier.yaml
+++ b/swagger/v1/profile_identifier.yaml
@@ -1,8 +1,8 @@
 ProfileIdentifier:
   type: object
   required:
-  - value
-  - identifier_type
+    - value
+    - identifier_type
   properties:
     value:
       type: string
@@ -11,10 +11,9 @@ ProfileIdentifier:
     identifier_type:
       type: string
       enum:
-      - police_national_computer
-      - criminal_records_office
-      - prison_number
-      - niche_reference
-      - athena_reference
-      description: Different services have different schemes for identifying people,
+        - police_national_computer
+        - criminal_records_office
+        - prison_number
+      description:
+        Different services have different schemes for identifying people,
         e.g. police PNC number, prison number.


### PR DESCRIPTION
Removes dead references from swagger docs. It is impossible that these are returned as they are never populated.