### PR TITLE
[P4-1852] Fix importing offenders from Nomis in v2

### DIFF
--- a/app/services/people/import_from_nomis.rb
+++ b/app/services/people/import_from_nomis.rb
@@ -19,10 +19,7 @@ module People
     def call
       @prison_numbers.each do |prison_number|
         person = Person.find_or_initialize_by(prison_number: prison_number)
-
-        nomis_person = people_from_nomis.find do |nomis_person|
-          nomis_person[:prison_number] == prison_number
-        end
+        nomis_person = nomis_person(prison_number)
 
         next unless nomis_person
 
@@ -47,6 +44,12 @@ module People
         gender: gender(nomis_person),
         ethnicity: ethnicity(nomis_person),
       )
+    end
+
+    def nomis_person(prison_number)
+      people_from_nomis.find do |nomis_person|
+        nomis_person[:prison_number] == prison_number
+      end
     end
 
     def people_from_nomis

--- a/app/services/people/import_from_nomis.rb
+++ b/app/services/people/import_from_nomis.rb
@@ -2,7 +2,7 @@
 
 module People
   class ImportFromNomis
-    MAPPING = {
+    NOMIS_OFFENDER_TO_PERSON_MAPPING = {
       cro_number: :criminal_records_office,
       date_of_birth: :date_of_birth,
       first_name: :first_names,
@@ -12,43 +12,53 @@ module People
       prison_number: :prison_number,
     }.freeze
 
-    def initialize(prison_number)
-      @prison_number = prison_number
+    def initialize(prison_numbers)
+      @prison_numbers = prison_numbers
     end
 
     def call
-      person = Person.find_or_initialize_by(prison_number: @prison_number)
-      person.assign_attributes(person_attributes)
-      person.save!
+      @prison_numbers.each do |prison_number|
+        person = Person.find_or_initialize_by(prison_number: prison_number)
+
+        nomis_person = people_from_nomis.find do |nomis_person|
+          nomis_person[:prison_number] == prison_number
+        end
+
+        next unless nomis_person
+
+        person.assign_attributes(person_attributes(nomis_person))
+        person.save!
+      end
     end
 
   private
 
-    def person_attributes
-      person_attributes = person_from_nomis.filter_map { |attribute, value|
-        [MAPPING[attribute], value] if MAPPING[attribute]
-      }.to_h
+    def person_attributes(nomis_person)
+      person_attributes = nomis_person.filter_map do |attribute, value|
+        if NOMIS_OFFENDER_TO_PERSON_MAPPING[attribute]
+          [NOMIS_OFFENDER_TO_PERSON_MAPPING[attribute], value]
+        end
+      end
+      person_attributes = person_attributes.to_h
 
       person_attributes.merge(
-        nomis_prison_number: @prison_number,
+        nomis_prison_number: person_attributes[:prison_number],
         last_synced_with_nomis: Time.zone.now,
-        gender: gender,
-        ethnicity: ethnicity,
+        gender: gender(nomis_person),
+        ethnicity: ethnicity(nomis_person),
       )
     end
 
-    def person_from_nomis
-      @person_from_nomis ||= NomisClient::People
-          .get([@prison_number])
-          .find { |p| p[:prison_number] == @prison_number }
+    def people_from_nomis
+      @people_from_nomis ||= NomisClient::People.get(@prison_numbers)
     end
 
-    def gender
-      Gender.find_by(nomis_code: person_from_nomis[:gender])
+    def gender(nomis_person)
+      Gender.find_by(nomis_code: nomis_person[:gender])
     end
 
-    def ethnicity
-      Ethnicity.find_by(title: person_from_nomis[:ethnicity])
+    def ethnicity(nomis_person)
+      Ethnicity.find_by(title: nomis_person[:ethnicity])
     end
   end
 end

--- a/k8s_migrate_job.yml
+++ b/k8s_migrate_job.yml
@@ -16,6 +16,7 @@ spec:
         - name: app
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/book-a-secure-move/hmpps-book-secure-move-api:__ENV__.latest
           command: ["bundle", "exec", "rake", "db:migrate"]
+          imagePullPolicy: Always
           env:
             - name: SECRET_KEY_BASE
               valueFrom:

--- a/spec/services/people/import_from_nomis_spec.rb
+++ b/spec/services/people/import_from_nomis_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe People::ImportFromNomis do
   context 'when the person is present in NOMIS', with_nomis_client_authentication: true do
-    subject(:import) { described_class.new(prison_number) }
+    subject(:import) { described_class.new([prison_number, non_existent_prison_number]) }
 
     let(:response_status) { '200' }
     let(:response_body) { file_fixture('nomis_post_prisoners_200.json').read }
@@ -8,6 +8,7 @@ RSpec.describe People::ImportFromNomis do
     let(:prison_number) do
       JSON.parse(response_body).first['offenderNo'] # G3239GV
     end
+    let(:non_existent_prison_number) { 'foo' }
 
     context 'when the Person exists in the database' do
       before do


### PR DESCRIPTION
### Jira link

P4-1852

### What?

The service we wrote and were mocking out in the controller for
importing a person from Nomis was built to operate against a single
person which is inconsistent with filter param possibilities described
by the json:api spec.

- [x] Enable multi-offender support in `People::ImportFromNomis` service

![image](https://user-images.githubusercontent.com/8156884/86360379-303bc480-bc6a-11ea-9c34-e071701fedf2.png)


### Why?

This is critical functionality for the frontend and is currently broken.