### PR TITLE
[P4-1500] Removes move documents from hand_coded_paths_v1

### DIFF
--- a/spec/swagger/definitions/hand_coded_paths_v1.yaml
+++ b/spec/swagger/definitions/hand_coded_paths_v1.yaml
@@ -935,58 +935,6 @@
           application/vnd.api+json:
             schema:
               $ref: error_responses.yaml#/422
-/moves/{move_id}/documents:
-  post:
-    summary: Creates a new document
-    tags:
-    - Documents
-    consumes:
-    - application/vnd.api+json
-    parameters:
-    - $ref: move_id_parameter.yaml#/MoveId
-    - name: body
-      in: body
-      required: true
-      description: The document object to be created
-      schema:
-        $ref: document.yaml#/Document
-    responses:
-      '201':
-        description: created
-        content:
-          application/vnd.api+json:
-            schema:
-              $ref: post_documents_responses.yaml#/201
-      '400':
-        description: bad request
-        content:
-          application/vnd.api+json:
-            schema:
-              $ref: post_documents_responses.yaml#/400
-      '401':
-        description: unauthorized
-        content:
-          application/vnd.api+json:
-            schema:
-              $ref: post_documents_responses.yaml#/401
-      '404':
-        description: resource not found
-        content:
-          application/vnd.api+json:
-            schema:
-              $ref: post_documents_responses.yaml#/404
-      '415':
-        description: invalid media type
-        content:
-          application/vnd.api+json:
-            schema:
-              $ref: post_documents_responses.yaml#/415
-      '422':
-        description: unprocessable entity
-        content:
-          application/vnd.api+json:
-            schema:
-              $ref: post_documents_responses.yaml#/422
 /moves/{move_id}/journeys:
   get:
     summary: 'Gets a list of journeys'


### PR DESCRIPTION
### Jira link

P4-1500

### What?

- [x] Removes `POST /moves/{move_id}/documents` from swagger documentation

### Why?

This is no longer supported