### PR TITLE
Add support for automatically rebooking a move when rejecting

### DIFF
--- a/app/controllers/api/v1/move_events_controller.rb
+++ b/app/controllers/api/v1/move_events_controller.rb
@@ -10,7 +10,7 @@ module Api
       LOCKOUT_PARAMS = [:type, attributes: %i[timestamp notes], relationships: { from_location: {} }].freeze
       REDIRECT_PARAMS = [:type, attributes: %i[timestamp notes], relationships: { to_location: {} }].freeze
       APPROVE_PARAMS = [:type, attributes: %i[timestamp date]].freeze
-      REJECT_PARAMS = [:type, attributes: %i[timestamp rejection_reason cancellation_reason_comment]].freeze
+      REJECT_PARAMS = [:type, attributes: %i[timestamp rejection_reason cancellation_reason_comment rebook]].freeze
 
       def cancel
         validate_params!(cancel_params)

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -90,8 +90,12 @@ class Move < VersionedModel
     )
   end
 
+  def rebooked
+    self.class.find_by(original_move_id: id)
+  end
+
   def rebook
-    self.class.new(
+    rebooked || self.class.create(
       original_move_id: id,
       from_location_id: from_location_id,
       to_location_id: to_location_id,

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -42,6 +42,7 @@ class Move < VersionedModel
   belongs_to :profile, optional: true
   belongs_to :prison_transfer_reason, optional: true
   belongs_to :allocation, inverse_of: :moves, optional: true
+  belongs_to :original_move, class_name: 'Move', optional: true
   # using https://github.com/jhawthorn/discard for documents, so only include the non-soft-deleted documents here
   has_many :documents, -> { kept }, dependent: :destroy, inverse_of: :move
   has_many :notifications, as: :topic, dependent: :destroy # NB: polymorphic association
@@ -86,6 +87,19 @@ class Move < VersionedModel
       status: MOVE_STATUS_CANCELLED,
       cancellation_reason: reason,
       cancellation_reason_comment: comment,
+    )
+  end
+
+  def rebook
+    self.class.new(
+      original_move_id: id,
+      from_location_id: from_location_id,
+      to_location_id: to_location_id,
+      allocation_id: allocation_id,
+      profile_id: profile_id,
+      status: MOVE_STATUS_PROPOSED,
+      date: date + 7.days,
+      date_from: date + 7.days,
     )
   end
 

--- a/app/models/move_event.rb
+++ b/app/models/move_event.rb
@@ -1,6 +1,10 @@
 class MoveEvent < Event
   # NB: this class exposes a few methods specific to moves to the Event model
 
+  def rebook?
+    @rebook ||= event_params.dig(:attributes, :rebook).to_s == 'true'
+  end
+
   def date
     @date ||= event_params.dig(:attributes, :date)
   end

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -27,6 +27,7 @@ class MoveSerializer < ActiveModel::Serializer
   has_many :documents, serializer: DocumentSerializer
   has_many :court_hearings, serializer: CourtHearingSerializer
   belongs_to :allocation, serializer: AllocationSerializer
+  belongs_to :original_move, serializer: MoveSerializer
 
   # TODO: Remove support for person on a Move
   SUPPORTED_RELATIONSHIPS = %w[
@@ -42,6 +43,7 @@ class MoveSerializer < ActiveModel::Serializer
     prison_transfer_reason
     court_hearings
     allocation
+    original_move
   ].freeze
 
   INCLUDED_FIELDS = {

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -23,6 +23,7 @@ module EventLog
           move.rejection_reason = event.rejection_reason
           move.cancellation_reason = Move::CANCELLATION_REASON_REJECTED
           move.cancellation_reason_comment = event.cancellation_reason_comment
+          move.rebook.save if event.rebook?
         when Event::COMPLETE
           move.status = Move::MOVE_STATUS_COMPLETED
         when Event::LOCKOUT

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -23,7 +23,7 @@ module EventLog
           move.rejection_reason = event.rejection_reason
           move.cancellation_reason = Move::CANCELLATION_REASON_REJECTED
           move.cancellation_reason_comment = event.cancellation_reason_comment
-          move.rebook.save if event.rebook?
+          move.rebook if event.rebook?
         when Event::COMPLETE
           move.status = Move::MOVE_STATUS_COMPLETED
         when Event::LOCKOUT

--- a/db/migrate/20200612133540_add_original_move_id_to_moves.rb
+++ b/db/migrate/20200612133540_add_original_move_id_to_moves.rb
@@ -1,0 +1,5 @@
+class AddOriginalMoveIdToMoves < ActiveRecord::Migration[6.0]
+  def change
+    add_column :moves, :original_move_id, :uuid
+  end
+end

--- a/db/migrate/20200612133540_add_original_move_id_to_moves.rb
+++ b/db/migrate/20200612133540_add_original_move_id_to_moves.rb
@@ -1,5 +1,6 @@
 class AddOriginalMoveIdToMoves < ActiveRecord::Migration[6.0]
   def change
     add_column :moves, :original_move_id, :uuid
+    add_foreign_key :moves, :moves, column: :original_move_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -421,6 +421,7 @@ ActiveRecord::Schema.define(version: 2020_06_12_133540) do
   add_foreign_key "moves", "allocations"
   add_foreign_key "moves", "locations", column: "from_location_id", name: "fk_rails_moves_from_location_id"
   add_foreign_key "moves", "locations", column: "to_location_id", name: "fk_rails_moves_to_location_id"
+  add_foreign_key "moves", "moves", column: "original_move_id"
   add_foreign_key "moves", "people"
   add_foreign_key "notifications", "notification_types"
   add_foreign_key "notifications", "subscriptions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_11_110523) do
+ActiveRecord::Schema.define(version: 2020_06_12_133540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -218,6 +218,7 @@ ActiveRecord::Schema.define(version: 2020_06_11_110523) do
     t.date "date_to"
     t.uuid "allocation_id"
     t.string "rejection_reason"
+    t.uuid "original_move_id"
     t.index ["allocation_id"], name: "index_moves_on_allocation_id"
     t.index ["created_at"], name: "index_moves_on_created_at"
     t.index ["date"], name: "index_moves_on_date"

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -110,6 +110,19 @@ FactoryBot.define do
           } }
         end
       end
+
+      trait :reject_with_rebook do
+        event_name { 'reject' }
+        details do
+          { event_params: {
+            attributes: {
+              rejection_reason: 'no_transport_available',
+              cancellation_reason_comment: 'computer says no',
+              rebook: true,
+            },
+          } }
+        end
+      end
     end
   end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -413,46 +413,56 @@ RSpec.describe Move do
   end
 
   describe '#rebook' do
-    let(:original_move) { create(:move, :proposed, :with_allocation) }
+    let!(:original_move) { create(:move, :proposed, :with_allocation) }
 
-    it 'returns a move' do
-      expect(original_move.rebook).to be_a(described_class)
+    context 'when not yet rebooked' do
+      it 'creates a new move' do
+        expect { original_move.rebook }.to change(described_class, :count).by(1)
+      end
+
+      it 'copies the original move from location' do
+        expect(original_move.rebook.from_location_id).to eq(original_move.from_location_id)
+      end
+
+      it 'copies the original move to location' do
+        expect(original_move.rebook.to_location_id).to eq(original_move.to_location_id)
+      end
+
+      it 'copies the original move profile' do
+        expect(original_move.rebook.profile_id).to eq(original_move.profile_id)
+      end
+
+      it 'copies the original move allocation' do
+        expect(original_move.rebook.allocation_id).to eq(original_move.allocation_id)
+      end
+
+      it 'sets the move status to proposed' do
+        expect(original_move.rebook.status).to eq('proposed')
+      end
+
+      it 'sets the move date to 7 days in the future' do
+        expect(original_move.rebook.date).to eq(original_move.date + 7.days)
+      end
+
+      it 'sets the move from date to 7 days in the future' do
+        expect(original_move.rebook.date_from).to eq(original_move.date + 7.days)
+      end
+
+      it 'relates the new move to the original move' do
+        expect(original_move.rebook.original_move).to eq(original_move)
+      end
     end
 
-    it 'returns a new move instance' do
-      expect(original_move.rebook).not_to eq(original_move)
-    end
+    context 'when previously rebooked' do
+      it 'does not create a new move' do
+        original_move.rebook
+        expect { original_move.rebook }.not_to change(described_class, :count)
+      end
 
-    it 'copies the original move from location' do
-      expect(original_move.rebook.from_location_id).to eq(original_move.from_location_id)
-    end
-
-    it 'copies the original move to location' do
-      expect(original_move.rebook.to_location_id).to eq(original_move.to_location_id)
-    end
-
-    it 'copies the original move profile' do
-      expect(original_move.rebook.profile_id).to eq(original_move.profile_id)
-    end
-
-    it 'copies the original move allocation' do
-      expect(original_move.rebook.allocation_id).to eq(original_move.allocation_id)
-    end
-
-    it 'sets the move status to proposed' do
-      expect(original_move.rebook.status).to eq('proposed')
-    end
-
-    it 'sets the move date to 7 days in the future' do
-      expect(original_move.rebook.date).to eq(original_move.date + 7.days)
-    end
-
-    it 'sets the move from date to 7 days in the future' do
-      expect(original_move.rebook.date_from).to eq(original_move.date + 7.days)
-    end
-
-    it 'relates the new move to the original move' do
-      expect(original_move.rebook.original_move).to eq(original_move)
+      it 'returns the previously rebooked move' do
+        rebooked_before = original_move.rebook
+        expect(original_move.rebook).to eq(rebooked_before)
+      end
     end
   end
 

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -412,6 +412,50 @@ RSpec.describe Move do
     end
   end
 
+  describe '#rebook' do
+    let(:original_move) { create(:move, :proposed, :with_allocation) }
+
+    it 'returns a move' do
+      expect(original_move.rebook).to be_a(described_class)
+    end
+
+    it 'returns a new move instance' do
+      expect(original_move.rebook).not_to eq(original_move)
+    end
+
+    it 'copies the original move from location' do
+      expect(original_move.rebook.from_location_id).to eq(original_move.from_location_id)
+    end
+
+    it 'copies the original move to location' do
+      expect(original_move.rebook.to_location_id).to eq(original_move.to_location_id)
+    end
+
+    it 'copies the original move profile' do
+      expect(original_move.rebook.profile_id).to eq(original_move.profile_id)
+    end
+
+    it 'copies the original move allocation' do
+      expect(original_move.rebook.allocation_id).to eq(original_move.allocation_id)
+    end
+
+    it 'sets the move status to proposed' do
+      expect(original_move.rebook.status).to eq('proposed')
+    end
+
+    it 'sets the move date to 7 days in the future' do
+      expect(original_move.rebook.date).to eq(original_move.date + 7.days)
+    end
+
+    it 'sets the move from date to 7 days in the future' do
+      expect(original_move.rebook.date_from).to eq(original_move.date + 7.days)
+    end
+
+    it 'relates the new move to the original move' do
+      expect(original_move.rebook.original_move).to eq(original_move)
+    end
+  end
+
   describe '#documents' do
     let(:move) { create(:move) }
 

--- a/spec/requests/api/v1/move_events_controller_reject_spec.rb
+++ b/spec/requests/api/v1/move_events_controller_reject_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe Api::V1::MoveEventsController do
       end
 
       it 'creates a new move linked to the original move' do
-        expect(Move.last.original_move).to eq(move)
+        rebooked_move = move.reload.rebooked
+        expect(rebooked_move.original_move).to eq(move)
       end
 
       describe 'webhook and email notifications' do

--- a/spec/requests/api/v1/move_events_controller_reject_spec.rb
+++ b/spec/requests/api/v1/move_events_controller_reject_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Api::V1::MoveEventsController do
             timestamp: '2020-04-23T18:25:43.511Z',
             rejection_reason: 'no_space_at_receiving_prison',
             cancellation_reason_comment: 'no room on the broom',
+            rebook: 'true',
           },
         },
       }
@@ -51,6 +52,10 @@ RSpec.describe Api::V1::MoveEventsController do
 
       it 'updates the move rejection_reason' do
         expect(move.reload.rejection_reason).to eql('no_space_at_receiving_prison')
+      end
+
+      it 'creates a new move linked to the original move' do
+        expect(Move.last.original_move).to eq(move)
       end
 
       describe 'webhook and email notifications' do

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe MoveSerializer do
     end
   end
 
-  describe 'allocations' do
+  describe 'allocation' do
     context 'with an allocation' do
       let(:adapter_options) do
         { include: :allocation, fields: MoveSerializer::INCLUDED_FIELDS }
@@ -202,7 +202,34 @@ RSpec.describe MoveSerializer do
         expect(result_data[:relationships][:allocation]).to eq(data: nil)
       end
 
-      it 'does not contain an included allocation' do
+      it 'does not contain an included move' do
+        expect(result[:included].map { |r| r[:type] }).to match_array(%w[locations locations ethnicities genders people profiles])
+      end
+    end
+  end
+
+  describe 'original_move' do
+    let(:adapter_options) { { include: MoveSerializer::SUPPORTED_RELATIONSHIPS } }
+
+    context 'with an original_move' do
+      let(:original_move) { create(:move) }
+      let(:move) { create(:move, original_move: original_move) }
+
+      it 'contains an original_move relationship' do
+        expect(result_data[:relationships][:original_move]).to eq(data: { id: original_move.id, type: 'moves' })
+      end
+
+      it 'contains an included original_move' do
+        expect(result[:included].map { |r| r[:type] }).to match_array(%w[locations locations ethnicities genders people profiles moves])
+      end
+    end
+
+    context 'without an original_move' do
+      it 'contains an empty original_move' do
+        expect(result_data[:relationships][:allocation]).to eq(data: nil)
+      end
+
+      it 'does not contain an included move' do
         expect(result[:included].map { |r| r[:type] }).to match_array(%w[locations locations ethnicities genders people profiles])
       end
     end

--- a/spec/services/event_log/move_runner_spec.rb
+++ b/spec/services/event_log/move_runner_spec.rb
@@ -165,6 +165,16 @@ RSpec.describe EventLog::MoveRunner do
       it_behaves_like 'it calls the Notifier with an update_status action_name'
     end
 
+    context 'when a rebook is requested' do
+      let!(:event) { create(:move_event, :reject_with_rebook, eventable: move) }
+
+      it 'creates a new move' do
+        expect { runner.call }.to change(Move, :count).by(1)
+      end
+
+      it_behaves_like 'it calls the Notifier with an update_status action_name'
+    end
+
     context 'when the move is already rejected' do
       let!(:move) { create(:move, :cancelled, rejection_reason: 'no_transport_available', cancellation_reason: 'rejected', cancellation_reason_comment: 'computer says no') }
 

--- a/swagger/v1/post_move_reject.yaml
+++ b/swagger/v1/post_move_reject.yaml
@@ -22,3 +22,9 @@ PostMoveReject:
           $ref: move_rejection_reason_attribute.yaml#/MoveRejectionReason
         cancellation_reason_comment:
           $ref: move_cancellation_reason_comment_attribute.yaml#/MoveCancellationReasonComment
+        rebook:
+          oneOf:
+          - type: boolean
+          - type: 'null'
+          example: 'true'
+          description: Indicates if the move should be automatically rebooked in 7 days time


### PR DESCRIPTION
### Jira link

P4-1633

### What?

- [x] Adds an additional `rebook` parameter to the move reject request
- [x] Adds method to move model to rebook (create a new move) with pertinent details from original move
- [x] Added new `original_move` relationship to allow rebooked moves to relate to the original move
- [x] Included `original_move` relationship in Move serializer

### Why?

- This allows the front end to specify that a move should be automatically be rebooked in 7 days; the new move is a proposed move with allocation, profile, location and date details copied across from the original move. This provides a convenience for the PMU/OCA to create a new move in future.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- This API endpoint is not yet implemented in the front end, so low risk (story to implement is being worked on at present)