### PR TITLE
[P4-1878] Adds migration for supplier on move

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -44,6 +44,7 @@ class Move < VersionedModel
     REJECTION_REASON_NO_TRANSPORT = 'no_transport_available',
   ].freeze
 
+  belongs_to :supplier, optional: true
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location', optional: true
   belongs_to :profile, optional: true

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -3,6 +3,7 @@
 class Supplier < ApplicationRecord
   has_and_belongs_to_many :locations
   has_many :subscriptions, dependent: :destroy
+  has_many :moves, dependent: :restrict_with_exception
 
   # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates :name, :key, presence: true, uniqueness: true

--- a/db/migrate/20200708110909_add_supplier_to_moves.rb
+++ b/db/migrate/20200708110909_add_supplier_to_moves.rb
@@ -1,0 +1,5 @@
+class AddSupplierToMoves < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :moves, :supplier, type: :uuid, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_03_053232) do
+ActiveRecord::Schema.define(version: 2020_07_08_110909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -271,11 +271,13 @@ ActiveRecord::Schema.define(version: 2020_07_03_053232) do
     t.uuid "allocation_id"
     t.string "rejection_reason"
     t.uuid "original_move_id"
+    t.uuid "supplier_id"
     t.index ["allocation_id"], name: "index_moves_on_allocation_id"
     t.index ["created_at"], name: "index_moves_on_created_at"
     t.index ["date"], name: "index_moves_on_date"
     t.index ["prison_transfer_reason_id"], name: "index_moves_on_prison_transfer_reason_id"
     t.index ["reference"], name: "index_moves_on_reference", unique: true
+    t.index ["supplier_id"], name: "index_moves_on_supplier_id"
   end
 
   create_table "nationalities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -489,6 +491,7 @@ ActiveRecord::Schema.define(version: 2020_07_03_053232) do
   add_foreign_key "moves", "locations", column: "to_location_id", name: "fk_rails_moves_to_location_id"
   add_foreign_key "moves", "moves", column: "original_move_id"
   add_foreign_key "moves", "people", name: "fk_rails_moves_person_id"
+  add_foreign_key "moves", "suppliers"
   add_foreign_key "notifications", "notification_types"
   add_foreign_key "notifications", "subscriptions"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -13,6 +13,9 @@ FactoryBot.define do
     sequence(:created_at) { |n| Time.now - n.minutes }
     sequence(:date_from) { |n| Date.today - n.days }
 
+    trait :with_supplier do
+      association(:supplier)
+    end
     # Move types
     trait :court_appearance do
       # NB: Police / Prison / STC / SCH, YOI --> Court

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Move do
+  it { is_expected.to belong_to(:supplier).optional }
   it { is_expected.to belong_to(:from_location) }
   it { is_expected.to belong_to(:to_location).optional }
   it { is_expected.to belong_to(:profile).optional }

--- a/spec/models/supplier_spec.rb
+++ b/spec/models/supplier_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Supplier, type: :model do
 
   it { is_expected.to have_and_belong_to_many(:locations) }
   it { is_expected.to have_many(:subscriptions) }
+  it { is_expected.to have_many(:moves) }
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }


### PR DESCRIPTION
### Jira link

P4-1878

### What?

I have added/removed/altered:

- [x] Added supplier_id and indexes to moves table
- [x] Added `belongs_to` relationship to the `Move` model
- [x] Added `has_many` relationship to the `Supplier` model

### Why?

We are moving to having supplier ownership of moves. This is driven by the requirement that in the future two suppliers can have the same from location.

We can also more easily filter a suppliers moves in the frontend dashboard.