### PR TITLE
Amend includes for an allocation

### DIFF
--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -19,5 +19,13 @@ class AllocationSerializer < ActiveModel::Serializer
   has_one :to_location
   has_many :moves
 
-  SUPPORTED_RELATIONSHIPS = %w[from_location to_location moves.person moves.person.gender moves.person.ethnicity].freeze
+  SUPPORTED_RELATIONSHIPS = %w[
+    from_location
+    to_location
+    moves.person
+    moves.person.gender
+    moves.person.ethnicity
+    moves.profile.person.ethnicity
+    moves.profile.person.gender
+  ].freeze
 end

--- a/spec/requests/api/v1/allocations_controller_index_spec.rb
+++ b/spec/requests/api/v1/allocations_controller_index_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Api::V1::AllocationsController do
 
           it 'returns the default minimum includes' do
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
-            expect(returned_types).to contain_exactly('people', 'moves', 'locations', 'ethnicities', 'genders')
+            expect(returned_types).to contain_exactly('profiles', 'people', 'moves', 'locations', 'ethnicities', 'genders')
           end
         end
 
@@ -217,7 +217,7 @@ RSpec.describe Api::V1::AllocationsController do
               'errors' => [
                 {
                   'title' => 'Bad request',
-                  'detail' => '["foo.bar"] is not supported. Valid values are: ["from_location", "to_location", "moves", "moves.person", "moves.person.gender", "moves.person.ethnicity"]',
+                  'detail' => /\["foo\.bar"\] is not supported/,
                 },
               ],
             }
@@ -225,7 +225,7 @@ RSpec.describe Api::V1::AllocationsController do
 
           it 'returns a validation error' do
             expect(response).to have_http_status(:bad_request)
-            expect(response_json).to eq(expected_error)
+            expect(response_json).to include(expected_error)
           end
         end
 
@@ -243,7 +243,7 @@ RSpec.describe Api::V1::AllocationsController do
 
           it 'returns the default minimum includes' do
             returned_types = response_json['included'].map { |r| r['type'] }.uniq
-            expect(returned_types).to contain_exactly('people', 'moves', 'locations', 'ethnicities', 'genders')
+            expect(returned_types).to contain_exactly('profiles', 'people', 'moves', 'locations', 'ethnicities', 'genders')
           end
         end
       end

--- a/spec/serializers/allocation_serializer_spec.rb
+++ b/spec/serializers/allocation_serializer_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe AllocationSerializer do
       expect(result_data[:relationships][:moves][:data]).to contain_exactly(id: move.id, type: 'moves')
     end
 
-    it 'contains an included move and person' do
-      expect(result[:included].map { |r| r[:type] }).to match_array(%w[people moves locations locations genders ethnicities])
+    it 'contains an included move and profile' do
+      expect(result[:included].map { |r| r[:type] }).to match_array(%w[people profiles moves locations locations genders ethnicities])
     end
   end
 


### PR DESCRIPTION
Since we now support profiles instead of person, change includes to
support profile as well in the allocation serializer. I've kept the old person associations to allow for the final cleanup that will be done by the people/profile team.
