### PR TITLE
Update swagger documentation 

### DIFF
--- a/spec/requests/api/reference/prison_transfer_reasons_controller_rswag_spec.rb
+++ b/spec/requests/api/reference/prison_transfer_reasons_controller_rswag_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Api::Reference::PrisonTransferReasonsController, :rswag, :with_cl
 
   path '/reference/prison_transfer_reasons' do
     let(:"Content-Type") { content_type }
-    get 'Returns all reasons' do
-      tags 'Reasons'
+    get 'Returns all prison transfer reasons' do
+      tags 'PrisonTransferReasons'
       produces 'application/vnd.api+json'
 
       parameter name: :Authorization,

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -384,6 +384,57 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/post_court_hearing_responses.yaml#/422"
+  "/documents":
+    post:
+      summary: Creates a new document
+      tags:
+        - Documents
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: The document object to be created
+          schema:
+            "$ref": "../v1/document.yaml#/Document"
+      responses:
+        "201":
+          description: created
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_documents_responses.yaml#/201"
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_documents_responses.yaml#/400"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_documents_responses.yaml#/401"
+        "404":
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_documents_responses.yaml#/404"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_documents_responses.yaml#/415"
+        "422":
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_documents_responses.yaml#/422"
   "/moves":
     get:
       summary: Returns a list of moves
@@ -1192,59 +1243,6 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/error_responses.yaml#/422"
-  "/moves/{move_id}/documents":
-    post:
-      summary: Creates a new document
-      tags:
-        - Documents
-      consumes:
-        - application/vnd.api+json
-      parameters:
-        - "$ref": "../v2/accept_type_parameter.yaml#/Accept"
-        - "$ref": "../v1/move_id_parameter.yaml#/MoveId"
-        - name: body
-          in: body
-          required: true
-          description: The document object to be created
-          schema:
-            "$ref": "../v1/document.yaml#/Document"
-      responses:
-        "201":
-          description: created
-          content:
-            application/vnd.api+json:
-              schema:
-                "$ref": "../v1/post_documents_responses.yaml#/201"
-        "400":
-          description: bad request
-          content:
-            application/vnd.api+json:
-              schema:
-                "$ref": "../v1/post_documents_responses.yaml#/400"
-        "401":
-          description: unauthorized
-          content:
-            application/vnd.api+json:
-              schema:
-                "$ref": "../v1/post_documents_responses.yaml#/401"
-        "404":
-          description: resource not found
-          content:
-            application/vnd.api+json:
-              schema:
-                "$ref": "../v1/post_documents_responses.yaml#/404"
-        "415":
-          description: invalid media type
-          content:
-            application/vnd.api+json:
-              schema:
-                "$ref": "../v1/post_documents_responses.yaml#/415"
-        "422":
-          description: unprocessable entity
-          content:
-            application/vnd.api+json:
-              schema:
-                "$ref": "../v1/post_documents_responses.yaml#/422"
   "/moves/{move_id}/journeys":
     get:
       summary: Gets a list of journeys

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2219,6 +2219,53 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/put_people_responses.yaml#/422"
+  "/people/{person_id}/court_cases":
+    get:
+      summary: Returns a list of NOMIS court cases for a person
+      tags:
+        - PersonCourtCases
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - "$ref": "../v2/accept_type_parameter.yaml#/Accept"
+        - "$ref": "../v1/person_id_parameter.yaml#/PersonId"
+        - name: filter[active]
+          in: query
+          description:
+            Filters results to only include active court cases
+          schema:
+            type: boolean
+          example: true
+        - name: include
+          description: Returns a specific list of related resources to the court case
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - location
+          example: location
+      responses:
+        "200":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_court_cases_responses.yaml#/200"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_court_cases_responses.yaml#/401"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_court_cases_responses.yaml#/415"
   "/people/{person_id}/profiles":
     post:
       summary: Creates a new profile
@@ -2354,6 +2401,64 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/patch_profiles_responses.yaml#/422"
+  "/people/{person_id}/timetable":
+    get:
+      summary: Returns a list of NOMIS activities and court hearings for a person
+      tags:
+        - PersonTimetables
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - "$ref": "../v2/accept_type_parameter.yaml#/Accept"
+        - "$ref": "../v1/person_id_parameter.yaml#/PersonId"
+        - name: filter[date_from]
+          in: query
+          description:
+            Filters results to only include activities and court hearings on and after the
+            given date, e.g. `2019-05-02`
+          schema:
+            type: string
+          format: date
+          example: "2019-05-09"
+        - name: filter[date_to]
+          in: query
+          description:
+            Filters results to only include activities and court hearings up to and including
+            the given date, e.g. `2021-05-09`
+          schema:
+            type: string
+          format: date
+          example: "2021-05-09"
+        - name: include
+          description: Returns a specific list of related resources to the timetable entries
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - location
+          example: location
+      responses:
+        "200":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_timetable_responses.yaml#/200"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_timetable_responses.yaml#/401"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_timetable_responses.yaml#/415"
   "/reference/allocation_complex_cases":
     get:
       summary: Returns a list of allocation complex cases

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -333,6 +333,57 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/error_responses.yaml#/422"
+  "/court_hearings":
+    post:
+      summary: Creates a new court hearing
+      tags:
+        - CourtHearings
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: The court hearing object to be created
+          schema:
+            "$ref": "../v1/court_hearing.yaml#/CourtHearing"
+      responses:
+        "201":
+          description: created
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_court_hearing_responses.yaml#/201"
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_court_hearing_responses.yaml#/400"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_court_hearing_responses.yaml#/401"
+        "404":
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_court_hearing_responses.yaml#/404"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_court_hearing_responses.yaml#/415"
+        "422":
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_court_hearing_responses.yaml#/422"
   "/moves":
     get:
       summary: Returns a list of moves

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2683,7 +2683,6 @@
       summary: Returns a list of regions (location groups)
       tags:
         - Regions
-        - Locations
       consumes:
         - application/vnd.api+json
       parameters:

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -341,6 +341,17 @@
       consumes:
         - application/vnd.api+json
       parameters:
+        - name: do_not_save_to_nomis
+          in: query
+          description: Restrict creating the court hearing in Nomis as well as Book A Secure Move
+          schema:
+            type: boolean
+            default: 'false'
+            example: 'true'
+            enum:
+              - true
+              - false
+          required: false
         - name: body
           in: body
           required: true
@@ -2219,9 +2230,9 @@
                 "$ref": "../v1/put_people_responses.yaml#/422"
   "/people/{person_id}/court_cases":
     get:
-      summary: Returns a list of NOMIS court cases for a person
+      summary: Retrieves the active court cases related to a person. It filters out the non-active court cases.
       tags:
-        - PersonCourtCases
+        - People
       consumes:
         - application/vnd.api+json
       parameters:
@@ -2235,6 +2246,10 @@
           schema:
             type: boolean
           example: true
+          enum:
+            - true
+            - false
+          required: false
         - name: include
           description: Returns a specific list of related resources to the court case
           in: query
@@ -2252,18 +2267,18 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/get_court_cases_responses.yaml#/200"
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_court_cases_responses.yaml#/400"
         "401":
           description: unauthorized
           content:
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/get_court_cases_responses.yaml#/401"
-        "415":
-          description: invalid media type
-          content:
-            application/vnd.api+json:
-              schema:
-                "$ref": "../v1/get_court_cases_responses.yaml#/415"
   "/people/{person_id}/profiles":
     post:
       summary: Creates a new profile
@@ -2401,9 +2416,9 @@
                 "$ref": "../v1/patch_profiles_responses.yaml#/422"
   "/people/{person_id}/timetable":
     get:
-      summary: Returns a list of NOMIS activities and court hearings for a person
+      summary: Returns timetable entries for a date range which defaults to today
       tags:
-        - PersonTimetables
+        - People
       consumes:
         - application/vnd.api+json
       parameters:
@@ -2413,21 +2428,21 @@
         - name: filter[date_from]
           in: query
           description:
-            Filters results to only include activities and court hearings on and after the
-            given date, e.g. `2019-05-02`
+            Filter timetable entries that start on and not before this date. Defaults to today
           schema:
             type: string
           format: date
           example: "2019-05-09"
+          required: true
         - name: filter[date_to]
           in: query
           description:
-            Filters results to only include activities and court hearings up to and including
-            the given date, e.g. `2021-05-09`
+            Filter timetable entries that start up to and including this date. Defaults to today
           schema:
             type: string
           format: date
           example: "2021-05-09"
+          required: true
         - name: include
           description: Returns a specific list of related resources to the timetable entries
           in: query
@@ -2451,6 +2466,12 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/get_timetable_responses.yaml#/401"
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_timetable_responses.yaml#/400"
         "415":
           description: invalid media type
           content:
@@ -2678,6 +2699,35 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/get_location_responses.yaml#/415"
+  "/reference/prison_transfer_reasons":
+    get:
+      summary: Returns a list of prison transfer reasons
+      tags:
+        - PrisonTransferReasons
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": "../v2/accept_type_parameter.yaml#/Accept"
+        - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+      responses:
+        "200":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_prison_transfer_reasons_responses.yaml#/200"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_prison_transfer_reasons_responses.yaml#/401"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_prison_transfer_reasons_responses.yaml#/415"
   "/reference/regions":
     get:
       summary: Returns a list of regions (location groups)

--- a/swagger/v1/court_case.yaml
+++ b/swagger/v1/court_case.yaml
@@ -31,7 +31,7 @@ CourtCase:
         nomis_case_status:
           type: string
           example: ACTIVE
-          description: The state of the nomis court case
+          description: The state of the NOMIS court case
         case_start_date:
           type: string
           example: '2020-01-01'
@@ -39,18 +39,15 @@ CourtCase:
         case_type:
           type: string
           example: Adult
-          description: The type of the nomis court case
+          description: The type of the NOMIS court case
         case_number:
           type: string
           example: T20167984
           description: The case number that uniquely identifies the court case. This
-            is a number that is part of the court system not nomis specific.
+            is a number that is part of the court system not NOMIS specific.
     relationships:
       type: object
-      attributes:
+      properties:
         location:
-          type: object
-          attributes:
-            data:
-              type: object
-              nullable: true
+          $ref: location_reference.yaml#/LocationReference
+          description: The location that the court case will occur

--- a/swagger/v1/get_court_cases_responses.yaml
+++ b/swagger/v1/get_court_cases_responses.yaml
@@ -10,9 +10,18 @@
 '400':
   type: object
   required:
-    - errors
+  - errors
   properties:
     errors:
       type: array
       items:
         $ref: errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError

--- a/swagger/v1/person.yaml
+++ b/swagger/v1/person.yaml
@@ -35,12 +35,6 @@ Person:
           format: date
           example: '1965-10-24'
           description: Person's date of birth in ISO 8601 format
-        image_url:
-          type: string
-          format: uri
-          example: http://localhost:3000/api/v1/people/88089bbd-8719-4192-b309-f9db9105d3e1/image.jpg
-          description: URI pointing to the image of the person
-          readOnly: true
         assessment_answers:
           type: array
           items:

--- a/swagger/v1/person_id_parameter.yaml
+++ b/swagger/v1/person_id_parameter.yaml
@@ -1,0 +1,9 @@
+PersonId:
+  name: person_id
+  in: path
+  required: true
+  description: The ID of the person
+  schema:
+    type: string
+    format: uuid
+  example: 5b61f755-0fd7-4a91-b7a3-a33d751f985f

--- a/swagger/v1/post_court_hearing_responses.yaml
+++ b/swagger/v1/post_court_hearing_responses.yaml
@@ -5,3 +5,48 @@
   properties:
     data:
       $ref: court_hearing.yaml#/CourtHearing
+'400':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError
+'404':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/ResourceNotFound
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnsupportedMediaType
+'422':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnprocessableEntity


### PR DESCRIPTION
Update swagger documentation to include the following endpoints:
`POST /court_hearings`
`GET /people/{person_id}/court_cases`
`GET /people/{person_id}/timetable`
`POST /documents`

Remove old `POST /moves/{move_id}/documents` endpoint
Remove duplication in `GET /reference/regions` endpoint that appears under region and locations 