### PR TITLE
[P4-1898] Adds rake task for populating supplier moves

### DIFF
--- a/lib/tasks/move_supplier.rake
+++ b/lib/tasks/move_supplier.rake
@@ -10,11 +10,16 @@ namespace :move do
     moves_having_supplier = Move.where.not(supplier_id: nil).count
     moves_missing_supplier = Move.where.not(from_location: locations_with_supplier).where(supplier_id: nil).count
 
-    Move.where(from_location: locations_with_supplier).where(supplier_id: nil).in_batches(of: 200) do |batch|
-      supplier = batch.first.from_location.suppliers.first
+    locations_with_supplier.each do |from_location|
+      supplier = from_location.suppliers.first
 
-      total_updated += batch.update_all(supplier_id: supplier.id)
-      puts "#{total_updated}/#{total} moves populated..."
+      Move.where(from_location: from_location).where(supplier_id: nil).in_batches(of: 200) do |batch|
+        puts "Populating supplier #{supplier.name} for moves from #{from_location.title}"
+
+        total_updated += batch.update_all(supplier_id: supplier.id)
+        puts "#{total_updated}/#{total} moves populated..."
+        puts
+      end
     end
 
     puts "#{total} moves exist."

--- a/lib/tasks/move_supplier.rake
+++ b/lib/tasks/move_supplier.rake
@@ -1,0 +1,25 @@
+# TODO: Remove this once we've added all suppliers to the all moves in all environments
+namespace :move do
+  desc 'Populates a move with a supplier'
+  task supplier: :environment do
+    total = Move.count
+    total_updated = 0
+
+    locations_with_supplier = Location.joins(:suppliers)
+
+    moves_having_supplier = Move.where.not(supplier_id: nil).count
+    moves_missing_supplier = Move.where.not(from_location: locations_with_supplier).where(supplier_id: nil).count
+
+    Move.where(from_location: locations_with_supplier).where(supplier_id: nil).in_batches(of: 200) do |batch|
+      supplier = batch.first.from_location.suppliers.first
+
+      total_updated += batch.update_all(supplier_id: supplier.id)
+      puts "#{total_updated}/#{total} moves populated..."
+    end
+
+    puts "#{total} moves exist."
+    puts "#{total_updated} moves have had their supplier updated."
+    puts "#{moves_having_supplier} moves already have a supplier."
+    puts "#{moves_missing_supplier} moves could not be updated as their from_location does not have a supplier"
+  end
+end

--- a/lib/tasks/move_supplier.rake
+++ b/lib/tasks/move_supplier.rake
@@ -7,8 +7,8 @@ namespace :move do
 
     locations_with_supplier = Location.joins(:suppliers)
 
-    moves_having_supplier = Move.where.not(supplier_id: nil).count
-    moves_missing_supplier = Move.where.not(from_location: locations_with_supplier).where(supplier_id: nil).count
+    moves_having_supplier_count = Move.where.not(supplier_id: nil).count
+    moves_missing_supplier_count = Move.where.not(from_location: locations_with_supplier).where(supplier_id: nil).count
 
     locations_with_supplier.each do |from_location|
       supplier = from_location.suppliers.first
@@ -24,7 +24,7 @@ namespace :move do
 
     puts "#{total} moves exist."
     puts "#{total_updated} moves have had their supplier updated."
-    puts "#{moves_having_supplier} moves already have a supplier."
-    puts "#{moves_missing_supplier} moves could not be updated as their from_location does not have a supplier"
+    puts "#{moves_having_supplier_count} moves already have a supplier."
+    puts "#{moves_missing_supplier_count} moves could not be updated as their from_location does not have a supplier"
   end
 end


### PR DESCRIPTION
### Jira link

P4-1898

### What?

Adds a rake task to populate supplier relationships on historical moves.

In non-production environments it's possible for the supplier to be absent for a move - due to some locations not including definitions for suppliers [here](https://github.com/ministryofjustice/hmpps-book-secure-move-api/blob/move-supplier/lib/tasks/data/supplier_locations.yml) and us creating moves for those locations.

The way I've handled this is to report the count of these for informational purposes but (beyond changing the locations) there's no need to fix these.


```shell
rake move:supplier

Populating supplier Serco for moves from Bishopsgate Custody Suite
18/1265 moves populated...

Populating supplier GEOAmey for moves from CHANNINGS WOOD (HMP)
27/1265 moves populated...

Populating supplier GEOAmey for moves from DOVEGATE (HMP)
29/1265 moves populated...

Populating supplier GEOAmey for moves from Ammanford Custody Suite
32/1265 moves populated...

Populating supplier GEOAmey for moves from EASTWOOD PARK (HMP)
33/1265 moves populated...

Populating supplier GEOAmey for moves from EXETER (HMP)
43/1265 moves populated...

Populating supplier GEOAmey for moves from ELMLEY (HMP)
47/1265 moves populated...

Populating supplier GEOAmey for moves from FOREST BANK (HMP & YOI)
56/1265 moves populated...

Populating supplier GEOAmey for moves from FRANKLAND (HMP)
63/1265 moves populated...

Populating supplier GEOAmey for moves from FEATHERSTONE (HMP)
79/1265 moves populated...

Populating supplier GEOAmey for moves from LEICESTER (HMP)
85/1265 moves populated...

Populating supplier GEOAmey for moves from LONG LARTIN (HMP)
93/1265 moves populated...

Populating supplier GEOAmey for moves from LOW NEWTON (HMP)
95/1265 moves populated...

Populating supplier GEOAmey for moves from MOORLAND (HMP & YOI)
102/1265 moves populated...

Populating supplier GEOAmey for moves from PORTLAND (HMPYOI)
112/1265 moves populated...

Populating supplier GEOAmey for moves from Guildford Custody Suite
134/1265 moves populated...

Populating supplier GEOAmey for moves from WAKEFIELD (HMP)
334/1265 moves populated...

Populating supplier GEOAmey for moves from WAKEFIELD (HMP)
534/1265 moves populated...

Populating supplier GEOAmey for moves from WAKEFIELD (HMP)
734/1265 moves populated...

Populating supplier GEOAmey for moves from WAKEFIELD (HMP)
934/1265 moves populated...

Populating supplier GEOAmey for moves from WAKEFIELD (HMP)
1134/1265 moves populated...

Populating supplier GEOAmey for moves from WAKEFIELD (HMP)
1236/1265 moves populated...

Populating supplier GEOAmey for moves from WHATTON (HMP)
1240/1265 moves populated...

Populating supplier Serco for moves from WANDSWORTH (HMP)
1241/1265 moves populated...

Populating supplier Serco for moves from WETHERBY (HMPYOI)
1265/1265 moves populated...

1265 moves exist.
1265 moves have had their supplier updated.
0 moves already have a supplier.
0 moves could not be updated as their from_location does not have a supplier

rake move:supplier

1265 moves exist.
0 moves have had their supplier updated.
1265 moves already have a supplier.
0 moves could not be updated as their from_location does not have a supplier
```

**Dev**

```ruby
locations = Location.joins(:suppliers)
Move.where.not(from_location: locations).count
=> 0
 Move.count
=> 1000
```

**Staging:**
```ruby
locations = Location.joins(:suppliers)
Move.where.not(from_location: locations).count
=> 1078
Move.count
=> 22999
```

**Preprod**
```ruby
locations = Location.joins(:suppliers)
Move.where.not(from_location: locations).count
=> 35
Move.count
=> 35542
```

**Production**
```ruby
locations = Location.joins(:suppliers)
Move.where.not(from_location: locations).count
=> 0
Move.count
=> 81173
```

### Why?

We want to change the permissions model and filtering so that suppliers can only manage their own moves and clients of our api can retrieve moves based on the supplier specified via a filter (see [here](https://dsdmoj.atlassian.net/browse/P4-1879))

### Deployment risks (optional)

- This does affect production data but is additive and non-destructive
