### PR TITLE
Prevent V2 patch move to update from_location and to_location

### DIFF
--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -25,18 +25,13 @@ module Api::V2
 
     def update_and_render
       raise ActiveRecord::ReadOnlyRecord, "Can't change moves coming from Nomis" if move.from_nomis?
-      q
+
       @move.assign_attributes(update_move_attributes)
-
-      def notify
-        if @move.valid?
-          action_name = @move.status_changed? ? 'update_status' : 'update'
-          Notifier.prepare_notifications(topic: @move, action_name: action_name)
-        end
-      end
-
+      action_name = @move.status_changed? ? 'update_status' : 'update'
       @move.save!
       @move.allocation&.refresh_status_and_moves_count!
+
+      Notifier.prepare_notifications(topic: @move, action_name: action_name)
 
       render_move(@move, :ok)
     end
@@ -67,12 +62,9 @@ module Api::V2
     end
 
     def move_attributes
-      move_params[:attributes].tap do |attributes|
-        attributes[:profile] = profile unless profile_attributes.nil?
+      update_move_attributes.tap do |attributes|
         attributes[:from_location] = from_location unless from_location_attributes.nil?
         attributes[:to_location] = to_location unless to_location_attributes.nil?
-        attributes[:court_hearings] = court_hearings unless court_hearing_attributes.nil?
-        attributes[:prison_transfer_reason] = prison_transfer_reason unless prison_transfer_reason_attributes.nil?
       end
     end
 

--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -26,7 +26,7 @@ module Api::V2
     def update_and_render
       raise ActiveRecord::ReadOnlyRecord, "Can't change moves coming from Nomis" if move.from_nomis?
 
-      @move.assign_attributes(update_move_attributes)
+      @move.assign_attributes(common_move_attributes)
       action_name = @move.status_changed? ? 'update_status' : 'update'
       @move.save!
       @move.allocation&.refresh_status_and_moves_count!
@@ -62,13 +62,13 @@ module Api::V2
     end
 
     def move_attributes
-      update_move_attributes.tap do |attributes|
+      common_move_attributes.tap do |attributes|
         attributes[:from_location] = from_location unless from_location_attributes.nil?
         attributes[:to_location] = to_location unless to_location_attributes.nil?
       end
     end
 
-    def update_move_attributes
+    def common_move_attributes
       move_params[:attributes].tap do |attributes|
         attributes[:profile] = profile unless profile_attributes.nil?
         attributes[:court_hearings] = court_hearings unless court_hearing_attributes.nil?

--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -25,13 +25,18 @@ module Api::V2
 
     def update_and_render
       raise ActiveRecord::ReadOnlyRecord, "Can't change moves coming from Nomis" if move.from_nomis?
+      q
+      @move.assign_attributes(update_move_attributes)
 
-      @move.assign_attributes(move_attributes)
-      action_name = @move.status_changed? ? 'update_status' : 'update'
+      def notify
+        if @move.valid?
+          action_name = @move.status_changed? ? 'update_status' : 'update'
+          Notifier.prepare_notifications(topic: @move, action_name: action_name)
+        end
+      end
+
       @move.save!
       @move.allocation&.refresh_status_and_moves_count!
-
-      Notifier.prepare_notifications(topic: @move, action_name: action_name)
 
       render_move(@move, :ok)
     end
@@ -66,6 +71,14 @@ module Api::V2
         attributes[:profile] = profile unless profile_attributes.nil?
         attributes[:from_location] = from_location unless from_location_attributes.nil?
         attributes[:to_location] = to_location unless to_location_attributes.nil?
+        attributes[:court_hearings] = court_hearings unless court_hearing_attributes.nil?
+        attributes[:prison_transfer_reason] = prison_transfer_reason unless prison_transfer_reason_attributes.nil?
+      end
+    end
+
+    def update_move_attributes
+      move_params[:attributes].tap do |attributes|
+        attributes[:profile] = profile unless profile_attributes.nil?
         attributes[:court_hearings] = court_hearings unless court_hearing_attributes.nil?
         attributes[:prison_transfer_reason] = prison_transfer_reason unless prison_transfer_reason_attributes.nil?
       end

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -24,15 +24,9 @@ RSpec.describe Api::MovesController do
   end
 
   describe 'PATCH /moves' do
-    let!(:move) do
-      create :move, :proposed,
-             move_type: 'prison_recall',
-             from_location: from_location,
-             # to_location: to_location,
-             profile: profile
-    end
+    let!(:move) { create :move, :proposed, move_type: 'prison_recall', from_location: from_location, profile: profile }
+
     let(:from_location) { create :location, suppliers: [supplier] }
-    let(:to_location) { nil }
     let(:move_id) { move.id }
     let(:profile) { create(:profile) }
     let(:date_from) { Date.yesterday }

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -203,9 +203,6 @@ RSpec.describe Api::MovesController do
       end
 
       it 'does not affect both from_location and to_location' do
-        do_patch
-
-        move.reload
 
         expect { do_patch }.not_to change {
           [move.reload.from_location,

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -203,7 +203,6 @@ RSpec.describe Api::MovesController do
       end
 
       it 'does not affect both from_location and to_location' do
-
         expect { do_patch }.not_to change {
           [move.reload.from_location,
            move.reload.to_location]

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -24,8 +24,15 @@ RSpec.describe Api::MovesController do
   end
 
   describe 'PATCH /moves' do
-    let!(:move) { create :move, :proposed, move_type: 'prison_recall', from_location: from_location, profile: profile }
+    let!(:move) do
+      create :move, :proposed,
+             move_type: 'prison_recall',
+             from_location: from_location,
+             # to_location: to_location,
+             profile: profile
+    end
     let(:from_location) { create :location, suppliers: [supplier] }
+    let(:to_location) { nil }
     let(:move_id) { move.id }
     let(:profile) { create(:profile) }
     let(:date_from) { Date.yesterday }
@@ -181,6 +188,35 @@ RSpec.describe Api::MovesController do
 
           expect(move.reload.profile).to be_nil
         end
+      end
+    end
+
+    context 'when trying to update from_location and to_location' do
+      let(:new_from_location) { create :location }
+      let(:new_to_location) { create :location }
+
+      let(:move_params) do
+        {
+          type: 'moves',
+          attributes: {
+            status: 'requested',
+          },
+          relationships: {
+            from_location: { data: { type: 'locations', id: new_from_location.id } },
+            to_location: { data: { type: 'locations', id: new_to_location.id } },
+          },
+        }
+      end
+
+      it 'does not affect from_location' do
+        do_patch
+
+        move.reload
+
+        expect { do_patch }.not_to change {
+          [move.reload.from_location,
+           move.reload.to_location]
+        }
       end
     end
 

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Api::MovesController do
         }
       end
 
-      it 'does not affect from_location' do
+      it 'does not affect both from_location and to_location' do
         do_patch
 
         move.reload


### PR DESCRIPTION
### Jira link

P4-1904-prevent-updating-from-to

### What?
Fix the v2 move endpoint to ensure that from_location and to_location cannot be updated.

### Why?
This functionality was overlooked when creating the V2 endpoint. We still need it for V2.

