### PR TITLE
P4-1618 Remove default includes

### DIFF
--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -76,10 +76,6 @@ module Api
       end
     end
 
-    def included_relationships
-      IncludeParamHandler.new(params).call || AllocationSerializer::SUPPORTED_RELATIONSHIPS
-    end
-
     def supported_relationships
       AllocationSerializer::SUPPORTED_RELATIONSHIPS
     end

--- a/app/controllers/api/people_controller.rb
+++ b/app/controllers/api/people_controller.rb
@@ -92,11 +92,6 @@ module Api
       profile_validator.validate!
     end
 
-    def other_included_relationships
-      # Custom included relationships to avoid the people actions relationships
-      @other_included_relationships ||= IncludeParamHandler.new(params).call || OTHER_SUPPORTED_RELATIONSHIPS
-    end
-
     def validate_other_include_params
       # Custom validation for includes to avoid the default validation shared in API controller
       IncludeParamsValidator

--- a/app/controllers/api/v1/allocations_actions.rb
+++ b/app/controllers/api/v1/allocations_actions.rb
@@ -1,0 +1,7 @@
+module Api::V1
+  module AllocationsActions
+    def included_relationships
+      IncludeParamHandler.new(params).call || AllocationSerializer::SUPPORTED_RELATIONSHIPS
+    end
+  end
+end

--- a/app/controllers/api/v1/people_actions.rb
+++ b/app/controllers/api/v1/people_actions.rb
@@ -85,5 +85,10 @@ module Api::V1
     def included_relationships
       IncludeParamHandler.new(params).call || PersonSerializer::SUPPORTED_RELATIONSHIPS
     end
+
+    def other_included_relationships
+      # Custom included relationships to avoid the people actions relationships
+      @other_included_relationships ||= IncludeParamHandler.new(params).call || Api::PeopleController::OTHER_SUPPORTED_RELATIONSHIPS
+    end
   end
 end

--- a/app/controllers/api/v2/allocations_actions.rb
+++ b/app/controllers/api/v2/allocations_actions.rb
@@ -1,0 +1,7 @@
+module Api::V2
+  module AllocationsActions
+    def included_relationships
+      IncludeParamHandler.new(params).call
+    end
+  end
+end

--- a/app/controllers/api/v2/allocations_actions.rb
+++ b/app/controllers/api/v2/allocations_actions.rb
@@ -1,7 +1,0 @@
-module Api::V2
-  module AllocationsActions
-    def included_relationships
-      IncludeParamHandler.new(params).call
-    end
-  end
-end

--- a/app/controllers/api/v2/people_actions.rb
+++ b/app/controllers/api/v2/people_actions.rb
@@ -69,8 +69,7 @@ module Api::V2
     end
 
     def other_included_relationships
-      # Custom included relationships to avoid the people actions relationships
-      @other_included_relationships ||= IncludeParamHandler.new(params).call
+      included_relationships
     end
 
     def prison_numbers

--- a/app/controllers/api/v2/people_actions.rb
+++ b/app/controllers/api/v2/people_actions.rb
@@ -68,6 +68,11 @@ module Api::V2
       ::V2::PersonSerializer::SUPPORTED_RELATIONSHIPS
     end
 
+    def other_included_relationships
+      # Custom included relationships to avoid the people actions relationships
+      @other_included_relationships ||= IncludeParamHandler.new(params).call
+    end
+
     def prison_numbers
       filter_params[:prison_number]&.split(',')&.map(&:upcase)
     end

--- a/spec/requests/api/allocations_controller_create_v2_spec.rb
+++ b/spec/requests/api/allocations_controller_create_v2_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::AllocationsController do
+  include ActiveJob::TestHelper
+
+  describe 'POST /allocations' do
+    let(:response_json) { JSON.parse(response.body) }
+    let(:moves_count) { 2 }
+    let(:allocation_attributes) do
+      {
+        date: Date.today,
+        moves_count: moves_count,
+        prisoner_category: :b,
+        sentence_length: :short,
+        other_criteria: 'curly hair',
+        requested_by: 'Iama Requestor',
+        complete_in_full: true,
+      }
+    end
+    let!(:from_location) { create :location, suppliers: [supplier] }
+    let!(:to_location) { create :location }
+
+    let(:data) do
+      {
+        type: 'allocations',
+        attributes: allocation_attributes,
+        relationships: {
+          from_location: { data: { type: 'locations', id: from_location.id } },
+          to_location: { data: { type: 'locations', id: to_location.id } },
+        },
+      }
+    end
+
+    let(:supplier) { create(:supplier) }
+    let!(:application) { create(:application, owner_id: supplier.id) }
+    let(:access_token) { create(:access_token, application: application).token }
+    let(:content_type) { ApiController::CONTENT_TYPE }
+    let(:headers) do
+      {
+        'CONTENT_TYPE': content_type,
+        'Accept': 'application/vnd.api+json; version=2',
+        'Authorization' => "Bearer #{access_token}",
+      }
+    end
+
+    before do
+      post '/api/allocations', params: { data: data }, headers: headers, as: :json
+    end
+
+    context 'when not including the include query param' do
+      it 'returns no included relationships' do
+        expect(response_json).not_to include('included')
+      end
+    end
+  end
+end

--- a/spec/requests/api/allocations_controller_index_v2_spec.rb
+++ b/spec/requests/api/allocations_controller_index_v2_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::AllocationsController do
+  let(:supplier) { create(:supplier) }
+  let!(:application) { create(:application, owner_id: supplier.id) }
+  let!(:access_token) { create(:access_token, application: application).token }
+  let(:response_json) { JSON.parse(response.body) }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) do
+    {
+      'CONTENT_TYPE': content_type,
+      'Accept': 'application/vnd.api+json; version=2',
+      'Authorization' => "Bearer #{access_token}",
+    }
+  end
+
+  describe 'GET /allocations' do
+    before do
+      get '/api/allocations', params: params, headers: headers
+    end
+
+    context 'when not including the include query param' do
+      let!(:allocation) { create(:allocation, :with_moves) }
+      let(:params) { {} }
+
+      it 'returns no included relationships ' do
+        expect(response_json).not_to include('included')
+      end
+    end
+  end
+end

--- a/spec/requests/api/people_controller_court_cases_v2_spec.rb
+++ b/spec/requests/api/people_controller_court_cases_v2_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::PeopleController do
+  let(:supplier) { create(:supplier) }
+  let!(:application) { create(:application, owner_id: supplier.id) }
+  let(:access_token) { create(:access_token, application: application).token }
+  let(:response_json) { JSON.parse(response.body) }
+  let(:person) { create(:person, :nomis_synced, latest_nomis_booking_id: '1150262') }
+  let(:court_cases_from_nomis) do
+    OpenStruct.new(
+      success?: true,
+      court_cases: [
+        CourtCase.new.build_from_nomis('id' => '1495077', 'beginDate' => '2020-01-01', 'agency' => { 'agencyId' => 'SNARCC' }),
+        CourtCase.new.build_from_nomis('id' => '2222222', 'beginDate' => '2020-01-02', 'agency' => { 'agencyId' => 'SNARCC' }),
+      ],
+    )
+  end
+
+  let(:headers) do
+    {
+      'CONTENT_TYPE': ApiController::CONTENT_TYPE,
+      'Accept': 'application/vnd.api+json; version=2',
+      'Authorization' => "Bearer #{access_token}",
+    }
+  end
+
+  before do
+    allow(People::RetrieveCourtCases).to receive(:call).and_return(court_cases_from_nomis)
+  end
+
+  context 'when not including the include query param' do
+    it 'returns no included relationships' do
+      create(:location, nomis_agency_id: 'SNARCC', title: 'Snaresbrook Crown Court', location_type: 'CRT')
+      get "/api/v1/people/#{person.id}/court_cases", params: {}, headers: headers
+
+      expect(response_json).not_to include('included')
+    end
+  end
+end

--- a/spec/requests/api/people_controller_timetable_v2_spec.rb
+++ b/spec/requests/api/people_controller_timetable_v2_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::PeopleController do
+  let(:supplier) { create(:supplier) }
+  let!(:application) { create(:application, owner_id: supplier.id) }
+  let(:access_token) { create(:access_token, application: application).token }
+  let(:person) { create(:person, :nomis_synced, latest_nomis_booking_id: '1150262') }
+  let(:nomis_court_hearings_struct) do
+    OpenStruct.new(
+      success?: true,
+      content: nomis_court_hearings,
+      error: nil,
+    )
+  end
+  let(:nomis_activities_struct) do
+    OpenStruct.new(
+      success?: true,
+      content: nomis_activities,
+      error: nil,
+    )
+  end
+  let(:nomis_activities) do
+    [
+      Activity.new.build_from_nomis(
+        'eventId' => 401_732_488,
+        'startTime' => '2020-04-22T08:30:00',
+        'eventTypeDesc' => 'Prison Activities',
+        'locationCode' => 'PEI',
+      ),
+    ]
+  end
+  let(:nomis_court_hearings) do
+    [
+      NomisCourtHearing.new.build_from_nomis(
+        'id' => 330_253_339,
+        'dateTime' => '2017-01-27T10:00:00',
+        'location' => { 'agencyId' => 'PEI' },
+      ),
+    ]
+  end
+  let(:response_json) { JSON.parse(response.body) }
+  let(:date_from) { Date.today }
+  let(:date_to) { Date.tomorrow }
+
+  let(:params) do
+    {
+      filter: {
+        date_from: date_from.iso8601,
+        date_to: date_to.iso8601,
+      },
+    }
+  end
+
+  let(:headers) do
+    {
+      'CONTENT_TYPE': ApiController::CONTENT_TYPE,
+      'Accept': 'application/vnd.api+json; version=2',
+      'Authorization' => "Bearer #{access_token}",
+    }
+  end
+
+  before do
+    allow(People::RetrieveTimetable).to receive(:call).and_call_original
+    allow(People::RetrieveActivities).to receive(:call).and_return(nomis_activities_struct)
+    allow(People::RetrieveCourtHearings).to receive(:call).and_return(nomis_court_hearings_struct)
+  end
+
+  context 'when not including the include query param' do
+    it 'returns no included relationships' do
+      create(:location)
+      get "/api/v1/people/#{person.id}/timetable", params: params, headers: headers
+
+      expect(response_json).not_to include('included')
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[P4-1618](https://dsdmoj.atlassian.net/browse/P4-1618)
### What?

I have added/removed/altered:

- Removed default includes in people/allocation controllers into v2 version

### Why?

Since we have moved to using the include param, remove default includes from controllers everywhere in v2, but leave v1 the same

### Deployment risks (optional)

- Only change API in v2, v1 should remain exactly the same
