### PR TITLE
[P4-1896] Adds move supplier for allocation moves

### DIFF
--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -70,6 +70,7 @@ module Api
 
     def creator
       @creator ||= Allocations::Creator.new(
+        doorkeeper_application_owner: doorkeeper_application_owner,
         allocation_params: allocation_params,
         complex_case_params: complex_case_params,
       )

--- a/app/services/allocations/creator.rb
+++ b/app/services/allocations/creator.rb
@@ -2,9 +2,10 @@
 
 module Allocations
   class Creator
-    attr_accessor :allocation_params, :complex_case_params, :allocation
+    attr_accessor :doorkeeper_application_owner, :allocation_params, :complex_case_params, :allocation
 
-    def initialize(allocation_params:, complex_case_params:)
+    def initialize(doorkeeper_application_owner:, allocation_params:, complex_case_params:)
+      self.doorkeeper_application_owner = doorkeeper_application_owner
       self.allocation_params = allocation_params
       self.complex_case_params = complex_case_params
     end
@@ -27,11 +28,14 @@ module Allocations
     end
 
     def moves
+      supplier = SupplierChooser.new(doorkeeper_application_owner, allocation.from_location).call
+
       Array.new(allocation.moves_count) do
         Move.new(
           from_location: allocation.from_location,
           to_location: allocation.to_location,
           date: allocation.date,
+          supplier: supplier,
         )
       end
     end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -39,5 +39,9 @@ FactoryBot.define do
       location_type { Location::LOCATION_TYPE_HIGH_SECURITY_HOSPITAL }
       nomis_agency_id { 'GUISH' }
     end
+
+    trait :with_suppliers do
+      suppliers { [create(:supplier)] }
+    end
   end
 end

--- a/spec/requests/api/allocations_controller_create_spec.rb
+++ b/spec/requests/api/allocations_controller_create_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Api::AllocationsController do
 
       it 'sets the from_location supplier as the supplier on the move' do
         post_allocations
-        expect(allocation.moves.pluck(:supplier_id)).to contain_exactly(from_location.suppliers.first.id)
+        expect(allocation.moves.pluck(:supplier_id).uniq).to contain_exactly(from_location.suppliers.first.id)
       end
 
       context 'with a real access token' do
@@ -106,7 +106,7 @@ RSpec.describe Api::AllocationsController do
 
         it 'sets the application owner as the supplier on allocation moves' do
           post_allocations
-          expect(allocation.moves.pluck(:supplier_id)).to contain_exactly(supplier.id)
+          expect(allocation.moves.pluck(:supplier_id).uniq).to contain_exactly(supplier.id)
         end
       end
 

--- a/spec/requests/api/allocations_controller_create_spec.rb
+++ b/spec/requests/api/allocations_controller_create_spec.rb
@@ -90,6 +90,11 @@ RSpec.describe Api::AllocationsController do
         expect { post_allocations }.to change(Allocation, :count).by(1)
       end
 
+      it 'sets the from_location supplier as the supplier on the move' do
+        post_allocations
+        expect(allocation.moves.pluck(:supplier_id)).to contain_exactly(from_location.suppliers.first.id)
+      end
+
       context 'with a real access token' do
         let(:application) { create(:application, owner_id: supplier.id) }
         let(:access_token) { create(:access_token, application: application).token }
@@ -97,6 +102,11 @@ RSpec.describe Api::AllocationsController do
         it 'audits the supplier' do
           post_allocations
           expect(allocation.versions.map(&:whodunnit)).to eq([supplier.id])
+        end
+
+        it 'sets the application owner as the supplier on allocation moves' do
+          post_allocations
+          expect(allocation.moves.pluck(:supplier_id)).to contain_exactly(supplier.id)
         end
       end
 


### PR DESCRIPTION
### Jira link

P4-1896

### What?

This PR enables us to stamp an allocation move with the relevant
supplier based on either the token provided by the api request and then the
from location supplier.

**This is transparent to clients of the allocation controller api**

### Why?

As part of moving away from having a single supplier supporting each
location we are going to migrate our ownership model for the allocation
and singleton moves.