### PR TITLE
Force to pull a new image on migrations

### DIFF
--- a/k8s_migrate_job.yml
+++ b/k8s_migrate_job.yml
@@ -16,6 +16,7 @@ spec:
         - name: app
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/book-a-secure-move/hmpps-book-secure-move-api:__ENV__.latest
           command: ["bundle", "exec", "rake", "db:migrate"]
+          imagePullPolicy: Always
           env:
             - name: SECRET_KEY_BASE
               valueFrom:


### PR DESCRIPTION
### Jira link

n/a

### What?

I have added/removed/altered:

- [ ] Changed the imagePullPolicy to **always**

### Why?

I am doing this because:

- It's possible that migrations can run with the existent version of the  container. 
We are tracking the `env.lastest` tag, that as been just recently updated when this runs.  If we don't force pull it for this job and the job is running in a node that is running any of the other pods we might end up using the cached one.


