### PR TITLE
Add support for searching within GET /allocations endpoint

### DIFF
--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -7,7 +7,7 @@ module Api
     def index
       allocations_params = Allocations::ParamsValidator.new(filter_params, sort_params)
       if allocations_params.valid?
-        allocations = Allocations::Finder.new(filter_params, sort_params).call
+        allocations = Allocations::Finder.new(filters: filter_params, ordering: sort_params, search: search_params).call
         paginate allocations, include: included_relationships
       else
         render_allocation({ error: allocations_params.errors }, :bad_request)
@@ -30,6 +30,7 @@ module Api
 
     PERMITTED_FILTER_PARAMS = %i[date_from date_to locations from_locations to_locations status].freeze
     PERMITTED_SORT_PARAMS = %i[by direction].freeze
+    PERMITTED_SEARCH_PARAMS = %i[location person].freeze
 
     PERMITTED_ALLOCATION_PARAMS = [
       :type,
@@ -45,6 +46,10 @@ module Api
 
     def filter_params
       @filter_params ||= params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h
+    end
+
+    def search_params
+      params.fetch(:search, {}).permit(PERMITTED_SEARCH_PARAMS).to_h
     end
 
     def allocation_params

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -34,6 +34,7 @@ class Location < ApplicationRecord
   scope :ordered_by_title, ->(direction) { order('locations.title' => direction) }
 
   scope :prisons, -> { where(location_type: LOCATION_TYPE_PRISON) }
+  scope :search_by_title, ->(search) { select(:id).where('title ILIKE :search', search: "%#{search}%") }
 
   def prison?
     location_type.to_s == LOCATION_TYPE_PRISON

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -13,6 +13,7 @@ class Person < VersionedModel
   has_one_attached :image
 
   scope :ordered_by_name, ->(direction) { order('last_name' => direction, 'first_names' => direction) }
+  scope :search_by_last_name, ->(search) { select(:id).where('last_name ILIKE :search', search: "%#{search}%") }
 
   validates :last_name, presence: true
   validates :first_names, presence: true

--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -44,17 +44,17 @@ module Allocations
     end
 
     def apply_location_search(scope)
-      return scope unless search_params.key?(:location)
+      return scope unless search = search_params[:location].presence
 
-      scope.where(from_location_id: Location.search_by_title(search_params[:location])).or(
-        scope.where(to_location_id: Location.search_by_title(search_params[:location])),
+      scope.where(from_location_id: Location.search_by_title(search)).or(
+        scope.where(to_location_id: Location.search_by_title(search)),
       )
     end
 
     def apply_person_search(scope)
-      return scope unless search_params.key?(:person)
+      return scope unless search = search_params[:person].presence
 
-      scope.joins(moves: { profile: :person }).where('people.id' => Person.search_by_last_name(search_params[:person]))
+      scope.includes(moves: { profile: :person }).where('people.id' => Person.search_by_last_name(search))
     end
 
     def apply_filters(scope)

--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -44,7 +44,7 @@ module Allocations
     end
 
     def apply_location_search(scope)
-      return scope unless search = search_params[:location].presence
+      return scope unless (search = search_params[:location].presence)
 
       scope.where(from_location_id: Location.search_by_title(search)).or(
         scope.where(to_location_id: Location.search_by_title(search)),
@@ -52,7 +52,7 @@ module Allocations
     end
 
     def apply_person_search(scope)
-      return scope unless search = search_params[:person].presence
+      return scope unless (search = search_params[:person].presence)
 
       scope.includes(moves: { profile: :person }).where('people.id' => Person.search_by_last_name(search))
     end

--- a/spec/requests/api/allocations_controller_index_spec.rb
+++ b/spec/requests/api/allocations_controller_index_spec.rb
@@ -11,87 +11,45 @@ RSpec.describe Api::AllocationsController do
   let(:content_type) { ApiController::CONTENT_TYPE }
 
   describe 'GET /allocations' do
-    let(:schema) { load_yaml_schema('get_allocations_responses.yaml') }
+    subject(:get_allocations) { get '/api/v1/allocations', params: params, headers: headers }
 
-    let!(:allocations) { create_list :allocation, 2 }
+    let(:schema) { load_yaml_schema('get_allocations_responses.yaml') }
     let(:params) { {} }
 
-    before do
-      next if RSpec.current_example.metadata[:skip_before]
+    context 'when successful' do
+      before { get_allocations }
 
-      get '/api/v1/allocations', params: params, headers: headers
+      it_behaves_like 'an endpoint that responds with success 200'
     end
 
-    context 'when successful' do
-      it_behaves_like 'an endpoint that responds with success 200'
+    describe 'finding results' do
+      before do
+        allocations_finder = instance_double('Allocations::Finder', call: Allocation.all)
+        allow(Allocations::Finder).to receive(:new).and_return(allocations_finder)
+      end
 
-      describe 'filtering results by date' do
-        let(:allocation) { allocations.last }
+      context 'with filters' do
+        let(:allocation) { create :allocation }
+        let(:location) { allocation.from_location }
         let(:date_from) { allocation.date }
         let(:filters) do
           {
             bar: 'bar',
             date_from: date_from.to_s,
+            from_locations: location.id,
+            status: 'unfilled',
             foo: 'foo',
           }
         end
         let(:params) { { filter: filters } }
 
-        it 'delegates the query execution to Allocations::Finder with the correct filters', skip_before: true do
-          allocations_finder = instance_double('Allocations::Finder', call: Allocation.all)
-          allow(Allocations::Finder).to receive(:new).and_return(allocations_finder)
-
-          get '/api/v1/allocations', headers: headers, params: params
-
-          expect(Allocations::Finder).to have_received(:new).with({ date_from: date_from.to_s }, {})
-        end
-
-        it 'filters the results' do
-          expect(response_json['data'].size).to be 1
-        end
-
-        it 'returns the allocation that matches the filter' do
-          expect(response_json).to include_json(data: [{ id: allocation.id }])
+        it 'delegates the query execution to Allocations::Finder with the correct filters' do
+          get_allocations
+          expect(Allocations::Finder).to have_received(:new).with(filters: { date_from: date_from.to_s, from_locations: location.id, status: 'unfilled' }, ordering: {}, search: {})
         end
       end
 
-      describe 'filtering results by location' do
-        let(:allocation) { allocations.last }
-        let(:location) { allocations.last.from_location }
-        let(:params) { { filter: { from_locations: location.id } } }
-
-        it 'filters the results' do
-          expect(response_json['data'].size).to be 1
-        end
-
-        it 'returns the allocation that matches the filter' do
-          expect(response_json).to include_json(data: [{ id: allocation.id }])
-        end
-      end
-
-      describe 'filtering results by status' do
-        let(:unfilled_allocation) { create :allocation, :unfilled }
-        let(:filled_allocation) { create :allocation, :filled }
-        let(:cancelled_allocation) { create :allocation, :cancelled }
-        let!(:allocations) { [unfilled_allocation, filled_allocation, cancelled_allocation] }
-        let(:params) { { filter: { status: 'cancelled' } } }
-
-        it 'filters the results' do
-          expect(response_json['data'].size).to be 1
-        end
-
-        it 'returns the allocation that matches the filter' do
-          expect(response_json).to include_json(data: [{ id: cancelled_allocation.id }])
-        end
-      end
-
-      describe 'sorting results' do
-        let(:location) { create :location }
-        let(:allocation1) { create :allocation, moves_count: 1, from_location: location, to_location: location }
-        let(:allocation2) { create :allocation, moves_count: 2, from_location: location, to_location: location }
-        let(:allocation3) { create :allocation, moves_count: 3, from_location: location, to_location: location }
-        let!(:allocations) { [allocation1, allocation2, allocation3] }
-
+      context 'with sorting' do
         let(:sort) do
           {
             bar: 'bar',
@@ -100,168 +58,135 @@ RSpec.describe Api::AllocationsController do
             foo: 'foo',
           }
         end
-
         let(:params) { { sort: sort } }
 
-        it 'delegates the query execution to Allocations::Finder with the correct sorting', skip_before: true do
-          allocations_finder = instance_double('Allocations::Finder', call: Allocation.all)
-          allow(Allocations::Finder).to receive(:new).and_return(allocations_finder)
-
-          get '/api/v1/allocations', headers: headers, params: params
-
-          expect(Allocations::Finder).to have_received(:new).with({}, by: 'moves_count', direction: 'desc')
-        end
-
-        it 'returns the allocations in the correct order' do
-          expect(response_json).to include_json(data: [
-            { attributes: { moves_count: 3 } },
-            { attributes: { moves_count: 2 } },
-            { attributes: { moves_count: 1 } },
-          ])
+        it 'delegates the query execution to Allocations::Finder with the correct sorting' do
+          get_allocations
+          expect(Allocations::Finder).to have_received(:new).with(filters: {}, ordering: { by: 'moves_count', direction: 'desc' }, search: {})
         end
       end
 
-      describe 'paginating results' do
-        let!(:allocations) { create_list :allocation, 6 }
-
-        let(:meta_pagination) do
+      context 'with search' do
+        let(:search) do
           {
-            per_page: 5,
-            total_pages: 2,
-            total_objects: 6,
-            links: {
-              first: '/api/v1/allocations?page=1',
-              last: '/api/v1/allocations?page=2',
-              next: '/api/v1/allocations?page=2',
-            },
+            bar: 'bar',
+            location: 'nott',
+            foo: 'foo',
           }
         end
+        let(:params) { { search: search } }
 
-        it_behaves_like 'an endpoint that paginates resources'
-      end
-
-      describe 'validating dates before running queries' do
-        let(:filters) do
-          {
-            date_from: 'yyyy-09-Tu',
-          }
-        end
-        let(:params) { { filter: filters } }
-
-        before do
-          get '/api/v1/allocations', params: params, headers: headers
-        end
-
-        it 'is a bad request' do
-          expect(response.status).to eq(400)
-        end
-
-        it 'returns errors' do
-          expect(response.body).to eq('{"error":{"date_from":["is not a valid date."]}}')
-        end
-      end
-
-      describe 'validating locations before running queries' do
-        let(:filters) do
-          {
-            from_locations: 'foo',
-            to_locations: 'bar',
-            locations: 'baz',
-          }
-        end
-        let(:params) { { filter: filters } }
-
-        before do
-          get '/api/v1/allocations', params: params, headers: headers
-        end
-
-        it 'is a bad request' do
-          expect(response.status).to eq(400)
-        end
-
-        it 'returns errors' do
-          expect(response.body).to eq('{"error":{"locations":["may not be used in combination with `from_locations` or `to_locations` filters."]}}')
-        end
-      end
-
-      describe 'included relationships', :skip_before do
-        let!(:allocations) { create_list :allocation, 2, :with_moves }
-
-        before do
-          get "/api/v1/allocations#{query_params}", headers: headers
-        end
-
-        context 'when not including the include query param' do
-          let(:query_params) { '' }
-
-          it 'returns the default minimum includes' do
-            returned_types = response_json['included'].map { |r| r['type'] }.uniq
-            expect(returned_types).to contain_exactly('profiles', 'people', 'moves', 'locations', 'ethnicities', 'genders')
-          end
-        end
-
-        context 'when including the include query param' do
-          let(:query_params) { '?include=from_location' }
-
-          it 'returns the valid provided includes' do
-            returned_types = response_json['included'].map { |r| r['type'] }.uniq
-            expect(returned_types).to contain_exactly('locations')
-          end
-        end
-
-        context 'when including an invalid include query param' do
-          let(:query_params) { '?include=foo.bar,from_location' }
-
-          let(:expected_error) do
-            {
-              'errors' => [
-                {
-                  'title' => 'Bad request',
-                  'detail' => /\["foo\.bar"\] is not supported/,
-                },
-              ],
-            }
-          end
-
-          it 'returns a validation error' do
-            expect(response).to have_http_status(:bad_request)
-            expect(response_json).to include(expected_error)
-          end
-        end
-
-        context 'when including an empty include query param' do
-          let(:query_params) { '?include=' }
-
-          it 'returns none of the includes' do
-            returned_types = response_json['included']
-            expect(returned_types).to be_nil
-          end
-        end
-
-        context 'when including a nil include query param' do
-          let(:query_params) { '?include' }
-
-          it 'returns the default minimum includes' do
-            returned_types = response_json['included'].map { |r| r['type'] }.uniq
-            expect(returned_types).to contain_exactly('profiles', 'people', 'moves', 'locations', 'ethnicities', 'genders')
-          end
+        it 'delegates the query execution to Allocations::Finder with the correct sorting' do
+          get_allocations
+          expect(Allocations::Finder).to have_received(:new).with(filters: {}, ordering: {}, search: { location: 'nott' })
         end
       end
     end
 
-    context 'when not authorized', :skip_before, :with_invalid_auth_headers do
+    describe 'paginating results' do
+      let!(:allocations) { create_list :allocation, 6 }
+      let(:meta_pagination) do
+        {
+          per_page: 5,
+          total_pages: 2,
+          total_objects: 6,
+          links: {
+            first: '/api/v1/allocations?page=1',
+            last: '/api/v1/allocations?page=2',
+            next: '/api/v1/allocations?page=2',
+          },
+        }
+      end
+
+      before { get_allocations }
+
+      it_behaves_like 'an endpoint that paginates resources'
+    end
+
+    describe 'validating dates before running queries' do
+      let(:filters) do
+        {
+          date_from: 'yyyy-09-Tu',
+        }
+      end
+      let(:params) { { filter: filters } }
+
+      before { get_allocations }
+
+      it 'is a bad request' do
+        expect(response.status).to eq(400)
+      end
+
+      it 'returns errors' do
+        expect(response.body).to eq('{"error":{"date_from":["is not a valid date."]}}')
+      end
+    end
+
+    describe 'validating locations before running queries' do
+      let(:filters) do
+        {
+          from_locations: 'foo',
+          to_locations: 'bar',
+          locations: 'baz',
+        }
+      end
+      let(:params) { { filter: filters } }
+
+      before { get_allocations }
+
+      it 'is a bad request' do
+        expect(response.status).to eq(400)
+      end
+
+      it 'returns errors' do
+        expect(response.body).to eq('{"error":{"locations":["may not be used in combination with `from_locations` or `to_locations` filters."]}}')
+      end
+    end
+
+    describe 'included relationships' do
+      let!(:allocation) { create :allocation, :with_moves }
+
+      before { get_allocations }
+
+      context 'when not including the include param' do
+        it 'returns the default minimum includes' do
+          returned_types = response_json['included'].map { |r| r['type'] }.uniq
+          expect(returned_types).to contain_exactly('profiles', 'people', 'moves', 'locations', 'ethnicities', 'genders')
+        end
+      end
+
+      context 'when including the include param' do
+        let(:params) { { include: 'from_location' } }
+
+        it 'returns the valid provided includes' do
+          returned_types = response_json['included'].map { |r| r['type'] }.uniq
+          expect(returned_types).to contain_exactly('locations')
+        end
+      end
+
+      context 'when including an empty include param' do
+        let(:params) { { include: '' } }
+
+        it 'returns none of the includes' do
+          returned_types = response_json['included']
+          expect(returned_types).to be_nil
+        end
+      end
+    end
+
+    context 'when not authorized', :with_invalid_auth_headers do
       let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
       let(:detail_401) { 'Token expired or invalid' }
 
-      before do
-        get '/api/v1/allocations', headers: headers
-      end
+      before { get_allocations }
 
       it_behaves_like 'an endpoint that responds with error 401'
     end
 
     context 'with an invalid CONTENT_TYPE header' do
       let(:content_type) { 'application/xml' }
+
+      before { get_allocations }
 
       it_behaves_like 'an endpoint that responds with error 415'
     end

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Allocations::Finder do
 
   let!(:from_location) { create :location }
   let!(:to_location) { create :location }
-
   let!(:allocation) { create :allocation, from_location: from_location, to_location: to_location }
+
   let(:filter_params) { {} }
   let(:sort_params) { {} }
   let(:search_params) { {} }
@@ -212,10 +212,26 @@ RSpec.describe Allocations::Finder do
     let!(:profile) { create :profile, person: person }
     let!(:move) { create :move, profile: profile, allocation: allocation }
 
+    context 'with blank location' do
+      let(:search_params) { { location: '' } }
+
+      it 'ignores the search params and returns filtered allocations' do
+        expect(allocation_finder.call).to contain_exactly(allocation, other_allocation)
+      end
+    end
+
     context 'when by location' do
       let(:search_params) { { location: 'fOrD' } }
 
       it 'returns allocations including either from location name or to location name' do
+        expect(allocation_finder.call).to contain_exactly(allocation, other_allocation)
+      end
+    end
+
+    context 'with blank person' do
+      let(:search_params) { { person: '' } }
+
+      it 'ignores the search params and returns filtered allocations' do
         expect(allocation_finder.call).to contain_exactly(allocation, other_allocation)
       end
     end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -183,6 +183,18 @@
             enum:
               - asc
               - desc
+        - name: search[location]
+          description: Search expression for matching from/to location titles (case insensitive)
+          in: query
+          schema:
+            type: string
+          example: NOTT
+        - name: search[person]
+          description: Search expression for matching last name of people (case insensitive)
+          in: query
+          schema:
+            type: string
+          example: Bloggs
         - "$ref": "../v1/allocation_include_parameter.yaml#/AllocationIncludeParameter"
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"


### PR DESCRIPTION
### Jira link

P4-1327

### What?

- [x] Added new search[person] and search[location] params to GET /allocations endpoint
- [x] New params are propagated to revised Allocations::Finder service
- [x] Added scopes to Location and Person model to perform case insensitive substring match
- [x] Refactored request spec to avoid confusing `:skip_before` behaviour and remove redundant coverage

### Why?

- This supports adding a search feature in the front end. The original intent was to add a single search param covering both location titles and person name but this got very messy so I decided to separate the two searches for simplicity. This is an option we discussed during refinement and is likely to be more useful to the user.

- Tested locally with a copy of staging data and performance is good (searching across all allocations with no filters is around 400-500ms response time - the bulk of that being AMS rendering of included resources).

### Have you? (optional)

- [x] Updated API docs if necessary

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Extends a production API with a non breaking change; original behaviour remains unchanged if search params are not passed in request
