### PR TITLE
Defer log extraction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ commands:
             sed 's/__ENV__/<< parameters.env >>/' k8s_migrate_job.yml | kubectl apply -f -
             kubectl wait --for=condition=complete job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             exit_code=$?
-            kubectl logs job/hmpps-book-secure-move-api-migrate-db-< parameters.env >>
+            kubectl logs job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             kubectl delete job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             exit ${exit_code}
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,6 @@ commands:
             sed 's/__ENV__/<< parameters.env >>/' k8s_migrate_job.yml | kubectl apply -f -
             kubectl wait --for=condition=complete job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             exit_code=$?
-            kubectl logs job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             kubectl delete job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             exit ${exit_code}
       - deploy:


### PR DESCRIPTION
### Jira link

N/A

### What?

I have added/removed/altered:

- [ ] Removed step that extracts logs from the migrations job

### Why?

I am doing this because:

-  We need to modify permissions on cloud-platform, which might take some time to get sorted.
   so we are removing this for now until they are in place.

