### PR TITLE
Increase migrations timeout to 300s.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ commands:
           command: |
             set -o errexit
             sed 's/__ENV__/<< parameters.env >>/' k8s_migrate_job.yml | kubectl apply -f -
-            kubectl wait --for=condition=complete job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
+            kubectl wait --for=condition=complete --timeout=300s job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             exit_code=$?
             kubectl logs job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>
             kubectl delete job/hmpps-book-secure-move-api-migrate-db-<< parameters.env >>


### PR DESCRIPTION
### Jira link

N/A

### What?

I have added/removed/altered:

- [ ] Increase the timeout for the migrations job to 300s

### Why?

I am doing this because:

- Migrations might take longer to run on busier environments and the 60s default timeout is not enough.
