### PR TITLE
P4-1791 GET /person_escort_records/{person_escort_record_id}

### DIFF
--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -14,7 +14,13 @@ module Api
         profile_id: new_person_escort_record_params.dig(:relationships, :profile, :data, :id),
       )
 
-      render json: person_escort_record, status: :created, include: included_relationships
+      render_person_escort_record(person_escort_record, :created)
+    end
+
+    def show
+      person_escort_record = PersonEscortRecord.find(params[:id])
+
+      render_person_escort_record(person_escort_record, :ok)
     end
 
   private
@@ -25,6 +31,10 @@ module Api
 
     def supported_relationships
       PersonEscortRecordSerializer::SUPPORTED_RELATIONSHIPS
+    end
+
+    def render_person_escort_record(person_escort_record, status)
+      render json: person_escort_record, status: status, include: included_relationships
     end
   end
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -2,6 +2,7 @@
 
 class FrameworkResponse < VersionedModel
   validates :type, presence: true
+  validates :responded, inclusion: { in: [true, false] }
 
   belongs_to :framework_question
   belongs_to :person_escort_record
@@ -13,11 +14,19 @@ class FrameworkResponse < VersionedModel
     record.errors.add(:value, :blank) if requires_value?(value, record)
   end
 
+  after_validation :set_responded_value
+
   def self.requires_value?(value, record)
     return false if value.present? || !record.framework_question.required
 
     return true if record.parent.blank?
 
     record.parent.option_selected?(record.framework_question.dependent_value)
+  end
+
+private
+
+  def set_responded_value
+    self.responded = true if value_text.present? || value_json.present?
   end
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -14,7 +14,7 @@ class FrameworkResponse < VersionedModel
     record.errors.add(:value, :blank) if requires_value?(value, record)
   end
 
-  after_validation :set_responded_value
+  after_validation :set_responded_value, on: :update
 
   def self.requires_value?(value, record)
     return false if value.present? || !record.framework_question.required
@@ -27,6 +27,6 @@ class FrameworkResponse < VersionedModel
 private
 
   def set_responded_value
-    self.responded = true if value_text.present? || value_json.present?
+    self.responded = true
   end
 end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -47,8 +47,11 @@ class PersonEscortRecord < VersionedModel
   end
 
   def section_progress
-    sections_to_responded.each do |section, responses|
-      sections_to_responded[section] = set_progress(responses)
+    sections_to_responded.map do |section, responses|
+      {
+        key: section,
+        status: set_progress(responses),
+      }
     end
   end
 

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -62,11 +62,11 @@ private
   end
 
   def set_progress(responses)
-    responded = responses.pluck(:responded).uniq
-    if responded.include?(true)
-      responded.include?(false) ? PERSON_ESCORT_RECORD_IN_PROGRESS : PERSON_ESCORT_RECORD_COMPLETED
-    else
-      PERSON_ESCORT_RECORD_NOT_STARTED
-    end
+    responded = responses.pluck(:responded)
+
+    return PERSON_ESCORT_RECORD_COMPLETED if responded.all?(true)
+    return PERSON_ESCORT_RECORD_NOT_STARTED if responded.all?(false)
+
+    PERSON_ESCORT_RECORD_IN_PROGRESS
   end
 end

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -3,7 +3,7 @@ class FrameworkResponseSerializer < ActiveModel::Serializer
   belongs_to :person_escort_record
   belongs_to :framework_question, key: :question
 
-  attributes :value, :value_type
+  attributes :value, :value_type, :responded
 
   def value_type
     case object.type

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -6,6 +6,10 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   attribute :version
   attribute :state, key: :status
 
+  meta do
+    { section_progress: object.section_progress }
+  end
+
   def version
     object.framework.version
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :person_escort_records, only: %i[create]
+    resources :person_escort_records, only: %i[create show]
 
     namespace :reference do
       resources :allocation_complex_cases, only: :index

--- a/db/migrate/20200715041742_add_responded_to_framework_responses.rb
+++ b/db/migrate/20200715041742_add_responded_to_framework_responses.rb
@@ -1,0 +1,5 @@
+class AddRespondedToFrameworkResponses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :framework_responses, :responded, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_13_092251) do
+ActiveRecord::Schema.define(version: 2020_07_15_041742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -160,6 +160,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_092251) do
     t.uuid "parent_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "responded", default: false, null: false
     t.index ["framework_question_id"], name: "index_framework_responses_on_framework_question_id"
     t.index ["parent_id"], name: "index_framework_responses_on_parent_id"
     t.index ["person_escort_record_id"], name: "index_framework_responses_on_person_escort_record_id"

--- a/spec/factories/framework.rb
+++ b/spec/factories/framework.rb
@@ -4,5 +4,11 @@ FactoryBot.define do
   factory :framework do
     sequence(:name) { |x| "person-escort-record-#{x}" }
     version { '0.1' }
+
+    trait :with_questions do
+      after(:create) do |framework|
+        create_list(:framework_question, 2, framework: framework)
+      end
+    end
   end
 end

--- a/spec/factories/framework_question.rb
+++ b/spec/factories/framework_question.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :framework_question do
     association(:framework)
     sequence(:key) { |x| "key-#{x}" }
-    section { 'risk' }
+    section { %w[offence-information health-information risk-information].sample }
     question_type { 'radio' }
     options { %w[Yes No] }
 

--- a/spec/factories/person_escort_record.rb
+++ b/spec/factories/person_escort_record.rb
@@ -5,5 +5,18 @@ FactoryBot.define do
     association(:framework)
     association(:profile)
     state { 'in_progress' }
+
+    trait :with_responses do
+      association(:framework, :with_questions)
+      after(:create) do |person_escort_record|
+        person_escort_record.framework_questions.each do |question|
+          create(
+            :string_response,
+            framework_question: question,
+            person_escort_record: person_escort_record,
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -73,54 +73,6 @@ RSpec.describe FrameworkResponse do
     expect(response).not_to validate_presence_of(:value).on(:update)
   end
 
-  it 'sets the responded value to false if string value is empty' do
-    response = create(:string_response, value: nil)
-
-    expect(response.responded).to be(false)
-  end
-
-  it 'sets the responded value to false if object value is empty' do
-    response = create(:object_response, value: {})
-
-    expect(response.responded).to be(false)
-  end
-
-  it 'sets the responded value to false if collection value is empty' do
-    response = create(:collection_response, value: [])
-
-    expect(response.responded).to be(false)
-  end
-
-  it 'sets the responded value to false if array value is empty' do
-    response = create(:array_response, value: [])
-
-    expect(response.responded).to be(false)
-  end
-
-  it 'sets the responded value to true if string value is present' do
-    response = create(:string_response)
-
-    expect(response.responded).to be(true)
-  end
-
-  it 'sets the responded value to true if object value is present' do
-    response = create(:object_response, :details)
-
-    expect(response.responded).to be(true)
-  end
-
-  it 'sets the responded value to true if collection value is present' do
-    response = create(:collection_response)
-
-    expect(response.responded).to be(true)
-  end
-
-  it 'sets the responded value to true if array value is present' do
-    response = create(:array_response)
-
-    expect(response.responded).to be(true)
-  end
-
   describe '.requires_value?' do
     it 'returns false if value present' do
       question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
@@ -156,6 +108,34 @@ RSpec.describe FrameworkResponse do
       response = create(:string_response, value: nil, parent: parent_response, framework_question: question)
 
       expect(described_class.requires_value?(response.value, response)).to be(false)
+    end
+  end
+
+  describe '#responded' do
+    it 'sets the responded value to false on creation with empty value' do
+      response = create(:string_response, value: nil)
+
+      expect(response.responded).to be(false)
+    end
+
+    it 'sets the responded value to false on creation with value' do
+      response = create(:string_response, value: 'Yes')
+
+      expect(response.responded).to be(false)
+    end
+
+    it 'sets the responded value to true on update with empty value' do
+      response = create(:string_response, value: nil)
+      response.update(value: 'Yes')
+
+      expect(response.responded).to be(true)
+    end
+
+    it 'sets the responded value to update on update with value' do
+      response = create(:string_response, value: 'Yes')
+      response.update(value: nil)
+
+      expect(response.responded).to be(true)
     end
   end
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe FrameworkResponse do
   it { is_expected.to belong_to(:parent).optional }
 
   it { is_expected.to have_many(:dependents) }
+  it { is_expected.to validate_presence_of(:type) }
 
   it 'validates string dependent responses' do
     question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
@@ -70,6 +71,54 @@ RSpec.describe FrameworkResponse do
     response = create(:string_response, value: nil, parent: create(:collection_response, :details), framework_question: question)
 
     expect(response).not_to validate_presence_of(:value).on(:update)
+  end
+
+  it 'sets the responded value to false if string value is empty' do
+    response = create(:string_response, value: nil)
+
+    expect(response.responded).to be(false)
+  end
+
+  it 'sets the responded value to false if object value is empty' do
+    response = create(:object_response, value: {})
+
+    expect(response.responded).to be(false)
+  end
+
+  it 'sets the responded value to false if collection value is empty' do
+    response = create(:collection_response, value: [])
+
+    expect(response.responded).to be(false)
+  end
+
+  it 'sets the responded value to false if array value is empty' do
+    response = create(:array_response, value: [])
+
+    expect(response.responded).to be(false)
+  end
+
+  it 'sets the responded value to true if string value is present' do
+    response = create(:string_response)
+
+    expect(response.responded).to be(true)
+  end
+
+  it 'sets the responded value to true if object value is present' do
+    response = create(:object_response, :details)
+
+    expect(response.responded).to be(true)
+  end
+
+  it 'sets the responded value to true if collection value is present' do
+    response = create(:collection_response)
+
+    expect(response.responded).to be(true)
+  end
+
+  it 'sets the responded value to true if array value is present' do
+    response = create(:array_response)
+
+    expect(response.responded).to be(true)
   end
 
   describe '.requires_value?' do

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe PersonEscortRecord do
       person_escort_record = create(:person_escort_record)
       question1 = create(:framework_question, framework: person_escort_record.framework, section: 'risk')
       question2 = create(:framework_question, framework: person_escort_record.framework, section: 'risk')
-      create(:string_response, value: 'Yes', framework_question: question1, person_escort_record: person_escort_record)
+      create(:string_response, value: 'Yes', framework_question: question1, person_escort_record: person_escort_record, responded: true)
 
       create(:string_response, value: nil, framework_question: question2, person_escort_record: person_escort_record)
 
@@ -265,9 +265,9 @@ RSpec.describe PersonEscortRecord do
       person_escort_record = create(:person_escort_record)
       question1 = create(:framework_question, framework: person_escort_record.framework, section: 'risk')
       question2 = create(:framework_question, framework: person_escort_record.framework, section: 'risk')
-      create(:string_response, value: 'Yes', framework_question: question1, person_escort_record: person_escort_record)
+      create(:string_response, value: 'Yes', framework_question: question1, person_escort_record: person_escort_record, responded: true)
 
-      create(:string_response, value: 'No', framework_question: question2, person_escort_record: person_escort_record)
+      create(:string_response, value: nil, framework_question: question2, person_escort_record: person_escort_record, responded: true)
 
       expect(person_escort_record.section_progress).to contain_exactly(
         {

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe PersonEscortRecord do
       expect(dependent_responses.count).to eq(2)
     end
 
-    it 'returns person_escort_record valildation error if record is not valid' do
+    it 'returns person_escort_record validation error if record is not valid' do
       framework = create(:framework)
       create(:framework_question, framework: framework)
       create(:framework_question, :checkbox, framework: framework)
@@ -229,7 +229,7 @@ RSpec.describe PersonEscortRecord do
       question_sections = person_escort_record.framework_questions.pluck(:section).uniq
       progress_sections = person_escort_record.section_progress.map { |section| section[:key] }
 
-      expect(progress_sections).to contain_exactly(*question_sections)
+      expect(progress_sections).to match_array(question_sections)
     end
 
     it 'returns a section as `not_started` if all responded values are false' do

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -226,9 +226,10 @@ RSpec.describe PersonEscortRecord do
 
     it 'returns all section values for framework questions' do
       person_escort_record = create(:person_escort_record, :with_responses)
-      sections = FrameworkQuestion.all.uniq.pluck(:section)
+      question_sections = person_escort_record.framework_questions.pluck(:section).uniq
+      progress_sections = person_escort_record.section_progress.map { |section| section[:key] }
 
-      expect(person_escort_record.section_progress.keys).to contain_exactly(*sections)
+      expect(progress_sections).to contain_exactly(*question_sections)
     end
 
     it 'returns a section as `not_started` if all responded values are false' do
@@ -236,7 +237,12 @@ RSpec.describe PersonEscortRecord do
       question = create(:framework_question, framework: person_escort_record.framework)
       create(:string_response, value: nil, framework_question: question, person_escort_record: person_escort_record)
 
-      expect(person_escort_record.section_progress[question.section]).to eq('not_started')
+      expect(person_escort_record.section_progress).to contain_exactly(
+        {
+          key: question.section,
+          status: 'not_started',
+        },
+      )
     end
 
     it 'returns a section as `in_progress` if some responded values are true' do
@@ -247,7 +253,12 @@ RSpec.describe PersonEscortRecord do
 
       create(:string_response, value: nil, framework_question: question2, person_escort_record: person_escort_record)
 
-      expect(person_escort_record.section_progress['risk']).to eq('in_progress')
+      expect(person_escort_record.section_progress).to contain_exactly(
+        {
+          key: 'risk',
+          status: 'in_progress',
+        },
+      )
     end
 
     it 'returns a section as `completed` if all responded values are true' do
@@ -258,7 +269,12 @@ RSpec.describe PersonEscortRecord do
 
       create(:string_response, value: 'No', framework_question: question2, person_escort_record: person_escort_record)
 
-      expect(person_escort_record.section_progress['risk']).to eq('completed')
+      expect(person_escort_record.section_progress).to contain_exactly(
+        {
+          key: 'risk',
+          status: 'completed',
+        },
+      )
     end
   end
 end

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -40,34 +40,37 @@ RSpec.describe Api::PersonEscortRecordsController do
       let(:data) do
         {
           "id": PersonEscortRecord.last.id,
-          "type": "person_escort_records",
+          "type": 'person_escort_records',
           "attributes": {
             "version": framework_version,
-            "status": "in_progress",
+            "status": 'in_progress',
           },
           "meta": {
-            "section_progress" => {
-              "risk_information" => "not_started"
-            }
+            'section_progress' => [
+              {
+                "key": 'risk-information',
+                "status": 'not_started',
+              },
+            ],
           },
           "relationships": {
             "profile": {
               "data": {
                 "id": profile_id,
-                "type": "profiles",
+                "type": 'profiles',
               },
             },
             "framework": {
               "data": {
                 "id": framework.id,
-                "type": "frameworks",
+                "type": 'frameworks',
               },
             },
             "responses": {
               "data": [
                 {
                   "id": FrameworkResponse.last.id,
-                  "type": "framework_responses",
+                  "type": 'framework_responses',
                 },
               ],
             },

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::PersonEscortRecordsController do
     let(:response_json) { JSON.parse(response.body) }
     let(:profile) { create(:profile) }
     let(:profile_id) { profile.id }
-    let(:framework) { create(:framework, framework_questions: [build(:framework_question)]) }
+    let(:framework) { create(:framework, framework_questions: [build(:framework_question, section: 'risk-information')]) }
     let(:framework_version) { framework.version }
 
     let(:person_escort_record_params) do
@@ -40,29 +40,34 @@ RSpec.describe Api::PersonEscortRecordsController do
       let(:data) do
         {
           "id": PersonEscortRecord.last.id,
-          "type": 'person_escort_records',
+          "type": "person_escort_records",
           "attributes": {
             "version": framework_version,
-            "status": 'in_progress',
+            "status": "in_progress",
+          },
+          "meta": {
+            "section_progress" => {
+              "risk_information" => "not_started"
+            }
           },
           "relationships": {
             "profile": {
               "data": {
                 "id": profile_id,
-                "type": 'profiles',
+                "type": "profiles",
               },
             },
             "framework": {
               "data": {
                 "id": framework.id,
-                "type": 'frameworks',
+                "type": "frameworks",
               },
             },
             "responses": {
               "data": [
                 {
                   "id": FrameworkResponse.last.id,
-                  "type": 'framework_responses',
+                  "type": "framework_responses",
                 },
               ],
             },

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::PersonEscortRecordsController do
 
     let(:response_json) { JSON.parse(response.body) }
     let(:framework_question) { build(:framework_question, section: 'risk-information') }
-    let(:framework_response) { build(:string_response, framework_question: framework_question) }
+    let(:framework_response) { build(:string_response, framework_question: framework_question, responded: true) }
     let(:framework) { create(:framework, framework_questions: [framework_question]) }
     let(:person_escort_record) { create(:person_escort_record, framework_responses: [framework_response]) }
     let(:person_escort_record_id) { person_escort_record.id }

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::PersonEscortRecordsController do
+  describe 'GET /person_escort_records/:person_escort_record_id' do
+    include_context 'with supplier with spoofed access token'
+
+    let(:response_json) { JSON.parse(response.body) }
+    let(:framework_question) { build(:framework_question, section: 'risk-information') }
+    let(:framework_response) { build(:string_response, framework_question: framework_question) }
+    let(:framework) { create(:framework, framework_questions: [framework_question]) }
+    let(:person_escort_record) { create(:person_escort_record, framework_responses: [framework_response]) }
+    let(:person_escort_record_id) { person_escort_record.id }
+
+    before do
+      get "/api/v1/person_escort_records/#{person_escort_record_id}", headers: headers, as: :json
+    end
+
+    context 'when successful' do
+      let(:schema) { load_yaml_schema('get_person_escort_record_responses.yaml') }
+      let(:data) do
+        {
+          "id": person_escort_record.id,
+          "type": "person_escort_records",
+          "attributes": {
+            "version": person_escort_record.framework.version,
+            "status": "in_progress",
+          },
+          "meta": {
+            "section_progress" => {
+              "risk_information" => "completed",
+            },
+          },
+          "relationships": {
+            "profile": {
+              "data": {
+                "id": person_escort_record.profile.id,
+                "type": "profiles",
+              },
+            },
+            "framework": {
+              "data": {
+                "id": person_escort_record.framework.id,
+                "type": "frameworks",
+              },
+            },
+            "responses": {
+              "data": [
+                {
+                  "id": framework_response.id,
+                  "type": "framework_responses",
+                },
+              ],
+            },
+          },
+        }
+      end
+
+      it_behaves_like 'an endpoint that responds with success 200'
+
+      it 'returns the correct data' do
+        expect(response_json).to include_json(data: data)
+      end
+    end
+
+    context 'when unsuccessful' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+
+      context "when attempting to access another move's journey" do
+        let(:person_escort_record_id) { SecureRandom.uuid }
+        let(:detail_404) { "Couldn't find PersonEscortRecord with 'id'=#{person_escort_record_id}" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+    end
+  end
+end

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -22,34 +22,37 @@ RSpec.describe Api::PersonEscortRecordsController do
       let(:data) do
         {
           "id": person_escort_record.id,
-          "type": "person_escort_records",
+          "type": 'person_escort_records',
           "attributes": {
             "version": person_escort_record.framework.version,
-            "status": "in_progress",
+            "status": 'in_progress',
           },
           "meta": {
-            "section_progress" => {
-              "risk_information" => "completed",
-            },
+            'section_progress' => [
+              {
+                "key": 'risk-information',
+                "status": 'completed',
+              },
+            ],
           },
           "relationships": {
             "profile": {
               "data": {
                 "id": person_escort_record.profile.id,
-                "type": "profiles",
+                "type": 'profiles',
               },
             },
             "framework": {
               "data": {
                 "id": person_escort_record.framework.id,
-                "type": "frameworks",
+                "type": 'frameworks',
               },
             },
             "responses": {
               "data": [
                 {
                   "id": framework_response.id,
-                  "type": "framework_responses",
+                  "type": 'framework_responses',
                 },
               ],
             },

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe FrameworkResponseSerializer do
     expect(result[:data][:attributes][:value]).to eq(framework_response.value)
   end
 
+  it 'contains a `responded` attribute' do
+    expect(result[:data][:attributes][:responded]).to eq(framework_response.responded)
+  end
+
   it 'contains a `person_escort_record` relationship' do
     expect(result[:data][:relationships][:person_escort_record][:data]).to eq(
       id: framework_response.person_escort_record.id,

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -57,8 +57,9 @@ RSpec.describe PersonEscortRecordSerializer do
       question = create(:framework_question, framework: person_escort_record.framework, section: 'risk-information')
       create(:string_response, value: nil, framework_question: question, person_escort_record: person_escort_record)
 
-      expect(result[:data][:meta][:section_progress]).to eq(
-        'risk_information' => 'not_started',
+      expect(result[:data][:meta][:section_progress]).to contain_exactly(
+        key: 'risk-information',
+        status: 'not_started',
       )
     end
 

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe PersonEscortRecordSerializer do
   subject(:serializer) { described_class.new(person_escort_record) }
 
-  let(:person_escort_record) { create :person_escort_record }
+  let(:person_escort_record) { create(:person_escort_record) }
   let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
 
   it 'contains a `type` property' do
@@ -50,5 +50,22 @@ RSpec.describe PersonEscortRecordSerializer do
       id: response.id,
       type: 'framework_responses',
     )
+  end
+
+  describe 'meta' do
+    it 'includes section progress' do
+      question = create(:framework_question, framework: person_escort_record.framework, section: 'risk-information')
+      create(:string_response, value: nil, framework_question: question, person_escort_record: person_escort_record)
+
+      expect(result[:data][:meta][:section_progress]).to eq(
+        'risk_information' => 'not_started',
+      )
+    end
+
+    context 'with no questions' do
+      it 'does not include includes section progress' do
+        expect(result[:data][:meta][:section_progress]).to be_empty
+      end
+    end
   end
 end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2542,6 +2542,49 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/post_person_escort_record_responses.yaml#/422"
+  "/person_escort_record/{person_escort_record_id}":
+    get:
+      summary: Gets a person_escort_record
+      description:
+        "This method gets the specified person_escort_record"
+      tags:
+        - PersonEscortRecord
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - "$ref": "../v1/person_escort_record_id_parameter.yaml#/PersonEscortRecordId"
+      responses:
+        "200":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_person_escort_record_responses.yaml#/200"
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/400"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/401"
+        "404":
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/404"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/415"
   "/reference/allocation_complex_cases":
     get:
       summary: Returns a list of allocation complex cases

--- a/swagger/v1/get_person_escort_record_responses.yaml
+++ b/swagger/v1/get_person_escort_record_responses.yaml
@@ -1,0 +1,7 @@
+'200':
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      $ref: person_escort_record.yaml#/PersonEscortRecord

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -43,6 +43,23 @@ PersonEscortRecord:
           format: date-time
           description: Timestamp of when the person_escort_record was created
           readOnly: true
+    meta:
+      type: object
+      properties:
+        section_progress:
+          type: object
+          description: Determines the current progress of all responses in each `section` in the person_escort_record
+          example:
+            risk_information: not_started
+            health_information: not_started
+          additionalProperties:
+            type: string
+            example: in_progress
+            enum:
+              - not_started
+              - in_progress
+              - completed
+            description: status of progress of a section
     relationships:
       type: object
       required:

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -44,22 +44,30 @@ PersonEscortRecord:
           description: Timestamp of when the person_escort_record was created
           readOnly: true
     meta:
+      readOnly: true
       type: object
       properties:
         section_progress:
-          type: object
+          type: array
           description: Determines the current progress of all responses in each `section` in the person_escort_record
-          example:
-            risk_information: not_started
-            health_information: not_started
-          additionalProperties:
-            type: string
-            example: in_progress
-            enum:
-              - not_started
-              - in_progress
-              - completed
-            description: status of progress of a section
+          items:
+            type: object
+            required:
+              - key
+              - status
+            properties:
+              key:
+                type: string
+                example: risk-information
+                description: identifier of section
+              status:
+                type: string
+                example: in_progress
+                enum:
+                  - not_started
+                  - in_progress
+                  - completed
+                description: status of progress of a section
     relationships:
       type: object
       required:

--- a/swagger/v1/person_escort_record_id_parameter.yaml
+++ b/swagger/v1/person_escort_record_id_parameter.yaml
@@ -1,0 +1,9 @@
+PersonEscortRecordId:
+  name: person_escort_record_id
+  in: path
+  required: true
+  description: The ID of the person_escort_record
+  schema:
+    type: string
+    format: uuid
+  example: 5b61f755-0fd7-4a91-b7a3-a33d751f985f


### PR DESCRIPTION
### Jira link

[P4-1791](https://dsdmoj.atlassian.net/browse/P4-1791)

### What?

I have added/removed/altered:

- [x] Added responded field to responses
- [x] Added meta section to person escort record serializer
- [x] Added person escort record GET endpoint

### Why?

To support getting an existing PER, add new endpoint which accepts an id and returns a PER. To help the FE render different section progress, a new `meta` section has been added. This is supported by the [JSON:API spec](https://jsonapi.org/format/#document-resource-objects) in the data section. This will summarise all sections and their progress according to the new `responded` attribute on responses. The `responded` field is by default set to false. If a response is supplied and valid, the `responded` value is updated to true.

### Have you? (optional)

- [x] Updated API docs if necessary
