### PR TITLE
Add `police_transfer` to the move types

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -151,13 +151,15 @@ private
   def set_move_type
     return if move_type.present?
 
+    # TODO: The order is not important, here.
+    #       Remove this from the model when we migrate to mandatory move_type under v2
     self.move_type = if is_a_prison_recall?
                        'prison_recall'
                      elsif is_a_court_appearance?
                        'court_appearance'
                      elsif is_a_police_tranfer?
                        'police_transfer'
-                     elsif is_a_prison_transfer?
+                     else
                        'prison_transfer'
                      end
   end
@@ -167,8 +169,7 @@ private
   end
 
   def is_a_police_tranfer?
-    to_location&.location_type == Location::LOCATION_TYPE_POLICE and
-      (from_location&.location_type == Location::LOCATION_TYPE_POLICE)
+    to_location&.police? && from_location&.police?
   end
 
   def is_a_prison_recall?
@@ -176,11 +177,7 @@ private
   end
 
   def is_a_court_appearance?
-    to_location&.location_type == Location::LOCATION_TYPE_COURT
-  end
-
-  def is_a_prison_transfer?
-    to_location&.location_type == Location::LOCATION_TYPE_PRISON
+    to_location&.court?
   end
 
   def validate_move_uniqueness

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -27,6 +27,7 @@ class Move < VersionedModel
     court_appearance: 'court_appearance',
     prison_recall: 'prison_recall',
     prison_transfer: 'prison_transfer',
+    police_transfer: 'police_transfer',
   }
 
   CANCELLATION_REASONS = [
@@ -150,22 +151,36 @@ private
   def set_move_type
     return if move_type.present?
 
-    self.move_type =
-      if to_location.nil?
-        'prison_recall'
-      elsif to_location_is_court?
-        'court_appearance'
-      else
-        'prison_transfer'
-      end
+    self.move_type = if is_a_prison_recall?
+                       'prison_recall'
+                     elsif is_a_court_appearance?
+                       'court_appearance'
+                     elsif is_a_police_tranfer?
+                       'police_transfer'
+                     elsif is_a_prison_transfer?
+                       'prison_transfer'
+                     end
   end
 
   def ensure_event_nomis_ids_uniqueness
     nomis_event_ids.uniq!
   end
 
-  def to_location_is_court?
-    to_location&.location_type == 'court'
+  def is_a_police_tranfer?
+    to_location&.location_type == Location::LOCATION_TYPE_POLICE and
+      (from_location&.location_type == Location::LOCATION_TYPE_POLICE)
+  end
+
+  def is_a_prison_recall?
+    to_location.nil?
+  end
+
+  def is_a_court_appearance?
+    to_location&.location_type == Location::LOCATION_TYPE_COURT
+  end
+
+  def is_a_prison_transfer?
+    to_location&.location_type == Location::LOCATION_TYPE_PRISON
   end
 
   def validate_move_uniqueness

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -20,12 +20,14 @@ FactoryBot.define do
       association(:from_location, :police, factory: :location)
       association(:to_location, :court, factory: :location)
     end
+
     trait :prison_recall do
       # NB: Police --> Prison
       move_type { 'prison_recall' }
       association(:from_location, :police, factory: :location)
       to_location { nil } # NB: to_location is always nil for a prison_recall
     end
+
     trait :prison_transfer do
       # NB: believed to be Prison 1 --> Prison 2
       move_type { 'prison_transfer' }
@@ -34,24 +36,33 @@ FactoryBot.define do
       association(:prison_transfer_reason)
     end
 
+    trait :police_transfer do
+      move_type { 'police_transfer' }
+    end
+
     # Move statuses
     trait :proposed do
       status { 'proposed' }
     end
+
     trait :requested do
       status { 'requested' }
     end
+
     trait :booked do
       status { 'booked' }
     end
+
     trait :in_transit do
       status { 'in_transit' }
     end
+
     trait :cancelled do
       status { 'cancelled' }
       cancellation_reason { 'other' }
       cancellation_reason_comment { 'some other reason' }
     end
+
     trait :completed do
       status { 'completed' }
     end
@@ -62,16 +73,19 @@ FactoryBot.define do
       cancellation_reason { 'made_in_error' }
       cancellation_reason_comment { 'the move was made in error' }
     end
+
     trait :cancelled_supplier_declined_to_move do
       status { 'cancelled' }
       cancellation_reason { 'supplier_declined_to_move' }
       cancellation_reason_comment { 'the supplier declined to move' }
     end
+
     trait :cancelled_rejected do
       status { 'cancelled' }
       cancellation_reason { 'rejected' }
       cancellation_reason_comment { 'the proposed move was rejected' }
     end
+
     trait :cancelled_other do
       status { 'cancelled' }
       cancellation_reason { 'other' }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe Move do
   it { is_expected.to validate_presence_of(:date) }
   it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.values) }
 
-  # it { is_expected.to validate_inclusion_of(:move_type).in_array(['court_appearance', 'prison_recall', 'prison_transfer']) }
-
   describe 'cancellation_reason' do
     context 'when the move is not cancelled' do
       let(:move) { build(:move, status: 'requested') }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Move do
   it { is_expected.to validate_presence_of(:date) }
   it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.values) }
 
+  # it { is_expected.to validate_inclusion_of(:move_type).in_array(['court_appearance', 'prison_recall', 'prison_transfer']) }
+
   describe 'cancellation_reason' do
     context 'when the move is not cancelled' do
       let(:move) { build(:move, status: 'requested') }
@@ -255,7 +257,7 @@ RSpec.describe Move do
 
     before { move.valid? }
 
-    context 'with no `to_location`' do
+    context 'when to_location is empty' do
       let(:to_location) { nil }
 
       it 'sets the move type to `prison_recall` at validation time' do
@@ -263,7 +265,7 @@ RSpec.describe Move do
       end
     end
 
-    context 'with a court for it\'s `to_location`' do
+    context 'when to_location is a Court' do
       let(:to_location) { build :location, :court }
 
       it 'sets the move type to `court_appearance` at validation time' do
@@ -271,11 +273,20 @@ RSpec.describe Move do
       end
     end
 
-    context 'with a prison for it\'s `to_location`' do
+    context 'when to_location is a Prison' do
       let(:to_location) { build :location }
 
       it 'sets the move type to `prison_transfer` at validation time' do
         expect(move.move_type).to eq 'prison_transfer'
+      end
+    end
+
+    context 'when both to_location and from_location are police locations' do
+      let(:to_location) { build :location, :police }
+      let(:from_location) { build :location, :police }
+
+      it 'set move_type to police_transfer' do
+        expect(move.move_type).to eq 'police_transfer'
       end
     end
   end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Move do
       let(:to_location) { build :location, :police }
       let(:from_location) { build :location, :police }
 
-      it 'set move_type to police_transfer' do
+      it 'sets move_type to `police_transfer`' do
         expect(move.move_type).to eq 'police_transfer'
       end
     end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Moves::Finder do
         let(:filter_params) { { move_type: 'prison_transfer,prison_recall,police_transfer' } }
 
         it 'returns moves matching status' do
-          expect(results).to match_array [prison_recall_move, prison_transfer_move,police_transfer_move]
+          expect(results).to match_array [prison_recall_move, prison_transfer_move, police_transfer_move]
         end
       end
 

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -156,6 +156,7 @@ RSpec.describe Moves::Finder do
       let!(:court_appearance_move) { create :move, :court_appearance }
       let!(:prison_recall_move) { create :move, :prison_recall }
       let!(:prison_transfer_move) { create :move, :prison_transfer }
+      let!(:police_transfer_move) { create :move, move_type: :police_transfer }
 
       context 'with matching move_type' do
         let(:filter_params) { { move_type: 'court_appearance' } }
@@ -166,10 +167,10 @@ RSpec.describe Moves::Finder do
       end
 
       context 'with multiple move_types' do
-        let(:filter_params) { { move_type: 'prison_transfer,prison_recall' } }
+        let(:filter_params) { { move_type: 'prison_transfer,prison_recall,police_transfer' } }
 
         it 'returns moves matching status' do
-          expect(results).to match_array [prison_recall_move, prison_transfer_move]
+          expect(results).to match_array [prison_recall_move, prison_transfer_move,police_transfer_move]
         end
       end
 

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -404,6 +404,7 @@
               type: string
               enum:
                 - court_appearance
+                - police_transfer
                 - prison_recall
                 - prison_transfer
         - name: filter[cancellation_reason]

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -295,6 +295,7 @@
               type: string
               enum:
                 - court_appearance
+                - police_transfer
                 - prison_recall
                 - prison_transfer
         - name: filter[cancellation_reason]

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -43,6 +43,7 @@ Move:
           - court_appearance
           - prison_recall
           - prison_transfer
+          - police_transfer
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
           oneOf:

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -43,6 +43,7 @@ Move:
             - court_appearance
             - prison_recall
             - prison_transfer
+            - police_transfer
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
           oneOf:


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-1781

### What?

This PR adds `police_transfer` to the allowed move_type

### Why?

because we want to support transfer police -> police locations

### Have you? (optional)

- [x] Updated API docs
