### PR TITLE
Add support for new video_remand_hearing move_type

### DIFF
--- a/app/controllers/api/move_events_controller.rb
+++ b/app/controllers/api/move_events_controller.rb
@@ -17,49 +17,49 @@ module Api
     COMMON_PARAMS = [:type, attributes: %i[timestamp notes]].freeze # for accept, complete and start move events
 
     def accept
-      MoveEvents::ParamsValidator.new(common_params).validate!
+      MoveEvents::ParamsValidator.new(move, common_params).validate!
       process_event(move, Event::ACCEPT, common_params)
       render status: :no_content
     end
 
     def approve
-      MoveEvents::ParamsValidator.new(approve_params).validate!
+      MoveEvents::ParamsValidator.new(move, approve_params).validate!
       process_event(move, Event::APPROVE, approve_params)
       render status: :no_content
     end
 
     def cancel
-      MoveEvents::ParamsValidator.new(cancel_params).validate!
+      MoveEvents::ParamsValidator.new(move, cancel_params).validate!
       process_event(move, Event::CANCEL, cancel_params)
       render status: :no_content
     end
 
     def complete
-      MoveEvents::ParamsValidator.new(common_params).validate!
+      MoveEvents::ParamsValidator.new(move, common_params).validate!
       process_event(move, Event::COMPLETE, common_params)
       render status: :no_content
     end
 
     def lockouts
-      MoveEvents::ParamsValidator.new(lockout_params).validate!
+      MoveEvents::ParamsValidator.new(move, lockout_params).validate!
       process_event(move, Event::LOCKOUT, lockout_params)
       render status: :no_content
     end
 
     def redirects
-      MoveEvents::ParamsValidator.new(redirect_params).validate!
+      MoveEvents::ParamsValidator.new(move, redirect_params).validate!
       process_event(move, Event::REDIRECT, redirect_params)
       render status: :no_content
     end
 
     def reject
-      MoveEvents::ParamsValidator.new(reject_params).validate!
+      MoveEvents::ParamsValidator.new(move, reject_params).validate!
       process_event(move, Event::REJECT, reject_params)
       render status: :no_content
     end
 
     def start
-      MoveEvents::ParamsValidator.new(common_params).validate!
+      MoveEvents::ParamsValidator.new(move, common_params).validate!
       process_event(move, Event::START, common_params)
       render status: :no_content
     end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -28,6 +28,7 @@ class Move < VersionedModel
     prison_recall: 'prison_recall',
     prison_transfer: 'prison_transfer',
     police_transfer: 'police_transfer',
+    video_remand_hearing: 'video_remand_hearing',
   }
 
   self.ignored_columns = %w[person_id]
@@ -60,8 +61,10 @@ class Move < VersionedModel
   has_many :move_events, as: :eventable, dependent: :destroy # NB: polymorphic association
 
   validates :from_location, presence: true
-  validates :to_location, presence: true, unless: :prison_recall?
+  validates :to_location, presence: true, unless: -> { prison_recall? || video_remand_hearing? }
   validates :move_type, inclusion: { in: move_types }
+  validates_with Moves::MoveTypeValidator
+
   validates :profile, presence: true, unless: -> { requested? || cancelled? }
   validates :reference, presence: true
 

--- a/app/services/journey_events/params_validator.rb
+++ b/app/services/journey_events/params_validator.rb
@@ -4,7 +4,7 @@ module JourneyEvents
   class ParamsValidator
     include ActiveModel::Validations
 
-    attr_reader :timestamp, :type, :from_location, :to_location
+    attr_reader :timestamp, :type, :from_location_id, :to_location_id
 
     validates :type, presence: true, inclusion: { in: %w[cancels completes lockouts lodgings starts rejects uncompletes uncancels] }
     validates_each :timestamp, presence: true do |record, attr, value|
@@ -12,14 +12,14 @@ module JourneyEvents
     rescue ArgumentError
       record.errors.add(attr, 'must be formatted as a valid ISO-8601 date-time')
     end
-    validates_with LocationValidator, locations: [:from_location], if: -> { type == 'lockouts' }
-    validates_with LocationValidator, locations: [:to_location], if: -> { type == 'lodgings' }
+    validates_with LocationValidator, locations: [:from_location_id], if: -> { type == 'lockouts' }
+    validates_with LocationValidator, locations: [:to_location_id], if: -> { type == 'lodgings' }
 
     def initialize(params)
       @timestamp = params.dig(:attributes, :timestamp)
       @type = params[:type]
-      @from_location = params.dig(:relationships, :from_location, :data, :id)
-      @to_location = params.dig(:relationships, :to_location, :data, :id)
+      @from_location_id = params.dig(:relationships, :from_location, :data, :id)
+      @to_location_id = params.dig(:relationships, :to_location, :data, :id)
     end
   end
 end

--- a/app/services/move_events/params_validator.rb
+++ b/app/services/move_events/params_validator.rb
@@ -11,7 +11,7 @@ module MoveEvents
     # TODO: in the future when pluralising types, existing move event records will need updating from singular types to plural types.
     ACCEPTABLE_PLURAL_VERBS = %w[cancels completes approves rejects].freeze
 
-    attr_reader :move, :timestamp, :type, :date, :cancellation_reason, :rejection_reason, :from_location, :to_location
+    attr_reader :move, :timestamp, :type, :date, :cancellation_reason, :rejection_reason, :from_location_id, :to_location_id
 
     validates :type, presence: true, inclusion: { in: %w[accepts approve cancel complete lockouts redirects reject starts] }
     validates :cancellation_reason, inclusion: { in: Move::CANCELLATION_REASONS }, if: -> { type == 'cancel' }
@@ -32,8 +32,8 @@ module MoveEvents
       record.errors.add(attr, 'must be formatted as a valid ISO-8601 date-time')
     end
 
-    validates_with LocationValidator, locations: [:from_location], if: -> { type == 'lockouts' }
-    validates_with LocationValidator, locations: [:to_location], if: -> { type == 'redirects' }
+    validates_with LocationValidator, locations: [:from_location_id], if: -> { type == 'lockouts' }
+    validates_with LocationValidator, locations: [:to_location_id], if: -> { type == 'redirects' }
     validates_with Moves::MoveTypeValidator, if: -> { type == 'redirects' }
 
     delegate :move_type, to: :move
@@ -45,8 +45,8 @@ module MoveEvents
       @date = params.dig(:attributes, :date)
       @cancellation_reason = params.dig(:attributes, :cancellation_reason)
       @rejection_reason = params.dig(:attributes, :rejection_reason)
-      @from_location = params.dig(:relationships, :from_location, :data, :id)
-      @to_location = params.dig(:relationships, :to_location, :data, :id)
+      @from_location_id = params.dig(:relationships, :from_location, :data, :id)
+      @to_location_id = params.dig(:relationships, :to_location, :data, :id)
       singularize_acceptable_plural_types
     end
 

--- a/app/services/move_events/params_validator.rb
+++ b/app/services/move_events/params_validator.rb
@@ -36,7 +36,7 @@ module MoveEvents
     validates_with LocationValidator, locations: [:to_location_id], if: -> { type == 'redirects' }
     validates_with Moves::MoveTypeValidator, if: -> { type == 'redirects' }
 
-    delegate :move_type, to: :move
+    delegate :move_type, :from_location, to: :move
 
     def initialize(move, params)
       @move = move

--- a/app/services/moves/move_type_validator.rb
+++ b/app/services/moves/move_type_validator.rb
@@ -6,13 +6,13 @@ module Moves
 
     def validate(record)
       @record = record
-      return unless record.move_type.present?
+      return if record.move_type.blank?
 
       # Apply more complex validation rules for specific move types
       validate_police_from_location if includes? %w[video_remand_hearing]
     end
 
-    private
+  private
 
     def includes?(move_types)
       move_types.include?(record.move_type.to_s)

--- a/app/services/moves/move_type_validator.rb
+++ b/app/services/moves/move_type_validator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Moves
+  class MoveTypeValidator < ActiveModel::Validator
+    attr_reader :record
+
+    def validate(record)
+      @record = record
+      return unless record.move_type.present?
+
+      # Apply more complex validation rules for specific move types
+      validate_police_from_location if includes? %w[video_remand_hearing]
+    end
+
+    private
+
+    def includes?(move_types)
+      move_types.include?(record.move_type.to_s)
+    end
+
+    def human_move_type
+      record.move_type.to_s.humanize(capitalize: false)
+    end
+
+    def validate_police_from_location
+      record.errors.add(:from_location, "must be a police location for #{human_move_type}") unless record.from_location&.police?
+    end
+  end
+end

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -43,6 +43,12 @@ FactoryBot.define do
       move_type { 'police_transfer' }
     end
 
+    trait :video_remand_hearing do
+      move_type { 'video_remand_hearing' }
+      association(:from_location, :police, factory: :location)
+      to_location { nil } # NB: to_location is always nil for a video_remand_hearing
+    end
+
     # Move statuses
     trait :proposed do
       status { 'proposed' }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -70,6 +70,27 @@ RSpec.describe Move do
     )
   end
 
+  it 'does NOT validate presence of `to_location` if `move_type` is video_remand_hearing' do
+    expect(build(:move, move_type: 'video_remand_hearing')).not_to(
+      validate_presence_of(:to_location),
+    )
+  end
+
+  context 'with video remand hearing `move_type`' do
+    let(:court) { build(:location, :court) }
+
+    it 'validates `from_location` is a prison location' do
+      move = build(:move, :video_remand_hearing)
+      expect(move).to be_valid
+    end
+
+    it 'has an error if `from_location` is not a prison location' do
+      move = build(:move, :video_remand_hearing, from_location: court)
+      move.valid?
+      expect(move.errors[:from_location]).to be_present
+    end
+  end
+
   it 'validates presence of `profile` if `status` is NOT requested or cancelled' do
     expect(build(:move, status: :proposed)).to(
       validate_presence_of(:profile),

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -70,14 +70,14 @@ RSpec.describe Move do
     )
   end
 
-  it 'does NOT validate presence of `to_location` if `move_type` is video_remand_hearing' do
-    expect(build(:move, move_type: 'video_remand_hearing')).not_to(
-      validate_presence_of(:to_location),
-    )
-  end
-
   context 'with video remand hearing `move_type`' do
     let(:court) { build(:location, :court) }
+
+    it 'does NOT validate presence of `to_location`' do
+      expect(build(:move, move_type: 'video_remand_hearing')).not_to(
+        validate_presence_of(:to_location),
+      )
+    end
 
     it 'validates `from_location` is a prison location' do
       move = build(:move, :video_remand_hearing)
@@ -87,7 +87,7 @@ RSpec.describe Move do
     it 'has an error if `from_location` is not a prison location' do
       move = build(:move, :video_remand_hearing, from_location: court)
       move.valid?
-      expect(move.errors[:from_location]).to be_present
+      expect(move.errors[:from_location]).to match_array('must be a police location for video remand hearing')
     end
   end
 

--- a/spec/requests/api/move_events_controller_lockout_spec.rb
+++ b/spec/requests/api/move_events_controller_lockout_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Api::MoveEventsController do
         end
       end
 
-      context 'with a non-existent from_location' do
+      context 'with a non-existent from_location_id' do
         let(:lockout_params) do
           {
             data: {
@@ -106,7 +106,7 @@ RSpec.describe Api::MoveEventsController do
         it_behaves_like 'an endpoint that responds with error 422' do
           let(:errors_422) do
             [{
-              'title' => 'Invalid from_location',
+              'title' => 'Invalid from_location_id',
               'detail' => 'Validation failed: From location was not found',
             }]
           end

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Api::MoveEventsController do
         end
       end
 
-      context 'with a non-existent to_location' do
+      context 'with a non-existent to_location_id' do
         let(:redirect_params) do
           {
             data: {
@@ -106,7 +106,7 @@ RSpec.describe Api::MoveEventsController do
         it_behaves_like 'an endpoint that responds with error 422' do
           let(:errors_422) do
             [{
-              'title' => 'Invalid to_location',
+              'title' => 'Invalid to_location_id',
               'detail' => 'Validation failed: To location was not found',
             }]
           end

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe Api::MoveEventsController do
       end
     end
 
+    context 'with a video remand hearing' do
+      let(:move) { create(:move, :video_remand_hearing) }
+
+      it 'populates the move to_location' do
+        expect { move.reload }.to change(move, :to_location).from(nil).to(new_location)
+      end
+    end
+
     context 'with a bad request' do
       let(:redirect_params) { nil }
 

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Api::MovesController do
         move_type: 'court_appearance' }
     end
 
-    let!(:from_location) { create :location, location_type: :prison, suppliers: [supplier] }
+    let!(:from_location) { create :location, suppliers: [supplier] }
     let!(:to_location) { create :location, :court }
     let!(:person) { create(:person) }
     let!(:document) { create(:document) }
@@ -251,7 +251,9 @@ RSpec.describe Api::MovesController do
       end
 
       context 'with explicit `move_type`' do
-        let(:move_attributes) { attributes_for(:move, move_type: 'prison_recall') }
+        let(:move_attributes) { attributes_for(:move, move_type: 'video_remand_hearing') }
+        let(:from_location) { create :location, :police, suppliers: [supplier] }
+        let(:to_location) { nil }
 
         it_behaves_like 'an endpoint that responds with success 201'
 
@@ -260,8 +262,8 @@ RSpec.describe Api::MovesController do
             .to change(Move, :count).by(1)
         end
 
-        it 'sets the move_type to `prison_recall`' do
-          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'prison_recall'
+        it 'sets the move_type to `video_remand_hearing`' do
+          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand_hearing'
         end
       end
 

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Api::MovesController do
     end
 
     let(:profile) { create(:profile) }
-    let(:from_location) { create :location, location_type: :prison, suppliers: [supplier] }
+    let(:from_location) { create :location, suppliers: [supplier] }
     let(:to_location) { create :location, :court }
     let(:reason) { create(:prison_transfer_reason) }
     let(:data) do
@@ -276,7 +276,9 @@ RSpec.describe Api::MovesController do
     end
 
     context 'with explicit `move_type`' do
-      let(:move_attributes) { attributes_for(:move, move_type: 'prison_recall') }
+      let(:move_attributes) { attributes_for(:move, move_type: 'video_remand_hearing') }
+      let(:from_location) { create :location, :police, suppliers: [supplier] }
+      let(:to_location) { nil }
 
       it_behaves_like 'an endpoint that responds with success 201' do
         before { do_post }
@@ -286,10 +288,10 @@ RSpec.describe Api::MovesController do
         expect { do_post }.to change(Move, :count).by(1)
       end
 
-      it 'sets the move_type to `prison_recall`' do
+      it 'sets the move_type to `video_remand_hearing`' do
         do_post
 
-        expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'prison_recall'
+        expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand_hearing'
       end
     end
 

--- a/spec/services/move_events/params_validator_spec.rb
+++ b/spec/services/move_events/params_validator_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe MoveEvents::ParamsValidator do
-  subject(:params_validator) { described_class.new(params) }
+  subject(:params_validator) { described_class.new(move, params) }
 
+  let(:move) { nil }
   let(:attributes) { { timestamp: timestamp } }
   let(:params) { { type: type, attributes: attributes } }
   let(:timestamp) { '2020-04-29T22:45:59.000Z' }
@@ -186,6 +187,7 @@ RSpec.describe MoveEvents::ParamsValidator do
   end
 
   describe 'to_location' do
+    let(:move) { build(:move, :prison_recall) }
     let(:params) { { type: type, attributes: attributes, relationships: relationships } }
     let(:relationships) { { to_location: { data: { type: 'locations', id: location_id } } } }
     let(:type) { 'redirects' }

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -44,6 +44,7 @@ Move:
           - prison_recall
           - prison_transfer
           - police_transfer
+          - video_remand_hearing
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
           oneOf:

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -44,6 +44,7 @@ Move:
             - prison_recall
             - prison_transfer
             - police_transfer
+            - video_remand_hearing
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
           oneOf:


### PR DESCRIPTION
### Jira link

P4-1816

### What?

- [x] Added new `video_remand_hearing` to `move_type` enum
- [x] Allow video remand hearing moves to be created without specifying a `to_location`
- [x] Enforce validation of `police` type for `from_location` when creating `video_remand_hearing`
- [x] Add new `MoveTypeValidator` class

### Why?

- This is the first of many new move types to be added, each introducing additional validation rules on the permitted from and to location types. As the first step to implementing support for these rules, validation of move type and associated location types is extracted to a new custom validator; this allows the logic to be shared across the move model and move runner.

### Have you? (optional)

- [x] Updated API docs if necessary - this will be updated further in future PR's to document the behaviour of the different move types

### Deployment risks (optional)

- Adds support for new move type, but does not change behaviour of existing move types