### PR TITLE
Remove hiredis gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem 'elastic-apm'
 gem 'faraday'
 gem 'finite_machine'
 gem 'govuk_notify_rails', '~> 2.1.2'
-gem 'hiredis', '~> 0.6.3'
 # static page serving for extra API documentation
 gem 'json-schema'
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,6 @@ GEM
     govuk_notify_rails (2.1.2)
       notifications-ruby-client (~> 5.1)
       rails (>= 4.1.0)
-    hiredis (0.6.3)
     http (4.4.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -418,7 +417,6 @@ DEPENDENCIES
   finite_machine
   github_changelog_generator
   govuk_notify_rails (~> 2.1.2)
-  hiredis (~> 0.6.3)
   json-schema
   kaminari
   listen


### PR DESCRIPTION
### Remove hiredis gem
 its optional but broken sidekiq because it does not support ssl

