### PR TITLE
Support any credentials for oauth request when authentication is disabled

### DIFF
--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -1,0 +1,14 @@
+module Doorkeeper
+  class TokensController < Doorkeeper::ApplicationMetalController
+    def create
+      if authentication_enabled?
+        headers.merge!(authorize_response.headers)
+        render json: authorize_response.body, status: authorize_response.status
+      else
+        render json: { access_token: 'spoofed-token'  }
+      end
+    rescue Errors::DoorkeeperError => e
+      handle_token_exception(e)
+    end
+  end
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -74,6 +74,7 @@ Doorkeeper.configure do
   # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-base-controller
   #
   # base_controller 'ApplicationController'
+  base_metal_controller 'ApiController'
 
   # Reuse access token for the same resource owner within an application (disabled by default).
   #


### PR DESCRIPTION
### Jira link

P4-1872

### What?

- [x] Customise Doorkeeper configuration to inherit controller methods from `ApiController`
- [x] Monkey patch Doorkeeper implementation to simulate successful authentication when authentication is disabled. 

### Why?

- The end to end test suite authenticates against the backend API using Doorkeeper oauth request to `POST /oauth/tokens`. This needs to succeed to obtain an API bearer token that can be used for subsequent API calls.
- On a heroku review apps for backend PR's the intent is to disable API authentication; this is much more convenient than creating and retrieving application configuration for Doorkeeper.
- On a review app we don't really care whether valid credentials were passed to authenticate via oauth, so this allows any credentials to be provided and will return a `spoofed-token` access token response.
- This allows the end to end test suite to run successfully against a review app on heroku.