### PR TITLE
P4 1827 faster specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ jobs:
 
   rspec_tests:
     executor: test-executor
-    parallelism: 4
+    parallelism: 1
     steps:
       - checkout
       - build-base

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,4 @@
 --color
 --require spec_helper
---format d
+--format p
 --format Rswag::Specs::SwaggerFormatter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
-    cancancan (3.0.1)
+    cancancan (3.1.0)
     case_transform (0.2)
       activesupport
     choice (0.2.0)

--- a/app/controllers/api/allocation_events_controller.rb
+++ b/app/controllers/api/allocation_events_controller.rb
@@ -8,7 +8,7 @@ module Api
       validate_params!(cancel_params)
 
       allocation.transaction do
-        allocation.cancel(cancellation_details)
+        allocation.cancel(**cancellation_details)
         process_event(allocation.moves, Event::CANCEL, cancel_move_params)
       end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -26,12 +26,12 @@ class ApiController < ApplicationController
   rescue_from IncludeParamsValidator::ValidationError, with: :render_include_validation_error
 
   def current_user
+    return Doorkeeper::Application.new unless authentication_enabled?
+
     doorkeeper_token&.application
   end
 
   def user_for_paper_trail
-    return unless authentication_enabled?
-
     current_user.owner_id
   end
 
@@ -41,6 +41,8 @@ private
     return false if Rails.env.development? && ENV['DEV_DISABLE_AUTH'] =~ /true/i
 
     return false if Rails.env.production? && ENV['HEROKU_DISABLE_AUTH'] =~ /true/i
+
+    return false if Rails.env.test? && request.headers['Authorization'] =~ /spoofed/i
 
     true
   end

--- a/app/jobs/notify_email_job.rb
+++ b/app/jobs/notify_email_job.rb
@@ -5,7 +5,7 @@
 class NotifyEmailJob < ApplicationJob
   queue_as :notifications
 
-  def perform(notification_id:)
+  def perform(notification_id)
     notification = Notification.emails.kept.includes(:subscription).find(notification_id)
     return unless notification.subscription.enabled?
 

--- a/app/jobs/notify_webhook_job.rb
+++ b/app/jobs/notify_webhook_job.rb
@@ -4,7 +4,7 @@
 class NotifyWebhookJob < ApplicationJob
   queue_as :notifications
 
-  def perform(notification_id:)
+  def perform(notification_id)
     notification = Notification.webhooks.kept.includes(:subscription).find(notification_id)
     subscription = notification.subscription
     return unless subscription.enabled?

--- a/app/jobs/prepare_move_notifications_job.rb
+++ b/app/jobs/prepare_move_notifications_job.rb
@@ -31,12 +31,11 @@ class PrepareMoveNotificationsJob < ApplicationJob
 private
 
   def build_notification_id(subscription, type_id, topic, action_name)
-    { notification_id:
-          subscription.notifications.create!(
-            notification_type_id: type_id,
-            topic: topic,
-            event_type: event_type(action_name),
-          ).id }
+    subscription.notifications.create!(
+      notification_type_id: type_id,
+      topic: topic,
+      event_type: event_type(action_name),
+    ).id
   end
 
   def should_email?(move)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,10 @@ Rails.application.configure do
   config.active_job.queue_adapter   = :test
 
   config.cache_store = :memory_store
+
+  require 'active_record/connection_adapters/postgresql_adapter'
+
+  # Disable logs for test suite schema to speed up test suite (with slightly reduced resilience)
+  # See: https://edgeapi.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/PostgreSQLAdapter.html#method-c-create_unlogged_tables
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = true
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -126,7 +126,8 @@ Doorkeeper.configure do
   # If you wish to use bcrypt for application secret hashing, uncomment
   # this line instead:
   #
-  hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
+  # BCrypt is very secure but is slow by design. We don't want to slow down the test suite needlessly.
+  hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt' unless Rails.env.test?
 
   # When the above option is enabled,
   # and a hashed token or secret is not found,

--- a/spec/jobs/notify_email_job_spec.rb
+++ b/spec/jobs/notify_email_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe NotifyEmailJob, type: :job do
-  subject(:perform!) { described_class.new.perform(notification_id: notification.id) }
+  subject(:perform!) { described_class.new.perform(notification.id) }
 
   let(:perform_and_ignore_errors!) do
     perform!

--- a/spec/jobs/notify_webhook_job_spec.rb
+++ b/spec/jobs/notify_webhook_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe NotifyWebhookJob, type: :job do
-  subject(:perform!) { described_class.new.perform(notification_id: notification.id) }
+  subject(:perform!) { described_class.new.perform(notification.id) }
 
   let(:perform_and_ignore_errors!) do
     perform!

--- a/spec/jobs/prepare_move_notifications_job_spec.rb
+++ b/spec/jobs/prepare_move_notifications_job_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
   shared_examples_for 'it schedules NotifyWebhookJob' do
     before { perform }
 
-    it { expect(NotifyWebhookJob).to have_received(:perform_later).with(notification_id: Notification.webhooks.last.id) }
+    it { expect(NotifyWebhookJob).to have_received(:perform_later).with(Notification.webhooks.last.id) }
   end
 
   shared_examples_for 'it does not schedule NotifyWebhookJob' do
@@ -55,7 +55,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
   shared_examples_for 'it schedules NotifyEmailJob' do
     before { perform }
 
-    it { expect(NotifyEmailJob).to have_received(:perform_later).with(notification_id: Notification.emails.last.id) }
+    it { expect(NotifyEmailJob).to have_received(:perform_later).with(Notification.emails.last.id) }
   end
 
   shared_examples_for 'it does not schedule NotifyEmailJob' do

--- a/spec/requests/api/allocation_events_controller_cancel_spec.rb
+++ b/spec/requests/api/allocation_events_controller_cancel_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Api::AllocationEventsController do
   describe 'POST /allocations/:id/cancel' do
     let(:schema) { load_yaml_schema('post_allocation_cancel_responses.yaml') }
 
-    let(:supplier) { create(:supplier) }
-    let(:application) { create(:application, owner_id: supplier.id) }
-    let(:access_token) { create(:access_token, application: application).token }
+    let(:access_token) { 'spoofed-token' }
     let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
     let(:content_type) { ApiController::CONTENT_TYPE }
 

--- a/spec/requests/api/allocation_events_controller_cancel_spec.rb
+++ b/spec/requests/api/allocation_events_controller_cancel_spec.rb
@@ -79,24 +79,11 @@ RSpec.describe Api::AllocationEventsController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized' do
-      let(:access_token) { 'foo-bar' }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
     context 'with a missing id' do
       let(:allocation_id) { 'foo-bar' }
       let(:detail_404) { "Couldn't find Allocation with 'id'=foo-bar" }
 
       it_behaves_like 'an endpoint that responds with error 404'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415'
     end
 
     context 'with validation errors' do

--- a/spec/requests/api/allocations_controller_create_spec.rb
+++ b/spec/requests/api/allocations_controller_create_spec.rb
@@ -69,8 +69,7 @@ RSpec.describe Api::AllocationsController do
     end
 
     let(:supplier) { create(:supplier) }
-    let!(:application) { create(:application, owner_id: supplier.id) }
-    let(:access_token) { create(:access_token, application: application).token }
+    let(:access_token) { 'spoofed-token' }
     let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
     let(:content_type) { ApiController::CONTENT_TYPE }
 
@@ -109,8 +108,13 @@ RSpec.describe Api::AllocationsController do
           .to change(Move, :count).by(2)
       end
 
-      it 'audits the supplier' do
-        expect(allocation.versions.map(&:whodunnit)).to eq([supplier.id])
+      context 'with a real access token' do
+        let(:application) { create(:application, owner_id: supplier.id) }
+        let(:access_token) { create(:access_token, application: application).token }
+
+        it 'audits the supplier' do
+          expect(allocation.versions.map(&:whodunnit)).to eq([supplier.id])
+        end
       end
 
       it 'returns the correct data' do

--- a/spec/requests/api/allocations_controller_create_spec.rb
+++ b/spec/requests/api/allocations_controller_create_spec.rb
@@ -79,20 +79,6 @@ RSpec.describe Api::AllocationsController do
       post '/api/v1/allocations', params: { data: data }, headers: headers, as: :json
     end
 
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
-
     context 'when successful' do
       let(:allocation) { Allocation.find_by(from_location_id: from_location.id) }
 

--- a/spec/requests/api/allocations_controller_create_v2_spec.rb
+++ b/spec/requests/api/allocations_controller_create_v2_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe Api::AllocationsController do
     end
 
     let(:supplier) { create(:supplier) }
-    let!(:application) { create(:application, owner_id: supplier.id) }
-    let(:access_token) { create(:access_token, application: application).token }
+    let(:access_token) { 'spoofed-token' }
     let(:content_type) { ApiController::CONTENT_TYPE }
     let(:headers) do
       {

--- a/spec/requests/api/allocations_controller_index_spec.rb
+++ b/spec/requests/api/allocations_controller_index_spec.rb
@@ -171,22 +171,5 @@ RSpec.describe Api::AllocationsController do
         end
       end
     end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before { get_allocations }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { get_allocations }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 end

--- a/spec/requests/api/allocations_controller_index_spec.rb
+++ b/spec/requests/api/allocations_controller_index_spec.rb
@@ -3,9 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::AllocationsController do
-  let(:supplier) { create(:supplier) }
-  let!(:application) { create(:application, owner_id: supplier.id) }
-  let!(:access_token) { create(:access_token, application: application).token }
+  let(:access_token) { 'spoofed-token' }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
   let(:response_json) { JSON.parse(response.body) }
   let(:content_type) { ApiController::CONTENT_TYPE }

--- a/spec/requests/api/allocations_controller_index_v2_spec.rb
+++ b/spec/requests/api/allocations_controller_index_v2_spec.rb
@@ -3,9 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::AllocationsController do
-  let(:supplier) { create(:supplier) }
-  let!(:application) { create(:application, owner_id: supplier.id) }
-  let!(:access_token) { create(:access_token, application: application).token }
+  let(:access_token) { 'spoofed-token' }
   let(:response_json) { JSON.parse(response.body) }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) do

--- a/spec/requests/api/court_hearings_controller_create_spec.rb
+++ b/spec/requests/api/court_hearings_controller_create_spec.rb
@@ -24,9 +24,7 @@ RSpec.describe Api::CourtHearingsController do
       }
     end
 
-    let(:supplier) { create(:supplier) }
-    let(:application) { create(:application, owner_id: supplier.id) }
-    let(:access_token) { create(:access_token, application: application).token }
+    let(:access_token) { 'spoofed-token' }
     let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
     let(:content_type) { ApiController::CONTENT_TYPE }
 

--- a/spec/requests/api/documents_controller_create_spec.rb
+++ b/spec/requests/api/documents_controller_create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::DocumentsController do
   let(:response_json) { JSON.parse(response.body) }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { 'multipart/form-data' }
 
   let(:headers) do

--- a/spec/requests/api/journey_events_controller_cancel_spec.rb
+++ b/spec/requests/api/journey_events_controller_cancel_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/cancel' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, from_location: from_location) }

--- a/spec/requests/api/journey_events_controller_complete_spec.rb
+++ b/spec/requests/api/journey_events_controller_complete_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/complete' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, from_location: from_location) }

--- a/spec/requests/api/journey_events_controller_lockouts_spec.rb
+++ b/spec/requests/api/journey_events_controller_lockouts_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/lockouts' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, from_location: from_location) }

--- a/spec/requests/api/journey_events_controller_lodgings_spec.rb
+++ b/spec/requests/api/journey_events_controller_lodgings_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/lodgings' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, from_location: from_location) }

--- a/spec/requests/api/journey_events_controller_reject_spec.rb
+++ b/spec/requests/api/journey_events_controller_reject_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/reject' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, from_location: from_location) }

--- a/spec/requests/api/journey_events_controller_start_spec.rb
+++ b/spec/requests/api/journey_events_controller_start_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/start' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, from_location: from_location) }

--- a/spec/requests/api/journey_events_controller_uncancel_spec.rb
+++ b/spec/requests/api/journey_events_controller_uncancel_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/uncancel' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, from_location: from_location) }

--- a/spec/requests/api/journey_events_controller_uncomplete_spec.rb
+++ b/spec/requests/api/journey_events_controller_uncomplete_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/uncomplete' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, from_location: from_location) }

--- a/spec/requests/api/journeys_controller_create_spec.rb
+++ b/spec/requests/api/journeys_controller_create_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe Api::JourneysController do
     end
 
     context 'when successful' do
+      let(:application) { create(:application, owner: supplier) }
+      let(:access_token) { create(:access_token, application: application).token }
       let(:schema) { load_yaml_schema('post_journeys_responses.yaml') }
       let(:data) do
         {

--- a/spec/requests/api/journeys_controller_create_spec.rb
+++ b/spec/requests/api/journeys_controller_create_spec.rb
@@ -113,13 +113,6 @@ RSpec.describe Api::JourneysController do
         end
       end
 
-      context 'when not authorized' do
-        let(:access_token) { 'foo-bar' }
-        let(:detail_401) { 'Token expired or invalid' }
-
-        it_behaves_like 'an endpoint that responds with error 401'
-      end
-
       context 'when the move_id is not found' do
         let(:move_id) { 'foo-bar' }
         let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
@@ -136,12 +129,6 @@ RSpec.describe Api::JourneysController do
                'detail' => 'Validation failed: Location reference was not found id=foo-bar' }]
           end
         end
-      end
-
-      context 'with an invalid CONTENT_TYPE header' do
-        let(:content_type) { 'application/xml' }
-
-        it_behaves_like 'an endpoint that responds with error 415'
       end
     end
   end

--- a/spec/requests/api/journeys_controller_create_spec.rb
+++ b/spec/requests/api/journeys_controller_create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneysController do
   describe 'POST /moves/:move_id/journeys' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:response_json) { JSON.parse(response.body) }
     let(:from_location_id) { create(:location, suppliers: [supplier]).id }

--- a/spec/requests/api/journeys_controller_index_spec.rb
+++ b/spec/requests/api/journeys_controller_index_spec.rb
@@ -61,22 +61,5 @@ RSpec.describe Api::JourneysController do
         it_behaves_like 'an endpoint that paginates resources'
       end
     end
-
-    context 'when unsuccessful' do
-      let(:schema) { load_yaml_schema('error_responses.yaml') }
-
-      context 'when not authorized' do
-        let(:access_token) { 'foo-bar' }
-        let(:detail_401) { 'Token expired or invalid' }
-
-        it_behaves_like 'an endpoint that responds with error 401'
-      end
-
-      context 'with an invalid CONTENT_TYPE header' do
-        let(:content_type) { 'application/xml' }
-
-        it_behaves_like 'an endpoint that responds with error 415'
-      end
-    end
   end
 end

--- a/spec/requests/api/journeys_controller_index_spec.rb
+++ b/spec/requests/api/journeys_controller_index_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneysController do
   describe 'GET /moves/:move_id/journeys' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:response_json) { JSON.parse(response.body) }
     let(:locations) { create_list(:location, 2, suppliers: [supplier]) }

--- a/spec/requests/api/journeys_controller_index_spec.rb
+++ b/spec/requests/api/journeys_controller_index_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Api::JourneysController do
     end
 
     context 'when successful' do
+      let(:application) { create(:application, owner: supplier) }
+      let(:access_token) { create(:access_token, application: application).token }
       let(:schema) { load_yaml_schema('get_journeys_responses.yaml') }
 
       it_behaves_like 'an endpoint that responds with success 200'

--- a/spec/requests/api/journeys_controller_show_spec.rb
+++ b/spec/requests/api/journeys_controller_show_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe Api::JourneysController do
       end
 
       context "when attempting to access another supplier's journey" do
+        let(:application) { create(:application, owner: supplier) }
+        let(:access_token) { create(:access_token, application: application).token }
         let(:journey) { create(:journey, move: move) } # another journey for a different supplier, same move
         let(:detail_401) { 'Not authorized' }
 

--- a/spec/requests/api/journeys_controller_show_spec.rb
+++ b/spec/requests/api/journeys_controller_show_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneysController do
   describe 'GET /moves/:move_id/journeys/:journey_id' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:response_json) { JSON.parse(response.body) }
     let(:locations) { create_list(:location, 2, suppliers: [supplier]) }

--- a/spec/requests/api/journeys_controller_show_spec.rb
+++ b/spec/requests/api/journeys_controller_show_spec.rb
@@ -57,13 +57,6 @@ RSpec.describe Api::JourneysController do
     context 'when unsuccessful' do
       let(:schema) { load_yaml_schema('error_responses.yaml') }
 
-      context 'when not authorized' do
-        let(:access_token) { 'foo-bar' }
-        let(:detail_401) { 'Token expired or invalid' }
-
-        it_behaves_like 'an endpoint that responds with error 401'
-      end
-
       context "when attempting to access another supplier's journey" do
         let(:application) { create(:application, owner: supplier) }
         let(:access_token) { create(:access_token, application: application).token }
@@ -78,12 +71,6 @@ RSpec.describe Api::JourneysController do
         let(:detail_404) { "Couldn't find Journey with 'id'=#{journey.id}" }
 
         it_behaves_like 'an endpoint that responds with error 404'
-      end
-
-      context 'with an invalid CONTENT_TYPE header' do
-        let(:content_type) { 'application/xml' }
-
-        it_behaves_like 'an endpoint that responds with error 415'
       end
     end
   end

--- a/spec/requests/api/journeys_controller_update_spec.rb
+++ b/spec/requests/api/journeys_controller_update_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneysController do
   describe 'PATCH /moves/:move_id/journeys/:journey_id' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:response_json) { JSON.parse(response.body) }
     let(:from_location_id) { create(:location, suppliers: [supplier]).id }

--- a/spec/requests/api/journeys_controller_update_spec.rb
+++ b/spec/requests/api/journeys_controller_update_spec.rb
@@ -178,13 +178,6 @@ RSpec.describe Api::JourneysController do
         end
       end
 
-      context 'when not authorized' do
-        let(:access_token) { 'foo-bar' }
-        let(:detail_401) { 'Token expired or invalid' }
-
-        it_behaves_like 'an endpoint that responds with error 401'
-      end
-
       context 'when the move_id is not found' do
         let(:move_id) { 'foo-bar' }
         let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
@@ -197,12 +190,6 @@ RSpec.describe Api::JourneysController do
         let(:detail_404) { "Couldn't find Journey with 'id'=foo-bar" }
 
         it_behaves_like 'an endpoint that responds with error 404'
-      end
-
-      context 'with an invalid CONTENT_TYPE header' do
-        let(:content_type) { 'application/xml' }
-
-        it_behaves_like 'an endpoint that responds with error 415'
       end
     end
   end

--- a/spec/requests/api/journeys_controller_update_spec.rb
+++ b/spec/requests/api/journeys_controller_update_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Api::JourneysController do
     end
 
     context 'when successful' do
+      let(:application) { create(:application, owner: supplier) }
+      let(:access_token) { create(:access_token, application: application).token }
       let(:schema) { load_yaml_schema('get_journey_responses.yaml') }
 
       context 'when updating all attributes' do

--- a/spec/requests/api/move_events_controller_accept_spec.rb
+++ b/spec/requests/api/move_events_controller_accept_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::MoveEventsController do
   describe 'POST /moves/:move_id/accept' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, :requested, from_location: from_location) }

--- a/spec/requests/api/move_events_controller_approve_spec.rb
+++ b/spec/requests/api/move_events_controller_approve_spec.rb
@@ -53,24 +53,11 @@ RSpec.describe Api::MoveEventsController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized' do
-      let(:access_token) { 'foo-bar' }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
     context 'with a missing move_id' do
       let(:move_id) { 'foo-bar' }
       let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
 
       it_behaves_like 'an endpoint that responds with error 404'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415'
     end
 
     context 'with validation errors' do

--- a/spec/requests/api/move_events_controller_approve_spec.rb
+++ b/spec/requests/api/move_events_controller_approve_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::MoveEventsController do
   describe 'POST /moves/:move_id/approve' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:schema) { load_yaml_schema('post_move_events_responses.yaml') }
     let(:response_json) { JSON.parse(response.body) }

--- a/spec/requests/api/move_events_controller_cancel_spec.rb
+++ b/spec/requests/api/move_events_controller_cancel_spec.rb
@@ -59,24 +59,11 @@ RSpec.describe Api::MoveEventsController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized' do
-      let(:access_token) { 'foo-bar' }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
     context 'with a missing move_id' do
       let(:move_id) { 'foo-bar' }
       let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
 
       it_behaves_like 'an endpoint that responds with error 404'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415'
     end
 
     context 'with validation errors' do

--- a/spec/requests/api/move_events_controller_cancel_spec.rb
+++ b/spec/requests/api/move_events_controller_cancel_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::MoveEventsController do
   describe 'POST /moves/:move_id/cancel' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:schema) { load_yaml_schema('post_move_events_responses.yaml') }
     let(:response_json) { JSON.parse(response.body) }

--- a/spec/requests/api/move_events_controller_complete_spec.rb
+++ b/spec/requests/api/move_events_controller_complete_spec.rb
@@ -49,24 +49,11 @@ RSpec.describe Api::MoveEventsController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized' do
-      let(:access_token) { 'foo-bar' }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
     context 'with a missing move_id' do
       let(:move_id) { 'foo-bar' }
       let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
 
       it_behaves_like 'an endpoint that responds with error 404'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415'
     end
 
     context 'with validation errors' do

--- a/spec/requests/api/move_events_controller_complete_spec.rb
+++ b/spec/requests/api/move_events_controller_complete_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::MoveEventsController do
   describe 'POST /moves/:move_id/complete' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:response_json) { JSON.parse(response.body) }
     let(:schema) { load_yaml_schema('post_move_events_responses.yaml') }

--- a/spec/requests/api/move_events_controller_lockout_spec.rb
+++ b/spec/requests/api/move_events_controller_lockout_spec.rb
@@ -52,11 +52,17 @@ RSpec.describe Api::MoveEventsController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized' do
-      let(:access_token) { 'foo-bar' }
-      let(:detail_401) { 'Token expired or invalid' }
+    context 'with a missing from_location' do
+      let(:lockout_params) { { data: { type: 'lockouts', attributes: { timestamp: '2020-04-23T18:25:43.511Z' } } } }
 
-      it_behaves_like 'an endpoint that responds with error 401'
+      it_behaves_like 'an endpoint that responds with error 400' do
+        let(:errors_400) do
+          [{
+            'title' => 'Bad request',
+            'detail' => 'param is missing or the value is empty: relationships',
+          }]
+        end
+      end
     end
 
     context 'with a missing move_id' do
@@ -66,10 +72,20 @@ RSpec.describe Api::MoveEventsController do
       it_behaves_like 'an endpoint that responds with error 404'
     end
 
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
+    context 'with a non-existent from_location' do
+      let(:lockout_params) do
+        {
+          data: {
+            type: 'lockouts',
+            attributes: { timestamp: '2020-04-23T18:25:43.511Z' },
+            relationships: { from_location: { data: { type: 'locations', id: 'atlantis' } } },
+          },
+        }
+      end
 
-      it_behaves_like 'an endpoint that responds with error 415'
+      it_behaves_like 'an endpoint that responds with error 404' do
+        let(:detail_404) { "Couldn't find Location with 'id'=atlantis" }
+      end
     end
 
     context 'with validation errors' do

--- a/spec/requests/api/move_events_controller_lockout_spec.rb
+++ b/spec/requests/api/move_events_controller_lockout_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::MoveEventsController do
   describe 'POST /moves/:move_id/lockouts' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:response_json) { JSON.parse(response.body) }
     let(:schema) { load_yaml_schema('post_move_events_responses.yaml') }

--- a/spec/requests/api/move_events_controller_lockout_spec.rb
+++ b/spec/requests/api/move_events_controller_lockout_spec.rb
@@ -52,40 +52,11 @@ RSpec.describe Api::MoveEventsController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'with a missing from_location' do
-      let(:lockout_params) { { data: { type: 'lockouts', attributes: { timestamp: '2020-04-23T18:25:43.511Z' } } } }
-
-      it_behaves_like 'an endpoint that responds with error 400' do
-        let(:errors_400) do
-          [{
-            'title' => 'Bad request',
-            'detail' => 'param is missing or the value is empty: relationships',
-          }]
-        end
-      end
-    end
-
     context 'with a missing move_id' do
       let(:move_id) { 'foo-bar' }
       let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
 
       it_behaves_like 'an endpoint that responds with error 404'
-    end
-
-    context 'with a non-existent from_location' do
-      let(:lockout_params) do
-        {
-          data: {
-            type: 'lockouts',
-            attributes: { timestamp: '2020-04-23T18:25:43.511Z' },
-            relationships: { from_location: { data: { type: 'locations', id: 'atlantis' } } },
-          },
-        }
-      end
-
-      it_behaves_like 'an endpoint that responds with error 404' do
-        let(:detail_404) { "Couldn't find Location with 'id'=atlantis" }
-      end
     end
 
     context 'with validation errors' do

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -52,40 +52,11 @@ RSpec.describe Api::MoveEventsController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'with a missing to_location relationship' do
-      let(:redirect_params) { { data: { type: 'redirects', attributes: { timestamp: '2020-04-23T18:25:43.511Z' } } } }
-
-      it_behaves_like 'an endpoint that responds with error 400' do
-        let(:errors_400) do
-          [{
-            'title' => 'Bad request',
-            'detail' => 'param is missing or the value is empty: relationships',
-          }]
-        end
-      end
-    end
-
     context 'with a missing move_id' do
       let(:move_id) { 'foo-bar' }
       let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
 
       it_behaves_like 'an endpoint that responds with error 404'
-    end
-
-    context 'with a non-existent to_location' do
-      let(:redirect_params) do
-        {
-          data: {
-            type: 'redirects',
-            attributes: { timestamp: '2020-04-23T18:25:43.511Z' },
-            relationships: { to_location: { data: { type: 'locations', id: 'atlantis' } } },
-          },
-        }
-      end
-
-      it_behaves_like 'an endpoint that responds with error 404' do
-        let(:detail_404) { "Couldn't find Location with 'id'=atlantis" }
-      end
     end
 
     context 'with validation errors' do

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -52,11 +52,17 @@ RSpec.describe Api::MoveEventsController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized' do
-      let(:access_token) { 'foo-bar' }
-      let(:detail_401) { 'Token expired or invalid' }
+    context 'with a missing to_location relationship' do
+      let(:redirect_params) { { data: { type: 'redirects', attributes: { timestamp: '2020-04-23T18:25:43.511Z' } } } }
 
-      it_behaves_like 'an endpoint that responds with error 401'
+      it_behaves_like 'an endpoint that responds with error 400' do
+        let(:errors_400) do
+          [{
+            'title' => 'Bad request',
+            'detail' => 'param is missing or the value is empty: relationships',
+          }]
+        end
+      end
     end
 
     context 'with a missing move_id' do
@@ -66,10 +72,20 @@ RSpec.describe Api::MoveEventsController do
       it_behaves_like 'an endpoint that responds with error 404'
     end
 
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
+    context 'with a non-existent to_location' do
+      let(:redirect_params) do
+        {
+          data: {
+            type: 'redirects',
+            attributes: { timestamp: '2020-04-23T18:25:43.511Z' },
+            relationships: { to_location: { data: { type: 'locations', id: 'atlantis' } } },
+          },
+        }
+      end
 
-      it_behaves_like 'an endpoint that responds with error 415'
+      it_behaves_like 'an endpoint that responds with error 404' do
+        let(:detail_404) { "Couldn't find Location with 'id'=atlantis" }
+      end
     end
 
     context 'with validation errors' do

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::MoveEventsController do
   describe 'POST /moves/:move_id/redirects' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:response_json) { JSON.parse(response.body) }
     let(:schema) { load_yaml_schema('post_move_events_responses.yaml') }

--- a/spec/requests/api/move_events_controller_reject_spec.rb
+++ b/spec/requests/api/move_events_controller_reject_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::MoveEventsController do
   describe 'POST /moves/:move_id/reject' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:schema) { load_yaml_schema('post_move_events_responses.yaml') }
     let(:response_json) { JSON.parse(response.body) }

--- a/spec/requests/api/move_events_controller_reject_spec.rb
+++ b/spec/requests/api/move_events_controller_reject_spec.rb
@@ -68,24 +68,11 @@ RSpec.describe Api::MoveEventsController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized' do
-      let(:access_token) { 'foo-bar' }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
     context 'with a missing move_id' do
       let(:move_id) { 'foo-bar' }
       let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
 
       it_behaves_like 'an endpoint that responds with error 404'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415'
     end
 
     context 'with validation errors' do

--- a/spec/requests/api/move_events_controller_start_spec.rb
+++ b/spec/requests/api/move_events_controller_start_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::MoveEventsController do
   let(:response_json) { JSON.parse(response.body) }
 
   describe 'POST /moves/:move_id/start' do
-    include_context 'with supplier with access token'
+    include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, :booked, from_location: from_location) }

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe Api::MovesController do
       }
     end
     let(:supplier) { create(:supplier) }
-    let!(:application) { create(:application, owner_id: supplier.id) }
-    let(:access_token) { create(:access_token, application: application).token }
+    let(:access_token) { 'spoofed-token' }
     let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
     let(:content_type) { ApiController::CONTENT_TYPE }
 
@@ -80,8 +79,13 @@ RSpec.describe Api::MovesController do
           .to change(Move, :count).by(1)
       end
 
-      it 'audits the supplier' do
-        expect(move.versions.map(&:whodunnit)).to eq([supplier.id])
+      context 'with a real access token' do
+        let(:application) { create(:application, owner_id: supplier.id) }
+        let(:access_token) { create(:access_token, application: application).token }
+
+        it 'audits the supplier' do
+          expect(move.versions.map(&:whodunnit)).to eq([supplier.id])
+        end
       end
 
       it 'associates the documents with the newly created move' do

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -47,28 +47,6 @@ RSpec.describe Api::MovesController do
       post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
     end
 
-    context 'when not authorized', :skip_before, :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before do
-        post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
-      end
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before do
-        post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
-      end
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
-
     context 'when successful' do
       let(:move) { Move.find_by(from_location_id: from_location.id) }
 

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -323,23 +323,6 @@ RSpec.describe Api::MovesController do
       end
     end
 
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { {} }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      it_behaves_like 'an endpoint that responds with error 401' do
-        before { do_post }
-      end
-    end
-
-    context 'when the CONTENT_TYPE header is invalid' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415' do
-        before { do_post }
-      end
-    end
-
     context 'when the params are not valid' do
       let(:data) { nil }
 

--- a/spec/requests/api/moves_controller_filter_spec.rb
+++ b/spec/requests/api/moves_controller_filter_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Api::MovesController do
   let(:response_json) { JSON.parse(response.body) }
   let(:supplier) { create :supplier }
   let(:alternative_supplier) { create :supplier }
-  let(:application) { create(:application, owner_id: supplier.id) }
-  let(:access_token) { create(:access_token, application: application).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
   let(:schema) { load_yaml_schema('get_moves_responses.yaml') }

--- a/spec/requests/api/moves_controller_index_spec.rb
+++ b/spec/requests/api/moves_controller_index_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Api::MovesController do
   subject(:get_moves) { get '/api/v1/moves', params: params, headers: headers }
 
   let(:supplier) { create(:supplier) }
-  let!(:application) { create(:application, owner_id: supplier.id) }
-  let!(:access_token) { create(:access_token, application: application).token }
+  let(:access_token) { 'spoofed-token' }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
   let(:response_json) { JSON.parse(response.body) }
   let(:content_type) { ApiController::CONTENT_TYPE }

--- a/spec/requests/api/moves_controller_index_spec.rb
+++ b/spec/requests/api/moves_controller_index_spec.rb
@@ -241,22 +241,5 @@ RSpec.describe Api::MovesController do
         end
       end
     end
-
-    context 'when not authorized', :skip_before, :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before { get_moves }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { get_moves }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 end

--- a/spec/requests/api/moves_controller_index_v2_spec.rb
+++ b/spec/requests/api/moves_controller_index_v2_spec.rb
@@ -203,23 +203,6 @@ RSpec.describe Api::MovesController do
     end
   end
 
-  context 'when not authorized' do
-    let(:headers) { {} }
-    let(:detail_401) { 'Token expired or invalid' }
-
-    before { do_get }
-
-    it_behaves_like 'an endpoint that responds with error 401'
-  end
-
-  context 'with an invalid CONTENT_TYPE header' do
-    let(:content_type) { 'application/xml' }
-
-    before { do_get }
-
-    it_behaves_like 'an endpoint that responds with error 415'
-  end
-
   def do_get
     get '/api/moves', params: params, headers: headers
   end

--- a/spec/requests/api/moves_controller_index_v2_spec.rb
+++ b/spec/requests/api/moves_controller_index_v2_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::MovesController do
   let(:supplier) { create(:supplier) }
-  let(:application) { create(:application, owner_id: supplier.id) }
-  let(:access_token) { create(:access_token, application: application).token }
+  let(:access_token) { 'spoofed-token' }
   let(:response_json) { JSON.parse(response.body) }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:schema) { load_yaml_schema('get_moves_responses.yaml', version: 'v2') }

--- a/spec/requests/api/moves_controller_show_v2_spec.rb
+++ b/spec/requests/api/moves_controller_show_v2_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::MovesController do
   let(:supplier) { create(:supplier) }
-  let(:application) { create(:application, owner_id: supplier.id) }
-  let(:access_token) { create(:access_token, application: application).token }
+  let(:access_token) { 'spoofed-token' }
   let(:response_json) { JSON.parse(response.body) }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:schema) { load_yaml_schema('get_move_responses.yaml', version: 'v2') }

--- a/spec/requests/api/moves_controller_show_v2_spec.rb
+++ b/spec/requests/api/moves_controller_show_v2_spec.rb
@@ -92,23 +92,6 @@ RSpec.describe Api::MovesController do
         end
       end
     end
-
-    context 'when not authorized' do
-      let(:headers) { {} }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before { do_get }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { do_get }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 
   def do_get

--- a/spec/requests/api/moves_controller_sorting_spec.rb
+++ b/spec/requests/api/moves_controller_sorting_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Api::MovesController do
-  let(:token) { create(:access_token) }
-  let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization' => "Bearer #{token.token}" } }
+  let(:access_token) { 'spoofed-token' }
+  let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization' => "Bearer #{access_token}" } }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:response_json) { JSON.parse(response.body) }
   let(:schema) { load_yaml_schema('get_moves_responses.yaml') }

--- a/spec/requests/api/moves_controller_update_cancellation_reason_spec.rb
+++ b/spec/requests/api/moves_controller_update_cancellation_reason_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Api::MovesController do
 
   describe 'PATCH /moves/:move_id/journeys/:journey_id' do
     let(:supplier) { create(:supplier) }
-    let(:application) { create(:application, owner: supplier) }
-    let(:access_token) { create(:access_token, application: application).token }
+    let(:access_token) { 'spoofed-token' }
     let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
     let(:content_type) { ApiController::CONTENT_TYPE }
 

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Api::MovesController do
     end
 
     context 'when authorized' do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{token.token}") }
-      let(:token) { create(:access_token) }
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
+      let(:access_token) { 'spoofed-token' }
 
       context 'with an existing requested move', :skip_before do
         before do

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -48,12 +48,6 @@ RSpec.describe Api::MovesController do
       do_patch
     end
 
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:detail_401) { 'Token expired or invalid' }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
     context 'when authorized' do
       let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
       let(:access_token) { 'spoofed-token' }
@@ -682,12 +676,6 @@ RSpec.describe Api::MovesController do
         let(:detail_404) { "Couldn't find Move with 'id'=null" }
 
         it_behaves_like 'an endpoint that responds with error 404'
-      end
-
-      context 'with an invalid CONTENT_TYPE header' do
-        let(:content_type) { 'application/xml' }
-
-        it_behaves_like 'an endpoint that responds with error 415'
       end
 
       context 'with validation errors' do

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -461,23 +461,6 @@ RSpec.describe Api::MovesController do
       end
     end
 
-    context 'when the CONTENT_TYPE header is invalid' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415' do
-        before { do_patch }
-      end
-    end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:detail_401) { 'Token expired or invalid' }
-      let(:headers) { {} }
-
-      it_behaves_like 'an endpoint that responds with error 401' do
-        before { do_patch }
-      end
-    end
-
     context 'when the specified params are not valid' do
       let(:move_params) do
         {

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::MovesController do
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:response_json) { JSON.parse(response.body) }
   let(:schema) { load_yaml_schema('patch_move_responses.yaml', version: 'v2') }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:supplier) { create(:supplier) }
 
   let(:resource_to_json) do

--- a/spec/requests/api/people_controller_court_cases_v2_spec.rb
+++ b/spec/requests/api/people_controller_court_cases_v2_spec.rb
@@ -3,9 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::PeopleController do
-  let(:supplier) { create(:supplier) }
-  let!(:application) { create(:application, owner_id: supplier.id) }
-  let(:access_token) { create(:access_token, application: application).token }
+  let(:access_token) { 'spoofed-token' }
   let(:response_json) { JSON.parse(response.body) }
   let(:person) { create(:person, :nomis_synced, latest_nomis_booking_id: '1150262') }
   let(:court_cases_from_nomis) do

--- a/spec/requests/api/people_controller_create_spec.rb
+++ b/spec/requests/api/people_controller_create_spec.rb
@@ -161,24 +161,6 @@ RSpec.describe Api::PeopleController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:detail_401) { 'Token expired or invalid' }
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-
-      before { post '/api/v1/people', params: person_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { post '/api/v1/people', params: person_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
-
     context 'with validation errors' do
       let(:person_params) do
         {

--- a/spec/requests/api/people_controller_create_spec.rb
+++ b/spec/requests/api/people_controller_create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::PeopleController do
   let(:response_json) { JSON.parse(response.body) }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
 
   let(:headers) do

--- a/spec/requests/api/people_controller_create_v2_spec.rb
+++ b/spec/requests/api/people_controller_create_v2_spec.rb
@@ -165,24 +165,6 @@ RSpec.describe Api::PeopleController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:detail_401) { 'Token expired or invalid' }
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-
-      before { post '/api/people', params: person_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { post '/api/people', params: person_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
-
     context 'with an invalid api version header' do
       let(:headers_with_wrong_version) { headers.merge('Accept': 'application/vnd.api+json; version=9') }
 

--- a/spec/requests/api/people_controller_create_v2_spec.rb
+++ b/spec/requests/api/people_controller_create_v2_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::PeopleController do
   let(:response_json) { JSON.parse(response.body) }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
 
   let(:headers) do

--- a/spec/requests/api/people_controller_image_spec.rb
+++ b/spec/requests/api/people_controller_image_spec.rb
@@ -3,21 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe Api::PeopleController do
-  let(:token) { create(:access_token) }
+  subject(:get_image) { get "/api/v1/people/#{id}/images", headers: headers }
+
+  let(:id) { person.id }
+  let(:access_token) { 'spoofed-token' }
+  let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
+  let(:content_type) { ApiController::CONTENT_TYPE }
 
   context 'when person ID is NOT valid' do
+    let(:id) { 'non-existent-id' }
     it 'not found 404' do
-      id = 'non-existent-id'
-
-      get "/api/v1/people/#{id}/images", params: { access_token: token.token }
+      get_image
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
   context 'when person ID is valid' do
-    subject(:get_image) { get "/api/v1/people/#{person.id}/images", params: { access_token: token.token } }
-
     let!(:person) { create(:person, :nomis_synced, latest_nomis_booking_id: 'foobar') }
     let(:image_data) { File.read('spec/fixtures/Arctic_Tern.jpg') }
 
@@ -53,7 +55,7 @@ RSpec.describe Api::PeopleController do
       it 'return not found 404' do
         allow(NomisClient::Image).to receive(:get).and_return(nil)
 
-        get "/api/v1/people/#{person.id}/images", params: { access_token: token.token }
+        get_image
 
         expect(response).to have_http_status(:not_found)
       end

--- a/spec/requests/api/people_controller_image_spec.rb
+++ b/spec/requests/api/people_controller_image_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Api::PeopleController do
 
   context 'when person ID is NOT valid' do
     let(:id) { 'non-existent-id' }
+
     it 'not found 404' do
       get_image
 

--- a/spec/requests/api/people_controller_index_v2_spec.rb
+++ b/spec/requests/api/people_controller_index_v2_spec.rb
@@ -199,22 +199,5 @@ RSpec.describe Api::PeopleController do
         end
       end
     end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before { get '/api/people', headers: headers }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { get '/api/people', headers: headers }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 end

--- a/spec/requests/api/people_controller_index_v2_spec.rb
+++ b/spec/requests/api/people_controller_index_v2_spec.rb
@@ -4,9 +4,7 @@ require 'rails_helper'
 
 # TODO: this class will be renamed to Api::PeopleController
 RSpec.describe Api::PeopleController do
-  let(:supplier) { create(:supplier) }
-  let!(:application) { create(:application, owner_id: supplier.id) }
-  let!(:access_token) { create(:access_token, application: application).token }
+  let(:access_token) { 'spoofed-token' }
   let(:response_json) { JSON.parse(response.body) }
   let(:content_type) { ApiController::CONTENT_TYPE }
 

--- a/spec/requests/api/people_controller_patch_v2_spec.rb
+++ b/spec/requests/api/people_controller_patch_v2_spec.rb
@@ -148,23 +148,5 @@ RSpec.describe Api::PeopleController do
 
       it_behaves_like 'an endpoint that responds with error 400'
     end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:headers) { { 'CONTENT_TYPE': content_type } }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before { patch "/api/people/#{person.id}", params: person_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { patch "/api/people/#{person.id}", params: person_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 end

--- a/spec/requests/api/people_controller_patch_v2_spec.rb
+++ b/spec/requests/api/people_controller_patch_v2_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::PeopleController do
   let(:response_json) { JSON.parse(response.body) }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
 
   let(:headers) do

--- a/spec/requests/api/people_controller_timetable_spec.rb
+++ b/spec/requests/api/people_controller_timetable_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Api::PeopleController do
       let(:nomis_activities) { [] }
       let(:nomis_court_hearings) { [] }
 
-      let(:params) { { } }
+      let(:params) { {} }
 
       it 'returns an error' do
         get "/api/v1/people/#{person.id}/timetable", headers: headers, params: params

--- a/spec/requests/api/people_controller_timetable_spec.rb
+++ b/spec/requests/api/people_controller_timetable_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Api::PeopleController do
-  let(:token) { create(:access_token) }
+  let(:access_token) { 'spoofed-token' }
+  let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
+  let(:content_type) { ApiController::CONTENT_TYPE }
   let(:response_json) { JSON.parse(response.body) }
   let(:booking_id) { '1150262' }
 
@@ -14,7 +16,7 @@ RSpec.describe Api::PeopleController do
 
   let(:params) do
     {
-      access_token: token.token,
+      access_token: access_token,
       filter: {
         date_from: date_from.iso8601,
         date_to: date_to.iso8601,
@@ -70,7 +72,7 @@ RSpec.describe Api::PeopleController do
       end
 
       it 'returns 200' do
-        get "/api/v1/people/#{person.id}/timetable", params: params
+        get "/api/v1/people/#{person.id}/timetable", headers: headers, params: params
 
         expect(response).to have_http_status(:success)
       end
@@ -78,14 +80,14 @@ RSpec.describe Api::PeopleController do
       it 'returns location relationships' do
         create :location
 
-        get "/api/v1/people/#{person.id}/timetable", params: params
+        get "/api/v1/people/#{person.id}/timetable", headers: headers, params: params
 
         expect(response_json['included']).to be_a_kind_of Array
         expect(response_json['included'].first['type']).to eq 'locations'
       end
 
       it 'calls the People::RetrieveTimetable service with the correct filter params' do
-        get "/api/v1/people/#{person.id}/timetable", params: params
+        get "/api/v1/people/#{person.id}/timetable", headers: headers, params: params
 
         expect(People::RetrieveCourtHearings).to have_received(:call).with(an_instance_of(Person), date_from, date_to)
       end
@@ -93,13 +95,13 @@ RSpec.describe Api::PeopleController do
       context 'when we pass an include in the query params' do
         it 'includes location in the response' do
           create(:location)
-          get "/api/v1/people/#{person.id}/timetable?include=location", params: params
+          get "/api/v1/people/#{person.id}/timetable?include=location", headers: headers, params: params
 
           expect(response_json['included'].first['type']).to eq('locations')
         end
 
         it 'throws an error if query param invalid ' do
-          get "/api/v1/people/#{person.id}/timetable?include=foo.bar", params: params
+          get "/api/v1/people/#{person.id}/timetable?include=foo.bar", headers: headers, params: params
 
           expect(response).to have_http_status(:bad_request)
         end
@@ -110,7 +112,7 @@ RSpec.describe Api::PeopleController do
       it 'returns 404' do
         person_id = 'non-existent-person'
 
-        get "/api/v1/people/#{person_id}/timetable", params: params
+        get "/api/v1/people/#{person_id}/timetable", headers: headers, params: params
 
         expect(response_json['errors'][0]['title']).to eq('Resource not found')
         expect(response).to have_http_status(:not_found)
@@ -120,7 +122,6 @@ RSpec.describe Api::PeopleController do
     context 'when filter[date_from] or filter[date_to] are invalid' do
       let(:params) do
         {
-          access_token: token.token,
           filter: {
             date_from: '10-10-2019',
             date_to: '11-10-2019',
@@ -129,7 +130,7 @@ RSpec.describe Api::PeopleController do
       end
 
       it 'returns 400' do
-        get "/api/v1/people/#{person.id}/timetable", params: params
+        get "/api/v1/people/#{person.id}/timetable", headers: headers, params: params
 
         expect(response_json['errors'][0]['detail']).to eq('is not a valid iso8601 date.')
         expect(response).to have_http_status(:bad_request)
@@ -141,7 +142,7 @@ RSpec.describe Api::PeopleController do
       let(:nomis_court_hearings) { [] }
 
       it 'return an empty data key' do
-        get "/api/v1/people/#{person.id}/timetable", params: params
+        get "/api/v1/people/#{person.id}/timetable", headers: headers, params: params
 
         expect(response_json).to eq('data' => [])
         expect(response).to have_http_status(:success)
@@ -152,10 +153,10 @@ RSpec.describe Api::PeopleController do
       let(:nomis_activities) { [] }
       let(:nomis_court_hearings) { [] }
 
-      let(:params) { { access_token: token.token } }
+      let(:params) { { } }
 
       it 'returns an error' do
-        get "/api/v1/people/#{person.id}/timetable", params: params
+        get "/api/v1/people/#{person.id}/timetable", headers: headers, params: params
 
         expect(response_json['errors'][0]['detail']).to eq('param is missing or the value is empty: filter')
         expect(response).to have_http_status(:bad_request)

--- a/spec/requests/api/people_controller_timetable_spec.rb
+++ b/spec/requests/api/people_controller_timetable_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Api::PeopleController do
 
   let(:params) do
     {
-      access_token: access_token,
       filter: {
         date_from: date_from.iso8601,
         date_to: date_to.iso8601,

--- a/spec/requests/api/people_controller_timetable_v2_spec.rb
+++ b/spec/requests/api/people_controller_timetable_v2_spec.rb
@@ -3,9 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::PeopleController do
-  let(:supplier) { create(:supplier) }
-  let!(:application) { create(:application, owner_id: supplier.id) }
-  let(:access_token) { create(:access_token, application: application).token }
+  let(:access_token) { 'spoofed-token' }
   let(:person) { create(:person, :nomis_synced, latest_nomis_booking_id: '1150262') }
   let(:nomis_court_hearings_struct) do
     OpenStruct.new(

--- a/spec/requests/api/people_controller_update_spec.rb
+++ b/spec/requests/api/people_controller_update_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::PeopleController do
-  let!(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:response_json) { JSON.parse(response.body) }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }

--- a/spec/requests/api/people_controller_update_spec.rb
+++ b/spec/requests/api/people_controller_update_spec.rb
@@ -141,24 +141,6 @@ RSpec.describe Api::PeopleController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:headers) { { 'CONTENT_TYPE': content_type } }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before { put "/api/v1/people/#{person.id}", params: person_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { put "/api/v1/people/#{person.id}", params: person_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
-
     context 'with validation errors' do
       let(:person_params) do
         {

--- a/spec/requests/api/profiles_controller_create_spec.rb
+++ b/spec/requests/api/profiles_controller_create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::ProfilesController do
   let(:response_json) { JSON.parse(response.body) }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
   let(:person) { create(:person_without_profiles, prison_number: nil) }

--- a/spec/requests/api/profiles_controller_create_spec.rb
+++ b/spec/requests/api/profiles_controller_create_spec.rb
@@ -181,23 +181,5 @@ RSpec.describe Api::ProfilesController do
 
       it_behaves_like 'an endpoint that responds with error 404'
     end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:detail_401) { 'Token expired or invalid' }
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-
-      before { post "/api/v1/people/#{person.id}/profiles", params: profile_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { post "/api/v1/people/#{person.id}/profiles", params: profile_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 end

--- a/spec/requests/api/profiles_controller_update_spec.rb
+++ b/spec/requests/api/profiles_controller_update_spec.rb
@@ -233,17 +233,6 @@ RSpec.describe Api::ProfilesController do
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
-    context 'when not authorized' do
-      let(:access_token) { 'foo-bar' }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before do
-        patch "/api/v1/people/#{profile.person.id}/profiles/#{profile.id}", params: profile_params, headers: headers, as: :json
-      end
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
     context 'when the profile_id is not found' do
       let(:move_id) { 'foo-bar' }
       let(:detail_404) { "Couldn't find Profile with 'id'=foo-bar" }
@@ -259,14 +248,6 @@ RSpec.describe Api::ProfilesController do
       let(:detail_404) { "Couldn't find Person with 'id'=foo-bar" }
 
       it_behaves_like 'an endpoint that responds with error 404'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { patch "/api/v1/people/foo-bar/profiles/#{profile.id}", params: profile_params, headers: headers, as: :json }
-
-      it_behaves_like 'an endpoint that responds with error 415'
     end
   end
 end

--- a/spec/requests/api/profiles_controller_update_spec.rb
+++ b/spec/requests/api/profiles_controller_update_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::ProfilesController do
   let(:response_json) { JSON.parse(response.body) }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
   let(:risk_type_1) { create :assessment_question, :risk }

--- a/spec/requests/api/reference/allocation_complex_cases_controller_spec.rb
+++ b/spec/requests/api/reference/allocation_complex_cases_controller_spec.rb
@@ -45,27 +45,5 @@ RSpec.describe Api::Reference::AllocationComplexCasesController do
         expect(response_json).to include_json(data: data)
       end
     end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before do
-        get '/api/v1/reference/allocation_complex_cases', headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before do
-        get '/api/v1/reference/allocation_complex_cases', headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 end

--- a/spec/requests/api/reference/allocation_complex_cases_controller_spec.rb
+++ b/spec/requests/api/reference/allocation_complex_cases_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::Reference::AllocationComplexCasesController do
-  let!(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:response_json) { JSON.parse(response.body) }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }

--- a/spec/requests/api/reference/assessment_questions_controller_spec.rb
+++ b/spec/requests/api/reference/assessment_questions_controller_spec.rb
@@ -37,29 +37,6 @@ RSpec.describe Api::Reference::AssessmentQuestionsController do
       end
     end
 
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before do
-        get '/api/v1/reference/assessment_questions', params: params, headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
-      let(:content_type) { 'application/xml' }
-
-      before do
-        get '/api/v1/reference/assessment_questions', params: params, headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
-
     describe 'filtering' do
       let(:category_filter) { :health }
       let(:params) { { filter: { category: category_filter } } }

--- a/spec/requests/api/reference/assessment_questions_controller_spec.rb
+++ b/spec/requests/api/reference/assessment_questions_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::Reference::AssessmentQuestionsController do
   let(:response_json) { JSON.parse(response.body) }
-  let!(:token) { create(:access_token) }
+  let(:access_token) { 'spoofed-token' }
 
   describe 'GET /api/v1/reference/assessment_questions' do
     let(:schema) { load_yaml_schema('get_assessment_questions_responses.yaml') }
@@ -26,7 +26,7 @@ RSpec.describe Api::Reference::AssessmentQuestionsController do
     let(:params) { {} }
 
     before do
-      get '/api/v1/reference/assessment_questions', params: params, headers: { 'Authorization' => "Bearer #{token.token}" }
+      get '/api/v1/reference/assessment_questions', params: params, headers: { 'Authorization' => "Bearer #{access_token}" }
     end
 
     context 'when successful' do
@@ -50,7 +50,7 @@ RSpec.describe Api::Reference::AssessmentQuestionsController do
     end
 
     context 'with an invalid CONTENT_TYPE header' do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{token.token}") }
+      let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
       let(:content_type) { 'application/xml' }
 
       before do

--- a/spec/requests/api/reference/ethnicities_controller_spec.rb
+++ b/spec/requests/api/reference/ethnicities_controller_spec.rb
@@ -47,27 +47,5 @@ RSpec.describe Api::Reference::EthnicitiesController do
         expect(response_json).to include_json(data: data)
       end
     end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before do
-        get '/api/v1/reference/ethnicities', headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before do
-        get '/api/v1/reference/ethnicities', headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 end

--- a/spec/requests/api/reference/ethnicities_controller_spec.rb
+++ b/spec/requests/api/reference/ethnicities_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::Reference::EthnicitiesController do
-  let!(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:response_json) { JSON.parse(response.body) }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }

--- a/spec/requests/api/reference/genders_controller_spec.rb
+++ b/spec/requests/api/reference/genders_controller_spec.rb
@@ -55,27 +55,5 @@ RSpec.describe Api::Reference::GendersController do
         expect(response_json).to include_json(data: data)
       end
     end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before do
-        get '/api/v1/reference/genders', headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before do
-        get '/api/v1/reference/genders', headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 end

--- a/spec/requests/api/reference/genders_controller_spec.rb
+++ b/spec/requests/api/reference/genders_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::Reference::GendersController do
   let(:response_json) { JSON.parse(response.body) }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
 

--- a/spec/requests/api/reference/identifier_types_controller_spec.rb
+++ b/spec/requests/api/reference/identifier_types_controller_spec.rb
@@ -44,27 +44,5 @@ RSpec.describe Api::Reference::IdentifierTypesController do
         expect(response_json).to include_json(data: expected_response)
       end
     end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:detail_401) { 'Token expired or invalid' }
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-
-      before do
-        get '/api/v1/reference/identifier_types', headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before do
-        get '/api/v1/reference/identifier_types', headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 end

--- a/spec/requests/api/reference/identifier_types_controller_spec.rb
+++ b/spec/requests/api/reference/identifier_types_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::Reference::IdentifierTypesController do
   let(:response_json) { JSON.parse(response.body) }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
 

--- a/spec/requests/api/reference/locations_controller_spec.rb
+++ b/spec/requests/api/reference/locations_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::Reference::LocationsController do
   let(:response_json) { JSON.parse(response.body) }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
   let(:schema) { load_yaml_schema('get_locations_responses.yaml') }

--- a/spec/requests/api/reference/locations_controller_spec.rb
+++ b/spec/requests/api/reference/locations_controller_spec.rb
@@ -133,24 +133,6 @@ RSpec.describe Api::Reference::LocationsController do
       end
     end
 
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:detail_401) { 'Token expired or invalid' }
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-
-      before { get '/api/v1/reference/locations', headers: headers, params: params }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { get '/api/v1/reference/locations', headers: headers, params: params }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
-
     describe 'pagination' do
       let!(:prisons) { create_list :location, 4 }
       let!(:courts) { create_list :location, 2, :court }
@@ -225,24 +207,6 @@ RSpec.describe Api::Reference::LocationsController do
       it 'returns the correct data' do
         expect(response_json).to include_json(data: data)
       end
-    end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before { get "/api/v1/reference/locations/#{location_id}", headers: headers, params: params }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { get "/api/v1/reference/locations/#{location_id}", headers: headers, params: params }
-
-      it_behaves_like 'an endpoint that responds with error 415'
     end
 
     context 'when resource is not found' do

--- a/spec/requests/api/reference/regions_controller_spec.rb
+++ b/spec/requests/api/reference/regions_controller_spec.rb
@@ -102,19 +102,5 @@ RSpec.describe Api::Reference::RegionsController do
         expect(response_json).to include_json(data: expected_relationships)
       end
     end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 end

--- a/spec/requests/api/reference/regions_controller_spec.rb
+++ b/spec/requests/api/reference/regions_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::Reference::RegionsController do
-  let!(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:response_json) { JSON.parse(response.body) }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }

--- a/spec/requests/api/reference/suppliers_controller_spec.rb
+++ b/spec/requests/api/reference/suppliers_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::Reference::SuppliersController do
   let(:response_json) { JSON.parse(response.body) }
-  let(:access_token) { create(:access_token).token }
+  let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
 

--- a/spec/requests/api/reference/suppliers_controller_spec.rb
+++ b/spec/requests/api/reference/suppliers_controller_spec.rb
@@ -45,28 +45,6 @@ RSpec.describe Api::Reference::SuppliersController do
         expect(response_json).to include_json(data: data)
       end
     end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before do
-        get '/api/v1/reference/suppliers', headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before do
-        get '/api/v1/reference/suppliers', headers: headers
-      end
-
-      it_behaves_like 'an endpoint that responds with error 415'
-    end
   end
 
   describe 'GET /api/v1/reference/suppliers/:id' do
@@ -93,24 +71,6 @@ RSpec.describe Api::Reference::SuppliersController do
       it 'returns the correct data' do
         expect(response_json).to include_json(data: data)
       end
-    end
-
-    context 'when not authorized', :with_invalid_auth_headers do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge(auth_headers) }
-      let(:content_type) { ApiController::CONTENT_TYPE }
-      let(:detail_401) { 'Token expired or invalid' }
-
-      before { get "/api/v1/reference/suppliers/#{supplier_key}", headers: headers, params: params }
-
-      it_behaves_like 'an endpoint that responds with error 401'
-    end
-
-    context 'with an invalid CONTENT_TYPE header' do
-      let(:content_type) { 'application/xml' }
-
-      before { get "/api/v1/reference/suppliers/#{supplier_key}", headers: headers, params: params }
-
-      it_behaves_like 'an endpoint that responds with error 415'
     end
 
     context 'when resource is not found' do

--- a/spec/requests/mock/authentication_controller_spec.rb
+++ b/spec/requests/mock/authentication_controller_spec.rb
@@ -12,7 +12,7 @@ module Mock
 end
 
 RSpec.describe Mock::AuthenticationController, type: :request do
-  include_context 'with supplier with access token'
+  include_context 'with supplier with spoofed access token'
 
   let(:response_json) { JSON.parse(response.body) }
   let(:schema) { load_yaml_schema('error_responses.yaml') }

--- a/spec/support/supplier_with_access_token.rb
+++ b/spec/support/supplier_with_access_token.rb
@@ -2,8 +2,7 @@
 
 RSpec.shared_context 'with supplier with access token' do
   let(:supplier) { create(:supplier) }
-  let(:application) { create(:application, owner: supplier) }
-  let(:access_token) { create(:access_token, application: application).token }
+  let(:access_token) { 'spoofed-token' }
   # NB: In real environments (i.e. not in request specs) some rack/rails magic will automatically convert the header
   # IDEMPOTENCY_KEY to a case-insensitive IDEMPOTENCY-KEY. We sidestep that here by naming the key IDEMPOTENCY-KEY.
   let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}", 'IDEMPOTENCY-KEY': SecureRandom.uuid } }

--- a/spec/support/supplier_with_spoofed_access_token.rb
+++ b/spec/support/supplier_with_spoofed_access_token.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_context 'with supplier with access token' do
+RSpec.shared_context 'with supplier with spoofed access token' do
   let(:supplier) { create(:supplier) }
   let(:access_token) { 'spoofed-token' }
   # NB: In real environments (i.e. not in request specs) some rack/rails magic will automatically convert the header

--- a/spec/support/with_client_authentication.rb
+++ b/spec/support/with_client_authentication.rb
@@ -1,37 +1,15 @@
 # frozen_string_literal: true
 
-# Disable rubocop rule to improve test running performance
-# rubocop:disable RSpec/InstanceVariable
+# TODO: Remove this file completely when none of the specs are using rswag tag
+
 RSpec.shared_context 'with client authentication', shared_context: :metadata do
-  let(:application) { Doorkeeper::Application.create(name: 'test') }
-
-  before do
-    credentials = "#{application.uid}:#{application.plaintext_secret}"
-
-    session = ActionDispatch::Integration::Session.new(Rails.application)
-    session.process(
-      :post,
-      '/oauth/token',
-      params: { grant_type: 'client_credentials' },
-      headers: { 'Authorization': "Basic #{Base64.strict_encode64(credentials)}" },
-    )
-
-    @access_token = JSON.parse(session.response.body)['access_token']
-  end
-
-  let(:valid_bearer_header_value) { "Bearer #{@access_token}" }
+  let(:valid_bearer_header_value) { "Bearer spoofed-token" }
   let(:auth_headers) { { 'Authorization': valid_bearer_header_value } }
 
   # RSwag tests automagically add this into header where it's a defined parameter
   let!(:Authorization) { valid_bearer_header_value }
 end
 
-RSpec.shared_context 'with invalid authentication request headers', shared_context: :metadata do
-  let(:auth_headers) { { 'Authorization': 'Bearer invalid-token' } }
-end
-
 RSpec.configure do |rspec|
   rspec.include_context 'with client authentication', with_client_authentication: true
-  rspec.include_context 'with invalid authentication request headers', with_invalid_auth_headers: true
 end
-# rubocop:enable RSpec/InstanceVariable

--- a/spec/support/with_client_authentication.rb
+++ b/spec/support/with_client_authentication.rb
@@ -3,7 +3,7 @@
 # TODO: Remove this file completely when none of the specs are using rswag tag
 
 RSpec.shared_context 'with client authentication', shared_context: :metadata do
-  let(:valid_bearer_header_value) { "Bearer spoofed-token" }
+  let(:valid_bearer_header_value) { 'Bearer spoofed-token' }
   let(:auth_headers) { { 'Authorization': valid_bearer_header_value } }
 
   # RSwag tests automagically add this into header where it's a defined parameter


### PR DESCRIPTION
### Jira link

P4-1827

### What?

- [x] Sped up all the things
- [x] Use fewer build executors on Circle CI - shouldn't be needed now and will reduce build queues
- [x] Bypass authentication for most of the request specs, unless it's interesting to test something related (e.g. journeys)
- [x] Use a faster hashing mechanism for Doorkeeper secrets when running in test mode
- [x] Remove duplicated specs for authorization and content type headers that add no value in the various endpoints, and test these once
- [x] Remove various deprecation warnings when running test suite - these were hidden in the noisy test output so I've swapped that to progress (dots) indicator so we don't miss those in future. That also means less frantic scrolling to see what failed on Circle CI.
- [x] Use unlogged tables for the test database (this requires running `RAILS_ENV=test rails db:drop db:prepare` locally to pick up the change). This improves performance of Postgres significantly and your SSD will be pleased too.
- [x] Refactored a few specs that were passing auth details via request parameters rather than headers. I think it's nice to keep the approach consistent across the code base.

### Why?

- The test suite was irritatingly slow, and meant it was near impossible to perform TDD. When testing locally this drops the test suite time from almost 6 minutes to slightly over 1 minute. I've used a variety of techniques to achieve this with varying levels of controversy but the overall effect is pretty good.