### PR TITLE
P4-1750 Add flags to frameworks

### DIFF
--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Flag < VersionedModel
+  validates :key, presence: true
+  validates :name, presence: true
+  validates :question_value, presence: true
+
+  belongs_to :framework_question
+end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 class Flag < VersionedModel
-  validates :key, presence: true
+  enum flag_type: {
+    information: 'information',
+    attention: 'attention',
+    warning: 'warning',
+    alert: 'alert',
+  }
+
+  validates :flag_type, presence: true, inclusion: { in: flag_types }
   validates :name, presence: true
   validates :question_value, presence: true
 

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 class FrameworkQuestion < VersionedModel
+  enum question_type: {
+    radio: 'radio',
+    checkbox: 'checkbox',
+    text: 'text',
+    textarea: 'textarea',
+  }
+
   validates :key, presence: true
   validates :section, presence: true
-  validates :question_type, presence: true
+  validates :question_type, presence: true, inclusion: { in: question_types }
 
   belongs_to :framework
   has_many :dependents, class_name: 'FrameworkQuestion',

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -10,4 +10,5 @@ class FrameworkQuestion < VersionedModel
                         foreign_key: 'parent_id'
 
   belongs_to :parent, class_name: 'FrameworkQuestion', optional: true
+  has_many :flags
 end

--- a/app/services/frameworks/question.rb
+++ b/app/services/frameworks/question.rb
@@ -38,6 +38,8 @@ module Frameworks
           followup_comment: option['followup_comment'],
           value: option['value'],
         )
+
+        build_flags(flags: option.fetch('flags', []), value: option['value'])
       end
     end
 
@@ -54,6 +56,16 @@ module Frameworks
         questions[followup].section = question.section
         questions[followup].dependent_value = value
         questions[followup].parent = question
+      end
+    end
+
+    def build_flags(flags:, value:)
+      flags.each do |flag|
+        question.flags.new(
+          flag_type: flag['type'],
+          name: flag['label'],
+          question_value: value,
+        )
       end
     end
 

--- a/db/migrate/20200630071352_create_flags.rb
+++ b/db/migrate/20200630071352_create_flags.rb
@@ -2,7 +2,7 @@ class CreateFlags < ActiveRecord::Migration[6.0]
   def change
     create_table :flags, id: :uuid do |t|
       t.references :framework_question, type: :uuid, null: false, index: true, foreign_key: true
-      t.string :key, null: false
+      t.string :flag_type, null: false
       t.string "name", null: false
       t.string "question_value", null: false
 

--- a/db/migrate/20200630071352_create_flags.rb
+++ b/db/migrate/20200630071352_create_flags.rb
@@ -1,0 +1,12 @@
+class CreateFlags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :flags, id: :uuid do |t|
+      t.references :framework_question, type: :uuid, null: false, index: true, foreign_key: true
+      t.string :key, null: false
+      t.string "name", null: false
+      t.string "question_value", null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_052847) do
+ActiveRecord::Schema.define(version: 2020_06_30_071352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -119,6 +119,16 @@ ActiveRecord::Schema.define(version: 2020_06_24_052847) do
     t.index ["client_timestamp"], name: "index_events_on_client_timestamp"
     t.index ["eventable_id", "eventable_type", "event_name"], name: "index_events_on_eventable_id_and_eventable_type_and_event_name"
     t.index ["eventable_id", "eventable_type"], name: "index_events_on_eventable_id_and_eventable_type"
+  end
+
+  create_table "flags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "framework_question_id", null: false
+    t.string "key", null: false
+    t.string "name", null: false
+    t.string "question_value", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["framework_question_id"], name: "index_flags_on_framework_question_id"
   end
 
   create_table "framework_questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -435,6 +445,7 @@ ActiveRecord::Schema.define(version: 2020_06_24_052847) do
   add_foreign_key "allocations", "locations", column: "to_location_id", name: "fk_rails_allocations_to_location_id"
   add_foreign_key "court_hearings", "moves"
   add_foreign_key "documents", "moves"
+  add_foreign_key "flags", "framework_questions"
   add_foreign_key "framework_questions", "frameworks"
   add_foreign_key "journeys", "locations", column: "from_location_id"
   add_foreign_key "journeys", "locations", column: "to_location_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -123,7 +123,7 @@ ActiveRecord::Schema.define(version: 2020_06_30_071352) do
 
   create_table "flags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "framework_question_id", null: false
-    t.string "key", null: false
+    t.string "flag_type", null: false
     t.string "name", null: false
     t.string "question_value", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/flag.rb
+++ b/spec/factories/flag.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :flag do
+    sequence(:name) { |x| "High public interest #{x}" }
+    sequence(:key) { |x| "key-#{x}" }
+    sequence(:question_value) { 'Yes' }
+
+    association(:framework_question)
+  end
+end

--- a/spec/factories/flag.rb
+++ b/spec/factories/flag.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :flag do
     sequence(:name) { |x| "High public interest #{x}" }
-    sequence(:key) { |x| "key-#{x}" }
+    sequence(:flag_type) { 'warning' }
     sequence(:question_value) { 'Yes' }
 
     association(:framework_question)

--- a/spec/factories/framework_question.rb
+++ b/spec/factories/framework_question.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :framework_question do
+    association(:framework)
+    sequence(:key) { |x| "key-#{x}" }
+    section { 'risk' }
+    question_type { 'radio' }
+    options { %w[Yes No] }
+  end
+end

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/medical-professional-referral.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/medical-professional-referral.yml
@@ -4,6 +4,13 @@ options:
   -
     label: 'Yes'
     value: 'Yes'
+    flags:
+      -
+        type: alert
+        label: Physical Health
+      -
+        type: information
+        label: Medication
     followup_comment:
       label: Please give details
       validations:

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Flag do
+  subject { create(:flag) }
+
+  it { is_expected.to validate_presence_of(:key) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to belong_to(:framework_question) }
+end

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe Flag do
   subject { create(:flag) }
 
-  it { is_expected.to validate_presence_of(:key) }
+  it { is_expected.to validate_presence_of(:flag_type) }
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to belong_to(:framework_question) }
+  it { is_expected.to validate_inclusion_of(:flag_type).in_array(%w[information attention warning alert]) }
 end

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe FrameworkQuestion do
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_presence_of(:section) }
   it { is_expected.to validate_presence_of(:question_type) }
+  it { is_expected.to validate_inclusion_of(:question_type).in_array(%w[radio checkbox text textarea]) }
 
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:parent).optional }

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -11,4 +11,5 @@ RSpec.describe FrameworkQuestion do
   it { is_expected.to belong_to(:parent).optional }
 
   it { is_expected.to have_many(:dependents) }
+  it { is_expected.to have_many(:flags) }
 end

--- a/spec/services/frameworks/importer_spec.rb
+++ b/spec/services/frameworks/importer_spec.rb
@@ -86,5 +86,17 @@ RSpec.describe Frameworks::Importer do
         expect(question.dependents).to contain_exactly(FrameworkQuestion.find_by(key: 'medical-details-information'))
       end
     end
+
+    context 'when creating framework questions flags' do
+      it 'persists flags relative to a framework question' do
+        described_class.new(filepath: filepath, version: '0.1').call
+        framework_question = FrameworkQuestion.find_by(key: 'medical-professional-referral')
+
+        expect(framework_question.flags.pluck(:name)).to contain_exactly(
+          'Physical Health',
+          'Medication',
+        )
+      end
+    end
   end
 end

--- a/spec/services/frameworks/question_spec.rb
+++ b/spec/services/frameworks/question_spec.rb
@@ -97,5 +97,27 @@ RSpec.describe Frameworks::Question do
       questions = described_class.new(filepath: filepath, questions: {}).call
       expect(questions['medical-details-information']).to be_a(FrameworkQuestion)
     end
+
+    it 'sets flags on question answers' do
+      filepath = Rails.root.join(fixture_path, 'medical-professional-referral.yml')
+      question = FrameworkQuestion.new(section: 'health', key: 'medical-professional-referral')
+      questions = { 'medical-professional-referral' => question }
+      described_class.new(filepath: filepath, questions: questions).call
+
+      expect(question.flags.size).to eq(2)
+    end
+
+    it 'sets attributes on flag as well as question answer to conditionally surface the flag' do
+      filepath = Rails.root.join(fixture_path, 'medical-professional-referral.yml')
+      question = FrameworkQuestion.new(section: 'health', key: 'medical-professional-referral')
+      questions = { 'medical-professional-referral' => question }
+      described_class.new(filepath: filepath, questions: questions).call
+
+      expect(question.flags.first).to have_attributes(
+        flag_type: 'alert',
+        name: 'Physical Health',
+        question_value: 'Yes',
+      )
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[P4-1750](https://dsdmoj.atlassian.net/browse/P4-1750)

### What?

I have added/removed/altered:

- [x] Added flags table and associated it to framework questions
- [x] Amended framework importer to persist flags if they appear under a question option
- [x] Updated framework question enums and added relevant validations

### Why?

I am doing this because:
To show users on the summary pages on the Frontend application certain alerts a person transported might have, flags are linked to questions if they are answered in a certain way. A question can have multiple flags, with a `type`, `name` and the question value they relate to.
