### PR TITLE
Removes references to moves.person_id

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -30,6 +30,8 @@ class Move < VersionedModel
     police_transfer: 'police_transfer',
   }
 
+  self.ignored_columns = %w[person_id]
+
   CANCELLATION_REASONS = [
     CANCELLATION_REASON_MADE_IN_ERROR = 'made_in_error',
     CANCELLATION_REASON_SUPPLIER_DECLINED_TO_MOVE = 'supplier_declined_to_move',

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -50,15 +50,6 @@ class MoveSerializer < ActiveModel::Serializer
     allocation: %i[to_location from_location moves_count created_at],
   }.freeze
 
-  def person
-    # TODO: Remove the support for person id in future
-    if object.profile_id
-      object&.profile&.person
-    elsif object.person_id
-      Person.find(object.person_id)
-    end
-  end
-
   def documents
     object&.profile&.documents
   end

--- a/spec/requests/api/moves_controller_index_spec.rb
+++ b/spec/requests/api/moves_controller_index_spec.rb
@@ -208,38 +208,6 @@ RSpec.describe Api::MovesController do
           end
         end
       end
-
-      context 'when the move includes both a profile id and a person id' do
-        let(:person) { create(:person) }
-        let!(:move) { create(:move, person_id: person.id, profile_id: person.latest_profile.id) }
-
-        it 'returns the correct person' do
-          get_moves
-          person_id = response_json['data'][0].dig('relationships', 'person', 'data', 'id')
-          expect(person_id).to eq(person.id)
-        end
-      end
-
-      context 'when the move includes neither profile id or person id' do
-        let!(:move) { create(:move, person_id: nil, profile_id: nil) }
-
-        it 'returns the correct person' do
-          get_moves
-          person_id = response_json['data'][0].dig('relationships', 'person', 'data', 'id')
-          expect(person_id).to be_nil
-        end
-      end
-
-      context 'when the move includes only a profile id' do
-        let(:person) { create(:person) }
-        let!(:move) { create(:move, person_id: nil, profile_id: person.latest_profile.id) }
-
-        it 'returns the correct person' do
-          get_moves
-          person_id = response_json['data'][0].dig('relationships', 'person', 'data', 'id')
-          expect(person_id).to eq(person.id)
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

- [x]  Remove all references to `moves.person_id` field

### Why?

We migrated away from `Move#person` to `Move#profile#person`.

I've added the ignored_columns for person_id to soft-force our not referencing the person_id and to stop us loading it as an active record attribute on the model.
