### PR TITLE
Enable APM on config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'cancancan'
 # explicit soft-deletes
 gem 'discard'
 gem 'doorkeeper'
+gem 'elastic-apm'
 gem 'faraday'
 gem 'finite_machine'
 gem 'govuk_notify_rails', '~> 2.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,12 +108,17 @@ GEM
     discard (1.1.0)
       activerecord (>= 4.2, < 7)
     docile (1.3.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     doorkeeper (5.4.0)
       railties (>= 5)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
+    elastic-apm (3.8.0)
+      concurrent-ruby (~> 1.0)
+      http (>= 3.0)
     erubi (1.9.0)
     factory_bot (5.2.0)
       activesupport (>= 4.2.0)
@@ -127,6 +132,9 @@ GEM
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
     ffi (1.13.1)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     finite_machine (0.13.0)
       concurrent-ruby (~> 1.0)
       sync (~> 0.5)
@@ -143,6 +151,16 @@ GEM
     govuk_notify_rails (2.1.2)
       notifications-ruby-client (~> 5.1)
       rails (>= 4.1.0)
+    http (4.4.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http-parser (1.2.1)
+      ffi-compiler (>= 1.0, < 2.0)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
@@ -365,6 +383,9 @@ GEM
       citrus (~> 3.0, > 3.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     validate_url (1.0.11)
       activemodel (>= 3.0.0)
@@ -389,6 +410,7 @@ DEPENDENCIES
   doorkeeper
   dotenv
   dotenv-rails
+  elastic-apm
   factory_bot_rails
   faker
   faraday


### PR DESCRIPTION
### Jira link

P4

### What?

I have added/removed/altered:

- [ ] Adds gem to enable APM monitoring, depending on config

### Why?

I am doing this because:

- We want to evaluate Elastic APM
-
-

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

