### PR TITLE
Reinstate profile_identifier serializers

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -13,6 +13,7 @@ class Profile < VersionedModel
 
   validate :validate_assessment_answers
   attribute :assessment_answers, Types::Jsonb.new(Profile::AssessmentAnswers)
+  attribute :profile_identifiers, Types::Jsonb.new(Profile::ProfileIdentifiers)
 
   # Need to check whether this update actually involves a change, otherwise there will be a papertrail log
   # full of update records where nothing actually changes - making the audit next to useless.

--- a/app/models/profile/profile_identifier.rb
+++ b/app/models/profile/profile_identifier.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Profile
+  class ProfileIdentifier
+    attr_accessor :identifier_type, :value
+
+    IDENTIFIER_TYPES = %w[
+      police_national_computer criminal_records_office prison_number niche_reference athena_reference
+    ].freeze
+
+    def initialize(attribute_values = {})
+      attribute_values.symbolize_keys! if attribute_values.respond_to?(:symbolize_keys!)
+
+      self.identifier_type = attribute_values[:identifier_type]
+      self.value = attribute_values[:value]
+    end
+
+    def empty?
+      value.blank?
+    end
+
+    def as_json(_options = {})
+      {
+        identifier_type: identifier_type,
+        value: value,
+      }
+    end
+  end
+end

--- a/app/models/profile/profile_identifiers.rb
+++ b/app/models/profile/profile_identifiers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Profile
+  class ProfileIdentifiers < Types::BaseCollection
+    def concrete_class
+      ProfileIdentifier
+    end
+
+    def remove_empty_items?
+      true
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

Reinstate profile identifier serializers

### Why?

These are needed to move profile_identifiers around as part of the person populator