### PR TITLE
P4-1746 Build PER related tables

### DIFF
--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -6,4 +6,5 @@ class Framework < ApplicationRecord
   validates :name, uniqueness: { scope: :version }
 
   has_many :framework_questions
+  has_many :person_escort_records
 end

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -18,4 +18,5 @@ class FrameworkQuestion < VersionedModel
 
   belongs_to :parent, class_name: 'FrameworkQuestion', optional: true
   has_many :flags
+  has_many :framework_responses
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -9,9 +9,4 @@ class FrameworkResponse < VersionedModel
                         foreign_key: 'parent_id'
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
-
-  def self.find_sti_class(type_name)
-    type_name = self.name
-    super
-  end
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FrameworkResponse < VersionedModel
+  validates :type, presence: true
+
+  belongs_to :framework_question
+  belongs_to :person_escort_record
+  has_many :dependents, class_name: 'FrameworkResponse',
+                        foreign_key: 'parent_id'
+
+  belongs_to :parent, class_name: 'FrameworkResponse', optional: true
+
+  def self.find_sti_class(type_name)
+    type_name = self.name
+    super
+  end
+end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -9,8 +9,8 @@ class FrameworkResponse < VersionedModel
                         foreign_key: 'parent_id'
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
-  validates_each :value, on: :update do |record, _attr, _value|
-    if record.parent&.option_selected?(record.framework_question.dependent_value) && record.framework_question.required
+  validates_each :value, on: :update do |record, _attr, value|
+    if value.blank? && record.parent&.option_selected?(record.framework_question.dependent_value) && record.framework_question.required
       record.errors.add(:value, :blank)
     end
   end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -9,6 +9,11 @@ class FrameworkResponse < VersionedModel
                         foreign_key: 'parent_id'
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
+  validates_each :value, on: :update do |record, _attr, _value|
+    if record.parent&.option_selected?(record.framework_question.dependent_value) && record.framework_question.required
+      record.errors.add(:value, :blank)
+    end
+  end
 
   def self.find_sti_class(type_name)
     case type_name

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -10,23 +10,14 @@ class FrameworkResponse < VersionedModel
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
   validates_each :value, on: :update do |record, _attr, value|
-    if value.blank? && record.parent&.option_selected?(record.framework_question.dependent_value) && record.framework_question.required
-      record.errors.add(:value, :blank)
-    end
+    record.errors.add(:value, :blank) if requires_value?(value, record)
   end
 
-  def self.find_sti_class(type_name)
-    case type_name
-    when 'object'
-      type_name = 'FrameworkResponse::Object'
-    when 'string'
-      type_name = 'FrameworkResponse::String'
-    when 'array'
-      type_name = 'FrameworkResponse::Array'
-    when 'collection'
-      type_name = 'FrameworkResponse::Collection'
-    end
+  def self.requires_value?(value, record)
+    return false if value.present? || !record.framework_question.required
 
-    super
+    return true if record.parent.blank?
+
+    record.parent.option_selected?(record.framework_question.dependent_value)
   end
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -9,4 +9,19 @@ class FrameworkResponse < VersionedModel
                         foreign_key: 'parent_id'
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
+
+  def self.find_sti_class(type_name)
+    case type_name
+    when 'object'
+      type_name = 'FrameworkResponse::Object'
+    when 'string'
+      type_name = 'FrameworkResponse::String'
+    when 'array'
+      type_name = 'FrameworkResponse::Array'
+    when 'collection'
+      type_name = 'FrameworkResponse::Collection'
+    end
+
+    super
+  end
 end

--- a/app/models/framework_response/array.rb
+++ b/app/models/framework_response/array.rb
@@ -1,8 +1,8 @@
 class FrameworkResponse
   class Array < FrameworkResponse
     validates :value_text, absence: true
-    validates :value_json, presence: true, on: :update, if: -> { framework_question.required }
-    validates :value_json, on: :update, inclusion: { in: ->(response) { response.framework_question.options }, if: ->(response) { response.framework_question.options.any? } }
+    validates :value_json, presence: true, on: :update, if: -> { framework_question.required && parent.nil? }
+    validates :value_json, on: :update, inclusion: { in: :question_options }, if: :question_options
 
     def self.sti_name
       'array'
@@ -14,6 +14,16 @@ class FrameworkResponse
 
     def value=(answer)
       self.value_json = answer.presence || []
+    end
+
+    def option_selected?(option)
+      value.include?(option)
+    end
+
+  private
+
+    def question_options
+      framework_question.options.presence
     end
   end
 end

--- a/app/models/framework_response/array.rb
+++ b/app/models/framework_response/array.rb
@@ -1,0 +1,19 @@
+class FrameworkResponse
+  class Array < FrameworkResponse
+    validates :value_text, absence: true
+    validates :value_json, presence: true, on: :update, if: -> { framework_question.required }
+    validates :value_json, on: :update, inclusion: { in: ->(response) { response.framework_question.options }, if: ->(response) { response.framework_question.options.any? } }
+
+    def self.sti_name
+      'array'
+    end
+
+    def value
+      value_json.presence || []
+    end
+
+    def value=(answer)
+      self.value_json = answer.presence || []
+    end
+  end
+end

--- a/app/models/framework_response/array.rb
+++ b/app/models/framework_response/array.rb
@@ -1,19 +1,14 @@
 class FrameworkResponse
   class Array < FrameworkResponse
     validates :value_text, absence: true
-    validates :value_json, presence: true, on: :update, if: -> { framework_question.required && parent.nil? }
     validates :value_json, on: :update, inclusion: { in: :question_options }, if: :question_options
-
-    def self.sti_name
-      'array'
-    end
 
     def value
       value_json.presence || []
     end
 
-    def value=(answer)
-      self.value_json = answer.presence || []
+    def value=(raw_value)
+      self.value_json = raw_value.presence || []
     end
 
     def option_selected?(option)
@@ -23,7 +18,7 @@ class FrameworkResponse
   private
 
     def question_options
-      framework_question.options.presence
+      @question_options ||= framework_question.options.presence
     end
   end
 end

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -1,7 +1,7 @@
 class FrameworkResponse
   class Collection < FrameworkResponse
     validates :value_text, absence: true
-    validate :validate_presence, on: :update, if: -> { framework_question.required }
+    validate :validate_presence, on: :update, if: -> { framework_question.required && parent.nil? }
     validate :validate_details_collection, on: :update, if: -> { response_details? }
 
     def self.sti_name
@@ -21,6 +21,10 @@ class FrameworkResponse
         end
     end
 
+    def option_selected?(option)
+      value.map { |v| v['option'] }.include?(option)
+    end
+
   private
 
     def details_collection(collection)
@@ -32,7 +36,7 @@ class FrameworkResponse
     end
 
     def validate_presence
-      errors.add(:value_json, :presence) if value.empty?
+      errors.add(:value_json, :blank) if value.empty?
     end
 
     def validate_details_collection

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -1,0 +1,47 @@
+class FrameworkResponse
+  class Collection < FrameworkResponse
+    validates :value_text, absence: true
+    validate :validate_presence, on: :update, if: -> { framework_question.required }
+    validate :validate_details_collection, on: :update, if: -> { response_details? }
+
+    def self.sti_name
+      'collection'
+    end
+
+    def value
+      value_json.presence || []
+    end
+
+    def value=(answer)
+      self.value_json =
+        if response_details?
+          details_collection(answer).to_a
+        else
+          self.value_json = answer.presence || []
+        end
+    end
+
+  private
+
+    def details_collection(collection)
+      DetailsCollection.new(
+        collection: collection,
+        question_options: framework_question.options,
+        details_options: framework_question.followup_comment_options,
+      )
+    end
+
+    def validate_presence
+      errors.add(:value_json, :presence) if value.empty?
+    end
+
+    def validate_details_collection
+      # TODO: Add proper validation messages
+      errors.add(:value, 'Details collection is invalid') if details_collection(value).invalid?
+    end
+
+    def response_details?
+      framework_question.followup_comment
+    end
+  end
+end

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -12,7 +12,7 @@ class FrameworkResponse
         if response_details
           details_collection(raw_value).to_a
         else
-          self.value_json = raw_value.presence || []
+          raw_value.presence || []
         end
     end
 

--- a/app/models/framework_response/details_collection.rb
+++ b/app/models/framework_response/details_collection.rb
@@ -25,9 +25,7 @@ class FrameworkResponse
   private
 
     def details_objects
-      collection.each do |item|
-        return errors.add(:collection, 'One or more details objects invalid') if item.invalid?
-      end
+      errors.add(:collection, :invalid) if collection.any?(&:invalid?)
     end
   end
 end

--- a/app/models/framework_response/details_collection.rb
+++ b/app/models/framework_response/details_collection.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class FrameworkResponse
+  class DetailsCollection
+    include ActiveModel::Validations
+
+    attr_reader :collection
+
+    validate :details_objects
+
+    def initialize(collection:, question_options: [], details_options: [])
+      @collection = Array(collection).map do |item|
+        DetailsObject.new(
+          attributes: item,
+          question_options: question_options,
+          details_options: details_options,
+        )
+      end
+    end
+
+    def to_a
+      collection
+    end
+
+  private
+
+    def details_objects
+      collection.each do |item|
+        return errors.add(:collection, 'One or more details objects invalid') if item.invalid?
+      end
+    end
+  end
+end

--- a/app/models/framework_response/details_object.rb
+++ b/app/models/framework_response/details_object.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class FrameworkResponse
+  class DetailsObject
+    include ActiveModel::Validations
+    attr_reader :question_options, :details_options, :option, :details
+
+    validates :option, presence: true
+    validates :option, inclusion: { in: :question_options }, if: :question_options
+    validates :details, presence: true, if: :details_options
+
+    def initialize(attributes: {}, question_options: [], details_options: [])
+      @question_options = question_options.presence
+      @details_options = details_options.presence
+      attributes = attributes.presence || {}
+
+      attributes.symbolize_keys! if attributes.respond_to?(:symbolize_keys!)
+      @option = attributes[:option]
+      @details = attributes[:details]
+    end
+
+    def as_json(_options = {})
+      {
+        option: option,
+        details: details,
+      }
+    end
+  end
+end

--- a/app/models/framework_response/details_object.rb
+++ b/app/models/framework_response/details_object.rb
@@ -20,6 +20,8 @@ class FrameworkResponse
     end
 
     def as_json(_options = {})
+      return {} unless option.present? || details.present?
+
       {
         option: option,
         details: details,

--- a/app/models/framework_response/details_object.rb
+++ b/app/models/framework_response/details_object.rb
@@ -3,7 +3,8 @@
 class FrameworkResponse
   class DetailsObject
     include ActiveModel::Validations
-    attr_reader :question_options, :details_options, :option, :details
+
+    attr_accessor :question_options, :details_options, :option, :details
 
     validates :option, presence: true
     validates :option, inclusion: { in: :question_options }, if: :question_options

--- a/app/models/framework_response/object.rb
+++ b/app/models/framework_response/object.rb
@@ -1,7 +1,7 @@
 class FrameworkResponse
   class Object < FrameworkResponse
     validates :value_text, absence: true
-    validate :validate_presence, on: :update, if: -> { framework_question.required }
+    validate :validate_presence, on: :update, if: -> { framework_question.required && parent.nil? }
     validate :validate_details_object, on: :update, if: -> { response_details? }
 
     def self.sti_name
@@ -21,6 +21,10 @@ class FrameworkResponse
         end
     end
 
+    def option_selected?(option)
+      value['option'] == option
+    end
+
   private
 
     def details_object(attributes:)
@@ -36,7 +40,7 @@ class FrameworkResponse
     end
 
     def validate_presence
-      errors.add(:value_json, :presence) if value.values.empty?
+      errors.add(:value_json, :blank) if value.values.empty?
     end
 
     def validate_details_object

--- a/app/models/framework_response/object.rb
+++ b/app/models/framework_response/object.rb
@@ -40,7 +40,7 @@ class FrameworkResponse
     end
 
     def validate_presence
-      errors.add(:value_json, :blank) if value.values.empty?
+      errors.add(:value_json, :blank) if value.blank?
     end
 
     def validate_details_object

--- a/app/models/framework_response/object.rb
+++ b/app/models/framework_response/object.rb
@@ -1,0 +1,47 @@
+class FrameworkResponse
+  class Object < FrameworkResponse
+    validates :value_text, absence: true
+    validate :validate_presence, on: :update, if: -> { framework_question.required }
+    validate :validate_details_object, on: :update, if: -> { response_details? }
+
+    def self.sti_name
+      'object'
+    end
+
+    def value
+      value_json.presence || {}
+    end
+
+    def value=(answer)
+      self.value_json =
+        if response_details?
+          details_object(attributes: answer)
+        else
+          answer.presence || {}
+        end
+    end
+
+  private
+
+    def details_object(attributes:)
+      DetailsObject.new(
+        attributes: attributes,
+        question_options: framework_question.options,
+        details_options: framework_question.followup_comment_options,
+      )
+    end
+
+    def response_details?
+      framework_question.followup_comment
+    end
+
+    def validate_presence
+      errors.add(:value_json, :presence) if value.values.empty?
+    end
+
+    def validate_details_object
+      # TODO: Add proper validation messages
+      errors.add(:value, 'Option or details are invalid') if details_object(attributes: value).invalid?
+    end
+  end
+end

--- a/app/models/framework_response/string.rb
+++ b/app/models/framework_response/string.rb
@@ -1,19 +1,14 @@
 class FrameworkResponse
   class String < FrameworkResponse
     validates :value_json, absence: true
-    validates :value_text, presence: true, on: :update, if: -> { framework_question.required && parent.nil? }
     validates :value_text, on: :update, inclusion: { in: :question_options }, if: :question_options
-
-    def self.sti_name
-      'string'
-    end
 
     def value
       value_text
     end
 
-    def value=(answer)
-      self.value_text = answer
+    def value=(raw_value)
+      self.value_text = raw_value
     end
 
     def option_selected?(option)
@@ -23,7 +18,7 @@ class FrameworkResponse
   private
 
     def question_options
-      framework_question.options.presence
+      @question_options ||= framework_question.options.presence
     end
   end
 end

--- a/app/models/framework_response/string.rb
+++ b/app/models/framework_response/string.rb
@@ -1,0 +1,19 @@
+class FrameworkResponse
+  class String < FrameworkResponse
+    validates :value_json, absence: true
+    validates :value_text, presence: true, on: :update, if: -> { framework_question.required }
+    validates :value_text, on: :update, inclusion: { in: ->(response) { response.framework_question.options }, if: ->(response) { response.framework_question.options.any? } }
+
+    def self.sti_name
+      'string'
+    end
+
+    def value
+      value_text
+    end
+
+    def value=(answer)
+      self.value_text = answer
+    end
+  end
+end

--- a/app/models/framework_response/string.rb
+++ b/app/models/framework_response/string.rb
@@ -1,8 +1,8 @@
 class FrameworkResponse
   class String < FrameworkResponse
     validates :value_json, absence: true
-    validates :value_text, presence: true, on: :update, if: -> { framework_question.required }
-    validates :value_text, on: :update, inclusion: { in: ->(response) { response.framework_question.options }, if: ->(response) { response.framework_question.options.any? } }
+    validates :value_text, presence: true, on: :update, if: -> { framework_question.required && parent.nil? }
+    validates :value_text, on: :update, inclusion: { in: :question_options }, if: :question_options
 
     def self.sti_name
       'string'
@@ -14,6 +14,16 @@ class FrameworkResponse
 
     def value=(answer)
       self.value_text = answer
+    end
+
+    def option_selected?(option)
+      value == option
+    end
+
+  private
+
+    def question_options
+      framework_question.options.presence
     end
   end
 end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -1,0 +1,13 @@
+class PersonEscortRecord < VersionedModel
+  enum states: {
+    not_started: 'not_started',
+    in_progress: 'in_progress',
+    completed: 'completed',
+    confirmed: 'confirmed',
+  }
+
+  validates :state, presence: true, inclusion: { in: states }
+  has_many :framework_responses, dependent: :destroy
+  belongs_to :framework
+  belongs_to :profile
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -6,6 +6,7 @@ class Profile < VersionedModel
   belongs_to :person
 
   has_one :move, dependent: :nullify
+  has_one :person_escort_record
 
   has_many :documents, -> { kept }, as: :documentable, dependent: :destroy, inverse_of: :documentable
 

--- a/db/migrate/20200702063823_create_person_escort_record.rb
+++ b/db/migrate/20200702063823_create_person_escort_record.rb
@@ -1,0 +1,11 @@
+class CreatePersonEscortRecord < ActiveRecord::Migration[6.0]
+  def change
+    create_table :person_escort_records, id: :uuid do |t|
+      t.references :framework, type: :uuid, null: false, index: true, foreign_key: true
+      t.references :profile, type: :uuid, null: false, index: true, foreign_key: true
+      t.string "state", null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200702081808_create_framework_responses.rb
+++ b/db/migrate/20200702081808_create_framework_responses.rb
@@ -1,0 +1,16 @@
+class CreateFrameworkResponses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :framework_responses, id: :uuid do |t|
+      t.references :person_escort_record, type: :uuid, null: false, index: true, foreign_key: true
+      t.references :framework_question, type: :uuid, null: false, index: true, foreign_key: true
+      t.text :value_text
+      t.jsonb :value_json
+      t.string :type, null: false
+      t.references :parent, type: :uuid, index: true
+
+      t.timestamps
+    end
+
+    add_index  :framework_responses, :value_json, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_01_123259) do
+ActiveRecord::Schema.define(version: 2020_07_03_053232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -376,6 +376,16 @@ ActiveRecord::Schema.define(version: 2020_07_01_123259) do
     t.index ["prison_number"], name: "index_people_on_prison_number"
   end
 
+  create_table "person_escort_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "framework_id", null: false
+    t.uuid "profile_id", null: false
+    t.string "state", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
+    t.index ["profile_id"], name: "index_person_escort_records_on_profile_id"
+  end
+
   create_table "prison_transfer_reasons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "title", null: false
@@ -449,6 +459,7 @@ ActiveRecord::Schema.define(version: 2020_07_01_123259) do
   add_foreign_key "documents", "moves"
   add_foreign_key "flags", "framework_questions"
   add_foreign_key "framework_questions", "frameworks"
+  add_foreign_key "framework_responses", "person_escort_records"
   add_foreign_key "journeys", "locations", column: "from_location_id"
   add_foreign_key "journeys", "locations", column: "to_location_id"
   add_foreign_key "journeys", "moves"
@@ -466,6 +477,8 @@ ActiveRecord::Schema.define(version: 2020_07_01_123259) do
   add_foreign_key "notifications", "subscriptions"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "person_escort_records", "frameworks"
+  add_foreign_key "person_escort_records", "profiles"
   add_foreign_key "profiles", "people", name: "profiles_person_id"
   add_foreign_key "subscriptions", "suppliers"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -150,6 +150,21 @@ ActiveRecord::Schema.define(version: 2020_07_03_053232) do
     t.index ["parent_id"], name: "index_framework_questions_on_parent_id"
   end
 
+  create_table "framework_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "person_escort_record_id", null: false
+    t.uuid "framework_question_id", null: false
+    t.text "value_text"
+    t.jsonb "value_json"
+    t.string "type", null: false
+    t.uuid "parent_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["framework_question_id"], name: "index_framework_responses_on_framework_question_id"
+    t.index ["parent_id"], name: "index_framework_responses_on_parent_id"
+    t.index ["person_escort_record_id"], name: "index_framework_responses_on_person_escort_record_id"
+    t.index ["value_json"], name: "index_framework_responses_on_value_json", using: :gin
+  end
+
   create_table "frameworks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "version", null: false
@@ -459,6 +474,7 @@ ActiveRecord::Schema.define(version: 2020_07_03_053232) do
   add_foreign_key "documents", "moves"
   add_foreign_key "flags", "framework_questions"
   add_foreign_key "framework_questions", "frameworks"
+  add_foreign_key "framework_responses", "framework_questions"
   add_foreign_key "framework_responses", "person_escort_records"
   add_foreign_key "journeys", "locations", column: "from_location_id"
   add_foreign_key "journeys", "locations", column: "to_location_id"

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -8,7 +8,10 @@ FactoryBot.define do
 
   factory :object_response, parent: :framework_response, class: 'FrameworkResponse::Object' do
     type { 'object' }
-    value { { 'option' => 'Yes', 'details' => 'some comment' } }
+    trait :details do
+      association(:framework_question, followup_comment: true)
+      value { { 'option' => 'Yes', 'details' => 'some comment' } }
+    end
   end
 
   factory :collection_response, parent: :framework_response, class: 'FrameworkResponse::Collection' do

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -16,7 +16,11 @@ FactoryBot.define do
 
   factory :collection_response, parent: :framework_response, class: 'FrameworkResponse::Collection' do
     type { 'collection' }
-    value { [{ 'option' => 'Level 1', 'details' => 'some comment' }, { 'option' => 'Level 2', 'details' => 'another comment' }] }
+    value { [{ 'name' => 'Foo bar' }, { 'name' => 'Bar baz' }] }
+    trait :details do
+      association(:framework_question, followup_comment: true)
+      value { [{ 'option' => 'Level 1', 'details' => 'some comment' }, { 'option' => 'Level 2', 'details' => 'another comment' }] }
+    end
   end
 
   factory :string_response, parent: :framework_response, class: 'FrameworkResponse::String' do

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :framework_response do
+    association(:framework_question)
+    association(:person_escort_record)
+  end
+
+  factory :object_response, parent: :framework_response, class: 'FrameworkResponse::Object' do
+    type { 'object' }
+    value { { 'option' => 'Yes', 'details' => 'some comment' } }
+  end
+
+  factory :collection_response, parent: :framework_response, class: 'FrameworkResponse::Collection' do
+    type { 'collection' }
+    value { [{ 'option' => 'Level 1', 'details' => 'some comment' }, { 'option' => 'Level 2', 'details' => 'another comment' }] }
+  end
+
+  factory :string_response, parent: :framework_response, class: 'FrameworkResponse::String' do
+    type { 'string' }
+    value { 'Yes' }
+  end
+
+  factory :array_response, parent: :framework_response, class: 'FrameworkResponse::Array' do
+    association(:framework_question, options: ['Level 1', 'Level 2'])
+    type { 'array' }
+    value { ['Level 1'] }
+  end
+end

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
   end
 
   factory :object_response, parent: :framework_response, class: 'FrameworkResponse::Object' do
-    type { 'object' }
     trait :details do
       association(:framework_question, followup_comment: true)
       value { { 'option' => 'Yes', 'details' => 'some comment' } }
@@ -15,7 +14,6 @@ FactoryBot.define do
   end
 
   factory :collection_response, parent: :framework_response, class: 'FrameworkResponse::Collection' do
-    type { 'collection' }
     value { [{ 'name' => 'Foo bar' }, { 'name' => 'Bar baz' }] }
     trait :details do
       association(:framework_question, followup_comment: true)
@@ -24,13 +22,11 @@ FactoryBot.define do
   end
 
   factory :string_response, parent: :framework_response, class: 'FrameworkResponse::String' do
-    type { 'string' }
     value { 'Yes' }
   end
 
   factory :array_response, parent: :framework_response, class: 'FrameworkResponse::Array' do
     association(:framework_question, options: ['Level 1', 'Level 2'])
-    type { 'array' }
     value { ['Level 1'] }
   end
 end

--- a/spec/factories/person_escort_record.rb
+++ b/spec/factories/person_escort_record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :person_escort_record do
+    association(:framework)
+    association(:profile)
+    state { 'not_started' }
+  end
+end

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -13,4 +13,5 @@ RSpec.describe FrameworkQuestion do
 
   it { is_expected.to have_many(:dependents) }
   it { is_expected.to have_many(:flags) }
+  it { is_expected.to have_many(:framework_responses) }
 end

--- a/spec/models/framework_response/array_spec.rb
+++ b/spec/models/framework_response/array_spec.rb
@@ -15,7 +15,14 @@ RSpec.describe FrameworkResponse::Array do
     expect(response).to validate_presence_of(:value_json).on(:update)
   end
 
-  it 'does not validates value json inclusion if no options present on question' do
+  it 'does not validate value json presence when a record is updated if question required but dependent' do
+    question = create(:framework_question, required: true)
+    response = create(:array_response, value: nil, framework_question: question, parent: create(:string_response))
+
+    expect(response).not_to validate_presence_of(:value_json).on(:update)
+  end
+
+  it 'does not validate value json inclusion if no options present on question' do
     question = create(:framework_question, required: true, options: [])
     response = create(:array_response, value: ['Some value'], framework_question: question)
 
@@ -42,6 +49,26 @@ RSpec.describe FrameworkResponse::Array do
       response = create(:array_response, value: nil)
 
       expect(response.value).to be_empty
+    end
+  end
+
+  describe '#option_selected?' do
+    it 'returns true if option matches any option selected' do
+      response = create(
+        :array_response,
+        value: ['Level 1', 'Level 2'],
+      )
+
+      expect(response.option_selected?('Level 2')).to be(true)
+    end
+
+    it 'returns false if option does not match any option selected' do
+      response = create(
+        :array_response,
+        value: ['Level 1', 'Level 2'],
+      )
+
+      expect(response.option_selected?('Level 3')).to be(false)
     end
   end
 end

--- a/spec/models/framework_response/array_spec.rb
+++ b/spec/models/framework_response/array_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe FrameworkResponse::Array do
   it { is_expected.to validate_absence_of(:value_text) }
   it { is_expected.to validate_inclusion_of(:value_json).in_array(['Level 1', 'Level 2']) }
 
-  it 'validates value json presence when a record is updated if question required' do
+  it 'validates value presence when a record is updated if question required' do
     question = create(:framework_question, required: true)
     response = create(:array_response, value: nil, framework_question: question)
 
-    expect(response).to validate_presence_of(:value_json).on(:update)
+    expect(response).to validate_presence_of(:value).on(:update)
   end
 
   it 'does not validate value json presence when a record is updated if question required but dependent' do

--- a/spec/models/framework_response/array_spec.rb
+++ b/spec/models/framework_response/array_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponse::Array do
+  subject { create(:array_response) }
+
+  it { is_expected.to validate_absence_of(:value_text) }
+  it { is_expected.to validate_inclusion_of(:value_json).in_array(['Level 1', 'Level 2']) }
+
+  it 'validates value json presence when a record is updated if question required' do
+    question = create(:framework_question, required: true)
+    response = create(:array_response, value: nil, framework_question: question)
+
+    expect(response).to validate_presence_of(:value_json).on(:update)
+  end
+
+  it 'does not validates value json inclusion if no options present on question' do
+    question = create(:framework_question, required: true, options: [])
+    response = create(:array_response, value: ['Some value'], framework_question: question)
+
+    expect(response).not_to validate_inclusion_of(:value_text).in_array([])
+  end
+
+  describe '#value' do
+    it 'returns the response value if type is array' do
+      response = create(
+        :array_response,
+        value: ['Level 1', 'Level 2'],
+      )
+
+      expect(response.value).to contain_exactly('Level 1', 'Level 2')
+    end
+
+    it 'returns an empty response value if set as empty' do
+      response = create(:array_response, value: [])
+
+      expect(response.value).to be_empty
+    end
+
+    it 'defaults to an empty response value if set to nil' do
+      response = create(:array_response, value: nil)
+
+      expect(response.value).to be_empty
+    end
+  end
+end

--- a/spec/models/framework_response/collection_spec.rb
+++ b/spec/models/framework_response/collection_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe FrameworkResponse::Collection do
     expect(response).not_to be_valid
   end
 
+  it 'does not validate presence of value when a record is updated if question is required but dependent' do
+    question = create(:framework_question, required: true, options: [])
+    response = create(:collection_response, value: nil, framework_question: question, parent: create(:string_response))
+
+    expect(response).to be_valid
+  end
+
   it 'does not validate presence of value when a record is updated if question is not required' do
     question = create(:framework_question, options: [])
     response = create(:collection_response, value: nil, framework_question: question)
@@ -78,6 +85,20 @@ RSpec.describe FrameworkResponse::Collection do
       response = create(:collection_response, :details, value: nil)
 
       expect(response.value.as_json).to be_empty
+    end
+  end
+
+  describe '#option_selected?' do
+    it 'returns true if option matches any option selected' do
+      response = create(:collection_response, :details)
+
+      expect(response.option_selected?('Level 1')).to be(true)
+    end
+
+    it 'returns false if option does not match any option selected' do
+      response = create(:collection_response, :details)
+
+      expect(response.option_selected?('Level 3')).to be(false)
     end
   end
 end

--- a/spec/models/framework_response/collection_spec.rb
+++ b/spec/models/framework_response/collection_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponse::Collection do
+  subject { create(:collection_response) }
+
+  it { is_expected.to validate_absence_of(:value_text) }
+
+  it 'validates presence of value when a record is updated if question is required' do
+    question = create(:framework_question, required: true, options: [])
+    response = create(:collection_response, value: nil, framework_question: question)
+
+    expect(response).not_to be_valid
+  end
+
+  it 'does not validate presence of value when a record is updated if question is not required' do
+    question = create(:framework_question, options: [])
+    response = create(:collection_response, value: nil, framework_question: question)
+
+    expect(response).to be_valid
+  end
+
+  it 'validates presence of value when a record is updated if question and details are required' do
+    question = create(:framework_question, required: true, options: [], followup_comment: true)
+    response = create(:collection_response, value: nil, framework_question: question)
+
+    expect(response).not_to be_valid
+  end
+
+  it 'validates details collection' do
+    question = create(
+      :framework_question,
+      followup_comment: true,
+      followup_comment_options: %w[Yes],
+    )
+    response = create(:collection_response, :details, value: [{ 'option' => 'Yes' }], framework_question: question)
+
+    expect(response).not_to be_valid
+  end
+
+  describe '#value' do
+    it 'returns the response value as an array' do
+      response = create(
+        :collection_response,
+        value: [{ name: 'some name' }],
+      )
+
+      expect(response.value.as_json).to contain_exactly('name' => 'some name')
+    end
+
+    it 'returns an empty response value if set as empty' do
+      response = create(:collection_response, value: [])
+
+      expect(response.value).to be_empty
+    end
+
+    it 'defaults to an empty response value if set to nil' do
+      response = create(:collection_response, value: nil)
+
+      expect(response.value).to be_empty
+    end
+
+    it 'returns response value if details supplied' do
+      collection = [{ details: 'some comment', option: 'Level 1' }]
+      response = create(:collection_response, :details, value: collection)
+
+      expect(response.value.as_json).to contain_exactly('details' => 'some comment', 'option' => 'Level 1')
+    end
+
+    it 'returns response value if details supplied but empty' do
+      response = create(:collection_response, :details, value: {})
+
+      expect(response.value.as_json).to be_empty
+    end
+
+    it 'returns response value if details supplied but nil' do
+      response = create(:collection_response, :details, value: nil)
+
+      expect(response.value.as_json).to be_empty
+    end
+  end
+end

--- a/spec/models/framework_response/collection_spec.rb
+++ b/spec/models/framework_response/collection_spec.rb
@@ -11,28 +11,28 @@ RSpec.describe FrameworkResponse::Collection do
     question = create(:framework_question, required: true, options: [])
     response = create(:collection_response, value: nil, framework_question: question)
 
-    expect(response).not_to be_valid
+    expect(response).to validate_presence_of(:value)
   end
 
   it 'does not validate presence of value when a record is updated if question is required but dependent' do
     question = create(:framework_question, required: true, options: [])
     response = create(:collection_response, value: nil, framework_question: question, parent: create(:string_response))
 
-    expect(response).to be_valid
+    expect(response).not_to validate_presence_of(:value)
   end
 
   it 'does not validate presence of value when a record is updated if question is not required' do
     question = create(:framework_question, options: [])
     response = create(:collection_response, value: nil, framework_question: question)
 
-    expect(response).to be_valid
+    expect(response).not_to validate_presence_of(:value)
   end
 
   it 'validates presence of value when a record is updated if question and details are required' do
     question = create(:framework_question, required: true, options: [], followup_comment: true)
     response = create(:collection_response, value: nil, framework_question: question)
 
-    expect(response).not_to be_valid
+    expect(response).to validate_presence_of(:value)
   end
 
   it 'validates details collection' do

--- a/spec/models/framework_response/details_collection_spec.rb
+++ b/spec/models/framework_response/details_collection_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponse::DetailsCollection, type: :model do
+  it 'validates the details object passed' do
+    collection = [{ option: 'No' }, { option: 'Yes' }]
+    details_collection = described_class.new(collection: collection, question_options: %w[No])
+
+    expect(details_collection).not_to be_valid
+  end
+
+  describe '#to_a' do
+    it 'returns collection of detail objects' do
+      collection = [
+        {
+          option: 'Level 1',
+          details: 'some comment',
+        },
+        {
+          option: 'Level 2',
+          details: 'some comment',
+        },
+      ]
+
+      details_collection = described_class.new(collection: collection)
+      expect(details_collection.to_a.first).to be_a(FrameworkResponse::DetailsObject)
+    end
+
+    it 'maps collection of detail objects' do
+      collection = [
+        {
+          option: 'Level 1',
+          details: 'some comment',
+        },
+        {
+          option: 'Level 2',
+          details: 'some comment',
+        },
+      ]
+
+      details_collection = described_class.new(collection: collection)
+      expect(details_collection.to_a.count).to eq(2)
+    end
+
+    it 'returns an empty array if collection is empty' do
+      details_collection = described_class.new(collection: [])
+
+      expect(details_collection.to_a).to be_empty
+    end
+  end
+end

--- a/spec/models/framework_response/details_object_spec.rb
+++ b/spec/models/framework_response/details_object_spec.rb
@@ -7,35 +7,35 @@ RSpec.describe FrameworkResponse::DetailsObject, type: :model do
     attributes = { details: 'some comment' }
     details_object = described_class.new(attributes: attributes)
 
-    expect(details_object).not_to be_valid
+    expect(details_object).to validate_presence_of(:option)
   end
 
   it 'validates the inclusion of an option if question options are supplied' do
     attributes = { option: 'Yes' }
     details_object = described_class.new(attributes: attributes, question_options: %w[No])
 
-    expect(details_object).not_to be_valid
+    expect(details_object).to validate_inclusion_of(:option).in_array(%w[No])
   end
 
   it 'does not validate the inclusion of an option if no question options supplied' do
     attributes = { option: 'Yes' }
     details_object = described_class.new(attributes: attributes)
 
-    expect(details_object).to be_valid
+    expect(details_object).not_to validate_inclusion_of(:option).in_array([])
   end
 
   it 'validates the presence of details if detail options are supplied' do
     attributes = { option: 'No' }
     details_object = described_class.new(attributes: attributes, details_options: %w[No])
 
-    expect(details_object).not_to be_valid
+    expect(details_object).to validate_presence_of(:details)
   end
 
   it 'does not validate the presence of details if no detail options supplied' do
     attributes = { option: 'No' }
     details_object = described_class.new(attributes: attributes, question_options: %w[No])
 
-    expect(details_object).to be_valid
+    expect(details_object).not_to validate_presence_of(:details)
   end
 
   describe '#as_json' do

--- a/spec/models/framework_response/details_object_spec.rb
+++ b/spec/models/framework_response/details_object_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponse::DetailsObject, type: :model do
+  it 'validates the presence of an option' do
+    attributes = { details: 'some comment' }
+    details_object = described_class.new(attributes: attributes)
+
+    expect(details_object).not_to be_valid
+  end
+
+  it 'validates the inclusion of an option if question options are supplied' do
+    attributes = { option: 'Yes' }
+    details_object = described_class.new(attributes: attributes, question_options: %w[No])
+
+    expect(details_object).not_to be_valid
+  end
+
+  it 'does not validate the inclusion of an option if no question options supplied' do
+    attributes = { option: 'Yes' }
+    details_object = described_class.new(attributes: attributes)
+
+    expect(details_object).to be_valid
+  end
+
+  it 'validates the presence of details if detail options are supplied' do
+    attributes = { option: 'No' }
+    details_object = described_class.new(attributes: attributes, details_options: %w[No])
+
+    expect(details_object).not_to be_valid
+  end
+
+  it 'does not validate the presence of details if no detail options supplied' do
+    attributes = { option: 'No' }
+    details_object = described_class.new(attributes: attributes, question_options: %w[No])
+
+    expect(details_object).to be_valid
+  end
+
+  describe '#as_json' do
+    it 'returns a hash of all values' do
+      attributes = {
+        option: 'Yes',
+        details: 'some comment',
+      }
+      details_object = described_class.new(attributes: attributes)
+
+      expect(details_object.as_json).to eq(attributes)
+    end
+
+    it 'returns a hash of nil values of nothing passed in' do
+      attributes = {
+        option: nil,
+        details: nil,
+      }
+      details_object = described_class.new(attributes: {})
+
+      expect(details_object.as_json).to eq(attributes)
+    end
+  end
+end

--- a/spec/models/framework_response/details_object_spec.rb
+++ b/spec/models/framework_response/details_object_spec.rb
@@ -49,14 +49,10 @@ RSpec.describe FrameworkResponse::DetailsObject, type: :model do
       expect(details_object.as_json).to eq(attributes)
     end
 
-    it 'returns a hash of nil values of nothing passed in' do
-      attributes = {
-        option: nil,
-        details: nil,
-      }
+    it 'returns a empty hash if nothing passed in' do
       details_object = described_class.new(attributes: {})
 
-      expect(details_object.as_json).to eq(attributes)
+      expect(details_object.as_json).to be_empty
     end
   end
 end

--- a/spec/models/framework_response/object_spec.rb
+++ b/spec/models/framework_response/object_spec.rb
@@ -11,28 +11,28 @@ RSpec.describe FrameworkResponse::Object do
     question = create(:framework_question, required: true, options: [])
     response = create(:object_response, value: nil, framework_question: question)
 
-    expect(response).not_to be_valid
+    expect(response).to validate_presence_of(:value)
   end
 
   it 'does not validate presence of value when a record is updated if question is required and dependent' do
     question = create(:framework_question, required: true, options: [])
     response = create(:object_response, value: nil, framework_question: question, parent: create(:string_response))
 
-    expect(response).to be_valid
+    expect(response).not_to validate_presence_of(:value)
   end
 
   it 'does not validate presence of value when a record is updated if question is not required' do
     question = create(:framework_question, options: [])
     response = create(:object_response, value: nil, framework_question: question)
 
-    expect(response).to be_valid
+    expect(response).not_to validate_presence_of(:value)
   end
 
   it 'validates presence of value when a record is updated if question and details are required' do
     question = create(:framework_question, required: true, options: [], followup_comment: true)
     response = create(:object_response, value: nil, framework_question: question)
 
-    expect(response).not_to be_valid
+    expect(response).to validate_presence_of(:value)
   end
 
   it 'validates details object' do

--- a/spec/models/framework_response/object_spec.rb
+++ b/spec/models/framework_response/object_spec.rb
@@ -77,13 +77,13 @@ RSpec.describe FrameworkResponse::Object do
     it 'returns response value if details supplied but empty' do
       response = create(:object_response, :details, value: {})
 
-      expect(response.value.as_json).to eq('option' => nil, 'details' => nil)
+      expect(response.value.as_json).to be_empty
     end
 
     it 'returns response value if details supplied but nil' do
       response = create(:object_response, :details, value: nil)
 
-      expect(response.value.as_json).to eq('option' => nil, 'details' => nil)
+      expect(response.value.as_json).to be_empty
     end
   end
 

--- a/spec/models/framework_response/object_spec.rb
+++ b/spec/models/framework_response/object_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponse::Object do
+  subject { create(:object_response) }
+
+  it { is_expected.to validate_absence_of(:value_text) }
+
+  it 'validates presence of value when a record is updated if question is required' do
+    question = create(:framework_question, required: true, options: [])
+    response = create(:object_response, value: nil, framework_question: question)
+
+    expect(response).not_to be_valid
+  end
+
+  it 'does not validate presence of value when a record is updated if question is not required' do
+    question = create(:framework_question, options: [])
+    response = create(:object_response, value: nil, framework_question: question)
+
+    expect(response).to be_valid
+  end
+
+  it 'validates presence of value when a record is updated if question and details are required' do
+    question = create(:framework_question, required: true, options: [], followup_comment: true)
+    response = create(:object_response, value: nil, framework_question: question)
+
+    expect(response).not_to be_valid
+  end
+
+  it 'validates details object' do
+    question = create(
+      :framework_question,
+      followup_comment: true,
+      followup_comment_options: %w[Yes],
+    )
+    response = create(:object_response, :details, value: { 'option' => 'Yes' }, framework_question: question)
+
+    expect(response).not_to be_valid
+  end
+
+  describe '#value' do
+    it 'returns the response value as json' do
+      response = create(
+        :object_response,
+        value: { name: 'some name' },
+      )
+
+      expect(response.value.as_json).to eq('name' => 'some name')
+    end
+
+    it 'returns an empty response value if set as empty' do
+      response = create(:object_response, value: {})
+
+      expect(response.value).to be_empty
+    end
+
+    it 'defaults to an empty response value if set to nil' do
+      response = create(:object_response, value: nil)
+
+      expect(response.value).to be_empty
+    end
+
+    it 'returns response value if details supplied' do
+      response = create(:object_response, :details)
+
+      expect(response.value.as_json).to eq('option' => 'Yes', 'details' => 'some comment')
+    end
+
+    it 'returns response value if details supplied but empty' do
+      response = create(:object_response, :details, value: {})
+
+      expect(response.value.as_json).to eq('option' => nil, 'details' => nil)
+    end
+
+    it 'returns response value if details supplied but nil' do
+      response = create(:object_response, :details, value: nil)
+
+      expect(response.value.as_json).to eq('option' => nil, 'details' => nil)
+    end
+  end
+end

--- a/spec/models/framework_response/object_spec.rb
+++ b/spec/models/framework_response/object_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe FrameworkResponse::Object do
     expect(response).not_to be_valid
   end
 
+  it 'does not validate presence of value when a record is updated if question is required and dependent' do
+    question = create(:framework_question, required: true, options: [])
+    response = create(:object_response, value: nil, framework_question: question, parent: create(:string_response))
+
+    expect(response).to be_valid
+  end
+
   it 'does not validate presence of value when a record is updated if question is not required' do
     question = create(:framework_question, options: [])
     response = create(:object_response, value: nil, framework_question: question)
@@ -77,6 +84,20 @@ RSpec.describe FrameworkResponse::Object do
       response = create(:object_response, :details, value: nil)
 
       expect(response.value.as_json).to eq('option' => nil, 'details' => nil)
+    end
+  end
+
+  describe '#option_selected?' do
+    it 'returns true if option matches any option selected' do
+      response = create(:object_response, :details)
+
+      expect(response.option_selected?('Yes')).to be(true)
+    end
+
+    it 'returns false if option does not match any option selected' do
+      response = create(:object_response, :details)
+
+      expect(response.option_selected?('No')).to be(false)
     end
   end
 end

--- a/spec/models/framework_response/string_spec.rb
+++ b/spec/models/framework_response/string_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe FrameworkResponse::String do
     expect(response).to validate_presence_of(:value_text).on(:update)
   end
 
+  it 'does not validate value text presence when a record is updated if question required and dependent' do
+    question = create(:framework_question, required: true)
+    response = create(:string_response, value: nil, framework_question: question, parent: create(:string_response))
+
+    expect(response).not_to validate_presence_of(:value_text).on(:update)
+  end
+
   it 'does not validates value text inclusion if no options present on question' do
     question = create(:framework_question, required: true, options: [])
     response = create(:string_response, value: 'Some value', framework_question: question)
@@ -33,6 +40,20 @@ RSpec.describe FrameworkResponse::String do
       response = create(:string_response, value: nil)
 
       expect(response.value).to be_nil
+    end
+  end
+
+  describe '#option_selected?' do
+    it 'returns true if option matches any option selected' do
+      response = create(:string_response)
+
+      expect(response.option_selected?('Yes')).to be(true)
+    end
+
+    it 'returns false if option does not match any option selected' do
+      response = create(:string_response)
+
+      expect(response.option_selected?('No')).to be(false)
     end
   end
 end

--- a/spec/models/framework_response/string_spec.rb
+++ b/spec/models/framework_response/string_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponse::String do
+  subject { create(:string_response) }
+
+  it { is_expected.to validate_absence_of(:value_json) }
+  it { is_expected.to validate_inclusion_of(:value_text).in_array(%w[Yes No]) }
+
+  it 'validates value text presence when a record is updated if question required' do
+    question = create(:framework_question, required: true)
+    response = create(:string_response, value: nil, framework_question: question)
+
+    expect(response).to validate_presence_of(:value_text).on(:update)
+  end
+
+  it 'does not validates value text inclusion if no options present on question' do
+    question = create(:framework_question, required: true, options: [])
+    response = create(:string_response, value: 'Some value', framework_question: question)
+
+    expect(response).not_to validate_inclusion_of(:value_text).in_array([])
+  end
+
+  describe '#value' do
+    it 'returns the response value if type is string' do
+      response = create(:string_response, value: 'Yes')
+
+      expect(response.value).to eq('Yes')
+    end
+
+    it 'returns a nil response value if type is string and its empty' do
+      response = create(:string_response, value: nil)
+
+      expect(response.value).to be_nil
+    end
+  end
+end

--- a/spec/models/framework_response/string_spec.rb
+++ b/spec/models/framework_response/string_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FrameworkResponse::String do
     question = create(:framework_question, required: true)
     response = create(:string_response, value: nil, framework_question: question)
 
-    expect(response).to validate_presence_of(:value_text).on(:update)
+    expect(response).to validate_presence_of(:value).on(:update)
   end
 
   it 'does not validate value text presence when a record is updated if question required and dependent' do

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -9,6 +9,69 @@ RSpec.describe FrameworkResponse do
 
   it { is_expected.to have_many(:dependents) }
 
+  it 'validates string dependent responses' do
+    question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
+    response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
+
+    expect(response).not_to be_valid
+  end
+
+  it 'does not validate string dependent responses if parent response is not correct value' do
+    question = create(:framework_question, dependent_value: 'No', options: [], required: true)
+    response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
+
+    expect(response).to be_valid
+  end
+
+  it 'does not validate dependent responses if parent response is correct value but not required' do
+    question = create(:framework_question, dependent_value: 'Yes', options: [], required: false)
+    response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
+
+    expect(response).to be_valid
+  end
+
+  it 'validates array dependent responses' do
+    question = create(:framework_question, dependent_value: 'Level 1', options: [], required: true)
+    response = create(:string_response, value: nil, parent: create(:array_response), framework_question: question)
+
+    expect(response).not_to be_valid
+  end
+
+  it 'does not validate array dependent responses if parent response is not correct value' do
+    question = create(:framework_question, dependent_value: 'Level 2', options: [], required: true)
+    response = create(:string_response, value: nil, parent: create(:array_response), framework_question: question)
+
+    expect(response).to be_valid
+  end
+
+  it 'validates object dependent responses' do
+    question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
+    response = create(:string_response, value: nil, parent: create(:object_response, :details), framework_question: question)
+
+    expect(response).not_to be_valid
+  end
+
+  it 'does not validate object dependent responses if parent response is not correct value' do
+    question = create(:framework_question, dependent_value: 'No', options: [], required: true)
+    response = create(:string_response, value: nil, parent: create(:object_response, :details), framework_question: question)
+
+    expect(response).to be_valid
+  end
+
+  it 'validates collection dependent responses' do
+    question = create(:framework_question, dependent_value: 'Level 1', options: [], required: true)
+    response = create(:string_response, value: nil, parent: create(:collection_response, :details), framework_question: question)
+
+    expect(response).not_to be_valid
+  end
+
+  it 'does not validate collection dependent responses if parent response is not correct value' do
+    question = create(:framework_question, dependent_value: 'Level 3', options: [], required: true)
+    response = create(:string_response, value: nil, parent: create(:collection_response, :details), framework_question: question)
+
+    expect(response).to be_valid
+  end
+
   it 'sets correct type to framework response when object' do
     create(:object_response)
 
@@ -31,6 +94,5 @@ RSpec.describe FrameworkResponse do
     create(:array_response)
 
     expect(described_class.first).to be_a(FrameworkResponse::Array)
-
   end
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -8,4 +8,29 @@ RSpec.describe FrameworkResponse do
   it { is_expected.to belong_to(:parent).optional }
 
   it { is_expected.to have_many(:dependents) }
+
+  it 'sets correct type to framework response when object' do
+    create(:object_response)
+
+    expect(described_class.first).to be_a(FrameworkResponse::Object)
+  end
+
+  it 'sets correct type to framework response when collection' do
+    create(:collection_response)
+
+    expect(described_class.first).to be_a(FrameworkResponse::Collection)
+  end
+
+  it 'sets correct type to framework response when string' do
+    create(:string_response)
+
+    expect(described_class.first).to be_a(FrameworkResponse::String)
+  end
+
+  it 'sets correct type to framework response when array' do
+    create(:array_response)
+
+    expect(described_class.first).to be_a(FrameworkResponse::Array)
+
+  end
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -13,86 +13,100 @@ RSpec.describe FrameworkResponse do
     question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
     response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
 
-    expect(response).not_to be_valid
+    expect(response).to validate_presence_of(:value).on(:update)
   end
 
   it 'does not validate string dependent responses if parent response is not correct value' do
     question = create(:framework_question, dependent_value: 'No', options: [], required: true)
     response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
 
-    expect(response).to be_valid
+    expect(response).not_to validate_presence_of(:value).on(:update)
   end
 
   it 'does not validate dependent responses if parent response is correct value but not required' do
     question = create(:framework_question, dependent_value: 'Yes', options: [], required: false)
     response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
 
-    expect(response).to be_valid
+    expect(response).not_to validate_presence_of(:value).on(:update)
   end
 
   it 'validates array dependent responses' do
     question = create(:framework_question, dependent_value: 'Level 1', options: [], required: true)
     response = create(:string_response, value: nil, parent: create(:array_response), framework_question: question)
 
-    expect(response).not_to be_valid
+    expect(response).to validate_presence_of(:value).on(:update)
   end
 
   it 'does not validate array dependent responses if parent response is not correct value' do
     question = create(:framework_question, dependent_value: 'Level 2', options: [], required: true)
     response = create(:string_response, value: nil, parent: create(:array_response), framework_question: question)
 
-    expect(response).to be_valid
+    expect(response).not_to validate_presence_of(:value).on(:update)
   end
 
   it 'validates object dependent responses' do
     question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
     response = create(:string_response, value: nil, parent: create(:object_response, :details), framework_question: question)
 
-    expect(response).not_to be_valid
+    expect(response).to validate_presence_of(:value).on(:update)
   end
 
   it 'does not validate object dependent responses if parent response is not correct value' do
     question = create(:framework_question, dependent_value: 'No', options: [], required: true)
     response = create(:string_response, value: nil, parent: create(:object_response, :details), framework_question: question)
 
-    expect(response).to be_valid
+    expect(response).not_to validate_presence_of(:value).on(:update)
   end
 
   it 'validates collection dependent responses' do
     question = create(:framework_question, dependent_value: 'Level 1', options: [], required: true)
     response = create(:string_response, value: nil, parent: create(:collection_response, :details), framework_question: question)
 
-    expect(response).not_to be_valid
+    expect(response).to validate_presence_of(:value).on(:update)
   end
 
   it 'does not validate collection dependent responses if parent response is not correct value' do
     question = create(:framework_question, dependent_value: 'Level 3', options: [], required: true)
     response = create(:string_response, value: nil, parent: create(:collection_response, :details), framework_question: question)
 
-    expect(response).to be_valid
+    expect(response).not_to validate_presence_of(:value).on(:update)
   end
 
-  it 'sets correct type to framework response when object' do
-    create(:object_response)
+  describe '.requires_value?' do
+    it 'returns false if value present' do
+      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
+      response = create(:string_response, value: 'some value', parent: create(:string_response), framework_question: question)
 
-    expect(described_class.first).to be_a(FrameworkResponse::Object)
-  end
+      expect(described_class.requires_value?(response.value, response)).to be(false)
+    end
 
-  it 'sets correct type to framework response when collection' do
-    create(:collection_response)
+    it 'returns false if question not required' do
+      question = create(:framework_question, options: [], required: false)
+      response = create(:string_response, value: nil, framework_question: question)
 
-    expect(described_class.first).to be_a(FrameworkResponse::Collection)
-  end
+      expect(described_class.requires_value?(response.value, response)).to be(false)
+    end
 
-  it 'sets correct type to framework response when string' do
-    create(:string_response)
+    it 'returns true if question required, value is empty and has is not dependent' do
+      question = create(:framework_question, options: [], required: true)
+      response = create(:string_response, value: nil, framework_question: question)
 
-    expect(described_class.first).to be_a(FrameworkResponse::String)
-  end
+      expect(described_class.requires_value?(response.value, response)).to be(true)
+    end
 
-  it 'sets correct type to framework response when array' do
-    create(:array_response)
+    it 'returns true if record is dependent, required and missing value' do
+      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
+      response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
 
-    expect(described_class.first).to be_a(FrameworkResponse::Array)
+      expect(described_class.requires_value?(response.value, response)).to be(true)
+    end
+
+    it 'returns false if record is dependent but parent response does not match' do
+      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
+      parent_response = create(:string_response, value: 'No')
+      response = create(:string_response, value: nil, parent: parent_response, framework_question: question)
+
+      expect(described_class.requires_value?(response.value, response)).to be(false)
+    end
   end
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponse do
+  it { is_expected.to belong_to(:framework_question) }
+  it { is_expected.to belong_to(:person_escort_record) }
+  it { is_expected.to belong_to(:parent).optional }
+
+  it { is_expected.to have_many(:dependents) }
+end

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -8,4 +8,6 @@ RSpec.describe Framework do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:version) }
   it { is_expected.to validate_uniqueness_of(:name).scoped_to(:version) }
+  it { is_expected.to have_many(:person_escort_records) }
+  it { is_expected.to have_many(:framework_questions) }
 end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonEscortRecord do
+  it { is_expected.to validate_presence_of(:state) }
+  it { is_expected.to validate_inclusion_of(:state).in_array(%w[not_started in_progress completed confirmed]) }
+  it { is_expected.to have_many(:framework_responses) }
+  it { is_expected.to belong_to(:framework) }
+  it { is_expected.to belong_to(:profile) }
+end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Profile, type: :model do
   it { is_expected.to belong_to(:person).required }
   it { is_expected.to have_many(:documents) }
+  it { is_expected.to have_one(:person_escort_record) }
   it { is_expected.to validate_presence_of(:person) }
 
   describe '#validate_assessment_answers' do


### PR DESCRIPTION
### Jira link

[P4-1746](https://dsdmoj.atlassian.net/browse/P4-1746)

### What?

- [x] Added a person escort record table and model
- [x] Added a framework response table and model
- [x] Added STI on framework responses

### Why?

To facilitate person escort record creation with responses, add the relevant tables as well as the validations and associations.
A Person escort record can be created with a framework and version, and will contain many responses which are initially empty. A response depending on the question it is for, can hold many answer types. To store the different types we have added two fields on the response table: text and jsonb. Those two will be able to store all the required values sent to us as answers, and will be hidden under a single field called value. According to the value type, the relevant answers will be set accordingly to the underlying tables. 

The 4 types of responses are: string, array, object and collection

- **String**: This response is for questions with a text box, or a radio button which will require one string answer such as 'Yes'
- **Array**: This response is for questions which are a checklist, so users can select multiple options
- **Object**: This response is specifically for questions which are a radio, but could contain an optional/required comment or details box. To accommodate this client will send an object instead with an "option" and "details" field. 
- **Collection**: This response is for questions which are a checklist, but could contain an optional/required comment. 

Validations:
- If response is required based on attribute on question
- If option is included in list of options
- If radio response requires details 
- If checklist response requires details
- If question is a dependent question, response becomes required

