### PR TITLE
[P4-1663] Fix missing notifications when updating a profile

### DIFF
--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -16,6 +16,7 @@ module Api
       profile = person.profiles.find(params.require(:id))
 
       profile.update!(profile_attributes)
+      Notifier.prepare_notifications(topic: profile.person, action_name: 'update')
 
       render_profile(profile, :ok)
     end

--- a/spec/requests/api/profiles_controller_update_spec.rb
+++ b/spec/requests/api/profiles_controller_update_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe Api::ProfilesController do
       end
 
       before do
+        allow(Notifier).to receive(:prepare_notifications)
         patch "/api/v1/people/#{profile.person.id}/profiles/#{profile.id}", params: profile_params, headers: headers, as: :json
       end
 
@@ -95,6 +96,10 @@ RSpec.describe Api::ProfilesController do
 
       it 'returns the correct data' do
         expect(response_json['data']).to include_json(expected_data)
+      end
+
+      it 'calls the notifier' do
+        expect(Notifier).to have_received(:prepare_notifications).with(topic: profile.person, action_name: 'update')
       end
     end
 


### PR DESCRIPTION
### Jira link

P4-1663

### What?

Fixes notifications that update suppliers when changes to the PTR are made.

### Why?

We had a live production issues where a person on the road wasn't updated when the PTR was changed.

