### PR TITLE
Default to APM off for new devs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,5 @@ GOVUK_NOTIFY_TEMPLATE_ID=8f2e5473-15f2-4db8-a2de-153f26a0524c
 
 # Completely disable API authentication for local development if true.
 DEV_DISABLE_AUTH=false
+
+ELASTIC_APM_ENABLED=false


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

Default to disabling apm for new devs to avoid local log output noise.
