### PR TITLE
Revert "Fix uniqueness for Move model (#654)"

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -44,8 +44,6 @@ class Move < VersionedModel
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location', optional: true
   belongs_to :profile, optional: true
-  has_one :person, through: :profile
-
   belongs_to :prison_transfer_reason, optional: true
   belongs_to :allocation, inverse_of: :moves, optional: true
   belongs_to :original_move, class_name: 'Move', optional: true
@@ -64,7 +62,7 @@ class Move < VersionedModel
   # we need to avoid creating/updating a move with the same profile/date/from/to if there is already one in the same state
   # except that we need to allow multiple cancelled moves
   validates :date,
-            uniqueness: { scope: %i[status person_id from_location_id to_location_id] },
+            uniqueness: { scope: %i[status profile_id from_location_id to_location_id] },
             unless: -> { proposed? || cancelled? || profile_id.blank? }
   validates :date, presence: true, unless: -> { proposed? || cancelled? }
   validates :date_from, presence: true, if: :proposed?
@@ -136,8 +134,8 @@ class Move < VersionedModel
       (date.nil? && date_to.nil? && date_from.present? && date_from >= Time.zone.today)
   end
 
-  def person_id
-    person&.id
+  def person
+    raise 'Attempt to Access to person!!!'
   end
 
 private

--- a/app/services/court_hearings/create_in_nomis.rb
+++ b/app/services/court_hearings/create_in_nomis.rb
@@ -1,7 +1,7 @@
 module CourtHearings
   class CreateInNomis
     def self.call(move, court_hearings)
-      booking_id = move.person.latest_nomis_booking_id
+      booking_id = move.profile.person.latest_nomis_booking_id
 
       body_locations = {
         "fromPrisonLocation": move.from_location.nomis_agency_id,

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -99,6 +99,12 @@ RSpec.describe Move do
     )
   end
 
+  it 'validates uniqueness of `date` if `status` is NOT proposed or cancelled' do
+    expect(create(:move)).to(
+      validate_uniqueness_of(:date).scoped_to(:status, :profile_id, :from_location_id, :to_location_id),
+    )
+  end
+
   it 'does NOT validate uniqueness of `date` if `status` is cancelled' do
     expect(build(:move, status: :cancelled)).not_to(
       validate_uniqueness_of(:date),
@@ -160,47 +166,6 @@ RSpec.describe Move do
     move.nomis_event_ids << 123_456
     move.save
     expect(move.nomis_event_ids).to eq([123_456])
-  end
-
-  context 'when a Move for a Person has already been created' do
-    let(:move) { create(:move) }
-
-    let(:profile_for_new_move) { create(:profile, person: move.person) }
-
-    context 'when creating a new Move with the same from_location, to_location and date' do
-      it 'returns a validation error on date' do
-        new_move = described_class.create(profile: profile_for_new_move,
-                                          from_location: move.from_location,
-                                          to_location: move.to_location,
-                                          date: move.date)
-
-        expect(new_move.errors[:date]).to eq(['has already been taken'])
-      end
-    end
-
-    context 'when creating a new Move in Proposed status' do
-      it 'returns a valid Move' do
-        new_move = described_class.create(profile: profile_for_new_move,
-                                          from_location: move.from_location,
-                                          to_location: move.to_location,
-                                          date: move.date,
-                                          status: Move::MOVE_STATUS_PROPOSED)
-
-        expect(new_move.errors[:date]).to be_empty
-      end
-    end
-
-    context 'when creating a new Move having to_location empty' do
-      it 'returns a validation error on date' do
-        new_move = described_class.create(profile: profile_for_new_move,
-                                          from_location: move.from_location,
-                                          to_location: nil,
-                                          date: move.date,
-                                          status: Move::MOVE_STATUS_PROPOSED)
-
-        expect(new_move.errors[:date]).to be_empty
-      end
-    end
   end
 
   context 'without automatic reference generation' do

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -379,5 +379,46 @@ RSpec.describe Api::MovesController do
 
       it_behaves_like 'an endpoint that responds with error 422'
     end
+
+    context 'with a duplicate move', :skip_before do
+      let(:profile) { create(:profile) }
+      let(:person) { profile.person }
+      let(:move_attributes) do
+        attributes_for(:move).merge(
+          date: old_move.date,
+          person: profile.person,
+          from_location: from_location,
+          to_location: to_location,
+        )
+      end
+
+      before do
+        post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
+      end
+
+      context 'when there are multiple cancelled duplicates' do
+        let!(:old_move) { create(:move, :cancelled, profile: person.latest_profile, from_location: from_location, to_location: to_location) }
+        let!(:old_move2) { create(:move, :cancelled, profile: person.latest_profile, from_location: from_location, to_location: to_location, date: old_move.date) }
+
+        it_behaves_like 'an endpoint that responds with success 201'
+      end
+
+      context 'when duplicate is active' do
+        let!(:old_move) { create(:move, profile: person.latest_profile, from_location: from_location, to_location: to_location) }
+        let(:errors_422) do
+          [
+            {
+              title: 'Unprocessable entity',
+              detail: 'Date has already been taken',
+              source: { 'pointer' => '/data/attributes/date' },
+              code: 'taken',
+              meta: { 'existing_id' => old_move.id },
+            }.stringify_keys,
+          ]
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422'
+      end
+    end
   end
 end

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe Api::MovesController do
         end
       end
 
-      context 'when the Move has been already created' do
+      context 'when duplicate is active' do
         let!(:move) { create(:move, profile: profile, from_location: from_location, to_location: to_location) }
         let(:errors_422) do
           [

--- a/spec/requests/api/moves_controller_index_spec.rb
+++ b/spec/requests/api/moves_controller_index_spec.rb
@@ -231,6 +231,17 @@ RSpec.describe Api::MovesController do
         end
       end
 
+      context 'when the move includes only a person id' do
+        let(:person) { create(:person) }
+        let!(:move) { create(:move, person_id: person.id, profile_id: nil) }
+
+        it 'returns the correct person' do
+          get_moves
+          person_id = response_json['data'][0].dig('relationships', 'person', 'data', 'id')
+          expect(person_id).to eq(person.id)
+        end
+      end
+
       context 'when the move includes only a profile id' do
         let(:person) { create(:person) }
         let!(:move) { create(:move, person_id: nil, profile_id: person.latest_profile.id) }

--- a/spec/requests/api/moves_controller_sorting_spec.rb
+++ b/spec/requests/api/moves_controller_sorting_spec.rb
@@ -200,8 +200,8 @@ RSpec.describe Api::MovesController do
           let(:object_name) { 'person' }
           let(:move_data) do
             Move.all
-              .sort_by { |move| move.person.last_name }
-              .map(&:person)
+              .sort_by { |move| move.profile.person.last_name }
+              .map { |move| move.profile.person }
           end
           let(:last_names) { object_ids.map { |person_id| Person.find(person_id).last_name } }
 

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe MoveSerializer do
     let(:adapter_options) { { include: MoveSerializer::SUPPORTED_RELATIONSHIPS } }
 
     it 'contains a person' do
-      expect(result_data[:relationships][:person]).to eq(data: { id: move.person.id, type: 'people' })
+      expect(result_data[:relationships][:person]).to eq(data: { id: move.profile.person.id, type: 'people' })
     end
 
     it 'contains an included person' do
@@ -74,7 +74,7 @@ RSpec.describe MoveSerializer do
       let(:adapter_options) { { include: 'person', fields: MoveSerializer::INCLUDED_FIELDS } }
 
       let(:expected_json) do
-        person = move.person
+        person = move.profile.person
         [
           {
             id: person.id,

--- a/spec/services/court_hearings/create_in_nomis_spec.rb
+++ b/spec/services/court_hearings/create_in_nomis_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CourtHearings::CreateInNomis do
     before do
       allow(NomisClient::CourtHearings).to receive(:post)
                                               .and_return(instance_double('OAuth2::Response', status: nomis_response_status, body: { 'id' => 123 }.to_json))
-      move.person.update(latest_nomis_booking_id: booking_id)
+      move.profile.person.update(latest_nomis_booking_id: booking_id)
     end
 
     context 'when Nomis return 201 success' do


### PR DESCRIPTION
This reverts commit ba20e573af83d4174d5960983fdd730022ba1330.

### Why?
@teneightfive reported an error on creating a  prison recall move.
The API returns a 422 saying the date is a duplicate but does not return an ID for the duplicate move. 

the issue might be in  the validation the check the duplication based on the person