### PR TITLE
[P4-1906] Fix v2 profile serialization

### DIFF
--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -18,7 +18,7 @@ module V2
                :time_due,
                :updated_at
 
-    has_one :profile, serializer: ProfileSerializer
+    has_one :profile, serializer: V2::ProfileSerializer
     has_one :from_location, serializer: LocationSerializer
     has_one :to_location, serializer: LocationSerializer
     has_one :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
@@ -47,3 +47,4 @@ module V2
     }.freeze
   end
 end
+

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -47,4 +47,3 @@ module V2
     }.freeze
   end
 end
-

--- a/app/serializers/v2/profile_serializer.rb
+++ b/app/serializers/v2/profile_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class V2::ProfileSerializer < ActiveModel::Serializer
+  attributes(
+    :assessment_answers,
+  )
+
+  belongs_to :person, serializer: V2::PersonSerializer
+  has_many :documents, serializer: DocumentSerializer
+
+  SUPPORTED_RELATIONSHIPS = %w[documents person].freeze
+end
+

--- a/app/serializers/v2/profile_serializer.rb
+++ b/app/serializers/v2/profile_serializer.rb
@@ -10,4 +10,3 @@ class V2::ProfileSerializer < ActiveModel::Serializer
 
   SUPPORTED_RELATIONSHIPS = %w[documents person].freeze
 end
-

--- a/spec/serializers/v2/profile_serializer_spec.rb
+++ b/spec/serializers/v2/profile_serializer_spec.rb
@@ -88,4 +88,3 @@ RSpec.describe V2::ProfileSerializer do
     end
   end
 end
-

--- a/spec/serializers/v2/profile_serializer_spec.rb
+++ b/spec/serializers/v2/profile_serializer_spec.rb
@@ -99,4 +99,3 @@ RSpec.describe V2::ProfileSerializer do
     end
   end
 end
-

--- a/spec/serializers/v2/profile_serializer_spec.rb
+++ b/spec/serializers/v2/profile_serializer_spec.rb
@@ -63,6 +63,17 @@ RSpec.describe V2::ProfileSerializer do
   describe 'with supported includes' do
     let(:profile) { create(:profile, documents: [create(:document)]) }
     let(:adapter_options) { { include: 'documents,person' } }
+    let(:serialized_person) do
+      serializer = V2::PersonSerializer.new(profile.person)
+
+      JSON.parse(ActiveModelSerializers::Adapter.create(serializer, {}).to_json).deep_symbolize_keys
+    end
+
+    let(:serialized_document) do
+      serializer = DocumentSerializer.new(profile.documents.first)
+
+      JSON.parse(ActiveModelSerializers::Adapter.create(serializer, {}).to_json).deep_symbolize_keys
+    end
 
     let(:expected_document) do
       {
@@ -77,7 +88,7 @@ RSpec.describe V2::ProfileSerializer do
             documents: { data: [{ id: profile.documents.first.id, type: 'documents' }] },
           },
         },
-        included: [{ id: profile.person.id, type: 'people' }, { id: profile.documents.first.id, type: 'documents' }],
+        included: [serialized_person[:data], serialized_document[:data]],
       }
     end
 
@@ -88,3 +99,4 @@ RSpec.describe V2::ProfileSerializer do
     end
   end
 end
+

--- a/spec/serializers/v2/profile_serializer_spec.rb
+++ b/spec/serializers/v2/profile_serializer_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V2::ProfileSerializer do
+  subject(:serializer) { described_class.new(profile) }
+
+  let(:profile) { create(:profile) }
+  let(:adapter_options) { {} }
+  let(:result) { JSON.parse(ActiveModelSerializers::Adapter.create(serializer, adapter_options).to_json).deep_symbolize_keys }
+
+  let(:expected_document) do
+    {
+      data: {
+        id: profile.id,
+        type: 'profiles',
+        attributes: { assessment_answers: [] },
+        relationships: {
+          person: {
+            data: { id: profile.person.id, type: 'people' },
+          },
+          documents: {
+            data: [],
+          },
+        },
+      },
+    }
+  end
+
+  it 'returns the expected serialized `Profile`' do
+    expect(result).to eq(expected_document)
+  end
+
+  context 'with assessment_answers' do
+    let(:risk_alert_type) { create :assessment_question, :risk }
+    let(:health_alert_type) { create :assessment_question, :health }
+
+    let(:risk_alert) do
+      {
+        title: risk_alert_type.title,
+        comments: 'Former miner',
+        assessment_question_id: risk_alert_type.id,
+      }
+    end
+
+    let(:health_alert) do
+      {
+        title: health_alert_type.title,
+        comments: 'Needs something for a headache',
+        assessment_question_id: health_alert_type.id,
+      }
+    end
+
+    let(:profile) { create(:profile, assessment_answers: [risk_alert, health_alert]) }
+
+    it 'contains an `assessment_answers` nested collection' do
+      assessment_answers = result[:data][:attributes][:assessment_answers].map { |alert| alert[:title] }
+
+      expect(assessment_answers).to match_array [risk_alert_type.title, health_alert_type.title]
+    end
+  end
+
+  describe 'with supported includes' do
+    let(:profile) { create(:profile, documents: [create(:document)]) }
+    let(:adapter_options) { { include: 'documents,person' } }
+
+    let(:expected_document) do
+      {
+        data: {
+          id: profile.id,
+          type: 'profiles',
+          attributes: { assessment_answers: [] },
+          relationships: {
+            person: {
+              data: { id: profile.person.id, type: 'people' },
+            },
+            documents: { data: [{ id: profile.documents.first.id, type: 'documents' }] },
+          },
+        },
+        included: [{ id: profile.person.id, type: 'people' }, { id: profile.documents.first.id, type: 'documents' }],
+      }
+    end
+
+    before { ActiveStorage::Current.host = 'http://www.example.com' } # This is used in the serializer
+
+    it 'returns the expected serialized `Profile`' do
+      expect(result).to include_json(expected_document)
+    end
+  end
+end
+


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Added v2 profile serializer and specs
- [x] Altered v2 move serializer to use v2 profile serializer

### Why?

We need to conform to the swagger documentation for v2 and make sure that we're not coupling to v1 people.