### PR TITLE
Change Nomis Timeout to 10 Secs

### DIFF
--- a/app/controllers/api/v1/people_actions.rb
+++ b/app/controllers/api/v1/people_actions.rb
@@ -74,8 +74,6 @@ module Api::V1
       PaperTrail.request(whodunnit: nil) do
         Moves::ImportPeople.new([prison_number]).call
       end
-    rescue StandardError => e
-      Raven.capture_exception(e)
     end
 
     def supported_relationships

--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -4,22 +4,21 @@ module NomisClient
   class Base
     NOMIS_TIMEOUT = 10 # in seconds
     FIXTURE_DIRECTORY = Rails.root.join 'db/fixtures/nomis'
-    MAX_RETRIES = 2
 
     class << self
       def get(path, params = {})
         token.get("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
-        Rails.logger.info "Nomis Connection Error: #{e.message}"
-        raise e, 'Nomis Connection Error'
+        Rails.logger.warn "Nomis Connection Error: #{e.message}"
+        raise e
       end
 
       def post(path, params = {})
         params = update_json_headers(params)
         token.post("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
-        Rails.logger.info "Nomis Connection Error: #{e.message}"
-        raise e, 'Nomis Connection Error'
+        Rails.logger.warn "Nomis Connection Error: #{e.message}"
+        raise e
       end
 
     private

--- a/spec/lib/nomis_client/base_spec.rb
+++ b/spec/lib/nomis_client/base_spec.rb
@@ -102,42 +102,6 @@ RSpec.describe NomisClient::Base do
         expect(client_credentials).to have_received(:get_token).twice
       end
     end
-
-    context 'when the endpoint raises a ConnectionFailed' do
-      let(:token_expires_at) { 1.hour.from_now.to_i }
-      let(:response_body) { '' }
-      let(:response_status) { 200 }
-
-      before do
-        allow(token).to receive(:get).and_raise(Faraday::ConnectionFailed, 'connection failed')
-      end
-
-      it 'is called MAX_RETRIES + 1 times' do
-        expect {
-          described_class.get(api_endpoint)
-        }.to raise_exception(Faraday::ConnectionFailed)
-
-        expect(token).to have_received(:get).exactly(3).times
-      end
-    end
-
-    context 'when the endpoint raises a TimeoutError' do
-      let(:token_expires_at) { 1.hour.from_now.to_i }
-      let(:response_body) { '' }
-      let(:response_status) { 200 }
-
-      before do
-        allow(token).to receive(:get).and_raise(Faraday::TimeoutError)
-      end
-
-      it 'is called MAX_RETRIES + 1 times' do
-        expect {
-          described_class.get(api_endpoint)
-        }.to raise_exception(Faraday::TimeoutError)
-
-        expect(token).to have_received(:get).exactly(3).times
-      end
-    end
   end
 
   describe '.post' do
@@ -226,42 +190,6 @@ RSpec.describe NomisClient::Base do
         described_class.post(api_endpoint)
 
         expect(client_credentials).to have_received(:get_token).twice
-      end
-    end
-
-    context 'when the endpoint raises a ConnectionFailed' do
-      let(:token_expires_at) { 1.hour.from_now.to_i }
-      let(:response_body) { '' }
-      let(:response_status) { 200 }
-
-      before do
-        allow(token).to receive(:post).and_raise(Faraday::ConnectionFailed, 'connection failed')
-      end
-
-      it 'is called MAX_RETRIES times' do
-        expect {
-          described_class.post(api_endpoint)
-        }.to raise_exception(Faraday::ConnectionFailed)
-
-        expect(token).to have_received(:post).exactly(3).times
-      end
-    end
-
-    context 'when the endpoint raises a TimeoutError' do
-      let(:token_expires_at) { 1.hour.from_now.to_i }
-      let(:response_body) { '' }
-      let(:response_status) { 200 }
-
-      before do
-        allow(token).to receive(:post).and_raise(Faraday::TimeoutError)
-      end
-
-      it 'is called MAX_RETRIES times' do
-        expect {
-          described_class.post('/example')
-        }.to raise_exception(Faraday::TimeoutError)
-
-        expect(token).to have_received(:post).exactly(3).times
       end
     end
   end

--- a/spec/requests/api/people_controller_index_spec.rb
+++ b/spec/requests/api/people_controller_index_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Api::PeopleController do
         end
       end
 
-      context 'when Nomis does not reply in less than 10 secs' do
+      context 'when Nomis times out' do
         it 'returns 503 - gateway timeout error' do
           allow(NomisClient::People).to receive(:get).and_raise(Faraday::TimeoutError)
 


### PR DESCRIPTION
Add rescue from error Timeout

### Jira link

https://dsdmoj.atlassian.net/browse/P4-1787

### What?
Reduce timeout to 10s for all NOMIS calls

Ensure we propagate the timeout error message and code (504) to the client for all NOMIS calls

### Why?

To help FrontEnd to provide an appropriate error message

### Have you? (optional)

- [ ] Updated API docs if necessary	
