### PR TITLE
Default rswag ui to point at v2 docs first in list

### DIFF
--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -6,6 +6,6 @@ Rswag::Ui.configure do |c|
   # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON endpoints,
   # then the list below should correspond to the relative paths for those endpoints
 
-  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'PECS4 API V1 Docs'
   c.swagger_endpoint '/api-docs/v2/swagger.yaml', 'PECS4 API V2 Docs'
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'PECS4 API V1 Docs'
 end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

We're moving away from v1 and don't want to encourage integration with v1 apis.

Let's default to v2 so that links to our swagger docs point to what we want people to integrate with by default.

### Why?

Reduce accidents, generally.