### PR TITLE
Update moves.updated_at on journey updates

### DIFF
--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -20,7 +20,7 @@
 class Journey < ApplicationRecord
   include StateMachineable
 
-  belongs_to :move
+  belongs_to :move, touch: true
   belongs_to :supplier
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location'


### PR DESCRIPTION
### Jira link

related to: [P4-1788](https://dsdmoj.atlassian.net/browse/P4-1788)

### What?

I have added/removed/altered:

- [ ] Updates `moves` updated_at on journey changes. 

### Why?

I am doing this because:
- On the reporting task we want to filter for any moves that had journeys added or updated in the given time interval.

https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/659/files#diff-f45e1a76d527485f7af80db97fb81aa9R38-R39


### Deployment risks (optional)

- This will likely cause an increase in UPDATES on the `moves` table, but given the journey activity is not particularly busy, it's unlikely that it will cause UPDATE contention on the database. 
