### PR TITLE
Fix inconsistent/incorrect type names in swagger docs

### DIFF
--- a/spec/requests/api/journey_events_controller_reject_spec.rb
+++ b/spec/requests/api/journey_events_controller_reject_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Api::JourneyEventsController do
       it_behaves_like 'an endpoint that responds with success 204'
 
       it 'rejects the journey' do
-        puts response.body
         expect(journey.reload).to be_rejected
       end
     end

--- a/swagger/v1/assessment_question.yaml
+++ b/swagger/v1/assessment_question.yaml
@@ -32,8 +32,10 @@ AssessmentQuestion:
           description: The label displayed on the Create Move form for this assessment
             question
         disabled_at:
-          type: string
-          format: date-time
+          oneOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           example: '2017-07-21T17:32:28Z'
           description: The date-time at which a value was disabled, in ISO-8601 format,
             or null if it is enabled

--- a/swagger/v1/assessment_question.yaml
+++ b/swagger/v1/assessment_question.yaml
@@ -14,7 +14,7 @@ AssessmentQuestion:
       type: object
       properties:
         assessment_answer_category:
-          type: String
+          type: string
           enum:
           - health
           - risk
@@ -22,17 +22,17 @@ AssessmentQuestion:
           description: Category is the section in the Create Move form that an assessment
             question appears in, e.g. Health or Risks
         key:
-          type: String
+          type: string
           example: sight_impaired
           description: Machine readable unique key string attribute for this assessment
             question
         title:
-          type: String
+          type: string
           example: Sight Impaired
           description: The label displayed on the Create Move form for this assessment
             question
         disabled_at:
-          type: String
+          type: string
           format: date-time
           example: '2017-07-21T17:32:28Z'
           description: The date-time at which a value was disabled, in ISO-8601 format,

--- a/swagger/v1/ethnicity.yaml
+++ b/swagger/v1/ethnicity.yaml
@@ -34,7 +34,7 @@ Ethnicity:
           example: W1 - White British
           description: Human readable long label for this ethnicity
         disabled_at:
-          type: String
+          type: string
           format: date-time
           example: '2017-07-21T17:32:28Z'
           description: The date-time at which a value was disabled, in ISO-8601 format,

--- a/swagger/v1/ethnicity.yaml
+++ b/swagger/v1/ethnicity.yaml
@@ -34,8 +34,10 @@ Ethnicity:
           example: W1 - White British
           description: Human readable long label for this ethnicity
         disabled_at:
-          type: string
-          format: date-time
+          oneOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           example: '2017-07-21T17:32:28Z'
           description: The date-time at which a value was disabled, in ISO-8601 format,
             or null if it is enabled

--- a/swagger/v1/gender.yaml
+++ b/swagger/v1/gender.yaml
@@ -35,8 +35,10 @@ Gender:
           - type: 'null'
           description: The human readable description for this gender (optional)
         disabled_at:
-          type: string
-          format: date-time
+          oneOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           example: '2017-07-21T17:32:28Z'
           description: The date-time at which a value was disabled, in ISO-8601 format,
             or null if it is enabled

--- a/swagger/v1/gender.yaml
+++ b/swagger/v1/gender.yaml
@@ -35,7 +35,7 @@ Gender:
           - type: 'null'
           description: The human readable description for this gender (optional)
         disabled_at:
-          type: String
+          type: string
           format: date-time
           example: '2017-07-21T17:32:28Z'
           description: The date-time at which a value was disabled, in ISO-8601 format,

--- a/swagger/v1/identifier_type.yaml
+++ b/swagger/v1/identifier_type.yaml
@@ -38,7 +38,7 @@ IdentifierType:
             - type: "null"
           description: The human readable description for this identifier type (optional)
         disabled_at:
-          type: String
+          type: string
           format: date-time
           example: "2017-07-21T17:32:28Z"
           description:

--- a/swagger/v1/identifier_type.yaml
+++ b/swagger/v1/identifier_type.yaml
@@ -38,8 +38,10 @@ IdentifierType:
             - type: "null"
           description: The human readable description for this identifier type (optional)
         disabled_at:
-          type: string
-          format: date-time
+          oneOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           example: "2017-07-21T17:32:28Z"
           description:
             The date-time at which a value was disabled, in ISO-8601 format,

--- a/swagger/v1/location.yaml
+++ b/swagger/v1/location.yaml
@@ -42,12 +42,14 @@ Location:
           example: BAI
           description: The NOMIS `agency_id`, for prisons this is a 3-letter code
         disabled_at:
-          type: String
-          format: date-time
+          oneOf:
+          - type: string
+            format: date-time
+          - type: 'null'
           example: '2017-07-21T17:32:28Z'
           description: The date-time at which a value was disabled, in ISO-8601 format,
             or null if it is enabled
         can_upload_documents:
-          type: Boolean
+          type: boolean
           example: true
           description: A flag to indicate whether this location allows document uploads


### PR DESCRIPTION
### What?

- [x] Corrected type case in swagger schema definitions, and fixed support for `null` values where they should be allowed

### Why?

- "String" and "Boolean" are not defined types for swagger/open API schemas. These should be "string" or "boolean" (lower case) in all cases.
- This then caused a number of specs to fail - the root cause for that was that we did not correctly specify that `null` values are allowed for the failing attributes. Adding that fixes the tests. Presumably the JSON validator was confused by "String" and then finding "null" an acceptable substitute.
- I've searched through all of the type definitions within swagger schemas and can't find any other cases of this.

### Have you? (optional)

- [x] Updated API docs if necessary	
