### PR TITLE
[P4-1666] Fix swagger docs

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -213,7 +213,7 @@ private
   end
 
   def api_version
-    res = request.headers['Accept'].match(REGEXP_API_VERSION)
+    res = request.headers['Accept']&.match(REGEXP_API_VERSION)
     res&.[](:version)
   end
 

--- a/lib/routing_filter/versioned_path.rb
+++ b/lib/routing_filter/versioned_path.rb
@@ -2,7 +2,7 @@
 module RoutingFilter
   class VersionedPath < Filter
     def around_recognize(path, _env)
-      remove_version!(path) unless path.include?('yaml')
+      remove_version!(path) unless path.start_with?('/api-docs/')
 
       yield
     end

--- a/lib/routing_filter/versioned_path.rb
+++ b/lib/routing_filter/versioned_path.rb
@@ -2,7 +2,7 @@
 module RoutingFilter
   class VersionedPath < Filter
     def around_recognize(path, _env)
-      remove_version!(path) unless path.include?('swagger')
+      remove_version!(path) unless path.include?('yaml')
 
       yield
     end


### PR DESCRIPTION
### Jira link

P4-1666

### What?

- Fix swagger docs in staging by not changing routes for requests for swagger docs.
- Fix issue with matching missing Accept headers.

### Why?

We broke swagger docs when we started filtering out v1 in our apis. 

### TODO

- Fix v2 docs

