### PR TITLE
Trigger deploy to DEV on a branch suffix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ aliases:
         only:
           - master
           - dev-auth-from-docs
+          - /.*-deploydev/
   - &only_for_deployment
     filters:
       tags:
@@ -66,6 +67,7 @@ aliases:
         only:
           - master
           - dev-auth-from-docs
+          - /.*-deploydev/
   - &only_deploy_tags
     filters:
       tags:


### PR DESCRIPTION
### Jira link
Related to:
P4-1631
### What?

I have added/removed/altered:

- [ ] Added a branch filter rule to trigger deployment to dev.

### Why?

I am doing this because:
- It is useful to be able to deploy to the dev environment so that we can fully test the workflow and if a change runs in the target platform 

