### PR TITLE
Fix casing of the prison number when indexing by prison number

### DIFF
--- a/app/controllers/api/v1/people_actions.rb
+++ b/app/controllers/api/v1/people_actions.rb
@@ -25,7 +25,7 @@ module Api::V1
     PERMITTED_FILTER_PARAMS = %i[police_national_computer prison_number].freeze
 
     def index_and_render
-      prison_number = filter_params[:prison_number].upcase
+      prison_number = filter_params[:prison_number]&.upcase
 
       import_person_from_nomis(prison_number) if prison_number
 

--- a/app/controllers/api/v1/people_actions.rb
+++ b/app/controllers/api/v1/people_actions.rb
@@ -25,7 +25,7 @@ module Api::V1
     PERMITTED_FILTER_PARAMS = %i[police_national_computer prison_number].freeze
 
     def index_and_render
-      prison_number = filter_params[:prison_number]
+      prison_number = filter_params[:prison_number].upcase
 
       import_person_from_nomis(prison_number) if prison_number
 

--- a/spec/requests/api/people_controller_index_spec.rb
+++ b/spec/requests/api/people_controller_index_spec.rb
@@ -55,13 +55,21 @@ RSpec.describe Api::PeopleController do
 
       before do
         allow(People::Finder).to receive(:new).and_return(people_finder)
-        allow(Moves::ImportPeople).to receive(:new).with([prison_number])
+        allow(Moves::ImportPeople).to receive(:new).with([prison_number.upcase])
           .and_return(instance_double('Moves::ImportPeople', call: nil))
         get '/api/v1/people', headers: headers, params: params
       end
 
       it 'requests data from NOMIS' do
         expect(response).to have_http_status(:ok)
+      end
+
+      context 'when the prison_number is downcased' do
+        let(:params) { { filter: { prison_number: prison_number.downcase }, access_token: token.token } }
+
+        it 'requests data from NOMIS' do
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
 


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

prison_number/offender_number only comes in upcase form so just upcase them when they come into the index action

### Why?

- To support any casing on a prison number