### PR TITLE
[P4-1879] Filter moves by supplier

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -25,7 +25,7 @@ module Api
     end
 
     PERMITTED_FILTER_PARAMS = %i[
-      date_from date_to created_at_from created_at_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason has_relationship_to_allocation
+      date_from date_to created_at_from created_at_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason has_relationship_to_allocation supplier_id
     ].freeze
 
     def filter_params

--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -25,7 +25,7 @@ module Api
     end
 
     PERMITTED_FILTER_PARAMS = %i[
-      date_from date_to created_at_from created_at_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason has_relationship_to_allocation supplier_id
+      date_from date_to created_at_from created_at_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason has_relationship_to_allocation
     ].freeze
 
     def filter_params

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -46,12 +46,12 @@ module Moves
       scope = apply_date_range_filters(scope)
       scope = apply_location_type_filters(scope)
       scope = apply_allocation_relationship_filters(scope)
+      scope = apply_filter(scope, :supplier_id)
       scope = apply_filter(scope, :from_location_id)
       scope = apply_filter(scope, :to_location_id)
       scope = apply_filter(scope, :status)
       scope = apply_filter(scope, :move_type)
       scope = apply_filter(scope, :cancellation_reason)
-      scope = apply_supplier_filters(scope)
       scope
     end
 
@@ -78,12 +78,6 @@ module Moves
       scope
         .joins(:to_location)
         .where(locations: { location_type: filter_params[:location_type] })
-    end
-
-    def apply_supplier_filters(scope)
-      return scope unless filter_params.key?(:supplier_id)
-
-      scope.served_by(filter_params[:supplier_id])
     end
 
     def apply_allocation_relationship_filters(scope)

--- a/spec/requests/api/moves_controller_filter_spec.rb
+++ b/spec/requests/api/moves_controller_filter_spec.rb
@@ -13,16 +13,12 @@ RSpec.describe Api::MovesController do
   let(:expected_moves) { nil }
   let(:unexpected_moves) { nil }
 
-  shared_examples 'it returns the correct moves' do
+  shared_examples 'an api that filters moves correctly' do
     let(:size) { response_json['data'].size }
     let(:ids) { response_json['data'].map { |move| move['id'] } }
 
-    it 'contains all the expected moves' do
+    it 'contains the correct moves' do
       expect(ids).to match_array(expected_moves.pluck(:id))
-    end
-
-    it 'does not contain any unexpected moves' do
-      # NB: this is a necessary test to catch a dodgy test which has unexpected moves in the expected moves
       expect(ids & unexpected_moves.pluck(:id)).to be_empty
     end
   end
@@ -36,12 +32,10 @@ RSpec.describe Api::MovesController do
 
     describe 'by supplier_id' do
       let(:filter_params) { { filter: { supplier_id: supplier.id } } }
-      let(:supplier_location) { create :location, :with_moves, suppliers: [supplier] }
-      let(:alternative_supplier_location) { create :location, :with_moves, suppliers: [alternative_supplier] }
-      let(:expected_moves) { Move.where(from_location: supplier_location) }
-      let(:unexpected_moves) { Move.where(from_location: alternative_supplier_location) }
+      let(:expected_moves) { create_list :move, 2, supplier: supplier }
+      let(:unexpected_moves) { create_list :move, 2, supplier: alternative_supplier }
 
-      it_behaves_like 'it returns the correct moves'
+      it_behaves_like 'an api that filters moves correctly'
     end
 
     describe 'by from_location_id' do
@@ -50,7 +44,7 @@ RSpec.describe Api::MovesController do
       let(:expected_moves) { create_list :move, 3, from_location: location }
       let(:unexpected_moves) { create_list :move, 3 }
 
-      it_behaves_like 'it returns the correct moves'
+      it_behaves_like 'an api that filters moves correctly'
     end
 
     describe 'by created_at' do
@@ -67,7 +61,7 @@ RSpec.describe Api::MovesController do
         let(:expected_moves) { middle_moves + last_moves }
         let(:unexpected_moves) { first_moves }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'with a created_at_to' do
@@ -75,7 +69,7 @@ RSpec.describe Api::MovesController do
         let(:expected_moves) { first_moves + middle_moves }
         let(:unexpected_moves) { last_moves }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'with a created_at range' do
@@ -83,7 +77,7 @@ RSpec.describe Api::MovesController do
         let(:expected_moves) { first_moves + middle_moves }
         let(:unexpected_moves) { last_moves }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'when given bad start date' do
@@ -122,7 +116,7 @@ RSpec.describe Api::MovesController do
         let(:expected_moves) { court_appearance_moves }
         let(:unexpected_moves) { prison_recall_moves + prison_transfer_moves }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'when prison_transfer' do
@@ -130,7 +124,7 @@ RSpec.describe Api::MovesController do
         let(:expected_moves) { prison_transfer_moves }
         let(:unexpected_moves) { court_appearance_moves + prison_recall_moves }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'when prison_recall' do
@@ -138,7 +132,7 @@ RSpec.describe Api::MovesController do
         let(:expected_moves) { prison_recall_moves }
         let(:unexpected_moves) { court_appearance_moves + prison_transfer_moves }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
     end
 
@@ -152,7 +146,7 @@ RSpec.describe Api::MovesController do
         let(:unexpected_moves) { Move.where(id: move_without_allocation.id) }
         let(:filter_value) { true }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'when set to false' do
@@ -160,7 +154,7 @@ RSpec.describe Api::MovesController do
         let(:unexpected_moves) { Move.where(id: move_with_allocation.id) }
         let(:filter_value) { false }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'when set to incorrect type' do
@@ -168,7 +162,7 @@ RSpec.describe Api::MovesController do
         let(:unexpected_moves) { Move.none }
         let(:filter_value) { 'some-value' }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'when set to empty value' do
@@ -176,7 +170,7 @@ RSpec.describe Api::MovesController do
         let(:unexpected_moves) { Move.none }
         let(:filter_value) { nil }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'when filter not set' do
@@ -184,7 +178,7 @@ RSpec.describe Api::MovesController do
         let(:unexpected_moves) { Move.none }
         let(:filter_params) { {} }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
     end
 
@@ -200,7 +194,7 @@ RSpec.describe Api::MovesController do
         let(:expected_moves) { made_in_error_moves }
         let(:unexpected_moves) { supplier_declined_to_move_moves + rejected_moves + other_moves }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'when supplier_declined_to_move' do
@@ -208,7 +202,7 @@ RSpec.describe Api::MovesController do
         let(:expected_moves) { supplier_declined_to_move_moves }
         let(:unexpected_moves) { made_in_error_moves + rejected_moves + other_moves }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'when rejected' do
@@ -216,7 +210,7 @@ RSpec.describe Api::MovesController do
         let(:expected_moves) { rejected_moves }
         let(:unexpected_moves) { made_in_error_moves + supplier_declined_to_move_moves + other_moves }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
 
       context 'when other' do
@@ -224,7 +218,7 @@ RSpec.describe Api::MovesController do
         let(:expected_moves) { other_moves }
         let(:unexpected_moves) { made_in_error_moves + supplier_declined_to_move_moves + rejected_moves }
 
-        it_behaves_like 'it returns the correct moves'
+        it_behaves_like 'an api that filters moves correctly'
       end
     end
   end

--- a/spec/requests/api/moves_controller_filter_v2_spec.rb
+++ b/spec/requests/api/moves_controller_filter_v2_spec.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::MovesController do
+  let(:response_json) { JSON.parse(response.body) }
+  let(:supplier) { create :supplier }
+  let(:alternative_supplier) { create :supplier }
+  let(:access_token) { 'spoofed-token' }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:schema) { load_yaml_schema('get_moves_responses.yaml') }
+  let(:expected_moves) { nil }
+  let(:unexpected_moves) { nil }
+
+  let(:headers) do
+    {
+      'CONTENT_TYPE': content_type,
+      'Accept': 'application/vnd.api+json; version=2',
+      'Authorization' => "Bearer #{access_token}",
+    }
+  end
+
+  shared_examples 'an api that filters moves correctly' do
+    let(:size) { response_json['data'].size }
+    let(:ids) { response_json['data'].map { |move| move['id'] } }
+
+    it 'contains the correct moves' do
+      expect(ids).to match_array(expected_moves.pluck(:id))
+      expect(ids & unexpected_moves.pluck(:id)).to be_empty
+    end
+  end
+
+  describe 'GET /moves' do
+    before do
+      expected_moves # forces creation of expected and unexpected moves prior to querying data
+      unexpected_moves
+      get '/api/moves', params: filter_params, headers: headers
+    end
+
+    describe 'by supplier_id' do
+      let(:filter_params) { { filter: { supplier_id: supplier.id } } }
+      let(:expected_moves) { create_list :move, 2, supplier: supplier }
+      let(:unexpected_moves) { create_list :move, 2, supplier: alternative_supplier }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
+
+    describe 'by from_location_id' do
+      let(:filter_params) { { filter: { from_location_id: location.id } } }
+      let(:location) { create :location }
+      let(:expected_moves) { create_list :move, 3, from_location: location }
+      let(:unexpected_moves) { create_list :move, 3 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
+
+    describe 'by created_at' do
+      let(:first_date) { DateTime.new(2019, 12, 25, 12) }
+      let(:middle_date) { DateTime.new(2019, 12, 26, 12) }
+      let(:last_date) { DateTime.new(2019, 12, 27) }
+
+      let(:first_moves) { create_list :move, 2, created_at: first_date }
+      let(:middle_moves) { create_list :move, 2, created_at: middle_date }
+      let(:last_moves) { create_list :move, 2, created_at: last_date }
+
+      context 'with a created_at_from' do
+        let(:filter_params) { { filter: { created_at_from: middle_date.to_date.to_s } } }
+        let(:expected_moves) { middle_moves + last_moves }
+        let(:unexpected_moves) { first_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'with a created_at_to' do
+        let(:filter_params) { { filter: { created_at_to: middle_date.to_date.to_s } } }
+        let(:expected_moves) { first_moves + middle_moves }
+        let(:unexpected_moves) { last_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'with a created_at range' do
+        let(:filter_params) { { filter: { created_at_from: first_date.to_date.to_s, created_at_to: middle_date.to_date.to_s } } }
+        let(:expected_moves) { first_moves + middle_moves }
+        let(:unexpected_moves) { last_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when given bad start date' do
+        let(:filter_params) { { filter: { created_at_from: 'rabbit' } } }
+        let(:errors_422) do
+          [{
+            'title' => 'Invalid created_at_from',
+            'detail' => 'Validation failed: Created at from is not a valid date.',
+          }]
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422'
+      end
+
+      context 'when given bad end date' do
+        let(:filter_params) { { filter: { created_at_to: 'rabbit' } } }
+        let(:errors_422) do
+          [{
+            'title' => 'Invalid created_at_to',
+            'detail' => 'Validation failed: Created at to is not a valid date.',
+          }]
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422'
+      end
+    end
+
+    describe 'by move_type' do
+      let(:filter_params) { { filter: { move_type: move_type } } }
+      let(:court_appearance_moves) { create_list :move, 3, :court_appearance }
+      let(:prison_recall_moves) { create_list :move, 3, :prison_recall }
+      let(:prison_transfer_moves) { create_list :move, 3, :prison_transfer }
+
+      context 'when court_appearance' do
+        let(:move_type) { 'court_appearance' }
+        let(:expected_moves) { court_appearance_moves }
+        let(:unexpected_moves) { prison_recall_moves + prison_transfer_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when prison_transfer' do
+        let(:move_type) { 'prison_transfer' }
+        let(:expected_moves) { prison_transfer_moves }
+        let(:unexpected_moves) { court_appearance_moves + prison_recall_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when prison_recall' do
+        let(:move_type) { 'prison_recall' }
+        let(:expected_moves) { prison_recall_moves }
+        let(:unexpected_moves) { court_appearance_moves + prison_transfer_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+    end
+
+    describe 'by has_relationship_to_allocation' do
+      let(:filter_params) { { filter: { has_relationship_to_allocation: filter_value } } }
+      let(:move_with_allocation) { create(:move, :with_allocation) }
+      let(:move_without_allocation) { create(:move) }
+
+      context 'when set to true' do
+        let(:expected_moves) { Move.where(id: move_with_allocation.id) }
+        let(:unexpected_moves) { Move.where(id: move_without_allocation.id) }
+        let(:filter_value) { true }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when set to false' do
+        let(:expected_moves) { Move.where(id: move_without_allocation.id) }
+        let(:unexpected_moves) { Move.where(id: move_with_allocation.id) }
+        let(:filter_value) { false }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when set to incorrect type' do
+        let(:expected_moves) { Move.where(id: [move_without_allocation.id, move_with_allocation.id]) }
+        let(:unexpected_moves) { Move.none }
+        let(:filter_value) { 'some-value' }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when set to empty value' do
+        let(:expected_moves) { Move.where(id: [move_without_allocation.id, move_with_allocation.id]) }
+        let(:unexpected_moves) { Move.none }
+        let(:filter_value) { nil }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when filter not set' do
+        let(:expected_moves) { Move.where(id: [move_without_allocation.id, move_with_allocation.id]) }
+        let(:unexpected_moves) { Move.none }
+        let(:filter_params) { {} }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+    end
+
+    describe 'by cancellation_reason' do
+      let(:filter_params) { { filter: { cancellation_reason: cancellation_reason } } }
+      let(:made_in_error_moves) { create_list :move, 3, :cancelled_made_in_error }
+      let(:supplier_declined_to_move_moves) { create_list :move, 3, :cancelled_supplier_declined_to_move }
+      let(:rejected_moves) { create_list :move, 3, :cancelled_rejected }
+      let(:other_moves) { create_list :move, 3, :cancelled_other }
+
+      context 'when made_in_error' do
+        let(:cancellation_reason) { 'made_in_error' }
+        let(:expected_moves) { made_in_error_moves }
+        let(:unexpected_moves) { supplier_declined_to_move_moves + rejected_moves + other_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when supplier_declined_to_move' do
+        let(:cancellation_reason) { 'supplier_declined_to_move' }
+        let(:expected_moves) { supplier_declined_to_move_moves }
+        let(:unexpected_moves) { made_in_error_moves + rejected_moves + other_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when rejected' do
+        let(:cancellation_reason) { 'rejected' }
+        let(:expected_moves) { rejected_moves }
+        let(:unexpected_moves) { made_in_error_moves + supplier_declined_to_move_moves + other_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when other' do
+        let(:cancellation_reason) { 'other' }
+        let(:expected_moves) { other_moves }
+        let(:unexpected_moves) { made_in_error_moves + supplier_declined_to_move_moves + rejected_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+    end
+  end
+end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -75,12 +75,13 @@ RSpec.describe Moves::Finder do
 
     describe 'by supplier_id' do
       context 'with supplier filter' do
-        let(:supplier) { create :supplier }
-        let!(:location) { create :location, :with_moves, suppliers: [supplier] }
-        let(:filter_params) { { supplier_id: supplier.id } }
+        let(:move) { create :move, :with_supplier }
+        let(:filter_params) { { supplier_id: move.supplier_id } }
 
         it 'returns moves matching the supplier' do
-          expect(results).to match_array location.moves_from
+          create :move, from_location: move.from_location
+
+          expect(results).to contain_exactly move
         end
       end
     end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -535,6 +535,16 @@
                 - supplier_declined_to_move
                 - rejected
                 - other
+        - name: filter[supplier_id]
+          description: Filters results to only include moves for the given supplier UUIDs
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: filter[from_location_id]
           description:
             Filters results to only include moves from the given location

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -360,6 +360,16 @@
                 - supplier_declined_to_move
                 - rejected
                 - other
+        - name: filter[supplier_id]
+          description: Filters results to only include moves for the given supplier UUIDs
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: filter[from_location_id]
           description:
             Filters results to only include moves from the given location


### PR DESCRIPTION
### Jira link

P4-1879

### What?

- [x] Replaces existing/undocumented filter of supplier_id on the
from_location with supplier_id directly on the move
- [x] Simplifies shared examples around filtering
- [x] Extends swagger documentation to include supplier id filter
- [x] Duplicates filter tests for v1/v2 (removing v1 tests later)

### Why?

We're moving to supporting multiple suppliers on a location so our
authorisation model of move ownership through the location no longer
works.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- We may find that this breaks something for frontend since we technically supported - but didn't document - a version of supplier filter in the past based on the from location -> suppliers relationship.
