### PR TITLE
[P4-1907] Fix relationship patching on people v2

### DIFF
--- a/app/controllers/api/v2/people_actions.rb
+++ b/app/controllers/api/v2/people_actions.rb
@@ -56,8 +56,8 @@ module Api::V2
       # Patch relationships to new relationship when the resource is supplied and the id references a resource that exists
       #
       # Do not patch the relationship if the resource is not supplied
-      attributes[:ethnicity] = ethnicity unless ethnicity_params.nil?
-      attributes[:gender] = gender unless gender_params.nil?
+      attributes[:ethnicity] = ethnicity if ethnicity_params
+      attributes[:gender] = gender if gender_params
 
       attributes
     end

--- a/spec/requests/api/people_controller_patch_v2_spec.rb
+++ b/spec/requests/api/people_controller_patch_v2_spec.rb
@@ -98,6 +98,40 @@ RSpec.describe Api::PeopleController do
       expect(response_json).to include_json(data: expected_data.merge(id: person.id))
     end
 
+    context 'when gender relationship is not supplied' do
+      let(:person_params) do
+        {
+          data: {
+            type: 'people',
+            relationships: {
+              ethnicity: { data: { id: ethnicity_id, type: 'ethnicities' } },
+            },
+          },
+        }
+      end
+
+      it 'does not change the gender' do
+        expect { patch "/api/people/#{person.id}", params: person_params, headers: headers, as: :json }
+          .not_to change { person.reload.gender_id }
+      end
+    end
+
+    context 'when relationships are supplied but are specified as nil' do
+      let(:person_params) do
+        {
+          data: {
+            type: 'people',
+            relationships: { ethnicity: { data: nil } },
+          },
+        }
+      end
+
+      it 'sets the ethnicity to nil' do
+        expect { patch "/api/people/#{person.id}", params: person_params, headers: headers, as: :json }
+          .to change { person.reload.ethnicity_id }.to(nil)
+      end
+    end
+
     describe 'include query param' do
       before do
         patch "/api/people/#{person.id}#{query_params}", params: person_params, headers: headers, as: :json


### PR DESCRIPTION
### Jira link

P4-1907

### What?

Previously we were wiping out the gender and ethnicity and not
conforming to the json:api specification around patching relationships
in the people_actions v2.

This updates the people_actions behaviour so that we:

1. Update relationships to nil when they are passed but empty
2. Update relationships to the passed type if they exist and are passed
3. Do not change relationships if they are not passed

### Why?

Conform to json api specs