### PR TITLE
P4-1761 POST /person_escort_records endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,19 +16,17 @@ group :production do
   gem 'appinsights', github: 'ministryofjustice/appinsights'
 end
 
+gem 'activerecord-import', '~> 1.0', '>= 1.0.5'
 gem 'aws-sdk-s3', require: false
 gem 'bcrypt', require: false
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'cancancan'
-# explicit soft-deletes
 gem 'discard'
 gem 'doorkeeper'
 gem 'elastic-apm'
 gem 'faraday'
 gem 'finite_machine'
 gem 'govuk_notify_rails', '~> 2.1.2'
-# static page serving for extra API documentation
-gem 'activerecord-import', '~> 1.0', '>= 1.0.5'
 gem 'json-schema'
 gem 'kaminari'
 gem 'net-http-persistent'

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'faraday'
 gem 'finite_machine'
 gem 'govuk_notify_rails', '~> 2.1.2'
 # static page serving for extra API documentation
+gem 'activerecord-import', '~> 1.0', '>= 1.0.5'
 gem 'json-schema'
 gem 'kaminari'
 gem 'net-http-persistent'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
     activerecord (6.0.3.2)
       activemodel (= 6.0.3.2)
       activesupport (= 6.0.3.2)
+    activerecord-import (1.0.5)
+      activerecord (>= 3.2)
     activestorage (6.0.3.2)
       actionpack (= 6.0.3.2)
       activejob (= 6.0.3.2)
@@ -400,6 +402,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
+  activerecord-import (~> 1.0, >= 1.0.5)
   appinsights!
   aws-sdk-s3
   bcrypt

--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Api
+  class PersonEscortRecordsController < ApiController
+    NEW_PERMITTED_PER_PARAMS = [
+      :type,
+      attributes: [:version],
+      relationships: [profile: {}],
+    ].freeze
+
+    def create
+      person_escort_record = PersonEscortRecord.save_with_responses!(
+        version: new_person_escort_record_params.dig(:attributes, :version),
+        profile_id: new_person_escort_record_params.dig(:relationships, :profile, :data, :id),
+      )
+
+      render json: person_escort_record, status: :created, include: included_relationships
+    end
+
+  private
+
+    def new_person_escort_record_params
+      params.require(:data).permit(NEW_PERMITTED_PER_PARAMS).to_h
+    end
+
+    def supported_relationships
+      PersonEscortRecordSerializer::SUPPORTED_RELATIONSHIPS
+    end
+  end
+end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -7,4 +7,6 @@ class Framework < ApplicationRecord
 
   has_many :framework_questions
   has_many :person_escort_records
+
+  scope :ordered_by_latest_version, -> { order(Arel.sql('cast(version as double precision) desc')) }
 end

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -34,7 +34,7 @@ class FrameworkQuestion < VersionedModel
     response
   end
 
-  private
+private
 
   def build_response(question, person_escort_record)
     klass =

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -17,7 +17,36 @@ class FrameworkQuestion < VersionedModel
                         foreign_key: 'parent_id'
   belongs_to :parent, class_name: 'FrameworkQuestion', optional: true
 
-
   has_many :flags
   has_many :framework_responses
+
+  def build_responses(question: self, person_escort_record:)
+    response = build_response(question, person_escort_record)
+    return response unless question.dependents.any?
+
+    question.dependents.find_each do |dependent_question|
+      dependent_response = build_responses(question: dependent_question, person_escort_record: person_escort_record)
+      dependent_response_values = dependent_response.slice(:type, :framework_question_id, :dependents, :person_escort_record)
+
+      response.dependents.build(dependent_response_values)
+    end
+
+    response
+  end
+
+  private
+
+  def build_response(question, person_escort_record)
+    klass =
+      case question.question_type
+      when 'radio'
+        question.followup_comment ? FrameworkResponse::Object : FrameworkResponse::String
+      when 'checkbox'
+        question.followup_comment ? FrameworkResponse::Collection : FrameworkResponse::Array
+      else
+        FrameworkResponse::String
+      end
+
+    klass.new(framework_question_id: question.id, person_escort_record: person_escort_record)
+  end
 end

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -15,8 +15,9 @@ class FrameworkQuestion < VersionedModel
   belongs_to :framework
   has_many :dependents, class_name: 'FrameworkQuestion',
                         foreign_key: 'parent_id'
-
   belongs_to :parent, class_name: 'FrameworkQuestion', optional: true
+
+
   has_many :flags
   has_many :framework_responses
 end

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -20,14 +20,14 @@ class FrameworkQuestion < VersionedModel
   has_many :flags
   has_many :framework_responses
 
-  def build_responses(question: self, person_escort_record:)
+  def build_responses(question: self, person_escort_record:, questions:)
     response = build_response(question, person_escort_record)
-    return response unless question.dependents.any?
+    return response if question.dependents.empty?
 
-    question.dependents.find_each do |dependent_question|
-      dependent_response = build_responses(question: dependent_question, person_escort_record: person_escort_record)
+    question.dependents.each do |dependent_question|
+      # NB: to avoid extra queries use original set of questions
+      dependent_response = build_responses(question: questions[dependent_question.id], person_escort_record: person_escort_record, questions: questions)
       dependent_response_values = dependent_response.slice(:type, :framework_question_id, :dependents, :person_escort_record)
-
       response.dependents.build(dependent_response_values)
     end
 

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -27,8 +27,11 @@ class PersonEscortRecord < VersionedModel
     ActiveRecord::Base.transaction do
       save!
 
-      framework_questions.includes(:parent, :dependents).where(framework_question_parents: { parent_id: nil }).find_each do |question|
-        response = question.build_responses(person_escort_record: self)
+      questions = framework_questions.includes(:dependents).index_by(&:id)
+      questions.values.each do |question|
+        next unless question.parent_id.nil?
+
+        response = question.build_responses(person_escort_record: self, questions: questions)
         framework_responses.build(response.slice(:type, :framework_question_id, :dependents))
       end
 

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -7,6 +7,9 @@ class PersonEscortRecord < VersionedModel
 
   validates :state, presence: true, inclusion: { in: states }
   has_many :framework_responses, dependent: :destroy
+
   belongs_to :framework
+  has_many :framework_questions, through: :framework
   belongs_to :profile
+  validates :profile, uniqueness: true
 end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -1,6 +1,5 @@
 class PersonEscortRecord < VersionedModel
   enum states: {
-    not_started: 'not_started',
     in_progress: 'in_progress',
     completed: 'completed',
     confirmed: 'confirmed',

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -12,4 +12,29 @@ class PersonEscortRecord < VersionedModel
   has_many :framework_questions, through: :framework
   belongs_to :profile
   validates :profile, uniqueness: true
+
+  def self.save_with_responses!(profile_id:, version: nil)
+    profile = Profile.find(profile_id)
+    # TODO: remove default framework, getting the last framework is temporary until versioning is finalised
+    framework = version.present? ? Framework.find_by!(version: version) : Framework.ordered_by_latest_version.first
+
+    # TODO: add state machine
+    record = new(profile: profile, framework: framework, state: 'in_progress')
+    record.build_responses!
+  end
+
+  def build_responses!
+    ActiveRecord::Base.transaction do
+      save!
+
+      framework_questions.includes(:parent, :dependents).where(framework_question_parents: { parent_id: nil }).find_each do |question|
+        response = question.build_responses(person_escort_record: self)
+        framework_responses.build(response.slice(:type, :framework_question_id, :dependents))
+      end
+
+      PersonEscortRecord.import([self], validate: false, recursive: true, all_or_none: true, validate_uniqueness: true, on_duplicate_key_update: { conflict_target: [:id] })
+    end
+
+    self
+  end
 end

--- a/app/serializers/framework_question_serializer.rb
+++ b/app/serializers/framework_question_serializer.rb
@@ -1,0 +1,9 @@
+class FrameworkQuestionSerializer < ActiveModel::Serializer
+  belongs_to :framework
+
+  attributes :key, :question_type, :options
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    framework
+  ].freeze
+end

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -1,0 +1,25 @@
+class FrameworkResponseSerializer < ActiveModel::Serializer
+  type 'framework_responses'
+  belongs_to :person_escort_record
+  belongs_to :framework_question, key: :question
+
+  attributes :value, :value_type
+
+  def value_type
+    case object.type
+    when 'FrameworkResponse::String'
+      'string'
+    when 'FrameworkResponse::Array'
+      'array'
+    when 'FrameworkResponse::Object'
+      'object'
+    when 'FrameworkResponse::Collection'
+      'collection'
+    end
+  end
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    person_escort_record
+    framework_question
+  ].freeze
+end

--- a/app/serializers/framework_serializer.rb
+++ b/app/serializers/framework_serializer.rb
@@ -1,0 +1,9 @@
+class FrameworkSerializer < ActiveModel::Serializer
+  has_many :framework_questions, key: :questions
+
+  attributes :name, :version
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    questions
+  ].freeze
+end

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -1,0 +1,25 @@
+class PersonEscortRecordSerializer < ActiveModel::Serializer
+  belongs_to :profile, record_type: :profile
+  belongs_to :framework, record_type: :framework
+  has_many :framework_responses, serializer: FrameworkResponseSerializer, key: :responses
+
+  attributes :version, :status
+
+  def status
+    object.state
+  end
+
+  def version
+    object.framework.version
+  end
+
+  def framework_responses
+    object.framework_responses.includes(framework_question: :framework)
+  end
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    framework
+    profile.person
+    responses.question
+  ].freeze
+end

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -3,11 +3,8 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   belongs_to :framework, record_type: :framework
   has_many :framework_responses, serializer: FrameworkResponseSerializer, key: :responses
 
-  attributes :version, :status
-
-  def status
-    object.state
-  end
+  attribute :version
+  attribute :state, key: :status
 
   def version
     object.framework.version

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,9 @@ Rails.application.routes.draw do
         post 'start', controller: 'move_events'
       end
     end
+
+    resources :person_escort_records, only: %i[create]
+
     namespace :reference do
       resources :allocation_complex_cases, only: :index
       resources :assessment_questions, only: :index

--- a/db/migrate/20200710061513_add_unique_index_on_person_escort_record.rb
+++ b/db/migrate/20200710061513_add_unique_index_on_person_escort_record.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexOnPersonEscortRecord < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :person_escort_records, :profile_id
+    add_index :person_escort_records, :profile_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2020_07_13_092251) do
+=======
+ActiveRecord::Schema.define(version: 2020_07_10_061513) do
+>>>>>>> P4-1761 Add uniq index on profile
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -401,7 +405,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_092251) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
-    t.index ["profile_id"], name: "index_person_escort_records_on_profile_id"
+    t.index ["profile_id"], name: "index_person_escort_records_on_profile_id", unique: true
   end
 
   create_table "prison_transfer_reasons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2020_07_13_092251) do
-=======
-ActiveRecord::Schema.define(version: 2020_07_10_061513) do
->>>>>>> P4-1761 Add uniq index on profile
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/factories/framework_question.rb
+++ b/spec/factories/framework_question.rb
@@ -7,5 +7,20 @@ FactoryBot.define do
     section { 'risk' }
     question_type { 'radio' }
     options { %w[Yes No] }
+
+    trait :text do
+      question_type { 'text' }
+      options { [] }
+    end
+
+    trait :textarea do
+      question_type { 'textarea' }
+      options { [] }
+    end
+
+    trait :checkbox do
+      question_type { 'checkbox' }
+      options { ['Level 1', 'Level 2'] }
+    end
   end
 end

--- a/spec/factories/person_escort_record.rb
+++ b/spec/factories/person_escort_record.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :person_escort_record do
     association(:framework)
     association(:profile)
-    state { 'not_started' }
+    state { 'in_progress' }
   end
 end

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -14,4 +14,121 @@ RSpec.describe FrameworkQuestion do
   it { is_expected.to have_many(:dependents) }
   it { is_expected.to have_many(:flags) }
   it { is_expected.to have_many(:framework_responses) }
+
+  describe '#build_responses' do
+    it 'builds a string response for radio questions' do
+      question = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+
+      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::String)
+    end
+
+    it 'builds an array response for checkbox questions' do
+      question = create(:framework_question, :checkbox)
+      person_escort_record = create(:person_escort_record)
+
+      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::Array)
+    end
+
+    it 'builds a string response for text questions' do
+      question = create(:framework_question, :text)
+      person_escort_record = create(:person_escort_record)
+
+      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::String)
+    end
+
+    it 'builds a string response for textarea questions' do
+      question = create(:framework_question, :textarea)
+      person_escort_record = create(:person_escort_record)
+
+      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::String)
+    end
+
+    it 'builds an object response for radio with followup questions' do
+      question = create(:framework_question, followup_comment: true)
+      person_escort_record = create(:person_escort_record)
+
+      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::Object)
+    end
+
+    it 'builds a collection response for checkbox with followup questions' do
+      question = create(:framework_question, :checkbox, followup_comment: true)
+      person_escort_record = create(:person_escort_record)
+
+      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::Collection)
+    end
+
+    it 'builds response associated to correct question' do
+      question1 = create(:framework_question)
+      question2 = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+      response = question1.build_responses(person_escort_record: person_escort_record, question: question2)
+
+      expect(response.framework_question).to eq(question2)
+    end
+
+    it 'builds response associated to correct person_escort_record' do
+      question = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_responses(person_escort_record: person_escort_record)
+
+      expect(response.person_escort_record).to eq(person_escort_record)
+    end
+
+    it 'builds response and defaults to current question' do
+      question = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_responses(person_escort_record: person_escort_record)
+
+      expect(response.framework_question).to eq(question)
+    end
+
+    it 'builds response dependents if question is dependent' do
+      person_escort_record = create(:person_escort_record)
+      question = create(:framework_question)
+      create(:framework_question, :checkbox, parent: question)
+      create(:framework_question, :textarea, parent: question)
+
+      expect(question.build_responses(person_escort_record: person_escort_record).dependents.size).to eq(2)
+    end
+
+    it 'builds response dependents associated to correct dependent question' do
+      person_escort_record = create(:person_escort_record)
+      question = create(:framework_question)
+      dependent_question = create(:framework_question, :checkbox, parent: question)
+
+      expect(question.build_responses(person_escort_record: person_escort_record).dependents.first.framework_question).to eq(dependent_question)
+    end
+
+    it 'sets person_escort_record on dependent responses' do
+      person_escort_record = create(:person_escort_record)
+      question = create(:framework_question)
+      create(:framework_question, :checkbox, parent: question)
+
+      expect(question.build_responses(person_escort_record: person_escort_record).dependents.first.person_escort_record).to eq(person_escort_record)
+    end
+
+    it 'sets correct types on dependent responses' do
+      person_escort_record = create(:person_escort_record)
+      question = create(:framework_question)
+      create(:framework_question, :checkbox, followup_comment: true, parent: question)
+      create(:framework_question, :textarea, parent: question)
+
+      expect(question.build_responses(person_escort_record: person_escort_record).dependents.map(&:type)).to contain_exactly(
+        'FrameworkResponse::Collection',
+        'FrameworkResponse::String',
+      )
+    end
+
+    it 'builds response with multiple levels of nested dependent responses' do
+      person_escort_record = create(:person_escort_record)
+      parent_question = create(:framework_question, :textarea)
+      child_question = create(:framework_question, :checkbox, followup_comment: true, parent: parent_question)
+      create(:framework_question, parent: child_question)
+      create(:framework_question, parent: child_question)
+
+      dependent_responses = parent_question.build_responses(person_escort_record: person_escort_record).dependents
+      expect(dependent_responses.first.dependents.size).to eq(2)
+    end
+  end
 end

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -16,53 +16,83 @@ RSpec.describe FrameworkQuestion do
   it { is_expected.to have_many(:framework_responses) }
 
   describe '#build_responses' do
+    let(:questions) { described_class.all.index_by(&:id) }
+
     it 'builds a string response for radio questions' do
       question = create(:framework_question)
       person_escort_record = create(:person_escort_record)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::String)
+      expect(response).to be_a(FrameworkResponse::String)
     end
 
     it 'builds an array response for checkbox questions' do
       question = create(:framework_question, :checkbox)
       person_escort_record = create(:person_escort_record)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::Array)
+      expect(response).to be_a(FrameworkResponse::Array)
     end
 
     it 'builds a string response for text questions' do
       question = create(:framework_question, :text)
       person_escort_record = create(:person_escort_record)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::String)
+      expect(response).to be_a(FrameworkResponse::String)
     end
 
     it 'builds a string response for textarea questions' do
       question = create(:framework_question, :textarea)
       person_escort_record = create(:person_escort_record)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::String)
+      expect(response).to be_a(FrameworkResponse::String)
     end
 
     it 'builds an object response for radio with followup questions' do
       question = create(:framework_question, followup_comment: true)
       person_escort_record = create(:person_escort_record)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::Object)
+      expect(response).to be_a(FrameworkResponse::Object)
     end
 
     it 'builds a collection response for checkbox with followup questions' do
       question = create(:framework_question, :checkbox, followup_comment: true)
       person_escort_record = create(:person_escort_record)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      expect(question.build_responses(person_escort_record: person_escort_record)).to be_a(FrameworkResponse::Collection)
+      expect(response).to be_a(FrameworkResponse::Collection)
     end
 
     it 'builds response associated to correct question' do
       question1 = create(:framework_question)
       question2 = create(:framework_question)
       person_escort_record = create(:person_escort_record)
-      response = question1.build_responses(person_escort_record: person_escort_record, question: question2)
+      response = question1.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+        question: question2,
+      )
 
       expect(response.framework_question).to eq(question2)
     end
@@ -70,7 +100,10 @@ RSpec.describe FrameworkQuestion do
     it 'builds response associated to correct person_escort_record' do
       question = create(:framework_question)
       person_escort_record = create(:person_escort_record)
-      response = question.build_responses(person_escort_record: person_escort_record)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
       expect(response.person_escort_record).to eq(person_escort_record)
     end
@@ -78,7 +111,10 @@ RSpec.describe FrameworkQuestion do
     it 'builds response and defaults to current question' do
       question = create(:framework_question)
       person_escort_record = create(:person_escort_record)
-      response = question.build_responses(person_escort_record: person_escort_record)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
       expect(response.framework_question).to eq(question)
     end
@@ -88,24 +124,36 @@ RSpec.describe FrameworkQuestion do
       question = create(:framework_question)
       create(:framework_question, :checkbox, parent: question)
       create(:framework_question, :textarea, parent: question)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      expect(question.build_responses(person_escort_record: person_escort_record).dependents.size).to eq(2)
+      expect(response.dependents.size).to eq(2)
     end
 
     it 'builds response dependents associated to correct dependent question' do
       person_escort_record = create(:person_escort_record)
       question = create(:framework_question)
       dependent_question = create(:framework_question, :checkbox, parent: question)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      expect(question.build_responses(person_escort_record: person_escort_record).dependents.first.framework_question).to eq(dependent_question)
+      expect(response.dependents.first.framework_question).to eq(dependent_question)
     end
 
     it 'sets person_escort_record on dependent responses' do
       person_escort_record = create(:person_escort_record)
       question = create(:framework_question)
       create(:framework_question, :checkbox, parent: question)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      expect(question.build_responses(person_escort_record: person_escort_record).dependents.first.person_escort_record).to eq(person_escort_record)
+      expect(response.dependents.first.person_escort_record).to eq(person_escort_record)
     end
 
     it 'sets correct types on dependent responses' do
@@ -113,8 +161,12 @@ RSpec.describe FrameworkQuestion do
       question = create(:framework_question)
       create(:framework_question, :checkbox, followup_comment: true, parent: question)
       create(:framework_question, :textarea, parent: question)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      expect(question.build_responses(person_escort_record: person_escort_record).dependents.map(&:type)).to contain_exactly(
+      expect(response.dependents.map(&:type)).to contain_exactly(
         'FrameworkResponse::Collection',
         'FrameworkResponse::String',
       )
@@ -126,8 +178,12 @@ RSpec.describe FrameworkQuestion do
       child_question = create(:framework_question, :checkbox, followup_comment: true, parent: parent_question)
       create(:framework_question, parent: child_question)
       create(:framework_question, parent: child_question)
+      response = parent_question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
 
-      dependent_responses = parent_question.build_responses(person_escort_record: person_escort_record).dependents
+      dependent_responses = response.dependents
       expect(dependent_responses.first.dependents.size).to eq(2)
     end
   end

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -10,4 +10,16 @@ RSpec.describe Framework do
   it { is_expected.to validate_uniqueness_of(:name).scoped_to(:version) }
   it { is_expected.to have_many(:person_escort_records) }
   it { is_expected.to have_many(:framework_questions) }
+
+  describe '.ordered_by_latest_version' do
+    it 'orders frameworks by descending order of versions' do
+      framework1 = create(:framework, version: '1.01')
+      framework2 = create(:framework, version: '0.1')
+      framework3 = create(:framework, version: '1.12')
+
+      expect(described_class.ordered_by_latest_version).to eq(
+        [framework3, framework1, framework2],
+      )
+    end
+  end
 end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -71,9 +71,7 @@ RSpec.describe PersonEscortRecord do
       create(:framework_question, :checkbox, framework: framework)
       person_escort_record = described_class.save_with_responses!(profile_id: profile.id)
 
-      responses = person_escort_record.framework_responses
-
-      expect(responses.count).to eq(2)
+      expect(person_escort_record.framework_responses.count).to eq(2)
     end
 
     it 'sets correct response for framework questions' do
@@ -82,9 +80,7 @@ RSpec.describe PersonEscortRecord do
       checkbox_question = create(:framework_question, :checkbox, framework: framework)
       person_escort_record = described_class.save_with_responses!(profile_id: profile.id)
 
-      response = person_escort_record.framework_responses.first
-
-      expect(response).to have_attributes(
+      expect(person_escort_record.framework_responses.first).to have_attributes(
         framework_question_id: checkbox_question.id,
         type: 'FrameworkResponse::Array',
       )
@@ -96,9 +92,7 @@ RSpec.describe PersonEscortRecord do
       create(:framework_question, :checkbox, framework: framework)
       person_escort_record = described_class.save_with_responses!(profile_id: profile.id)
 
-      questions = person_escort_record.framework_questions
-
-      expect(questions.count).to eq(1)
+      expect(person_escort_record.framework_questions.count).to eq(1)
     end
   end
 
@@ -109,7 +103,7 @@ RSpec.describe PersonEscortRecord do
       profile = create(:profile)
       person_escort_record = build(:person_escort_record, framework: framework, profile: profile)
 
-      expect { person_escort_record.build_responses! }.to change(described_class, :count).from(0).to(1)
+      expect { person_escort_record.build_responses! }.to change(described_class, :count).by(1)
     end
 
     it 'creates responses for a question' do
@@ -133,7 +127,7 @@ RSpec.describe PersonEscortRecord do
       profile = create(:profile)
       person_escort_record = build(:person_escort_record, framework: framework, profile: profile)
 
-      expect { person_escort_record.build_responses! }.to change(FrameworkResponse, :count).from(0).to(2)
+      expect { person_escort_record.build_responses! }.to change(FrameworkResponse, :count).by(2)
     end
 
     it 'creates responses for dependent questions' do
@@ -162,7 +156,7 @@ RSpec.describe PersonEscortRecord do
       person_escort_record.build_responses!
       dependent_responses = FrameworkResponse.find_by(framework_question: parent_question, person_escort_record: person_escort_record).dependents
 
-      expect(dependent_responses.size).to eq(2)
+      expect(dependent_responses.count).to eq(2)
     end
 
     it 'creates responses for deeply nested dependent questions' do
@@ -193,7 +187,7 @@ RSpec.describe PersonEscortRecord do
       person_escort_record.build_responses!
       dependent_responses = FrameworkResponse.find_by(framework_question: child_question, person_escort_record: person_escort_record).dependents
 
-      expect(dependent_responses.size).to eq(2)
+      expect(dependent_responses.count).to eq(2)
     end
 
     it 'returns person_escort_record valildation error if record is not valid' do

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe PersonEscortRecord do
   it { is_expected.to validate_presence_of(:state) }
-  it { is_expected.to validate_inclusion_of(:state).in_array(%w[not_started in_progress completed confirmed]) }
+  it { is_expected.to validate_inclusion_of(:state).in_array(%w[in_progress completed confirmed]) }
   it { is_expected.to have_many(:framework_responses) }
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:profile) }

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -12,6 +12,214 @@ RSpec.describe PersonEscortRecord do
 
   it 'validates uniqueness of profile' do
     person_escort_record = build(:person_escort_record)
-     expect(person_escort_record).to validate_uniqueness_of(:profile)
+    expect(person_escort_record).to validate_uniqueness_of(:profile)
+  end
+
+  describe '.save_with_responses!' do
+    it 'returns error if profile does not exist' do
+      expect { described_class.save_with_responses!(profile_id: 'some-id', version: '1.2') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'returns framework with version specified' do
+      framework = create(:framework, version: '1.2')
+      profile = create(:profile)
+      described_class.save_with_responses!(profile_id: profile.id, version: '1.2')
+
+      expect(described_class.last.framework).to eq(framework)
+    end
+
+    it 'defaults to latest framework with latest version' do
+      framework = create(:framework, version: '1.2')
+      create(:framework, version: '1.0')
+      profile = create(:profile)
+      described_class.save_with_responses!(profile_id: profile.id)
+
+      expect(described_class.last.framework).to eq(framework)
+    end
+
+    it 'returns error if wrong version passed' do
+      create(:framework, version: '1.0')
+      profile = create(:profile)
+
+      expect { described_class.save_with_responses!(profile_id: profile.id, version: '2.2') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'returns error if no framework found' do
+      profile = create(:profile)
+      expect { described_class.save_with_responses!(profile_id: profile.id) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'does not allow multiple person_escort_records on a profile' do
+      profile = create(:profile)
+      create(:framework)
+      described_class.save_with_responses!(profile_id: profile.id)
+
+      expect { described_class.save_with_responses!(profile_id: profile.id) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'sets initial state to in_progress' do
+      profile = create(:profile)
+      create(:framework)
+
+      expect(described_class.save_with_responses!(profile_id: profile.id).state).to eq('in_progress')
+    end
+
+    it 'creates responses for framework questions' do
+      profile = create(:profile)
+      framework = create(:framework)
+      create(:framework_question, :checkbox, framework: framework)
+      create(:framework_question, :checkbox, framework: framework)
+      person_escort_record = described_class.save_with_responses!(profile_id: profile.id)
+
+      responses = person_escort_record.framework_responses
+
+      expect(responses.count).to eq(2)
+    end
+
+    it 'sets correct response for framework questions' do
+      profile = create(:profile)
+      framework = create(:framework)
+      checkbox_question = create(:framework_question, :checkbox, framework: framework)
+      person_escort_record = described_class.save_with_responses!(profile_id: profile.id)
+
+      response = person_escort_record.framework_responses.first
+
+      expect(response).to have_attributes(
+        framework_question_id: checkbox_question.id,
+        type: 'FrameworkResponse::Array',
+      )
+    end
+
+    it 'allows access to framework question through person escort record' do
+      profile = create(:profile)
+      framework = create(:framework)
+      create(:framework_question, :checkbox, framework: framework)
+      person_escort_record = described_class.save_with_responses!(profile_id: profile.id)
+
+      questions = person_escort_record.framework_questions
+
+      expect(questions.count).to eq(1)
+    end
+  end
+
+  describe '#build_responses' do
+    it 'persists the person_escort_record' do
+      framework = create(:framework)
+      create(:framework_question, framework: framework)
+      profile = create(:profile)
+      person_escort_record = build(:person_escort_record, framework: framework, profile: profile)
+
+      expect { person_escort_record.build_responses! }.to change(described_class, :count).from(0).to(1)
+    end
+
+    it 'creates responses for a question' do
+      framework = create(:framework)
+      radio_question = create(:framework_question, framework: framework)
+      profile = create(:profile)
+      person_escort_record = build(:person_escort_record, framework: framework, profile: profile)
+      person_escort_record.build_responses!
+
+      expect(person_escort_record.framework_responses.first).to have_attributes(
+        framework_question_id: radio_question.id,
+        person_escort_record_id: person_escort_record.id,
+        type: 'FrameworkResponse::String',
+      )
+    end
+
+    it 'creates responses for multiple questions' do
+      framework = create(:framework)
+      create(:framework_question, framework: framework)
+      create(:framework_question, :checkbox, framework: framework)
+      profile = create(:profile)
+      person_escort_record = build(:person_escort_record, framework: framework, profile: profile)
+
+      expect { person_escort_record.build_responses! }.to change(FrameworkResponse, :count).from(0).to(2)
+    end
+
+    it 'creates responses for dependent questions' do
+      framework = create(:framework)
+      parent_question = create(:framework_question, framework: framework)
+      child_question = create(:framework_question, :checkbox, framework: framework, parent: parent_question)
+
+      person_escort_record = build(:person_escort_record, framework: framework, profile: create(:profile))
+      person_escort_record.build_responses!
+      dependent_response = FrameworkResponse.find_by(framework_question: child_question, person_escort_record: person_escort_record)
+
+      expect(dependent_response).to have_attributes(
+        framework_question_id: child_question.id,
+        person_escort_record_id: person_escort_record.id,
+        type: 'FrameworkResponse::Array',
+      )
+    end
+
+    it 'creates responses for multiple dependent questions' do
+      framework = create(:framework)
+      parent_question = create(:framework_question, framework: framework)
+      create(:framework_question, framework: framework, parent: parent_question)
+      create(:framework_question, framework: framework, parent: parent_question)
+
+      person_escort_record = build(:person_escort_record, framework: framework, profile: create(:profile))
+      person_escort_record.build_responses!
+      dependent_responses = FrameworkResponse.find_by(framework_question: parent_question, person_escort_record: person_escort_record).dependents
+
+      expect(dependent_responses.size).to eq(2)
+    end
+
+    it 'creates responses for deeply nested dependent questions' do
+      framework = create(:framework)
+      parent_question = create(:framework_question, framework: framework)
+      child_question = create(:framework_question, :checkbox, framework: framework, parent: parent_question)
+      grand_child_question = create(:framework_question, :text, framework: framework, parent: child_question)
+
+      person_escort_record = build(:person_escort_record, framework: framework, profile: create(:profile))
+      person_escort_record.build_responses!
+      dependent_response = FrameworkResponse.find_by(framework_question: grand_child_question, person_escort_record: person_escort_record)
+
+      expect(dependent_response).to have_attributes(
+        framework_question_id: grand_child_question.id,
+        person_escort_record_id: person_escort_record.id,
+        type: 'FrameworkResponse::String',
+      )
+    end
+
+    it 'creates responses for multiple deeply nested dependent questions' do
+      framework = create(:framework)
+      parent_question = create(:framework_question, framework: framework)
+      child_question = create(:framework_question, :checkbox, framework: framework, parent: parent_question)
+      create(:framework_question, :text, framework: framework, parent: child_question)
+      create(:framework_question, :text, framework: framework, parent: child_question)
+
+      person_escort_record = build(:person_escort_record, framework: framework, profile: create(:profile))
+      person_escort_record.build_responses!
+      dependent_responses = FrameworkResponse.find_by(framework_question: child_question, person_escort_record: person_escort_record).dependents
+
+      expect(dependent_responses.size).to eq(2)
+    end
+
+    it 'returns person_escort_record valildation error if record is not valid' do
+      framework = create(:framework)
+      create(:framework_question, framework: framework)
+      create(:framework_question, :checkbox, framework: framework)
+      person_escort_record = build(:person_escort_record, framework: framework, state: 'some-status', profile: create(:profile))
+
+      expect { person_escort_record.build_responses! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'does not persist any responses if there are any invalid person_escort_record records' do
+      framework = create(:framework)
+      framework_responses = [
+        build(:framework_response, type: 'wrong-type'),
+      ]
+      person_escort_record = build(
+        :person_escort_record,
+        framework: framework,
+        profile: create(:profile),
+        framework_responses: framework_responses,
+      )
+
+      person_escort_record.build_responses!
+    rescue ActiveRecord::RecordInvalid
+      expect(FrameworkResponse.count).to be_zero
+    end
   end
 end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe PersonEscortRecord do
   it { is_expected.to validate_presence_of(:state) }
   it { is_expected.to validate_inclusion_of(:state).in_array(%w[in_progress completed confirmed]) }
   it { is_expected.to have_many(:framework_responses) }
+  it { is_expected.to have_many(:framework_questions).through(:framework) }
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:profile) }
+
+  it 'validates uniqueness of profile' do
+    person_escort_record = build(:person_escort_record)
+     expect(person_escort_record).to validate_uniqueness_of(:profile)
+  end
 end

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -36,12 +36,10 @@ RSpec.describe Api::PersonEscortRecordsController do
     end
 
     context 'when successful' do
-      let(:application) { create(:application, owner: supplier) }
-      let(:access_token) { create(:access_token, application: application).token }
       let(:schema) { load_yaml_schema('post_person_escort_record_responses.yaml') }
       let(:data) do
         {
-          "id": PersonEscortRecord.first&.id,
+          "id": PersonEscortRecord.last.id,
           "type": 'person_escort_records',
           "attributes": {
             "version": framework_version,
@@ -63,7 +61,7 @@ RSpec.describe Api::PersonEscortRecordsController do
             "responses": {
               "data": [
                 {
-                  "id": FrameworkResponse.first&.id,
+                  "id": FrameworkResponse.last.id,
                   "type": 'framework_responses',
                 },
               ],

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::PersonEscortRecordsController do
+  describe 'POST /person_escort_records' do
+    include_context 'with supplier with spoofed access token'
+
+    let(:response_json) { JSON.parse(response.body) }
+    let(:profile) { create(:profile) }
+    let(:profile_id) { profile.id }
+    let(:framework) { create(:framework, framework_questions: [build(:framework_question)]) }
+    let(:framework_version) { framework.version }
+
+    let(:person_escort_record_params) do
+      {
+        data: {
+          "type": 'person_escort_records',
+          "attributes": {
+            "version": framework_version,
+          },
+          "relationships": {
+            "profile": {
+              "data": {
+                "id": profile_id,
+                "type": 'profiles',
+              },
+            },
+          },
+        },
+      }
+    end
+
+    before do
+      post '/api/v1/person_escort_records', params: person_escort_record_params, headers: headers, as: :json
+    end
+
+    context 'when successful' do
+      let(:application) { create(:application, owner: supplier) }
+      let(:access_token) { create(:access_token, application: application).token }
+      let(:schema) { load_yaml_schema('post_person_escort_record_responses.yaml') }
+      let(:data) do
+        {
+          "id": PersonEscortRecord.first&.id,
+          "type": 'person_escort_records',
+          "attributes": {
+            "version": framework_version,
+            "status": 'in_progress',
+          },
+          "relationships": {
+            "profile": {
+              "data": {
+                "id": profile_id,
+                "type": 'profiles',
+              },
+            },
+            "framework": {
+              "data": {
+                "id": framework.id,
+                "type": 'frameworks',
+              },
+            },
+            "responses": {
+              "data": [
+                {
+                  "id": FrameworkResponse.first&.id,
+                  "type": 'framework_responses',
+                },
+              ],
+            },
+          },
+        }
+      end
+
+      it_behaves_like 'an endpoint that responds with success 201'
+
+      it 'returns the correct data' do
+        expect(response_json).to include_json(data: data)
+      end
+    end
+
+    context 'when unsuccessful' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+
+      context 'with a bad request' do
+        let(:person_escort_record_params) { nil }
+
+        it_behaves_like 'an endpoint that responds with error 400'
+      end
+
+      context 'when the profile is not found' do
+        let(:profile_id) { 'foo-bar' }
+        let(:detail_404) { "Couldn't find Profile with 'id'=foo-bar" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+
+      context 'with a reference to a missing framework' do
+        let(:framework_version) { '0.2' }
+        let(:detail_404) { "Couldn't find Framework" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+
+      context 'with no framework' do
+        let(:person_escort_record_params) do
+          {
+            data: {
+              "type": 'person_escort_records',
+              "relationships": {
+                "profile": {
+                  "data": {
+                    "id": profile_id,
+                    "type": 'profiles',
+                  },
+                },
+              },
+            },
+          }
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [{ 'title' => 'Unprocessable entity',
+               'detail' => 'Framework must exist' }]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/framework_question_serializer_spec.rb
+++ b/spec/serializers/framework_question_serializer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkQuestionSerializer do
+  subject(:serializer) { described_class.new(framework_question) }
+
+  let(:framework_question) { create :framework_question }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('framework_questions')
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eq(framework_question.id)
+  end
+
+  it 'contains a `key` attribute' do
+    expect(result[:data][:attributes][:key]).to eq(framework_question.key)
+  end
+
+  it 'contains a `question_type` attribute' do
+    expect(result[:data][:attributes][:question_type]).to eq(framework_question.question_type)
+  end
+
+  it 'contains a `options` attribute' do
+    expect(result[:data][:attributes][:options]).to eq(framework_question.options)
+  end
+
+  it 'contains a `framework` relationship' do
+    expect(result[:data][:relationships][:framework][:data]).to eq(
+      id: framework_question.framework.id,
+      type: 'frameworks',
+    )
+  end
+end

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponseSerializer do
+  subject(:serializer) { described_class.new(framework_response) }
+
+  let(:framework_response) { create :string_response }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('framework_responses')
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eq(framework_response.id)
+  end
+
+  it 'contains a `value` attribute' do
+    expect(result[:data][:attributes][:value]).to eq(framework_response.value)
+  end
+
+  it 'contains a `person_escort_record` relationship' do
+    expect(result[:data][:relationships][:person_escort_record][:data]).to eq(
+      id: framework_response.person_escort_record.id,
+      type: 'person_escort_records',
+    )
+  end
+
+  it 'contains a `question` relationship' do
+    expect(result[:data][:relationships][:question][:data]).to eq(
+      id: framework_response.framework_question.id,
+      type: 'framework_questions',
+    )
+  end
+
+  describe 'value_type' do
+    context 'when response is an object response' do
+      let(:framework_response) { create(:object_response) }
+
+      it 'returns value_type `object`' do
+        expect(result[:data][:attributes][:value_type]).to eq('object')
+      end
+    end
+
+    context 'when response is an string response' do
+      let(:framework_response) { create(:string_response) }
+
+      it 'returns value_type `string`' do
+        expect(result[:data][:attributes][:value_type]).to eq('string')
+      end
+    end
+
+    context 'when response is an collection response' do
+      let(:framework_response) { create(:collection_response) }
+
+      it 'returns value_type `collection`' do
+        expect(result[:data][:attributes][:value_type]).to eq('collection')
+      end
+    end
+
+    context 'when response is an array response' do
+      let(:framework_response) { create(:array_response) }
+
+      it 'returns value_type `array`' do
+        expect(result[:data][:attributes][:value_type]).to eq('array')
+      end
+    end
+  end
+end

--- a/spec/serializers/framework_serializer_spec.rb
+++ b/spec/serializers/framework_serializer_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkSerializer do
+  subject(:serializer) { described_class.new(framework) }
+
+  let(:framework) { create :framework }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('frameworks')
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eq(framework.id)
+  end
+
+  it 'contains a `version` attribute' do
+    expect(result[:data][:attributes][:version]).to eq(framework.version)
+  end
+
+  it 'contains a `name` attribute' do
+    expect(result[:data][:attributes][:name]).to eq(framework.name)
+  end
+
+  it 'contains an empty `questions` relationship if no framework questions present' do
+    expect(result[:data][:relationships][:questions][:data]).to be_empty
+  end
+
+  it 'contains a `questions` relationship with framework questions' do
+    question = create(:framework_question, framework: framework)
+
+    expect(result[:data][:relationships][:questions][:data]).to contain_exactly(
+      id: question.id,
+      type: 'framework_questions',
+    )
+  end
+end

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonEscortRecordSerializer do
+  subject(:serializer) { described_class.new(person_escort_record) }
+
+  let(:person_escort_record) { create :person_escort_record }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('person_escort_records')
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eq(person_escort_record.id)
+  end
+
+  it 'contains a `status` attribute' do
+    expect(result[:data][:attributes][:status]).to eq('in_progress')
+  end
+
+  it 'contains a `version` attribute' do
+    expect(result[:data][:attributes][:version]).to eq(person_escort_record.framework.version)
+  end
+
+  it 'contains a `profile` relationship' do
+    expect(result[:data][:relationships][:profile][:data]).to eq(
+      id: person_escort_record.profile.id,
+      type: 'profiles',
+    )
+  end
+
+  it 'contains a `framework` relationship' do
+    expect(result[:data][:relationships][:framework][:data]).to eq(
+      id: person_escort_record.framework.id,
+      type: 'frameworks',
+    )
+  end
+
+  it 'contains an empty `responses` relationship if no responses present' do
+    expect(result[:data][:relationships][:responses][:data]).to be_empty
+  end
+
+  it 'contains a`responses` relationship with framework responses' do
+    question = create(:framework_question)
+    response = serializer.framework_responses.create!(type: 'FrameworkResponse::String', framework_question: question)
+
+    expect(result[:data][:relationships][:responses][:data]).to contain_exactly(
+      id: response.id,
+      type: 'framework_responses',
+    )
+  end
+end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -72,6 +72,8 @@
       :$ref: "../v1/person.yaml#/Person"
     :PersonReference:
       :$ref: "../v1/person_reference.yaml#/PersonReference"
+    :PersonEscortRecord:
+      :$ref: "../v1/person_escort_record.yaml#/PersonEscortRecord"
     :PrisonTransferReason:
       :$ref: "../v1/prison_transfer_reason.yaml#/PrisonTransferReason"
     :ProfileIdentifier:
@@ -2479,6 +2481,57 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/get_timetable_responses.yaml#/415"
+  "/person_escort_records":
+    post:
+      summary: Creates a new person escort record
+      tags:
+      - PersonEscortRecord
+      consumes:
+      - application/vnd.api+json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        description: The person_escort_record object to be created
+        schema:
+          "$ref": "../v1/person_escort_record.yaml#/PersonEscortRecord"
+      responses:
+        '201':
+          description: created
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_person_escort_record_responses.yaml#/201"
+        '400':
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_person_escort_record_responses.yaml#/400"
+        '401':
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_person_escort_record_responses.yaml#/401"
+        '404':
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_person_escort_record_responses.yaml#/404"
+        '415':
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_person_escort_record_responses.yaml#/415"
+        '422':
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_person_escort_record_responses.yaml#/422"
   "/reference/allocation_complex_cases":
     get:
       summary: Returns a list of allocation complex cases

--- a/swagger/v1/framework_reference.yaml
+++ b/swagger/v1/framework_reference.yaml
@@ -1,0 +1,24 @@
+FrameworkReference:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      type: object
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          example: frameworks
+          enum:
+            - frameworks
+          description: The type of this object - always `frameworks`
+        id:
+          type: string
+          format: uuid
+          example: ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154
+          description:
+            The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v1/framework_response_reference.yaml
+++ b/swagger/v1/framework_response_reference.yaml
@@ -1,0 +1,27 @@
+FrameworkResponseReference:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      oneOf:
+      - type: object
+      - type: 'null'
+      - type: array
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          example: framework_responses
+          enum:
+            - framework_responses
+          description: The type of this object - always `framework_responses`
+        id:
+          type: string
+          format: uuid
+          example: ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154
+          description:
+            The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v1/framework_response_reference.yaml
+++ b/swagger/v1/framework_response_reference.yaml
@@ -6,8 +6,10 @@ FrameworkResponseReference:
     data:
       oneOf:
       - type: object
+        description:  single object returned if resource is associated to only one framework_response
       - type: 'null'
       - type: array
+        description:  Multiple objects returned if resource is associated to multiple framework_responses
       required:
         - type
         - id

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -1,0 +1,62 @@
+PersonEscortRecord:
+  type: object
+  required:
+    - id
+    - type
+    - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: person_escort_records
+      enum:
+      - person_escort_records
+      description: The type of this object - always `person_escort_records`
+    attributes:
+      type: object
+      required:
+      - version
+      - status
+      properties:
+        status:
+          example: in_progress
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - confirmed
+          description: Determines the current status of the `person_escort_record`
+        version:
+          type: string
+          example: '0.1'
+          description: Determines the version of framework questions of the `person_escort_record`
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of when the person_escort_record was last created or updated
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp of when the person_escort_record was created
+          readOnly: true
+    relationships:
+      type: object
+      required:
+        - profile
+        - framework
+        - responses
+      properties:
+        profile:
+          $ref: profile_reference.yaml#/ProfileReference
+          description: The profile of the person being moved
+        framework:
+          $ref: framework_reference.yaml#/FrameworkReference
+          description: The framework associated with this person_escort_record
+        responses:
+          $ref: framework_response_reference.yaml#/FrameworkResponseReference
+          description: The framework response associated with this person_escort_record

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -20,7 +20,6 @@ PersonEscortRecord:
       type: object
       required:
       - version
-      - status
       properties:
         status:
           example: in_progress

--- a/swagger/v1/post_person_escort_record_responses.yaml
+++ b/swagger/v1/post_person_escort_record_responses.yaml
@@ -1,0 +1,52 @@
+'201':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: person_escort_record.yaml#/PersonEscortRecord
+'400':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError
+'404':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/ResourceNotFound
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnsupportedMediaType
+'422':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnprocessableEntity


### PR DESCRIPTION
### Jira link

[P4-1761](https://dsdmoj.atlassian.net/browse/P4-1761)

### What?

- [x] Removed unstarted status from the PER state enums
- [x] Added ability to build framework responses from questions
- [x] Added ability to build a new PER from a framework and Profile
- [x] Added controller and new routes for POSTing the PER
- [x] Added swagger documentation for new endpoint

### Why?

To allow clients to create a new PER, add POST `/person_escort_records` endpoint which accepts a profile, and a version of the framework to build empty responses for all questions related to a framework. If the version of the framework is not passed in use the latest framework (versioning is going to be revised, this is only temporary).

To bulk create a PER record, active record import gem has been added. This allows us passing in an actual object rather than a hash, and helps with deeply nested record creation. However to associate a PER record to deeply nested responses, we have had to create it first then associate them after. 

### Have you? (optional)

- [x] Updated API docs if necessary	
