### PR TITLE
P4-1616 Support includes in all relevant controllers

### DIFF
--- a/app/controllers/api/journeys_controller.rb
+++ b/app/controllers/api/journeys_controller.rb
@@ -21,21 +21,29 @@ module Api
     end
 
     def show
-      render json: journey, status: :ok
+      render_journey(journey, :ok)
     end
 
     def create
       authorize!(:create, journey)
       journey.save!
-      render json: journey, status: :created
+      render_journey(journey, :created)
     end
 
     def update
       journey.update!(update_journey_attributes)
-      render json: journey, status: :ok
+      render_journey(journey, :ok)
     end
 
   private
+
+    def render_journey(journey, status)
+      render json: journey, status: status, include: included_relationships
+    end
+
+    def supported_relationships
+      JourneySerializer::SUPPORTED_RELATIONSHIPS
+    end
 
     def move
       @move ||= Move.accessible_by(current_ability).find(params.require(:move_id))

--- a/app/serializers/journey_serializer.rb
+++ b/app/serializers/journey_serializer.rb
@@ -6,4 +6,11 @@ class JourneySerializer < ActiveModel::Serializer
 
   has_one :from_location
   has_one :to_location
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    from_location
+    from_location.suppliers
+    to_location
+    to_location.suppliers
+  ].freeze
 end

--- a/spec/requests/api/people_controller_court_cases_spec.rb
+++ b/spec/requests/api/people_controller_court_cases_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe Api::PeopleController do
           expect(People::RetrieveCourtCases).to have_received(:call).with(person, 'active' => 'true')
         end
       end
+
+      context 'when we pass an include in the query params' do
+        it 'includes location in the response' do
+          create(:location, nomis_agency_id: 'SNARCC', title: 'Snaresbrook Crown Court', location_type: 'CRT')
+          get "/api/v1/people/#{person.id}/court_cases?include=location", params: { access_token: token.token }
+
+          expect(response_json['included'].first['type']).to eq('locations')
+        end
+
+        it 'throws an error if query param invalid ' do
+          get "/api/v1/people/#{person.id}/court_cases?include=foo.bar", params: { access_token: token.token }
+
+          expect(response).to have_http_status(:bad_request)
+        end
+      end
     end
 
     context 'when person does not exist' do

--- a/spec/requests/api/people_controller_timetable_spec.rb
+++ b/spec/requests/api/people_controller_timetable_spec.rb
@@ -89,6 +89,21 @@ RSpec.describe Api::PeopleController do
 
         expect(People::RetrieveCourtHearings).to have_received(:call).with(an_instance_of(Person), date_from, date_to)
       end
+
+      context 'when we pass an include in the query params' do
+        it 'includes location in the response' do
+          create(:location)
+          get "/api/v1/people/#{person.id}/timetable?include=location", params: params
+
+          expect(response_json['included'].first['type']).to eq('locations')
+        end
+
+        it 'throws an error if query param invalid ' do
+          get "/api/v1/people/#{person.id}/timetable?include=foo.bar", params: params
+
+          expect(response).to have_http_status(:bad_request)
+        end
+      end
     end
 
     context 'when person does not exist' do

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -183,6 +183,24 @@
             enum:
               - asc
               - desc
+        - name: include
+          description: Returns a specific list of related resources to the allocation
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - from_location
+              - to_location
+              - moves.person
+              - moves.person.gender
+              - moves.person.ethnicity
+              - moves.profile
+              - moves.profile.person
+              - moves.profile.person.ethnicity
+              - moves.profile.person.gender
+          example: from_location
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:
@@ -217,6 +235,24 @@
           description: The allocation object to be created
           schema:
             "$ref": "../v1/allocation.yaml#/Allocation"
+        - name: include
+          description: Returns a specific list of related resources to the allocation
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - from_location
+              - to_location
+              - moves.person
+              - moves.person.gender
+              - moves.person.ethnicity
+              - moves.profile
+              - moves.profile.person
+              - moves.profile.person.ethnicity
+              - moves.profile.person.gender
+          example: from_location
       responses:
         "201":
           description: created
@@ -462,6 +498,31 @@
             enum:
               - asc
               - desc
+        - name: include
+          description: Returns a specific list of related resources to the move
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - allocation
+              - court_hearings
+              - documents
+              - from_location
+              - to_location
+              - original_move
+              - prison_transfer_reason
+              - person
+              - profile
+              - from_location.suppliers
+              - to_location.suppliers
+              - person.gender
+              - person.ethnicity
+              - profile.person
+              - profile.person.gender
+              - profile.person.ethnicity
+          example: from_location
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:
@@ -497,6 +558,31 @@
           description: The move object to be created
           schema:
             "$ref": "../v1/move.yaml#/Move"
+        - name: include
+          description: Returns a specific list of related resources to the move
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - allocation
+              - court_hearings
+              - documents
+              - from_location
+              - to_location
+              - original_move
+              - prison_transfer_reason
+              - person
+              - profile
+              - from_location.suppliers
+              - to_location.suppliers
+              - person.gender
+              - person.ethnicity
+              - profile.person
+              - profile.person.gender
+              - profile.person.ethnicity
+          example: from_location
       responses:
         "201":
           description: created
@@ -550,6 +636,31 @@
           description: The move object to be modified
           schema:
             "$ref": "../v1/move.yaml#/Move"
+        - name: include
+          description: Returns a specific list of related resources to the move
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - allocation
+              - court_hearings
+              - documents
+              - from_location
+              - to_location
+              - original_move
+              - prison_transfer_reason
+              - person
+              - profile
+              - from_location.suppliers
+              - to_location.suppliers
+              - person.gender
+              - person.ethnicity
+              - profile.person
+              - profile.person.gender
+              - profile.person.ethnicity
+          example: from_location
       responses:
         "200":
           description: success
@@ -1945,6 +2056,17 @@
             example: G1234UT
           format: string
           required: false
+        - name: include
+          description: Returns a specific list of related resources to the person
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - gender
+              - ethnicity
+          example: gender
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:
@@ -1980,6 +2102,17 @@
           description: The person object to be created
           schema:
             "$ref": "../v1/person.yaml#/Person"
+        - name: include
+          description: Returns a specific list of related resources to the person
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - gender
+              - ethnicity
+          example: gender
       responses:
         "201":
           description: created
@@ -2041,6 +2174,17 @@
           description: The person object to be updated
           schema:
             "$ref": "../v1/person.yaml#/Person"
+        - name: include
+          description: Returns a specific list of related resources to the person
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - gender
+              - ethnicity
+          example: gender
       responses:
         "200":
           description: updated
@@ -2106,6 +2250,17 @@
           description: The profile object to be created
           schema:
             "$ref": "../v1/profile.yaml#/Profile"
+        - name: include
+          description: Returns a specific list of related resources to the profile
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - documents
+              - person
+          example: documents
       responses:
         "201":
           description: created
@@ -2174,6 +2329,17 @@
           description: The profile object to be modified
           schema:
             "$ref": "../v1/profile.yaml#/Profile"
+        - name: include
+          description: Returns a specific list of related resources to the profile
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - documents
+              - person
+          example: documents
       responses:
         "200":
           description: success
@@ -2368,6 +2534,16 @@
             type: string
           format: uuid
           example: 950ef512-a25f-46d7-8ced-7ad09510659b
+        - name: include
+          description: Returns a specific list of related resources to the location
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - suppliers
+            example: suppliers
       responses:
         "200":
           description: success
@@ -2405,6 +2581,16 @@
             type: string
           format: uuid
           example: 00525ecb-7316-492a-aae2-f69334b2a155
+        - name: include
+          description: Returns a specific list of related resources to the location
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - suppliers
+            example: suppliers
       responses:
         "200":
           description: success

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -183,24 +183,7 @@
             enum:
               - asc
               - desc
-        - name: include
-          description: Returns a specific list of related resources to the allocation
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - from_location
-              - to_location
-              - moves.person
-              - moves.person.gender
-              - moves.person.ethnicity
-              - moves.profile
-              - moves.profile.person
-              - moves.profile.person.ethnicity
-              - moves.profile.person.gender
-          example: from_location
+        - "$ref": "../v1/allocation_include_parameter.yaml#/AllocationIncludeParameter"
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:
@@ -235,24 +218,7 @@
           description: The allocation object to be created
           schema:
             "$ref": "../v1/allocation.yaml#/Allocation"
-        - name: include
-          description: Returns a specific list of related resources to the allocation
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - from_location
-              - to_location
-              - moves.person
-              - moves.person.gender
-              - moves.person.ethnicity
-              - moves.profile
-              - moves.profile.person
-              - moves.profile.person.ethnicity
-              - moves.profile.person.gender
-          example: from_location
+        - "$ref": "../v1/allocation_include_parameter.yaml#/AllocationIncludeParameter"
       responses:
         "201":
           description: created
@@ -498,31 +464,7 @@
             enum:
               - asc
               - desc
-        - name: include
-          description: Returns a specific list of related resources to the move
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - allocation
-              - court_hearings
-              - documents
-              - from_location
-              - to_location
-              - original_move
-              - prison_transfer_reason
-              - person
-              - profile
-              - from_location.suppliers
-              - to_location.suppliers
-              - person.gender
-              - person.ethnicity
-              - profile.person
-              - profile.person.gender
-              - profile.person.ethnicity
-          example: from_location
+        - "$ref": "../v1/move_include_parameter.yaml#/MoveIncludeParameter"
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:
@@ -558,31 +500,7 @@
           description: The move object to be created
           schema:
             "$ref": "../v1/move.yaml#/Move"
-        - name: include
-          description: Returns a specific list of related resources to the move
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - allocation
-              - court_hearings
-              - documents
-              - from_location
-              - to_location
-              - original_move
-              - prison_transfer_reason
-              - person
-              - profile
-              - from_location.suppliers
-              - to_location.suppliers
-              - person.gender
-              - person.ethnicity
-              - profile.person
-              - profile.person.gender
-              - profile.person.ethnicity
-          example: from_location
+        - "$ref": "../v1/move_include_parameter.yaml#/MoveIncludeParameter"
       responses:
         "201":
           description: created
@@ -636,31 +554,7 @@
           description: The move object to be modified
           schema:
             "$ref": "../v1/move.yaml#/Move"
-        - name: include
-          description: Returns a specific list of related resources to the move
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - allocation
-              - court_hearings
-              - documents
-              - from_location
-              - to_location
-              - original_move
-              - prison_transfer_reason
-              - person
-              - profile
-              - from_location.suppliers
-              - to_location.suppliers
-              - person.gender
-              - person.ethnicity
-              - profile.person
-              - profile.person.gender
-              - profile.person.ethnicity
-          example: from_location
+        - "$ref": "../v1/move_include_parameter.yaml#/MoveIncludeParameter"
       responses:
         "200":
           description: success
@@ -1306,19 +1200,7 @@
             from the logged-in account).
           schema:
             "$ref": "../v1/post_journey.yaml#/PostJourney"
-        - name: include
-          description: Returns a specific list of related resources to the journey
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - from_location
-              - to_location
-              - from_location.suppliers
-              - to_location.suppliers
-          example: from_location
+        - "$ref": "../v1/journey_include_parameter.yaml#/JourneyIncludeParameter"
       responses:
         "201":
           description: created
@@ -1379,19 +1261,7 @@
         - "$ref": "../v1/journey_id_parameter.yaml#/JourneyId"
         - "$ref": "../v1/idempotency_key_parameter.yaml#/IdempotencyKey"
         - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
-        - name: include
-          description: Returns a specific list of related resources to the journey
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - from_location
-              - to_location
-              - from_location.suppliers
-              - to_location.suppliers
-          example: from_location
+        - "$ref": "../v1/journey_include_parameter.yaml#/JourneyIncludeParameter"
       responses:
         "200":
           description: success
@@ -1459,19 +1329,7 @@
             `billable`; it must not specify locations or `state`.
           schema:
             "$ref": "../v1/patch_journey.yaml#/PatchJourney"
-        - name: include
-          description: Returns a specific list of related resources to the journey
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - from_location
-              - to_location
-              - from_location.suppliers
-              - to_location.suppliers
-          example: from_location
+        - "$ref": "../v1/journey_include_parameter.yaml#/JourneyIncludeParameter"
       responses:
         "200":
           description: success
@@ -2095,17 +1953,7 @@
             example: G1234UT
           format: string
           required: false
-        - name: include
-          description: Returns a specific list of related resources to the person
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - gender
-              - ethnicity
-          example: gender
+        - "$ref": "../v1/person_include_parameter.yaml#/PersonIncludeParameter"
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:
@@ -2141,17 +1989,7 @@
           description: The person object to be created
           schema:
             "$ref": "../v1/person.yaml#/Person"
-        - name: include
-          description: Returns a specific list of related resources to the person
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - gender
-              - ethnicity
-          example: gender
+        - "$ref": "../v1/person_include_parameter.yaml#/PersonIncludeParameter"
       responses:
         "201":
           description: created
@@ -2213,17 +2051,7 @@
           description: The person object to be updated
           schema:
             "$ref": "../v1/person.yaml#/Person"
-        - name: include
-          description: Returns a specific list of related resources to the person
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - gender
-              - ethnicity
-          example: gender
+        - "$ref": "../v1/person_include_parameter.yaml#/PersonIncludeParameter"
       responses:
         "200":
           description: updated
@@ -2289,17 +2117,7 @@
           description: The profile object to be created
           schema:
             "$ref": "../v1/profile.yaml#/Profile"
-        - name: include
-          description: Returns a specific list of related resources to the profile
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - documents
-              - person
-          example: documents
+        - "$ref": "../v1/profile_include_parameter.yaml#/ProfileIncludeParameter"
       responses:
         "201":
           description: created
@@ -2368,17 +2186,7 @@
           description: The profile object to be modified
           schema:
             "$ref": "../v1/profile.yaml#/Profile"
-        - name: include
-          description: Returns a specific list of related resources to the profile
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - documents
-              - person
-          example: documents
+        - "$ref": "../v1/profile_include_parameter.yaml#/ProfileIncludeParameter"
       responses:
         "200":
           description: success
@@ -2573,16 +2381,7 @@
             type: string
           format: uuid
           example: 950ef512-a25f-46d7-8ced-7ad09510659b
-        - name: include
-          description: Returns a specific list of related resources to the location
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - suppliers
-            example: suppliers
+        - "$ref": "../v1/location_include_parameter.yaml#/LocationIncludeParameter"
       responses:
         "200":
           description: success
@@ -2620,16 +2419,7 @@
             type: string
           format: uuid
           example: 00525ecb-7316-492a-aae2-f69334b2a155
-        - name: include
-          description: Returns a specific list of related resources to the location
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - suppliers
-            example: suppliers
+        - "$ref": "../v1/location_include_parameter.yaml#/LocationIncludeParameter"
       responses:
         "200":
           description: success

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -1306,6 +1306,19 @@
             from the logged-in account).
           schema:
             "$ref": "../v1/post_journey.yaml#/PostJourney"
+        - name: include
+          description: Returns a specific list of related resources to the journey
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - from_location
+              - to_location
+              - from_location.suppliers
+              - to_location.suppliers
+          example: from_location
       responses:
         "201":
           description: created
@@ -1366,6 +1379,19 @@
         - "$ref": "../v1/journey_id_parameter.yaml#/JourneyId"
         - "$ref": "../v1/idempotency_key_parameter.yaml#/IdempotencyKey"
         - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - name: include
+          description: Returns a specific list of related resources to the journey
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - from_location
+              - to_location
+              - from_location.suppliers
+              - to_location.suppliers
+          example: from_location
       responses:
         "200":
           description: success
@@ -1433,6 +1459,19 @@
             `billable`; it must not specify locations or `state`.
           schema:
             "$ref": "../v1/patch_journey.yaml#/PatchJourney"
+        - name: include
+          description: Returns a specific list of related resources to the journey
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - from_location
+              - to_location
+              - from_location.suppliers
+              - to_location.suppliers
+          example: from_location
       responses:
         "200":
           description: success

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -87,6 +87,18 @@
             example: G1234UT
           format: string
           required: false
+        - name: include
+          description: Returns a specific list of related resources to the person
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - gender
+              - ethnicity
+              - profiles
+          example: gender
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:
@@ -122,6 +134,18 @@
           description: The person object to be created
           schema:
             "$ref": person.yaml#/Person
+        - name: include
+          description: Returns a specific list of related resources to the person
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - gender
+              - ethnicity
+              - profiles
+          example: gender
       responses:
         "201":
           description: created
@@ -182,6 +206,18 @@
           description: The person object to be updated
           schema:
             "$ref": "../v2/person.yaml#/Person"
+        - name: include
+          description: Returns a specific list of related resources to the person
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - gender
+              - ethnicity
+              - profiles
+          example: gender
       responses:
         "200":
           description: updated
@@ -362,6 +398,28 @@
             enum:
               - asc
               - desc
+        - name: include
+          description: Returns a specific list of related resources to the move
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - allocation
+              - court_hearings
+              - documents
+              - from_location
+              - to_location
+              - original_move
+              - prison_transfer_reason
+              - profile
+              - profile.person
+              - profile.person.ethnicity
+              - profile.person.gender
+              - from_location.suppliers
+              - to_location.suppliers
+          example: from_location
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:
@@ -397,6 +455,28 @@
           description: The move object to be created
           schema:
             "$ref": "../v2/move.yaml#/Move"
+        - name: include
+          description: Returns a specific list of related resources to the move
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - allocation
+              - court_hearings
+              - documents
+              - from_location
+              - to_location
+              - original_move
+              - prison_transfer_reason
+              - profile
+              - profile.person
+              - profile.person.ethnicity
+              - profile.person.gender
+              - from_location.suppliers
+              - to_location.suppliers
+          example: from_location
       responses:
         "201":
           description: created
@@ -450,6 +530,28 @@
           description: The move object to be modified
           schema:
             "$ref": "../v2/move.yaml#/Move"
+        - name: include
+          description: Returns a specific list of related resources to the move
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - allocation
+              - court_hearings
+              - documents
+              - from_location
+              - to_location
+              - original_move
+              - prison_transfer_reason
+              - profile
+              - profile.person
+              - profile.person.ethnicity
+              - profile.person.gender
+              - from_location.suppliers
+              - to_location.suppliers
+          example: from_location
       responses:
         "200":
           description: success
@@ -514,6 +616,28 @@
           format: uuid
           example: 00525ecb-7316-492a-aae2-f69334b2a155
           required: true
+        - name: include
+          description: Returns a specific list of related resources to the move
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - allocation
+              - court_hearings
+              - documents
+              - from_location
+              - to_location
+              - original_move
+              - prison_transfer_reason
+              - profile
+              - profile.person
+              - profile.person.ethnicity
+              - profile.person.gender
+              - from_location.suppliers
+              - to_location.suppliers
+          example: from_location
       responses:
         "200":
           description: success

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -87,18 +87,7 @@
             example: G1234UT
           format: string
           required: false
-        - name: include
-          description: Returns a specific list of related resources to the person
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - gender
-              - ethnicity
-              - profiles
-          example: gender
+        - "$ref": "../v2/person_include_parameter.yaml#/PersonIncludeParameter"
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:
@@ -134,18 +123,7 @@
           description: The person object to be created
           schema:
             "$ref": person.yaml#/Person
-        - name: include
-          description: Returns a specific list of related resources to the person
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - gender
-              - ethnicity
-              - profiles
-          example: gender
+        - "$ref": "../v2/person_include_parameter.yaml#/PersonIncludeParameter"
       responses:
         "201":
           description: created
@@ -206,18 +184,7 @@
           description: The person object to be updated
           schema:
             "$ref": "../v2/person.yaml#/Person"
-        - name: include
-          description: Returns a specific list of related resources to the person
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - gender
-              - ethnicity
-              - profiles
-          example: gender
+        - "$ref": "../v2/person_include_parameter.yaml#/PersonIncludeParameter"
       responses:
         "200":
           description: updated
@@ -398,28 +365,7 @@
             enum:
               - asc
               - desc
-        - name: include
-          description: Returns a specific list of related resources to the move
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - allocation
-              - court_hearings
-              - documents
-              - from_location
-              - to_location
-              - original_move
-              - prison_transfer_reason
-              - profile
-              - profile.person
-              - profile.person.ethnicity
-              - profile.person.gender
-              - from_location.suppliers
-              - to_location.suppliers
-          example: from_location
+        - "$ref": "../v2/move_include_parameter.yaml#/MoveIncludeParameter"
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:
@@ -455,28 +401,7 @@
           description: The move object to be created
           schema:
             "$ref": "../v2/move.yaml#/Move"
-        - name: include
-          description: Returns a specific list of related resources to the move
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - allocation
-              - court_hearings
-              - documents
-              - from_location
-              - to_location
-              - original_move
-              - prison_transfer_reason
-              - profile
-              - profile.person
-              - profile.person.ethnicity
-              - profile.person.gender
-              - from_location.suppliers
-              - to_location.suppliers
-          example: from_location
+        - "$ref": "../v2/move_include_parameter.yaml#/MoveIncludeParameter"
       responses:
         "201":
           description: created
@@ -530,28 +455,7 @@
           description: The move object to be modified
           schema:
             "$ref": "../v2/move.yaml#/Move"
-        - name: include
-          description: Returns a specific list of related resources to the move
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - allocation
-              - court_hearings
-              - documents
-              - from_location
-              - to_location
-              - original_move
-              - prison_transfer_reason
-              - profile
-              - profile.person
-              - profile.person.ethnicity
-              - profile.person.gender
-              - from_location.suppliers
-              - to_location.suppliers
-          example: from_location
+        - "$ref": "../v2/move_include_parameter.yaml#/MoveIncludeParameter"
       responses:
         "200":
           description: success
@@ -616,28 +520,7 @@
           format: uuid
           example: 00525ecb-7316-492a-aae2-f69334b2a155
           required: true
-        - name: include
-          description: Returns a specific list of related resources to the move
-          in: query
-          style: form
-          explode: false
-          schema:
-            type: string
-            enum:
-              - allocation
-              - court_hearings
-              - documents
-              - from_location
-              - to_location
-              - original_move
-              - prison_transfer_reason
-              - profile
-              - profile.person
-              - profile.person.ethnicity
-              - profile.person.gender
-              - from_location.suppliers
-              - to_location.suppliers
-          example: from_location
+        - "$ref": "../v2/move_include_parameter.yaml#/MoveIncludeParameter"
       responses:
         "200":
           description: success

--- a/swagger/v1/allocation_include_parameter.yaml
+++ b/swagger/v1/allocation_include_parameter.yaml
@@ -1,0 +1,19 @@
+AllocationIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the allocation
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - from_location
+      - to_location
+      - moves.person
+      - moves.person.gender
+      - moves.person.ethnicity
+      - moves.profile
+      - moves.profile.person
+      - moves.profile.person.ethnicity
+      - moves.profile.person.gender
+  example: from_location

--- a/swagger/v1/journey_include_parameter.yaml
+++ b/swagger/v1/journey_include_parameter.yaml
@@ -1,0 +1,14 @@
+JourneyIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the journey
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - from_location
+      - to_location
+      - from_location.suppliers
+      - to_location.suppliers
+  example: from_location

--- a/swagger/v1/location_include_parameter.yaml
+++ b/swagger/v1/location_include_parameter.yaml
@@ -1,0 +1,11 @@
+LocationIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the location
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - suppliers
+    example: suppliers

--- a/swagger/v1/move_include_parameter.yaml
+++ b/swagger/v1/move_include_parameter.yaml
@@ -1,0 +1,26 @@
+MoveIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the move
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - allocation
+      - court_hearings
+      - documents
+      - from_location
+      - to_location
+      - original_move
+      - prison_transfer_reason
+      - person
+      - profile
+      - from_location.suppliers
+      - to_location.suppliers
+      - person.gender
+      - person.ethnicity
+      - profile.person
+      - profile.person.gender
+      - profile.person.ethnicity
+  example: from_location

--- a/swagger/v1/person_include_parameter.yaml
+++ b/swagger/v1/person_include_parameter.yaml
@@ -1,0 +1,12 @@
+PersonIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the person
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - gender
+      - ethnicity
+  example: gender

--- a/swagger/v1/profile_include_parameter.yaml
+++ b/swagger/v1/profile_include_parameter.yaml
@@ -1,0 +1,12 @@
+ProfileIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the profile
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - documents
+      - person
+  example: documents

--- a/swagger/v2/move_include_parameter.yml
+++ b/swagger/v2/move_include_parameter.yml
@@ -1,0 +1,23 @@
+MoveIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the move
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - allocation
+      - court_hearings
+      - documents
+      - from_location
+      - to_location
+      - original_move
+      - prison_transfer_reason
+      - profile
+      - profile.person
+      - profile.person.ethnicity
+      - profile.person.gender
+      - from_location.suppliers
+      - to_location.suppliers
+  example: from_location

--- a/swagger/v2/person_include_parameter.yaml
+++ b/swagger/v2/person_include_parameter.yaml
@@ -1,0 +1,13 @@
+PersonIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the person
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - gender
+      - ethnicity
+      - profiles
+  example: gender


### PR DESCRIPTION
### Jira link

[P4-1616](https://dsdmoj.atlassian.net/browse/P4-1616)

### What?
- Add swagger docs for all include endpoints
- Add Include params to court cases and timetable people endpoints

### Why?

To support includes everywhere we have associated resources in the serializer, add `include` param to allow the resources to be rendered with its associated resources under the `included` section.

In the people controller however, since we are supporting multiple endpoints, we had to disable the normal validation which happens at the API controller level, and add custom validations for the extra endpoints themselves.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

