### PR TITLE
Remove tty-prompt from project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ gem 'puma', '~> 3.12.6'
 gem 'rails', '~> 6.0.3'
 gem 'sentry-raven'
 gem 'sidekiq'
-gem 'tty-prompt'
 gem 'validate_url', '~> 1.0.8'
 
 # Swagger API documentation. We need CORS to enable the Swagger UI to make requests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,6 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
-    equatable (0.6.1)
     erubi (1.9.0)
     factory_bot (5.2.0)
       activesupport (>= 4.2.0)
@@ -190,7 +189,6 @@ GEM
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    necromancer (0.5.1)
     net-http-persistent (3.1.0)
       connection_pool (~> 2.2)
     nio4r (2.5.2)
@@ -214,9 +212,6 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.3)
       ast (~> 2.4.0)
-    pastel (0.7.3)
-      equatable (~> 0.6)
-      tty-color (~> 0.5)
     pg (1.0.0)
     prometheus_exporter (0.4.13)
     pry (0.13.1)
@@ -365,17 +360,6 @@ GEM
     timecop (0.9.1)
     toml-rb (0.3.15)
       citrus (~> 3.0, > 3.0)
-    tty-color (0.5.0)
-    tty-cursor (0.7.0)
-    tty-prompt (0.20.0)
-      necromancer (~> 0.5.0)
-      pastel (~> 0.7.0)
-      tty-reader (~> 0.7.0)
-    tty-reader (0.7.0)
-      tty-cursor (~> 0.7)
-      tty-screen (~> 0.7)
-      wisper (~> 2.0.0)
-    tty-screen (0.7.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -385,7 +369,6 @@ GEM
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wisper (2.0.1)
     zeitwerk (2.3.0)
 
 PLATFORMS
@@ -442,7 +425,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen
   timecop
-  tty-prompt
   validate_url (~> 1.0.8)
 
 RUBY VERSION

--- a/lib/tasks/create_application.rake
+++ b/lib/tasks/create_application.rake
@@ -25,5 +25,6 @@ namespace :auth do
     puts "client_id: #{application.uid}"
     puts "client_secret: #{application.plaintext_secret}"
     puts "supplier: #{supplier}"
+    puts "supplier_id: #{application.owner_id}"
   end
 end

--- a/lib/tasks/create_application.rake
+++ b/lib/tasks/create_application.rake
@@ -1,40 +1,28 @@
 # frozen_string_literal: true
 
-# NB: there is an issue in Doorkeeper which will cause an "uninitialized constant Doorkeeper::Application" error when
-# running this rake task in production mode. It relates to the lazy-loading of ActiveRecord and the work-around is to call
-# ActiveRecord::Base.logger first. See https://github.com/doorkeeper-gem/doorkeeper/issues/1319
-ActiveRecord::Base.logger
-
 namespace :auth do
-  NO_OWNER = 'No owner'
-
   desc 'Create an OAuth2 authorised client application'
   task create_client_application: :environment do
     require 'doorkeeper/orm/active_record/application'
-    require 'tty-prompt'
 
-    prompt = TTY::Prompt.new
-
-    name = prompt.ask("What's the application's name?")
+    puts "What's the application's name?"
+    name = STDIN.gets.chomp
 
     application = Doorkeeper::Application.new(name: name)
 
     suppliers = Supplier.all.each_with_object({}) { |supplier, accumulator|
-      accumulator[supplier.name] = supplier.id
-    }.merge(NO_OWNER => nil)
-    owner_id = prompt.select('Is this application owned by a supplier?', suppliers)
-    if owner_id != NO_OWNER
-      owner = Supplier.find(owner_id)
-      application.owner = owner
-    end
+      accumulator[supplier.name.downcase] = supplier.id
+    }.merge('none' => nil)
 
-    if application.save
-      puts "Created OAuth2 client with (name: #{application.name})"
-      puts "client_id: #{application.uid}"
-      puts "client_secret: #{application.plaintext_secret}"
-      puts "supplier: #{application.owner.name}" if application.owner
-    else
-      puts application.errors.full_messages
-    end
+    puts "Which application owner should your tokens be associated with? #{suppliers.keys}"
+    supplier = STDIN.gets.chomp
+    supplier_id = suppliers[supplier]
+
+    application.owner_id = supplier_id if supplier_id.present?
+
+    puts "Created OAuth2 client with (name: #{application.name})"
+    puts "client_id: #{application.uid}"
+    puts "client_secret: #{application.plaintext_secret}"
+    puts "supplier: #{supplier}"
   end
 end

--- a/lib/tasks/create_application.rake
+++ b/lib/tasks/create_application.rake
@@ -19,6 +19,7 @@ namespace :auth do
     supplier_id = suppliers[supplier]
 
     application.owner_id = supplier_id if supplier_id.present?
+    application.save!
 
     puts "Created OAuth2 client with (name: #{application.name})"
     puts "client_id: #{application.uid}"


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

- Removes tty-prompt gem
- Remove references to tty-prompt

This 1 gem brings in 8 gems and adds very little value - it was giving us a fzf interface for choosing from 3 options when `gets` and a message saying which options are possible works just as well.

I've ran all three variations of this and it works as we expect.

### Why?

I generally prefer to maintain as few deps as possible to make our lives
easier/give us fewer things to worry about from a security point of view