### PR TITLE
Add support for include `locations` when retrieving regions

### DIFF
--- a/app/controllers/api/reference/regions_controller.rb
+++ b/app/controllers/api/reference/regions_controller.rb
@@ -4,7 +4,13 @@ module Api
   module Reference
     class RegionsController < ApiController
       def index
-        render json: Region.all.includes(:locations)
+        render json: Region.all.includes(locations: :suppliers), include: included_relationships
+      end
+
+    private
+
+      def supported_relationships
+        RegionSerializer::SUPPORTED_RELATIONSHIPS
       end
     end
   end

--- a/app/serializers/region_serializer.rb
+++ b/app/serializers/region_serializer.rb
@@ -4,4 +4,6 @@ class RegionSerializer < ActiveModel::Serializer
   attributes :key, :name, :created_at, :updated_at
 
   has_many :locations
+
+  SUPPORTED_RELATIONSHIPS = %w[locations].freeze
 end

--- a/spec/serializers/region_serializer_spec.rb
+++ b/spec/serializers/region_serializer_spec.rb
@@ -7,46 +7,50 @@ RSpec.describe RegionSerializer do
 
   let(:region) { create(:region) }
   let(:result) do
-    JSON.parse(ActiveModelSerializers::Adapter.create(serializer).to_json).deep_symbolize_keys
+    JSON.parse(ActiveModelSerializers::Adapter.create(serializer, adapter_options).to_json).deep_symbolize_keys
   end
   let(:result_data) { result[:data] }
   let(:attributes) { result_data[:attributes] }
+  let(:adapter_options) { {} }
 
-  it 'contains a type property' do
-    expect(result_data[:type]).to eql 'regions'
-  end
+  context 'with no options' do
+    it 'contains a type property' do
+      expect(result_data[:type]).to eql 'regions'
+    end
 
-  it 'contains an id property' do
-    expect(result_data[:id]).to eql region.id
-  end
+    it 'contains an id property' do
+      expect(result_data[:id]).to eql region.id
+    end
 
-  it 'contains a key attribute' do
-    expect(attributes[:key]).to eql region.key
-  end
+    it 'contains a key attribute' do
+      expect(attributes[:key]).to eql region.key
+    end
 
-  it 'contains a name attribute' do
-    expect(attributes[:name]).to eql region.name
-  end
+    it 'contains a name attribute' do
+      expect(attributes[:name]).to eql region.name
+    end
 
-  it 'contains a created_at attribute' do
-    expect(attributes[:created_at]).to eql region.created_at.iso8601
-  end
+    it 'contains a created_at attribute' do
+      expect(attributes[:created_at]).to eql region.created_at.iso8601
+    end
 
-  it 'contains an updated_at attribute' do
-    expect(attributes[:updated_at]).to eql region.updated_at.iso8601
+    it 'contains an updated_at attribute' do
+      expect(attributes[:updated_at]).to eql region.updated_at.iso8601
+    end
   end
 
   describe 'locations' do
     context 'with locations' do
       let(:location) { create(:location) }
       let(:region) { create(:region, locations: [location]) }
+      let(:adapter_options) { { include: 'locations' } }
 
       it 'contains a locations relationship' do
         expect(result_data[:relationships][:locations][:data]).to contain_exactly(id: location.id, type: 'locations')
       end
 
-      it 'does not contain an included location' do
-        expect(result[:included]).to be_nil
+      it 'contain an included location' do
+        expect(result[:included].map { |r| r[:type] }).to match_array('locations')
       end
     end
 

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2441,6 +2441,16 @@
       parameters:
         - "$ref": "../v2/accept_type_parameter.yaml#/Accept"
         - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - name: include
+          description: Returns a specific list of related resources to the region
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - locations
+          example: locations
       responses:
         "200":
           description: success


### PR DESCRIPTION
### Jira link

P4-1766

### What?

- [x] Adds supported relationships for region serializer (only `locations`)
- [x] If `include` is specified then full location details are included through `GET /reference/regions`

### Why?

- The front end requires this to correctly deserialize location id's through the Devour JSONAPI library. Although only location id's are needed to subsequently build up location filters on calling `GET /allocations` to filter by region, Devour seems unable to return relationship id's unless the corresponding entities are included in the response.

- This does increase the size of the response payload significantly, and is a bit slower. Local testing shows response time changing from ~35ms with a 10KB payload to ~85ms with a 40KB payload. I've been able to introduce this without any N+1 queries - the ActiveRecord element is only 2.3ms.

- API behaviour is unchanged if no include parameter is specified (i.e. locations are listed as relationships within each region, but not included).

### Deployment risks (optional)

- Regions API is not yet used in production