### PR TITLE
Added support for new 'hospital' move type

### DIFF
--- a/app/controllers/api/move_events_controller.rb
+++ b/app/controllers/api/move_events_controller.rb
@@ -17,49 +17,49 @@ module Api
     COMMON_PARAMS = [:type, attributes: %i[timestamp notes]].freeze # for accept, complete and start move events
 
     def accept
-      MoveEvents::ParamsValidator.new(move, common_params).validate!
+      MoveEvents::ParamsValidator.new(common_params).validate!
       process_event(move, Event::ACCEPT, common_params)
       render status: :no_content
     end
 
     def approve
-      MoveEvents::ParamsValidator.new(move, approve_params).validate!
+      MoveEvents::ParamsValidator.new(approve_params).validate!
       process_event(move, Event::APPROVE, approve_params)
       render status: :no_content
     end
 
     def cancel
-      MoveEvents::ParamsValidator.new(move, cancel_params).validate!
+      MoveEvents::ParamsValidator.new(cancel_params).validate!
       process_event(move, Event::CANCEL, cancel_params)
       render status: :no_content
     end
 
     def complete
-      MoveEvents::ParamsValidator.new(move, common_params).validate!
+      MoveEvents::ParamsValidator.new(common_params).validate!
       process_event(move, Event::COMPLETE, common_params)
       render status: :no_content
     end
 
     def lockouts
-      MoveEvents::ParamsValidator.new(move, lockout_params).validate!
+      MoveEvents::ParamsValidator.new(lockout_params).validate!
       process_event(move, Event::LOCKOUT, lockout_params)
       render status: :no_content
     end
 
     def redirects
-      MoveEvents::ParamsValidator.new(move, redirect_params).validate!
+      MoveEvents::ParamsValidator.new(redirect_params).validate!
       process_event(move, Event::REDIRECT, redirect_params)
       render status: :no_content
     end
 
     def reject
-      MoveEvents::ParamsValidator.new(move, reject_params).validate!
+      MoveEvents::ParamsValidator.new(reject_params).validate!
       process_event(move, Event::REJECT, reject_params)
       render status: :no_content
     end
 
     def start
-      MoveEvents::ParamsValidator.new(move, common_params).validate!
+      MoveEvents::ParamsValidator.new(common_params).validate!
       process_event(move, Event::START, common_params)
       render status: :no_content
     end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -29,6 +29,7 @@ class Move < VersionedModel
     prison_transfer: 'prison_transfer',
     police_transfer: 'police_transfer',
     video_remand_hearing: 'video_remand_hearing',
+    hospital: 'hospital',
   }
 
   self.ignored_columns = %w[person_id]

--- a/app/services/move_events/params_validator.rb
+++ b/app/services/move_events/params_validator.rb
@@ -36,6 +36,7 @@ module MoveEvents
     validates_with LocationValidator, locations: [:to_location_id], if: -> { type == 'redirects' }
     validates_with Moves::MoveTypeValidator, if: -> { type == 'redirects' }
 
+    # These attributes are validated against the existing move - i.e. before applying this event
     delegate :move_type, :from_location, to: :move
 
     def initialize(move, params)
@@ -48,6 +49,11 @@ module MoveEvents
       @from_location_id = params.dig(:relationships, :from_location, :data, :id)
       @to_location_id = params.dig(:relationships, :to_location, :data, :id)
       singularize_acceptable_plural_types
+    end
+
+    def to_location
+      # Determine the new Location defined by passed param to validate against existing move_type and from_location attributes
+      @to_location ||= Location.find_by(id: to_location_id)
     end
 
   private

--- a/app/services/moves/move_type_validator.rb
+++ b/app/services/moves/move_type_validator.rb
@@ -10,6 +10,7 @@ module Moves
 
       # Apply more complex validation rules for specific move types
       validate_police_from_location if includes? %w[video_remand_hearing]
+      validate_hospital_to_location if includes? %w[hospital]
     end
 
   private
@@ -23,7 +24,11 @@ module Moves
     end
 
     def validate_police_from_location
-      record.errors.add(:from_location, "must be a police location for #{human_move_type}") unless record.from_location&.police?
+      record.errors.add(:from_location, "must be a police location for #{human_move_type} move") unless record.from_location&.police?
+    end
+
+    def validate_hospital_to_location
+      record.errors.add(:to_location, "must be a high security hospital location for #{human_move_type} move") unless record.to_location&.high_security_hospital?
     end
   end
 end

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -49,6 +49,12 @@ FactoryBot.define do
       to_location { nil } # NB: to_location is always nil for a video_remand_hearing
     end
 
+    trait :hospital do
+      move_type { 'hospital' }
+      association(:from_location, :police, factory: :location)
+      association(:to_location, :hospital, factory: :location)
+    end
+
     # Move statuses
     trait :proposed do
       status { 'proposed' }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Move do
     end
   end
 
-  it 'validates presence of `to_location` if `move_type` is NOT prison_recall' do
+  it 'validates presence of `to_location` if `move_type` is NOT prison_recall or video_remand_hearing' do
     expect(build(:move, move_type: 'prison_transfer')).to(
       validate_presence_of(:to_location),
     )
@@ -70,25 +70,10 @@ RSpec.describe Move do
     )
   end
 
-  context 'with video remand hearing `move_type`' do
-    let(:court) { build(:location, :court) }
-
-    it 'does NOT validate presence of `to_location`' do
-      expect(build(:move, move_type: 'video_remand_hearing')).not_to(
-        validate_presence_of(:to_location),
-      )
-    end
-
-    it 'validates `from_location` is a prison location' do
-      move = build(:move, :video_remand_hearing)
-      expect(move).to be_valid
-    end
-
-    it 'has an error if `from_location` is not a prison location' do
-      move = build(:move, :video_remand_hearing, from_location: court)
-      move.valid?
-      expect(move.errors[:from_location]).to match_array('must be a police location for video remand hearing')
-    end
+  it 'does NOT validate presence of `to_location` if `move_type` is video_remand_hearing' do
+    expect(build(:move, move_type: 'video_remand_hearing')).not_to(
+      validate_presence_of(:to_location),
+    )
   end
 
   it 'validates presence of `profile` if `status` is NOT requested or cancelled' do

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe Api::MoveEventsController do
       end
     end
 
+    context 'with a hospital move' do
+      let(:move) { create(:move, :hospital) }
+      let(:new_location) { create(:location, :hospital) }
+
+      it 'updates the move to_location' do
+        expect(move.reload.to_location).to eql(new_location)
+      end
+    end
+
     context 'with a bad request' do
       let(:redirect_params) { nil }
 

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -129,6 +129,19 @@ RSpec.describe Api::MoveEventsController do
           end
         end
       end
+
+      context 'with a redirection to an invalid location for the move type' do
+        let(:move) { create(:move, :hospital) }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [{
+              'title' => 'Unprocessable entity',
+              'detail' => 'To location must be a high security hospital location for hospital move',
+            }]
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe Api::MovesController do
         end
       end
 
-      context 'with explicit `move_type`' do
+      context 'with explicit video_remand_hearing `move_type`' do
         let(:move_attributes) { attributes_for(:move, move_type: 'video_remand_hearing') }
         let(:from_location) { create :location, :police, suppliers: [supplier] }
         let(:to_location) { nil }
@@ -278,6 +278,22 @@ RSpec.describe Api::MovesController do
 
         it 'sets the move_type to `video_remand_hearing`' do
           expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand_hearing'
+        end
+      end
+
+      context 'with explicit hospital `move_type`' do
+        let(:move_attributes) { attributes_for(:move, move_type: 'hospital') }
+        let(:to_location) { create :location, :hospital, suppliers: [supplier] }
+
+        it_behaves_like 'an endpoint that responds with success 201'
+
+        it 'creates a move', skip_before: true do
+          expect { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
+            .to change(Move, :count).by(1)
+        end
+
+        it 'sets the move_type to `hospital`' do
+          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'hospital'
         end
       end
 

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Api::MovesController do
       end
     end
 
-    context 'with explicit `move_type`' do
+    context 'with explicit video_remand_hearing `move_type`' do
       let(:move_attributes) { attributes_for(:move, move_type: 'video_remand_hearing') }
       let(:from_location) { create :location, :police, suppliers: [supplier] }
       let(:to_location) { nil }
@@ -304,6 +304,25 @@ RSpec.describe Api::MovesController do
         do_post
 
         expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand_hearing'
+      end
+    end
+
+    context 'with explicit hospital `move_type`' do
+      let(:move_attributes) { attributes_for(:move, move_type: 'hospital') }
+      let(:to_location) { create :location, :hospital, suppliers: [supplier] }
+
+      it_behaves_like 'an endpoint that responds with success 201' do
+        before { do_post }
+      end
+
+      it 'creates a move' do
+        expect { do_post }.to change(Move, :count).by(1)
+      end
+
+      it 'sets the move_type to `hospital`' do
+        do_post
+
+        expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'hospital'
       end
     end
 

--- a/spec/services/move_events/params_validator_spec.rb
+++ b/spec/services/move_events/params_validator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe MoveEvents::ParamsValidator do
-  subject(:params_validator) { described_class.new(move, params) }
+  subject(:params_validator) { described_class.new(params) }
 
   let(:move) { nil }
   let(:attributes) { { timestamp: timestamp } }
@@ -213,43 +213,6 @@ RSpec.describe MoveEvents::ParamsValidator do
       before { relationships.delete(:to_location) }
 
       it { is_expected.not_to be_valid }
-    end
-  end
-
-  describe 'move_type' do
-    let(:move) { build(:move, :prison_recall) }
-
-    it 'delegates to the existing move type for the associated move' do
-      expect(params_validator.move_type).to eq('prison_recall')
-    end
-  end
-
-  describe 'from_location' do
-    let(:move) { build(:move, :prison_recall) }
-
-    it 'delegates to the existing from location for the associated move' do
-      expect(params_validator.from_location).to eq(move.from_location)
-    end
-  end
-
-  describe 'to_location' do
-    let(:move) { build(:move, :prison_recall) }
-    let(:params) { { type: type, attributes: attributes, relationships: relationships } }
-    let(:relationships) { { to_location: { data: { type: 'locations', id: location_id } } } }
-    let(:type) { 'redirects' }
-    let(:location) { create(:location) }
-    let(:location_id) { location.id }
-
-    it 'returns the Location instance specified by to_location_id param (new to_location)' do
-      expect(params_validator.to_location).to eq(location)
-    end
-
-    context 'when not found' do
-      let(:location_id) { 'meh' }
-
-      it 'returns nil' do
-        expect(params_validator.to_location).to be_nil
-      end
     end
   end
 end

--- a/spec/services/move_events/params_validator_spec.rb
+++ b/spec/services/move_events/params_validator_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe MoveEvents::ParamsValidator do
     end
   end
 
-  describe 'from_location' do
+  describe 'from_location_id' do
     let(:params) { { type: type, attributes: attributes, relationships: relationships } }
     let(:relationships) { { from_location: { data: { type: 'locations', id: location_id } } } }
     let(:type) { 'lockouts' }
@@ -186,7 +186,7 @@ RSpec.describe MoveEvents::ParamsValidator do
     end
   end
 
-  describe 'to_location' do
+  describe 'to_location_id' do
     let(:move) { build(:move, :prison_recall) }
     let(:params) { { type: type, attributes: attributes, relationships: relationships } }
     let(:relationships) { { to_location: { data: { type: 'locations', id: location_id } } } }
@@ -213,6 +213,43 @@ RSpec.describe MoveEvents::ParamsValidator do
       before { relationships.delete(:to_location) }
 
       it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe 'move_type' do
+    let(:move) { build(:move, :prison_recall) }
+
+    it 'delegates to the existing move type for the associated move' do
+      expect(params_validator.move_type).to eq('prison_recall')
+    end
+  end
+
+  describe 'from_location' do
+    let(:move) { build(:move, :prison_recall) }
+
+    it 'delegates to the existing from location for the associated move' do
+      expect(params_validator.from_location).to eq(move.from_location)
+    end
+  end
+
+  describe 'to_location' do
+    let(:move) { build(:move, :prison_recall) }
+    let(:params) { { type: type, attributes: attributes, relationships: relationships } }
+    let(:relationships) { { to_location: { data: { type: 'locations', id: location_id } } } }
+    let(:type) { 'redirects' }
+    let(:location) { create(:location) }
+    let(:location_id) { location.id }
+
+    it 'returns the Location instance specified by to_location_id param (new to_location)' do
+      expect(params_validator.to_location).to eq(location)
+    end
+
+    context 'when not found' do
+      let(:location_id) { 'meh' }
+
+      it 'returns nil' do
+        expect(params_validator.to_location).to be_nil
+      end
     end
   end
 end

--- a/spec/services/moves/move_type_validator_spec.rb
+++ b/spec/services/moves/move_type_validator_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moves::MoveTypeValidator do
+  subject(:target) do
+    # anonymous class to test validation against
+    Class.new {
+      include ActiveModel::Validations
+      attr_accessor :from_location, :to_location, :move_type
+      validates_with Moves::MoveTypeValidator
+
+      def self.name
+        'TestValidationClass'
+      end
+    }.new
+  end
+
+  before { target.move_type = move_type }
+
+  context 'when valid' do
+    let(:move_type) { nil }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with video remand hearing `move_type`' do
+    let(:move_type) { 'video_remand_hearing' }
+
+    it 'validates `from_location` is a police location' do
+      target.from_location = build(:location, :police)
+      expect(target).to be_valid
+    end
+
+    it 'validates `from_location` is not nil' do
+      target.from_location = nil
+      expect(target).not_to be_valid
+    end
+
+    it 'has an error if `from_location` is not a police location' do
+      target.from_location = build(:location, :court)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:from_location]).to match_array('must be a police location for video remand hearing move')
+    end
+  end
+
+  context 'with hospital `move_type`' do
+    let(:move_type) { 'hospital' }
+
+    it 'validates `to_location` is a high_security_hospital' do
+      target.to_location = build(:location, :hospital)
+      expect(target).to be_valid
+    end
+
+    it 'validates `to_location` is not nil' do
+      target.to_location = nil
+      expect(target).not_to be_valid
+    end
+
+    it 'has an error if `to_location` is not a high security hospital' do
+      target.from_location = build(:location, :court)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:to_location]).to match_array('must be a high security hospital location for hospital move')
+    end
+  end
+end

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -44,6 +44,7 @@ Move:
           - prison_transfer
           - police_transfer
           - video_remand_hearing
+          - hospital
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
           oneOf:

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -44,6 +44,7 @@ Move:
             - prison_transfer
             - police_transfer
             - video_remand_hearing
+            - hospital
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
           oneOf:


### PR DESCRIPTION

### Jira link

P4-1830, P4-1832, P4-1835, P4-1836

### What?

- [x] Refactored and improved coverage for move_type_validator - now moved to a dedicated spec.
- [x] Added the new enum member and associated validation rules (to_location must be a hospital).
- [x] Added some comments to explain validation approach within ParamsValidator
- [x] Added additional request specs to ensure new move type can be created successfully

### Why?

- We want to support hospital moves (moves from any location to a high security hospital) in the near future.

### Have you? (optional)

- [x] Updated API docs if necessary (v1 and v2 Move schema)

### Deployment risks (optional)

- Adds support for a new move type when creating a move, but is not a breaking change
