### PR TITLE
Add new estate type and comment to allocation model

### DIFF
--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -34,7 +34,7 @@ module Api
 
     PERMITTED_ALLOCATION_PARAMS = [
       :type,
-      attributes: %i[date estate prisoner_category sentence_length sentence_length_comment moves_count complete_in_full other_criteria requested_by],
+      attributes: %i[date estate estate_comment prisoner_category sentence_length sentence_length_comment moves_count complete_in_full other_criteria requested_by],
       relationships: {},
     ].freeze
 

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -28,6 +28,7 @@ class Allocation < VersionedModel
     juvenile_male: 'Juvenile Male',
     young_offender_female: 'Young Offender Female',
     young_offender_male: 'Young Offender Male',
+    other_estate: 'Other',
   }
 
   enum states: {

--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -4,6 +4,7 @@ class AllocationSerializer < ActiveModel::Serializer
   attributes :moves_count,
              :date,
              :estate,
+             :estate_comment,
              :prisoner_category,
              :sentence_length,
              :sentence_length_comment,

--- a/db/migrate/20200713092251_add_estate_comment_to_allocations.rb
+++ b/db/migrate/20200713092251_add_estate_comment_to_allocations.rb
@@ -1,0 +1,5 @@
+class AddEstateCommentToAllocations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :allocations, :estate_comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_08_110909) do
+ActiveRecord::Schema.define(version: 2020_07_13_092251) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 2020_07_08_110909) do
     t.string "requested_by"
     t.string "estate"
     t.text "sentence_length_comment"
+    t.text "estate_comment"
     t.index ["date"], name: "index_allocations_on_date"
   end
 

--- a/spec/requests/api/allocations_controller_create_spec.rb
+++ b/spec/requests/api/allocations_controller_create_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe Api::AllocationsController do
       {
         date: Date.today,
         moves_count: moves_count,
-        estate: :adult_male,
+        estate: :other_estate,
+        estate_comment: 'Another estate description',
         prisoner_category: :b,
         sentence_length: :other,
         sentence_length_comment: '30 years',

--- a/spec/requests/api/allocations_controller_create_v2_spec.rb
+++ b/spec/requests/api/allocations_controller_create_v2_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Api::AllocationsController do
       {
         date: Date.today,
         moves_count: moves_count,
+        estate: :other_estate,
+        estate_comment: 'Another estate description',
         prisoner_category: :b,
         sentence_length: :short,
         other_criteria: 'curly hair',

--- a/spec/serializers/allocation_serializer_spec.rb
+++ b/spec/serializers/allocation_serializer_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe AllocationSerializer do
       expect(attributes[:estate]).to eql allocation.estate
     end
 
+    it 'contains an estate comment attribute' do
+      expect(attributes[:estate_comment]).to eql allocation.estate_comment
+    end
+
     it 'contains a prisoner_category attribute' do
       expect(attributes[:prisoner_category]).to eql allocation.prisoner_category
     end

--- a/swagger/v1/allocation.yaml
+++ b/swagger/v1/allocation.yaml
@@ -35,9 +35,15 @@ Allocation:
             - juvenile_male
             - young_offender_female
             - young_offender_male
+            - other_estate
           - type: 'null'
           example: adult_male
           description: Indicates the prison estate type
+        estate_comment:
+          oneOf:
+          - type: string
+          - type: 'null'
+          description: Optional description of estate type (if 'other_estate')
         prisoner_category:
           oneOf:
           - type: string


### PR DESCRIPTION
### Jira link

P4-1914

### What?

- [x] Added new enum member for allocation estate
- [x] Added new estate_comment attribute to store custom value for "other" estate type

### Why?

- This supports corresponding front end changes. Note that the new enum member is named `other_estate` - this could not be named `other` as we already have a member within sentence length enum in the same model. Rails creates methods for each enum member but in this case that causes a conflict. I don't think it's worth renaming the existing sentence length `other` member now, but we need to keep this in mind for future naming where the enum members have generic terms.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Adds support for an additional attribute in existing production API, but the new value is optional to avoid a breaking change