### PR TITLE
* Use a partitioned S3 prefix format for daily runs

### DIFF
--- a/lib/tasks/journeys_report.rake
+++ b/lib/tasks/journeys_report.rake
@@ -7,6 +7,7 @@ namespace :journeys do
   task json_report: :environment do
     date = ENV['REPORT_DATE'] || Date.yesterday.to_s
     report_date = Date.parse(date).strftime('%Y/%m/%d')
+    report_prefix = Date.parse(date).strftime('%Y-%m-%d')
     bucket_name = ENV['S3_REPORTING_BUCKET_NAME'] || raise('S3_REPORTING_BUCKET_NAME not defined')
 
     puts report_date
@@ -20,7 +21,7 @@ namespace :journeys do
     end
 
     Supplier.order(:key).each do |supplier|
-      filename = "#{supplier.key}.json"
+      filename = "#{report_prefix}-#{supplier.key}.json"
       print "Generating #{filename}..."
       moves = []
       # Only include moves with journeys on them.

--- a/lib/tasks/journeys_report.rake
+++ b/lib/tasks/journeys_report.rake
@@ -54,7 +54,8 @@ namespace :journeys do
           id: move.id,
           supplier: supplier.key,
           reference: move.reference,
-          notification_date: move.created_at.to_date, # TODO: use notifications table
+          notification_date: move.created_at, # TODO: use notifications table
+          updated_at: move.updated_at,
           move_date: move.date,
           from: move.from_location.nomis_agency_id,
           to: move.to_location&.nomis_agency_id,


### PR DESCRIPTION
* Run report for a given calendar day (defaults to yesterday)

### Jira link

[[P4-1897](https://dsdmoj.atlassian.net/browse/P4-1897)]

### What?

I have added/removed/altered:

- [ ] Use an S3 partitioned prefix format
- [ ] Run report for a single day interval, defined or defaults to yesterday. 

new format:
```
 awslocal s3 ls --recursive s3://reports
2020-07-09 14:55:11     610923 2020/07/05/geoamey.json
2020-07-09 14:55:22     444080 2020/07/05/serco.json
2020-07-09 14:35:52    1278690 2020/07/08/geoamey.json
2020-07-09 14:36:16     819143 2020/07/08/serco.json
2020-07-09 13:20:52    1278690 2020/07/09/geoamey.json
2020-07-09 13:21:12     819143 2020/07/09/serco.json
```
### Why?

I am doing this because:
- Aligned the reporting service with the intended daily frequency as opposed to an arbitrary one.
- Allows to back fill specific days manually if required.

### Have you? (optional)

### Deployment risks (optional)

- It has an impact  downstream on the integration with the HUB team, but these changes were negotiated and agreed. 

