### PR TITLE
[P4-1797] Make logs parseable by fluentd

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require 'log_formatter/json'
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -73,8 +75,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
+  config.log_formatter = LogFormatter::Json.new
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,5 +1,5 @@
 Rails.application.configure do
   config.lograge.base_controller_class = 'ActionController::API'
-  config.lograge.formatter = Lograge::Formatters::Logstash.new
+  config.lograge.formatter = Lograge::Formatters::Json.new
 end
 

--- a/lib/log_formatter/json.rb
+++ b/lib/log_formatter/json.rb
@@ -1,0 +1,22 @@
+require 'json'
+
+module LogFormatter
+  class Json
+    def call(severity, timestamp, progname, msg)
+      data = {}
+      data[:severity] = severity if severity
+      data[:timestamp] = timestamp if timestamp
+      data[:progname] = progname if progname
+
+      # Handle messages coming from lograge and other json preformatted log messages
+      begin
+        msg = JSON.parse(msg)
+        data.merge!(msg)
+      rescue JSON::ParserError
+        data[:msg] = msg
+      end
+
+      ::JSON.dump(data) + "\n"
+    end
+  end
+end

--- a/spec/lib/log_formatter/json_spec.rb
+++ b/spec/lib/log_formatter/json_spec.rb
@@ -1,0 +1,50 @@
+require 'log_formatter/json'
+
+RSpec.describe LogFormatter::Json do
+  subject(:formatter) { described_class.new }
+
+  let(:severity) { 'DEBUG' }
+  let(:timestamp) { '2020-07-03T15:33:17+01:00' }
+  let(:progname) { nil }
+  let(:expected) { JSON.dump(expected_json) + "\n" }
+
+  context 'when the message argument is not parsable json' do
+    let(:msg) { '[ElasticAPM] Agent disabled with `enabled: false' }
+
+    let(:expected_json) do
+      {
+        'severity' => 'DEBUG',
+        'timestamp' => '2020-07-03T15:33:17+01:00',
+        'msg' => '[ElasticAPM] Agent disabled with `enabled: false',
+      }
+    end
+
+    it 'returns the correctly formatted log line' do
+      expect(formatter.call(severity, timestamp, progname, msg)).to eq(expected)
+    end
+  end
+
+  context 'when the message argument is parsable json' do
+    let(:msg) { '{"method":"GET","path":"/api/people","format":"json","controller":"Api::PeopleController","action":"index","status":200,"duration":760.87,"view":50.15,"db":57.81}' }
+
+    let(:expected_json) do
+      {
+        'severity' => 'DEBUG',
+        'timestamp' => '2020-07-03T15:33:17+01:00',
+        'method' => 'GET',
+        'path' => '/api/people',
+        'format' => 'json',
+        'controller' => 'Api::PeopleController',
+        'action' => 'index',
+        'status' => 200,
+        'duration' => 760.87,
+        'view' => 50.15,
+        'db' => 57.81,
+      }
+    end
+
+    it 'returns the correctly formatted log line' do
+      expect(formatter.call(severity, timestamp, progname, msg)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

P4-1797

### What?

This PR moves our logs (in production, only) to spit out json rather than unparseable strings.

### Why?

Fluentd defines a json parser for pod logs:

https://github.com/ministryofjustice/analytics-platform-fluentd/blob/eb7d529ba83abaa58c8253a39d2d11a86b91dc39/conf/kubernetes.conf#L8-L16

We think that if we move our logs to a json document per line we'll be able to filter our logs for useful things like request id in future (more on this later).

This will help us to debug issues in production more conveniently and generally make our logs more useable.

### E2E tests

```
 Running tests in:
 - Chrome 83.0.4103.116 / macOS 10.15.5

 Cancel allocation
 ✓ Cancel allocation

 New PMU allocation
 ✓ Create allocation and verify the result
 ✓ Check validation errors on allocation details page

 New move from Police Custody to Court
 ✓ With unfound person
 ✓ With existing person

 New move from Police Custody to Prison (recall)
 ✓ With a new person

 Cancel move from Police Custody
 ✓ Reason - `Made in error`
 ✓ Reason - `Supplier declined to move this person`
 ✓ Reason - `Another reason`

 New move from Prison to Court
 ✓ With unfound person
 ✓ With existing person

 New move from Prison to Prison
 ✓ With existing person

 Download moves
 ✓ As Police user
 ✓ As Prison user
 ✓ As STC user
 ✓ As Supplier user

 Smoke tests
 ✓ As Police user
 ✓ As STC user
 ✓ As Prison user
 ✓ As Supplier user
 ✓ As OCA user


 21 passed
```
