### PR TITLE
Allow specific plural types within move events validator

### DIFF
--- a/app/services/move_events/params_validator.rb
+++ b/app/services/move_events/params_validator.rb
@@ -4,6 +4,8 @@ module MoveEvents
   class ParamsValidator
     include ActiveModel::Validations
 
+    ACCEPTABLE_PLURAL_VERBS = %w[cancels completes approves rejects].freeze
+
     attr_reader :timestamp, :type, :date, :cancellation_reason, :rejection_reason
 
     validates :type, presence: true, inclusion: { in: %w[cancel complete lockouts redirects approve reject] }
@@ -31,6 +33,14 @@ module MoveEvents
       @date = params.dig(:attributes, :date)
       @cancellation_reason = params.dig(:attributes, :cancellation_reason)
       @rejection_reason = params.dig(:attributes, :rejection_reason)
+
+      singularize_acceptable_plural_types
+    end
+
+  private
+
+    def singularize_acceptable_plural_types
+      @type = @type.singularize if ACCEPTABLE_PLURAL_VERBS.include?(@type)
     end
   end
 end

--- a/spec/services/move_events/params_validator_spec.rb
+++ b/spec/services/move_events/params_validator_spec.rb
@@ -116,6 +116,24 @@ RSpec.describe MoveEvents::ParamsValidator do
 
       it { is_expected.not_to be_valid }
     end
+
+    context 'with acceptable plural actions' do
+      let(:type) { 'cancels' }
+
+      it 'converts to singular action' do
+        expect(params_validator.type).to eq('cancel')
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with expected plural actions' do
+      let(:type) { 'lockouts' }
+
+      it 'remains as a plural action' do
+        expect(params_validator.type).to eq('lockouts')
+      end
+    end
   end
 
   describe 'timestamp' do

--- a/spec/services/move_events/params_validator_spec.rb
+++ b/spec/services/move_events/params_validator_spec.rb
@@ -118,10 +118,10 @@ RSpec.describe MoveEvents::ParamsValidator do
     end
 
     context 'with acceptable plural actions' do
-      let(:type) { 'cancels' }
+      let(:type) { 'completes' }
 
       it 'converts to singular action' do
-        expect(params_validator.type).to eq('cancel')
+        expect(params_validator.type).to eq('complete')
       end
 
       it { is_expected.to be_valid }

--- a/swagger/v1/post_allocation_cancel.yaml
+++ b/swagger/v1/post_allocation_cancel.yaml
@@ -6,10 +6,10 @@ PostAllocationCancel:
   properties:
     type:
       type: string
-      example: cancel
+      example: cancels
       enum:
-      - cancel
-      description: The type of this object - always `cancel`
+      - cancels
+      description: The type of this object - always `cancels`
     attributes:
       type: object
       required:

--- a/swagger/v1/post_move_approve.yaml
+++ b/swagger/v1/post_move_approve.yaml
@@ -6,10 +6,10 @@ PostMoveReject:
   properties:
     type:
       type: string
-      example: approve
+      example: approves
       enum:
-      - approve
-      description: The type of this object - always `approve`
+      - approves
+      description: The type of this object - always `approves`
     attributes:
       type: object
       required:

--- a/swagger/v1/post_move_cancel.yaml
+++ b/swagger/v1/post_move_cancel.yaml
@@ -6,10 +6,10 @@ PostMoveCancel:
   properties:
     type:
       type: string
-      example: cancel
+      example: cancels
       enum:
-      - cancel
-      description: The type of this object - always `cancel`
+      - cancels
+      description: The type of this object - always `cancels`
     attributes:
       type: object
       required:

--- a/swagger/v1/post_move_complete.yaml
+++ b/swagger/v1/post_move_complete.yaml
@@ -6,10 +6,10 @@ PostMoveComplete:
   properties:
     type:
       type: string
-      example: complete
+      example: completes
       enum:
-      - complete
-      description: The type of this object - always `complete`
+      - completes
+      description: The type of this object - always `completes`
     attributes:
       type: object
       required:

--- a/swagger/v1/post_move_reject.yaml
+++ b/swagger/v1/post_move_reject.yaml
@@ -6,10 +6,10 @@ PostMoveReject:
   properties:
     type:
       type: string
-      example: reject
+      example: rejects
       enum:
-      - reject
-      description: The type of this object - always `reject`
+      - rejects
+      description: The type of this object - always `rejects`
     attributes:
       type: object
       required:


### PR DESCRIPTION
### Jira link

P4-1633

### What?

- [x] POST endpoints to `/moves/:id/cancel`, `/moves/:id/approve`, `/moves/:id/reject` and `/moves/:id/complete` all expect a singular corresponding `type` attribute in the `body` payload
- [x] Amended these endpoints to also accept a plural version of the same `type` attribute (e.g. `rejects` => `reject`)
- [x] Updated API documentation for these endpoints to recommend passing a plural `type` attribute
- [x] The type is converted internally as needed to the singular version for compatibility with existing `Event` data in production.

### Why?

- The front end code base makes use of a JSONAPI client library Devour which does not have the flexibility to provide singular types and so would require significant changes to use an alternate approach to call endpoints with singular types defined.
- Strictly speaking, the JSONAPI spec suggests that an API should use either singular or plural terms consistently throughout the implementation. In almost every case we adopt plural terms but this seems less grammatically correct for some verbs used in these endpoints that fall outside the usual RESTful conventions.
- We don't really want to update existing production `Event` data as this would require a coordinated change across front end, back end and the database meaning a likely planned outage, plus is tricky to manipulate nested JSONB data in situ.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Makes the existing API for these endpoints more forgiving so this unblocks some current work streams but does not break usage of the previous types.