### PR TITLE
Deferring log extraction until we sort out permissions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,6 @@ commands:
             sed 's/__ENV__/<< parameters.env >>/' k8s_migrate_job.yml | kubectl apply -f -
             kubectl wait --for=condition=complete job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             exit_code=$?
-            kubectl logs job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             kubectl delete job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             exit ${exit_code}
       - deploy:


### PR DESCRIPTION
### Jira link

N/A

### What?

I have added/removed/altered:

- [ ] Remove log extraction step, on migrations run.

### Why?

I am doing this because:
- We need to get additional permissions for circleCI to be able to do this. Until then we are suppressing it so that we can deploy.

