### PR TITLE
Reinstate importing of latest_nomis_booking_id

### DIFF
--- a/app/services/people/importer.rb
+++ b/app/services/people/importer.rb
@@ -33,6 +33,7 @@ module People
         prison_number: prison_number,
         criminal_records_office: criminal_records_office,
         last_synced_with_nomis: last_synced_with_nomis,
+        latest_nomis_booking_id: latest_nomis_booking_id,
       )
     end
 

--- a/app/services/person_populator.rb
+++ b/app/services/person_populator.rb
@@ -1,0 +1,48 @@
+# TODO: Remove this once we've migrated all profile attributes to a person and are updating these attributes dynamically
+class PersonPopulator
+  def initialize(person, profile)
+    @person = person
+    @profile = profile
+  end
+
+  def call
+    populate_standard_attributes
+    populate_identifier_attributes
+    person.save
+  end
+
+private
+
+  attr_reader :person, :profile
+
+  STANDARD_ATTRIBUTES = %w[
+    first_names
+    last_name
+    date_of_birth
+    gender_additional_information
+    latest_nomis_booking_id
+    ethnicity_id
+    gender_id
+  ].freeze
+
+  IDENTIFIER_ATTRIBUTES = %w[
+    prison_number
+    criminal_records_office
+    police_national_computer
+  ].freeze
+
+  def populate_standard_attributes
+    attributes = profile.attributes.slice(*STANDARD_ATTRIBUTES)
+
+    person.assign_attributes(attributes)
+  end
+
+  def populate_identifier_attributes
+    attributes = profile.profile_identifiers.each_with_object({}) do |identifier, acc|
+      acc[identifier.identifier_type] = identifier.value
+    end
+    attributes = attributes.slice(*IDENTIFIER_ATTRIBUTES)
+
+    person.assign_attributes(attributes)
+  end
+end

--- a/spec/services/people/importer_spec.rb
+++ b/spec/services/people/importer_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe People::Importer do
         'gender_id' => gender.id,
         'ethnicity_id' => ethnicity.id,
         'last_synced_with_nomis' => be_within(2.seconds).of(now),
+        'latest_nomis_booking_id' => 1_093_139,
       }
     end
     let(:expected_profile_attributes) do


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

Fixes missing import for the latest_nomis_booking_id in the Nomis Importer service.

This is a bug and needs fixing so that Nomis court hearings, court cases, personal care needs, risks and activities can be returned correctly.

There is no data loss resulting from this bug.

### Why?

- Integrations with Nomis are critical