### PR TITLE
Refactor state machine integration with models

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -18,7 +18,7 @@ class Allocation < VersionedModel
     long: 'more_than_16',
   }
 
-  enum status: {
+  enum states: {
     unfilled: ALLOCATION_STATUS_UNFILLED,
     filled: ALLOCATION_STATUS_FILLED,
     cancelled: ALLOCATION_STATUS_CANCELLED,
@@ -37,7 +37,7 @@ class Allocation < VersionedModel
   has_many :moves, inverse_of: :allocation, dependent: :destroy, autosave: true
   has_many :events, as: :eventable, dependent: :destroy
 
-  validates :status, presence: true
+  validates :status, presence: true, inclusion: { in: states }
 
   validates :from_location, presence: true
   validates :to_location, presence: true
@@ -55,7 +55,7 @@ class Allocation < VersionedModel
 
   has_state_machine AllocationStateMachine, on: :status
 
-  delegate :fill, :unfill, to: :state_machine
+  delegate :fill, :unfill, :filled?, :unfilled?, :cancelled?, to: :state_machine
 
   def cancel(reason: CANCELLATION_REASON_OTHER, comment: 'Allocation was cancelled')
     assign_attributes(

--- a/app/models/concerns/state_machineable.rb
+++ b/app/models/concerns/state_machineable.rb
@@ -1,0 +1,41 @@
+require 'active_support/concern'
+
+module StateMachineable
+  extend ActiveSupport::Concern
+
+  included do
+    after_initialize :initialize_state
+
+    class_attribute :state_attribute
+    class_attribute :state_machine_class
+  end
+
+  def reload(options = nil)
+    # Override to ensure state machine state is correctly restored. Unfortunately there's not a callback for this.
+    super.tap { restore_state }
+  end
+
+  def initialize_state
+    if read_attribute(state_attribute).blank?
+      write_attribute(state_attribute, state_machine.current)
+    else
+      restore_state
+    end
+  end
+
+  def restore_state
+    state = read_attribute(state_attribute)
+    state_machine.restore!(state.to_sym)
+  end
+
+  def state_machine
+    @state_machine ||= state_machine_class.new(self)
+  end
+
+  class_methods do
+    def has_state_machine(state_machine_class, options = {})
+      self.state_machine_class = state_machine_class
+      self.state_attribute = options[:on] || :state
+    end
+  end
+end

--- a/app/models/concerns/state_machineable.rb
+++ b/app/models/concerns/state_machineable.rb
@@ -12,20 +12,16 @@ module StateMachineable
 
   def reload(options = nil)
     # Override to ensure state machine state is correctly restored. Unfortunately there's not a callback for this.
-    super.tap { restore_state }
+    super.tap { initialize_state }
   end
 
   def initialize_state
-    if read_attribute(state_attribute).blank?
-      write_attribute(state_attribute, state_machine.current)
-    else
-      restore_state
-    end
-  end
-
-  def restore_state
     state = read_attribute(state_attribute)
-    state_machine.restore!(state.to_sym) if state.present?
+    if state.present?
+      state_machine.restore!(state.to_sym)
+    else
+      write_attribute(state_attribute, state_machine.current)
+    end
   end
 
   def state_machine

--- a/app/models/concerns/state_machineable.rb
+++ b/app/models/concerns/state_machineable.rb
@@ -16,11 +16,11 @@ module StateMachineable
   end
 
   def initialize_state
-    state = read_attribute(state_attribute)
+    state = self[state_attribute]
     if state.present?
       state_machine.restore!(state.to_sym)
     else
-      write_attribute(state_attribute, state_machine.current)
+      self[state_attribute] = state_machine.current
     end
   end
 

--- a/app/models/concerns/state_machineable.rb
+++ b/app/models/concerns/state_machineable.rb
@@ -25,7 +25,7 @@ module StateMachineable
 
   def restore_state
     state = read_attribute(state_attribute)
-    state_machine.restore!(state.to_sym)
+    state_machine.restore!(state.to_sym) if state.present?
   end
 
   def state_machine

--- a/app/state_machines/allocation_state_machine.rb
+++ b/app/state_machines/allocation_state_machine.rb
@@ -1,8 +1,8 @@
 class AllocationStateMachine < FiniteMachine::Definition
   initial :unfilled
 
-  event :fill, %i[unfilled filled] => :filled
-  event :unfill, %i[unfilled filled] => :unfilled
+  event :fill, unfilled: :filled
+  event :unfill, filled: :unfilled
   event :cancel, %i[unfilled filled] => :cancelled
 
   terminal :cancelled

--- a/db/migrate/20200617155359_change_null_allocation_status.rb
+++ b/db/migrate/20200617155359_change_null_allocation_status.rb
@@ -1,0 +1,5 @@
+class ChangeNullAllocationStatus < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :allocations, :status, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_12_133540) do
+ActiveRecord::Schema.define(version: 2020_06_17_155359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2020_06_12_133540) do
     t.text "other_criteria"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "status"
+    t.string "status", null: false
     t.string "cancellation_reason"
     t.text "cancellation_reason_comment"
     t.string "requested_by"

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     complete_in_full { false }
 
     # NB we need to initialize_state because FactoryBot fires the after_initialize callback before the attributes are initialised!
-    after(:build) { |allocation| allocation.initialize_state }
+    after(:build, &:initialize_state)
 
     trait :unfilled do
       status { 'unfilled' }

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -12,7 +12,8 @@ FactoryBot.define do
     moves_count { Faker::Number.non_zero_digit }
     complete_in_full { false }
 
-    after(:build) { |object| object.send(:initialize_state) }
+    # NB we need to restore_state because FactoryBot fires the after_initialize callback before the attributes are initialised!
+    after(:build) { |allocation| allocation.restore_state }
 
     trait :unfilled do
       status { 'unfilled' }
@@ -23,13 +24,6 @@ FactoryBot.define do
     trait :cancelled do
       status { 'cancelled' }
       cancellation_reason { 'other' }
-    end
-
-    # TODO: remove when we no longer support nil statuses on allocations
-    trait :none do
-      before(:create) do |allocation|
-        allocation.assign_attributes(status: nil)
-      end
     end
 
     trait :with_moves do

--- a/spec/factories/allocation.rb
+++ b/spec/factories/allocation.rb
@@ -12,8 +12,8 @@ FactoryBot.define do
     moves_count { Faker::Number.non_zero_digit }
     complete_in_full { false }
 
-    # NB we need to restore_state because FactoryBot fires the after_initialize callback before the attributes are initialised!
-    after(:build) { |allocation| allocation.restore_state }
+    # NB we need to initialize_state because FactoryBot fires the after_initialize callback before the attributes are initialised!
+    after(:build) { |allocation| allocation.initialize_state }
 
     trait :unfilled do
       status { 'unfilled' }

--- a/spec/factories/journeys.rb
+++ b/spec/factories/journeys.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     vehicle { { id: '12345678ABC', registration: 'AB12 CDE' } }
 
     # NB we need to initialize_state because FactoryBot fires the after_initialize callback before the attributes are initialised!
-    after(:build) { |journey| journey.initialize_state }
+    after(:build, &:initialize_state)
 
     # Journey statuses
     trait :proposed do

--- a/spec/factories/journeys.rb
+++ b/spec/factories/journeys.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     client_timestamp { Time.now.utc + rand(-60..60).seconds } # NB: the client_timestamp will never be perfectly in sync with system clock
     vehicle { { id: '12345678ABC', registration: 'AB12 CDE' } }
 
-    # NB we need to initialize_state because FactoryBot fires the after_initialize callback before the attributes are initialised!
-    after(:build) { |object| object.send(:initialize_state) }
+    # NB we need to restore_state because FactoryBot fires the after_initialize callback before the attributes are initialised!
+    after(:build) { |journey| journey.restore_state }
 
     # Journey statuses
     trait :proposed do

--- a/spec/factories/journeys.rb
+++ b/spec/factories/journeys.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     client_timestamp { Time.now.utc + rand(-60..60).seconds } # NB: the client_timestamp will never be perfectly in sync with system clock
     vehicle { { id: '12345678ABC', registration: 'AB12 CDE' } }
 
-    # NB we need to restore_state because FactoryBot fires the after_initialize callback before the attributes are initialised!
-    after(:build) { |journey| journey.restore_state }
+    # NB we need to initialize_state because FactoryBot fires the after_initialize callback before the attributes are initialised!
+    after(:build) { |journey| journey.initialize_state }
 
     # Journey statuses
     trait :proposed do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Allocation do
   it { is_expected.to define_enum_for(:sentence_length).backed_by_column_of_type(:string) }
 
   it { is_expected.to validate_presence_of(:status) }
-  it { is_expected.to define_enum_for(:status).backed_by_column_of_type(:string) }
+  it { is_expected.to validate_inclusion_of(:status).in_array(%w[unfilled filled cancelled]) }
 
   it { is_expected.to validate_presence_of(:moves_count) }
   it { is_expected.to validate_numericality_of(:moves_count) }

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Allocation do
   it { is_expected.to allow_value(nil).for(:sentence_length) }
   it { is_expected.to define_enum_for(:sentence_length).backed_by_column_of_type(:string) }
 
-  it { is_expected.to allow_value(nil).for(:status) }
+  it { is_expected.to validate_presence_of(:status) }
   it { is_expected.to define_enum_for(:status).backed_by_column_of_type(:string) }
 
   it { is_expected.to validate_presence_of(:moves_count) }
@@ -113,7 +113,7 @@ RSpec.describe Allocation do
   end
 
   describe '#cancel' do
-    let(:allocation) { create(:allocation, :with_moves, status: nil) }
+    let(:allocation) { create(:allocation, :with_moves) }
 
     it 'changes the status of an allocation to cancelled' do
       allocation.cancel
@@ -160,84 +160,33 @@ RSpec.describe Allocation do
 
   describe '#status' do
     it 'sets the initial status to unfilled' do
-      allocation = create(:allocation)
+      allocation = build(:allocation)
 
       expect(allocation).to be_unfilled
-    end
-
-    it 'sets the initial status to nil if set as none' do
-      allocation = create(:allocation, :none)
-
-      expect(allocation.status).to be_nil
     end
 
     it 'restores the current status if it is set' do
-      allocation = create(:allocation, :filled)
+      allocation = build(:allocation, :filled)
 
       expect(allocation).to be_filled
     end
+  end
 
-    it 'updates the status from unfilled if it is filled' do
-      allocation = create(:allocation, :unfilled)
+  describe '#fill' do
+    it 'updates the status from unfilled' do
+      allocation = build(:allocation, :unfilled)
 
       allocation.fill
       expect(allocation).to be_filled
     end
+  end
 
-    it 'updates the status from unfilled if it is cancelled' do
-      allocation = create(:allocation, :unfilled)
-
-      allocation.cancel
-      expect(allocation).to be_cancelled
-    end
-
-    it 'updates the status from filled if it is unfilled' do
-      allocation = create(:allocation, :filled)
+  describe '#unfill' do
+    it 'updates the status from filled' do
+      allocation = build(:allocation, :filled)
 
       allocation.unfill
       expect(allocation).to be_unfilled
-    end
-
-    it 'updates the status from filled if it is cancelled' do
-      allocation = create(:allocation, :filled)
-
-      allocation.cancel
-      expect(allocation).to be_cancelled
-    end
-
-    it 'keeps the status filled if already set' do
-      allocation = create(:allocation, :filled)
-
-      allocation.fill
-      expect(allocation).to be_filled
-    end
-
-    it 'keeps the status unfilled if already set' do
-      allocation = create(:allocation, :unfilled)
-
-      allocation.unfill
-      expect(allocation).to be_unfilled
-    end
-
-    it 'updates the status from nil if it is filled' do
-      allocation = create(:allocation, :none)
-
-      allocation.fill
-      expect(allocation).to be_filled
-    end
-
-    it 'updates the status from nil if it is unfilled' do
-      allocation = create(:allocation, :none)
-
-      allocation.unfill
-      expect(allocation).to be_unfilled
-    end
-
-    it 'updates the status from nil if it is cancelled' do
-      allocation = create(:allocation, :none)
-
-      allocation.cancel
-      expect(allocation).to be_cancelled
     end
   end
 end

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Allocations::Finder do
   let!(:from_location) { create :location }
   let!(:to_location) { create :location }
 
-  let!(:allocation) { create :allocation, :none, from_location: from_location, to_location: to_location }
+  let!(:allocation) { create :allocation, from_location: from_location, to_location: to_location }
   let(:filter_params) { {} }
   let(:sort_params) { {} }
 
@@ -113,7 +113,6 @@ RSpec.describe Allocations::Finder do
     end
 
     describe 'by status' do
-      let!(:unfilled_allocation) { create :allocation, :unfilled, from_location: from_location, to_location: to_location }
       let!(:filled_allocation) { create :allocation, :filled, from_location: from_location, to_location: to_location }
       let!(:cancelled_allocation) { create :allocation, :cancelled, from_location: from_location, to_location: to_location }
 
@@ -129,7 +128,7 @@ RSpec.describe Allocations::Finder do
         let(:filter_params) { { status: 'unfilled,cancelled' } }
 
         it 'returns allocations matching status' do
-          expect(allocation_finder.call).to contain_exactly(unfilled_allocation, cancelled_allocation)
+          expect(allocation_finder.call).to contain_exactly(allocation, cancelled_allocation)
         end
       end
 
@@ -144,8 +143,8 @@ RSpec.describe Allocations::Finder do
       context 'with nil status' do
         let(:filter_params) { { status: nil } }
 
-        it 'returns only allocations without a status' do
-          expect(allocation_finder.call).to contain_exactly(allocation)
+        it 'returns empty results set' do
+          expect(allocation_finder.call).to be_empty
         end
       end
     end


### PR DESCRIPTION
### Jira link

P4-1657

### What?

- [x] Added a shared concern to be used where we want to include a state machine with a model
- [x] Refactored `Allocation` and `Journey` models to use shared concern for state machine inclusion
- [x] Remove legacy handling for nil/none state on allocations (all allocations now have a state)
- [x] Added a DB constraint and model validation rule to ensure allocation status is not null
- [x] Removed/reduced redundant specs

### Why?

- There was some divergence in the approach to integrating the state machine with each model, this cleans that up and means it's more straightforward to add a state machine to `Move` in future.
- The `Allocation` state machine no longer needs to handle `nil` status (the state machine and status attribute was added after we already had some production data, but all production data has been cleaned up to set an explicit status value).
