### PR TITLE
Update rules for rebooking a move

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -102,8 +102,9 @@ class Move < VersionedModel
       allocation_id: allocation_id,
       profile_id: profile_id,
       status: MOVE_STATUS_PROPOSED,
-      date: date + 7.days,
-      date_from: date + 7.days,
+      date: date && date + 7.days,
+      date_from: date_from && date_from + 7.days,
+      date_to: date_to && date_to + 7.days,
     )
   end
 

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -84,6 +84,10 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :with_date_to do
+      date_to { date + 3.days }
+    end
   end
 
   factory :from_court_to_prison, class: 'Move' do

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -413,7 +413,7 @@ RSpec.describe Move do
   end
 
   describe '#rebook' do
-    let!(:original_move) { create(:move, :proposed, :with_allocation) }
+    let!(:original_move) { create(:move, :proposed, :with_allocation, :with_date_to) }
 
     context 'when not yet rebooked' do
       it 'creates a new move' do
@@ -440,12 +440,31 @@ RSpec.describe Move do
         expect(original_move.rebook.status).to eq('proposed')
       end
 
-      it 'sets the move date to 7 days in the future' do
+      it 'sets the move date to 7 days in the future if present' do
         expect(original_move.rebook.date).to eq(original_move.date + 7.days)
       end
 
-      it 'sets the move from date to 7 days in the future' do
-        expect(original_move.rebook.date_from).to eq(original_move.date + 7.days)
+      it 'sets the move date to nil if not present' do
+        original_move.date = nil
+        expect(original_move.rebook.date).to be_nil
+      end
+
+      it 'sets the move from date to 7 days in the future if present' do
+        expect(original_move.rebook.date_from).to eq(original_move.date_from + 7.days)
+      end
+
+      it 'sets the move date from to nil if not present' do
+        original_move.date_from = nil
+        expect(original_move.rebook.date_from).to be_nil
+      end
+
+      it 'sets the move to date to 7 days in the future if present' do
+        expect(original_move.rebook.date_to).to eq(original_move.date_to + 7.days)
+      end
+
+      it 'sets the move to date to nil if not present' do
+        original_move.date_to = nil
+        expect(original_move.rebook.date_to).to be_nil
       end
 
       it 'relates the new move to the original move' do


### PR DESCRIPTION
### Jira link

P4-1633

### What?

- [x] Updated implementation of `.rebook` method for `Move` model

### Why?

- This now sets the move `date`, `date_from` and `date_to` to 7 days ahead from their current values if present, otherwise they are kept as nil values.
- It's possible that a proposed move would have any of these values set - at a minimum `date_from` must be set but we want to preserve everything if possible, whilst also not throwing a 500 error if one of the values happens to be nil.

### Deployment risks (optional)

- This forms part of the `POST /moves/:id/reject` endpoint that is not yet in production
