### PR TITLE
Improve Framework importer and error logging

### DIFF
--- a/app/services/frameworks/importer.rb
+++ b/app/services/frameworks/importer.rb
@@ -1,10 +1,11 @@
 module Frameworks
   class Importer
-    attr_reader :filepath, :version
+    attr_reader :filepath, :version, :errors
 
     def initialize(filepath:, version:)
       @filepath = filepath
       @version = version
+      @errors = []
     end
 
     def call
@@ -12,17 +13,20 @@ module Frameworks
 
       ActiveRecord::Base.transaction do
         Dir.glob("#{filepath}/**") do |framework|
-          if File.directory?(framework)
-            questions = {}
-            build_manifests(framework, questions)
-            build_questions(framework, questions)
+          basename = File.basename(framework)
 
-            basename = File.basename(framework)
-            Framework.create!(name: basename, version: version, framework_questions: questions.values)
-          end
+          next unless File.directory?(framework) && Framework.find_by(name: basename, version: version).blank?
+
+          questions = {}
+
+          build_manifests(framework, questions)
+          build_questions(framework, questions)
+          persist_framework(basename, questions)
         end
       end
     end
+
+  private
 
     def build_manifests(framework, questions)
       Dir.glob("#{framework}/manifests/*.yml") do |manifest|
@@ -34,6 +38,31 @@ module Frameworks
       Dir.glob("#{framework}/questions/*.yml") do |question|
         questions.merge!(Frameworks::Question.new(filepath: question, questions: questions.dup).call)
       end
+    end
+
+    def persist_framework(name, questions)
+      framework = Framework.new(name: name, version: version, framework_questions: questions.values)
+
+      if framework.save
+        return log("Successfully persisted Framework: '#{name}' with version: '#{version}'\n")
+      end
+
+      log_errors_for(framework)
+    end
+
+    def log(message)
+      print(message) unless Rails.env.test? # rubocop:disable Rails/Output
+    end
+
+    def log_errors_for(framework)
+      log("Failed to persist Framework: '#{framework.name}' with version: '#{version}'\n")
+
+      add_errors(framework.name, framework)
+      framework.framework_questions.each { |question| add_errors(question.key, question) }
+    end
+
+    def add_errors(name, object)
+      errors << "#{name}: #{object.errors.full_messages.join(', ')}" if object.errors.any?
     end
   end
 end

--- a/lib/tasks/populate_framework_data.rake
+++ b/lib/tasks/populate_framework_data.rake
@@ -5,6 +5,9 @@ namespace :frameworks do
       abort('No filepath or version provided')
     end
 
-    Frameworks::Importer.new(filepath: filepath, version: version).call
+    framework_importer = Frameworks::Importer.new(filepath: filepath, version: version)
+    framework_importer.call
+
+    print("Errors: #{framework_importer.errors}\n") if framework_importer.errors.any?
   end
 end

--- a/spec/services/frameworks/importer_spec.rb
+++ b/spec/services/frameworks/importer_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Frameworks::Importer do
       rescue ActiveRecord::RecordInvalid
         expect(Framework.count).to be_zero
       end
+
+      it 'does not attempt to persist framework if it already exists' do
+        filepath = Rails.root.join('spec/fixtures/files/frameworks/')
+        described_class.new(filepath: filepath, version: '0.1').call
+
+        expect { described_class.new(filepath: filepath, version: '0.1').call }.not_to change(Framework, :count).from(2)
+      end
     end
 
     context 'when creating framework questions' do


### PR DESCRIPTION
* Don't attempt to persist already imported framework
* Add logging for framework import success
* Add logging for framework import failure, with additional logging of all errors coming from the framework and the questions specifically with keys to help point out the offending files coming from the framework
