### PR TITLE
Prevent access to Nomis when assessment_answers are passed.

### DIFF
--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -5,7 +5,7 @@ module Api
     def create
       profile = person.profiles.create(profile_attributes)
 
-      if person.prison_number.present?
+      if person.prison_number.present? && profile_attributes[:assessment_answers].blank?
         Profiles::ImportAlertsAndPersonalCareNeeds.new(profile, person.prison_number).call
       end
 
@@ -16,6 +16,7 @@ module Api
       profile = person.profiles.find(params.require(:id))
 
       profile.update!(profile_attributes)
+
       render_profile(profile, :ok)
     end
 

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2283,10 +2283,10 @@
   "/people/{person_id}/profiles":
     post:
       summary: Creates a new profile
-      description: "This creates a new profile for a person. If the person has a
-        prison_number, the new profile is updated with Alerts and Personal Care
-        Needs from NOMIS.
-
+      description: "This creates a new profile for a person.<br>
+        Note: this endpoint accesses to Nomis:<br>
+        If the `assessment_answers` param is not present AND the person's profile has a `prison_number`
+        THEN the new profile will be updated with Alerts and Personal Care from NOMIS.
         "
       tags:
         - Profiles

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2284,7 +2284,7 @@
     post:
       summary: Creates a new profile
       description: "This creates a new profile for a person.<br>
-        Note: this endpoint accesses to Nomis:<br>
+        Note: this endpoint retrieves Assessment Answers from Nomis:<br>
         If the `assessment_answers` param is not present AND the person's profile has a `prison_number`
         THEN the new profile will be updated with Alerts and Personal Care from NOMIS.
         "

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2285,7 +2285,7 @@
       summary: Creates a new profile
       description: "This creates a new profile for a person.<br>
         Note: this endpoint retrieves Assessment Answers from Nomis:<br>
-        If the `assessment_answers` param is not present AND the person's profile has a `prison_number`
+        If the `assessment_answers` param is not present AND the person has a `prison_number`
         THEN the new profile will be updated with Alerts and Personal Care from NOMIS.
         "
       tags:

--- a/swagger/v1/profile.yaml
+++ b/swagger/v1/profile.yaml
@@ -18,8 +18,6 @@ Profile:
       description: The type of this object - always `profiles`
     attributes:
       type: object
-      required:
-        - assessment_answers
       properties:
         assessment_answers:
           type: array


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-1881

### What?

If the `assessment_answers` param is not present AND the person's profile has a `prison_number`
THEN the new profile will be updated with Alerts and Personal Care from NOMIS.

I have added/removed/altered:

the endpoint POST /people/:id/profiles

### Why?
This is because an individual may have been out (released) for a while and when they are remanded at court NOMIS would be out of date

### Have you? (optional)

- [x] Updated API docs if necessary	
