### PR TITLE
P4-1746 Build PER related tables

### DIFF
--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -13,4 +13,5 @@ class Flag < VersionedModel
   validates :question_value, presence: true
 
   belongs_to :framework_question
+  has_and_belongs_to_many :framework_responses, join_table: 'framework_responses_flags'
 end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -6,4 +6,5 @@ class Framework < ApplicationRecord
   validates :name, uniqueness: { scope: :version }
 
   has_many :framework_questions
+  has_many :person_escort_records
 end

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -18,4 +18,5 @@ class FrameworkQuestion < VersionedModel
 
   belongs_to :parent, class_name: 'FrameworkQuestion', optional: true
   has_many :flags
+  has_many :framework_responses
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -18,15 +18,18 @@ class FrameworkResponse < VersionedModel
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
   has_and_belongs_to_many :flags, join_table: 'framework_responses_flags'
 
+  validates :value_text, absence: true, if: -> { json? || array? }
+  validates :value_json, absence: true, if: -> { (string? || text?) && value_json != '{}' }
+
   def value
-    json? ? value_json : value_text
+    json? || array? ? value_json : value_text
   end
 
   def value=(answer)
-    if json?
-      value_json = answer
+    if json? || array?
+      self.value_json = answer
     else
-      value_text = answer
+      self.value_text = answer
     end
   end
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FrameworkResponse < VersionedModel
+  enum value_type: {
+    string: 'string',
+    list: 'list',
+    text: 'text',
+    json: 'json',
+  }
+
+  validates :value_type, presence: true, inclusion: { in: value_types }
+
+  belongs_to :framework_question
+  belongs_to :person_escort_record
+  has_many :dependents, class_name: 'FrameworkResponse',
+                        foreign_key: 'parent_id'
+
+  belongs_to :parent, class_name: 'FrameworkResponse', optional: true
+  has_and_belongs_to_many :flags, optional: true
+end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -19,15 +19,25 @@ class FrameworkResponse < VersionedModel
   has_and_belongs_to_many :flags, join_table: 'framework_responses_flags'
 
   validates :value_text, absence: true, if: -> { json? || array? }
-  validates :value_json, absence: true, if: -> { (string? || text?) && value_json != '{}' }
+  validates :value_json, absence: true, if: -> { string? || text? }
 
   def value
-    json? || array? ? value_json : value_text
+    case value_type
+    when 'json'
+      value_json.presence || '{}'
+    when 'array'
+      value_json.presence || []
+    else
+      value_text
+    end
   end
 
   def value=(answer)
-    if json? || array?
-      self.value_json = answer
+    case value_type
+    when 'json'
+      self.value_json = answer.presence || '{}'
+    when 'array'
+      self.value_json = answer.presence || []
     else
       self.value_text = answer
     end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -3,7 +3,7 @@
 class FrameworkResponse < VersionedModel
   enum value_type: {
     string: 'string',
-    list: 'list',
+    array: 'array',
     text: 'text',
     json: 'json',
   }
@@ -16,5 +16,17 @@ class FrameworkResponse < VersionedModel
                         foreign_key: 'parent_id'
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
-  has_and_belongs_to_many :flags, optional: true
+  has_and_belongs_to_many :flags, join_table: 'framework_responses_flags'
+
+  def value
+    json? ? value_json : value_text
+  end
+
+  def value=(answer)
+    if json?
+      value_json = answer
+    else
+      value_text = answer
+    end
+  end
 end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -1,0 +1,12 @@
+class PersonEscortRecord < VersionedModel
+  enum states: {
+    not_started: 'not_started',
+    in_progress: 'in_progress',
+    completed: 'completed',
+    confirmed: 'confirmed',
+  }
+
+  validates :state, presence: true, inclusion: { in: states }
+  has_many :framework_responses
+  belongs_to :framework
+end

--- a/db/migrate/20200702063823_create_person_escort_record.rb
+++ b/db/migrate/20200702063823_create_person_escort_record.rb
@@ -1,0 +1,10 @@
+class CreatePersonEscortRecord < ActiveRecord::Migration[6.0]
+  def change
+    create_table :person_escort_records, id: :uuid do |t|
+      t.references :framework, type: :uuid, null: false, index: true, foreign_key: true
+      t.string "state", null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200702081808_create_framework_responses.rb
+++ b/db/migrate/20200702081808_create_framework_responses.rb
@@ -1,0 +1,16 @@
+class CreateFrameworkResponses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :framework_responses, id: :uuid do |t|
+      t.references :person_escort_record, type: :uuid, null: false, index: true, foreign_key: true
+      t.references :framework_question, type: :uuid, null: false, index: true, foreign_key: true
+      t.text :value_text
+      t.jsonb :value_json, null: false, default: '{}'
+      t.string "value_type", null: false
+      t.references :parent, type: :uuid, index: true
+
+      t.timestamps
+    end
+
+    add_index  :framework_responses, :value_json, using: :gin
+  end
+end

--- a/db/migrate/20200702081808_create_framework_responses.rb
+++ b/db/migrate/20200702081808_create_framework_responses.rb
@@ -4,7 +4,7 @@ class CreateFrameworkResponses < ActiveRecord::Migration[6.0]
       t.references :person_escort_record, type: :uuid, null: false, index: true, foreign_key: true
       t.references :framework_question, type: :uuid, null: false, index: true, foreign_key: true
       t.text :value_text
-      t.jsonb :value_json, null: false, default: '{}'
+      t.jsonb :value_json
       t.string "value_type", null: false
       t.references :parent, type: :uuid, index: true
 

--- a/db/migrate/20200703053232_create_framework_responses_flags.rb
+++ b/db/migrate/20200703053232_create_framework_responses_flags.rb
@@ -1,0 +1,8 @@
+class CreateFrameworkResponsesFlags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :framework_responses_flags, id: :uuid do |t|
+      t.belongs_to :flag
+      t.belongs_to :framework_response
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -376,6 +376,14 @@ ActiveRecord::Schema.define(version: 2020_07_01_123259) do
     t.index ["prison_number"], name: "index_people_on_prison_number"
   end
 
+  create_table "person_escort_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "framework_id", null: false
+    t.string "state", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
+  end
+
   create_table "prison_transfer_reasons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "title", null: false
@@ -466,6 +474,7 @@ ActiveRecord::Schema.define(version: 2020_07_01_123259) do
   add_foreign_key "notifications", "subscriptions"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "person_escort_records", "frameworks"
   add_foreign_key "profiles", "people", name: "profiles_person_id"
   add_foreign_key "subscriptions", "suppliers"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -165,6 +165,13 @@ ActiveRecord::Schema.define(version: 2020_07_03_053232) do
     t.index ["value_json"], name: "index_framework_responses_on_value_json", using: :gin
   end
 
+  create_table "framework_responses_flags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "flag_id"
+    t.bigint "framework_response_id"
+    t.index ["flag_id"], name: "index_framework_responses_flags_on_flag_id"
+    t.index ["framework_response_id"], name: "index_framework_responses_flags_on_framework_response_id"
+  end
+
   create_table "frameworks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "version", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,7 +154,7 @@ ActiveRecord::Schema.define(version: 2020_07_03_053232) do
     t.uuid "person_escort_record_id", null: false
     t.uuid "framework_question_id", null: false
     t.text "value_text"
-    t.jsonb "value_json", default: "{}", null: false
+    t.jsonb "value_json"
     t.string "value_type", null: false
     t.uuid "parent_id"
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_01_123259) do
+ActiveRecord::Schema.define(version: 2020_07_03_053232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -148,6 +148,21 @@ ActiveRecord::Schema.define(version: 2020_07_01_123259) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["framework_id"], name: "index_framework_questions_on_framework_id"
     t.index ["parent_id"], name: "index_framework_questions_on_parent_id"
+  end
+
+  create_table "framework_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "person_escort_record_id", null: false
+    t.uuid "framework_question_id", null: false
+    t.text "value_text"
+    t.jsonb "value_json", default: "{}", null: false
+    t.string "value_type", null: false
+    t.uuid "parent_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["framework_question_id"], name: "index_framework_responses_on_framework_question_id"
+    t.index ["parent_id"], name: "index_framework_responses_on_parent_id"
+    t.index ["person_escort_record_id"], name: "index_framework_responses_on_person_escort_record_id"
+    t.index ["value_json"], name: "index_framework_responses_on_value_json", using: :gin
   end
 
   create_table "frameworks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -457,6 +472,8 @@ ActiveRecord::Schema.define(version: 2020_07_01_123259) do
   add_foreign_key "documents", "moves"
   add_foreign_key "flags", "framework_questions"
   add_foreign_key "framework_questions", "frameworks"
+  add_foreign_key "framework_responses", "framework_questions"
+  add_foreign_key "framework_responses", "person_escort_records"
   add_foreign_key "journeys", "locations", column: "from_location_id"
   add_foreign_key "journeys", "locations", column: "to_location_id"
   add_foreign_key "journeys", "moves"

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :framework_response do
+    association(:framework_question)
+    association(:person_escort_record)
+    value_type { 'string' }
+  end
+end

--- a/spec/factories/person_escort_record.rb
+++ b/spec/factories/person_escort_record.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :person_escort_record do
+    association(:framework)
+    state { 'not_started' }
+  end
+end

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe Flag do
 
   it { is_expected.to validate_presence_of(:flag_type) }
   it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to belong_to(:framework_question) }
+  it { is_expected.to validate_presence_of(:question_value) }
   it { is_expected.to validate_inclusion_of(:flag_type).in_array(%w[information attention warning alert]) }
+
+  it { is_expected.to belong_to(:framework_question) }
+  it { is_expected.to have_and_belong_to_many(:framework_responses) }
 end

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -13,4 +13,5 @@ RSpec.describe FrameworkQuestion do
 
   it { is_expected.to have_many(:dependents) }
   it { is_expected.to have_many(:flags) }
+  it { is_expected.to have_many(:framework_responses) }
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -11,4 +11,105 @@ RSpec.describe FrameworkResponse do
 
   it { is_expected.to have_many(:dependents) }
   it { is_expected.to have_and_belong_to_many(:flags) }
+
+  it 'validates absence of value text if response type is array' do
+    response = create(:framework_response, value_type: 'array')
+
+    expect(response).to validate_absence_of(:value_text)
+  end
+
+  it 'validates absence of value text if response type is json' do
+    response = create(:framework_response, value_type: 'json')
+
+    expect(response).to validate_absence_of(:value_text)
+  end
+
+  it 'validates absence of value json if response type is string' do
+    response = create(:framework_response, value_type: 'string')
+
+    expect(response).to validate_absence_of(:value_json)
+  end
+
+  it 'validates absence of value json if response type is text' do
+    response = create(:framework_response, value_type: 'text')
+
+    expect(response).to validate_absence_of(:value_json)
+  end
+
+  describe '#value' do
+    it 'returns the response value if type is string' do
+      response = create(:framework_response, value_type: 'string', value: 'Yes')
+
+      expect(response.value).to eq('Yes')
+    end
+
+    it 'returns the response value if type is array' do
+      response = create(
+        :framework_response,
+        value_type: 'array',
+        value: ['Level 1', 'Level 2'],
+      )
+
+      expect(response.value).to contain_exactly('Level 1', 'Level 2')
+    end
+
+    it 'returns the response value if type is text' do
+      response = create(
+        :framework_response,
+        value_type: 'text',
+        value: 'Some text here that should probably be longer',
+      )
+
+      expect(response.value).to eq('Some text here that should probably be longer')
+    end
+
+    it 'returns the response value if type is json' do
+      response = create(
+        :framework_response,
+        value_type: 'json',
+        value: {
+          value: 'Yes',
+          comment: 'Some text',
+        },
+      )
+
+      expect(response.value).to eq('value' => 'Yes', 'comment' => 'Some text')
+    end
+
+    it 'returns a nil response value if type is string and its empty' do
+      response = create(:framework_response, value_type: 'string', value: nil)
+
+      expect(response.value).to be_nil
+    end
+
+    it 'returns a nil response value if type is text and its empty' do
+      response = create(:framework_response, value_type: 'text', value: nil)
+
+      expect(response.value).to be_nil
+    end
+
+    it 'returns an empty response value if type is json and its set as empty' do
+      response = create(:framework_response, value_type: 'json', value: {})
+
+      expect(response.value).to be_empty
+    end
+
+    it 'returns an empty response value if type is array and its set as empty' do
+      response = create(:framework_response, value_type: 'array', value: [])
+
+      expect(response.value).to be_empty
+    end
+
+    it 'returns an empty response value if type is json and its empty' do
+      response = create(:framework_response, value_type: 'json')
+
+      expect(response.value).to eq('{}')
+    end
+
+    it 'returns an empty response value if type is array and its empty' do
+      response = create(:framework_response, value_type: 'array')
+
+      expect(response.value).to eq('{}')
+    end
+  end
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponse do
+  it { is_expected.to validate_inclusion_of(:value_type).in_array(%w[string array text json]) }
+
+  it { is_expected.to belong_to(:framework_question) }
+  it { is_expected.to belong_to(:person_escort_record) }
+  it { is_expected.to belong_to(:parent).optional }
+
+  it { is_expected.to have_many(:dependents) }
+  it { is_expected.to have_and_belong_to_many(:flags) }
+end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe FrameworkResponse do
     it 'returns an empty response value if type is json and its set as empty' do
       response = create(:framework_response, value_type: 'json', value: {})
 
-      expect(response.value).to be_empty
+      expect(response.value).to eq('{}')
     end
 
     it 'returns an empty response value if type is array and its set as empty' do
@@ -109,7 +109,7 @@ RSpec.describe FrameworkResponse do
     it 'returns an empty response value if type is array and its empty' do
       response = create(:framework_response, value_type: 'array')
 
-      expect(response.value).to eq('{}')
+      expect(response.value).to be_empty
     end
   end
 end

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -8,4 +8,6 @@ RSpec.describe Framework do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:version) }
   it { is_expected.to validate_uniqueness_of(:name).scoped_to(:version) }
+  it { is_expected.to have_many(:person_escort_records) }
+  it { is_expected.to have_many(:framework_questions) }
 end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonEscortRecord do
+  it { is_expected.to validate_presence_of(:state) }
+  it { is_expected.to validate_inclusion_of(:state).in_array(%w[not_started in_progress completed confirmed]) }
+  it { is_expected.to have_many(:framework_responses) }
+  it { is_expected.to belong_to(:framework) }
+end


### PR DESCRIPTION
### Jira link

[P4-1746](https://dsdmoj.atlassian.net/browse/P4-1746)

### What?

- [x] Added a person escort record table and model
- [x] Added a framework response table and model
- [x] Added a framework response and flag join table
- [x] Added ability to set one value on framework responses

### Why?

To facilitate person escort record creation with responses, add the relevant tables as well as the validations and associations.
A Person escort record can be created with a framework and version, and will contain many responses which are initially empty. A response depending on the question it is for, can hold many answer types. To store the different types we have added two fields on the response table: text and jsonb. Those two will be able to store all the required values sent to us as answers, and will be hidden under a single field called value. According to the value type, the relevant answers will be set accordingly to the underlying tables. 

