### PR TITLE
Adds swagger directory specs back into api_docs job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ references:
     run:
       name: Generate API Docs
       command: |
-        TESTS=$(circleci tests glob "spec/requests/**/*_rswag_spec.rb" | circleci tests split )
+        TESTS=$(circleci tests glob "spec/{requests,swagger}/**/*_spec.rb" | grep -e rswag -e swagger | circleci tests split )
         bundle exec rspec ${TESTS} --format Rswag::Specs::SwaggerFormatter --order defined
   _rspec: &rspec
     run:


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

- Add swagger directory back into api_docs generation job

The glob pattern enhancement to the api_docs job ended up missing
all of our swagger directory doc generation tests.

The TEST variable includes only our rswag tests in full now:

```
spec/requests/api/documents_controller_create_rswag_spec.rb
spec/requests/api/moves_controller_role_access_rswag_spec.rb
spec/requests/api/reference/prison_transfer_reasons_controller_rswag_spec.rb
spec/swagger/api/allocations_controller_show_spec.rb
spec/swagger/api/court_hearings_controller_create_spec.rb
spec/swagger/api/moves_controller_show_spec.rb
spec/swagger/api/people_controller_court_cases_spec.rb
spec/swagger/api/people_controller_image_spec.rb
spec/swagger/api/people_controller_timetable_spec.rb
```

### Why?

We are missing a whole bunch of documentation in staging/production since we made this enhancement.