### PR TITLE
[P4-1813] Adds support for profile.documents in MoveSerializer

### DIFF
--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -29,8 +29,8 @@ class MoveSerializer < ActiveModel::Serializer
   belongs_to :allocation, serializer: AllocationSerializer
   belongs_to :original_move, serializer: MoveSerializer
 
-  # TODO: Remove support for person on a Move
   SUPPORTED_RELATIONSHIPS = %w[
+    profile.documents
     person.ethnicity
     person.gender
     profile.person.ethnicity

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -29,6 +29,7 @@ module V2
     belongs_to :original_move, serializer: MoveSerializer
 
     SUPPORTED_RELATIONSHIPS = %w[
+      profile.documents
       profile.person.ethnicity
       profile.person.gender
       from_location

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -91,6 +91,16 @@ FactoryBot.define do
     trait :with_date_to do
       date_to { date + 3.days }
     end
+
+    trait :with_original_move do
+      association(:original_move, factory: :move)
+    end
+
+    trait :with_court_hearings do
+      after(:create) do |move|
+        create_list(:court_hearing, 1, move: move)
+      end
+    end
   end
 
   factory :from_court_to_prison, class: 'Move' do

--- a/spec/factories/profile.rb
+++ b/spec/factories/profile.rb
@@ -4,4 +4,10 @@ FactoryBot.define do
   factory :profile do
     association(:person, factory: :person_without_profiles)
   end
+
+  trait :with_documents do
+    after(:create) do |profile|
+      create_list(:document, 1, documentable: profile)
+    end
+  end
 end

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -271,4 +271,14 @@ RSpec.describe MoveSerializer do
       end
     end
   end
+
+  describe 'documents' do
+    let(:adapter_options) { { include: ['profile.documents'] } }
+    let(:move) { create(:move, profile: create(:profile, :with_documents)) }
+
+    it 'contains included documents relationships' do
+      expect(result[:included].map { |r| r[:type] })
+        .to match_array(%w[profiles documents])
+    end
+  end
 end

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V2::MoveSerializer do
+  subject(:serializer) { described_class.new(move) }
+
+  let(:move) { create :move }
+
+  let(:result) do
+    JSON.parse(ActiveModelSerializers::Adapter.create(serializer, adapter_options).to_json).deep_symbolize_keys
+  end
+
+  context 'with no options' do
+    let(:adapter_options) { {} }
+    let(:expected_json) do
+      {
+        data: {
+          id: move.id,
+          type: 'moves',
+          attributes: {
+            additional_information: 'some more info about the move that the supplier might need to know',
+            cancellation_reason: nil,
+            cancellation_reason_comment: nil,
+            created_at: move.created_at.iso8601,
+            date: move.date.iso8601,
+            date_from: move.date_from.iso8601,
+            date_to: nil,
+            move_agreed: nil,
+            move_agreed_by: nil,
+            move_type: 'court_appearance',
+            reference: move.reference,
+            rejection_reason: nil,
+            status: 'requested',
+            time_due: move.time_due.iso8601,
+            updated_at: move.updated_at.iso8601,
+          },
+          relationships: {
+            profile: { data: { id: move.profile.id, type: 'profiles' } },
+            from_location: { data: { id: move.from_location.id, type: 'locations' } },
+            to_location: { data: { id: move.to_location.id, type: 'locations' } },
+            prison_transfer_reason: { data: nil },
+            court_hearings: { data: [] },
+            allocation: { data: nil },
+            original_move: { data: nil },
+          },
+        },
+      }
+    end
+
+    it { expect(result).to include_json(expected_json) }
+    it { expect(result[:included]).to be_nil }
+  end
+
+  context 'with all supported includes' do
+    let(:move) do
+      create(
+        :move,
+        :with_original_move,
+        :with_court_hearings,
+        :prison_transfer,
+        profile: create(:profile, :with_documents),
+      )
+    end
+
+    let(:adapter_options) { { include: described_class::SUPPORTED_RELATIONSHIPS } }
+
+    it 'contains all included relationships' do
+      expect(result[:included].map { |r| r[:type] })
+        .to match_array(%w[people ethnicities genders locations locations profiles moves documents prison_transfer_reasons court_hearings])
+    end
+  end
+end

--- a/swagger/v1/move_include_parameter.yaml
+++ b/swagger/v1/move_include_parameter.yaml
@@ -14,12 +14,13 @@ MoveIncludeParameter:
       - to_location
       - original_move
       - prison_transfer_reason
-      - person
-      - profile
       - from_location.suppliers
       - to_location.suppliers
+      - person
       - person.gender
       - person.ethnicity
+      - profile
+      - profile.documents
       - profile.person
       - profile.person.gender
       - profile.person.ethnicity

--- a/swagger/v2/move_include_parameter.yaml
+++ b/swagger/v2/move_include_parameter.yaml
@@ -9,15 +9,14 @@ MoveIncludeParameter:
     enum:
       - allocation
       - court_hearings
-      - documents
-      - from_location
-      - to_location
       - original_move
       - prison_transfer_reason
-      - profile
-      - profile.person
-      - profile.person.ethnicity
-      - profile.person.gender
+      - from_location
       - from_location.suppliers
+      - to_location
       - to_location.suppliers
+      - profile.documents
+      - profile.person
+      - profile.person.gender
+      - profile.person.ethnicity
   example: from_location


### PR DESCRIPTION
### Jira link

P4-1813

### What?

- [x] Surface profile documents for the move.
- [x] Updates documentation to reflect include options in v1/v2

### Why?

Reduce impact of migration of documents for frontend.

### Have you? (optional)

- [x] Updated API docs if necessary	
