### PR TITLE
Clean ECR images weekly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ executors:
           RACK_ENV: test
           DATABASE_URL: "postgres://postgres@localhost/hmpps-book-secure-move-api"
           EXTERNAL_URL: mocked_in_tests
-          ENCRYPTOR_SALT: "*\xDB\x9E\a\x1ES1\xB7\xE3\xB8{\xF9Fl\x8Fnn?\x83\xC6\xBBR\x9Eq\x0F\x01./U\x0E\xF1\xDE"
+          ENCRYPTOR_SALT: "2EREZ8Xub/vt0ya1ZM6YKUwIMN72MbmqeWMq7KS4BV8oSJJc27rDpZYmA6AQGYcS"
       - image: circleci/postgres:10-alpine-ram
         environment:
           POSTGRES_USER: postgres
@@ -378,6 +378,38 @@ jobs:
           env: "production"
           notify_slack: "true"
 
+  ecr-cleanup:
+    executor: cloud-platform-executor
+    steps:
+      - run:
+          name: Check for too many images
+          command: |
+            COUNT=$(aws ecr list-images --repository-name 'book-a-secure-move/hmpps-book-secure-move-api' | jq '.imageIds | unique_by(.imageDigest) | length')
+            if [ "$COUNT" -lt 200 ]; then circleci step halt; exit 0;  fi
+            echo "More than 200 images found. Proceeding with cleanup"
+      - run:
+          name: Build manifest
+          command: |
+            TO_DELETE=$(aws ecr describe-images --region=eu-west-2 \
+              --repository-name book-a-secure-move/hmpps-book-secure-move-api \
+              --query 'imageDetails[]' --output json |\
+              jq 'sort_by(.imagePushedAt)|map(select(any(.imageTags[]? ; contains("latest"))|not))|map({imageDigest})|.[:100]')
+            echo "Tags to be deleted:"
+            aws ecr describe-images --region=eu-west-2 \
+              --repository-name book-a-secure-move/hmpps-book-secure-move-api \
+              --image-ids "${TO_DELETE}" --output json  | jq '.[][].imageTags[]'
+            echo "Deleting:"
+            aws ecr batch-delete-image --region eu-west-2 \
+            --repository-name book-a-secure-move/hmpps-book-secure-move-api \
+            --image-ids ${TO_DELETE}
+      - run:
+          name: Confirm live latest images
+          command: |
+            echo "Images tagged latest left behind"
+            aws ecr describe-images --region=eu-west-2 \
+            --repository-name  book-a-secure-move/hmpps-book-secure-move-api \
+            --query 'imageDetails[]' --output json | \
+            jq 'map(select(any(.imageTags[]? ; contains("latest"))))|map(.imageTags)'
 workflows:
   version: 2
 
@@ -434,3 +466,10 @@ workflows:
           <<: *only_deploy_tags
           requires:
             - hold_production
+  ecr-cleanup:
+    jobs: [ecr-cleanup]
+    triggers:
+      - schedule:
+          cron: "0 9 * * 1"
+          <<: *only_master
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,23 +390,23 @@ jobs:
       - run:
           name: Build manifest
           command: |
-            TO_DELETE=$(aws ecr describe-images --region=eu-west-2 \
+            TO_DELETE=$(aws ecr describe-images \
               --repository-name book-a-secure-move/hmpps-book-secure-move-api \
               --query 'imageDetails[]' --output json |\
               jq 'sort_by(.imagePushedAt)|map(select(any(.imageTags[]? ; contains("latest"))|not))|map({imageDigest})|.[:100]')
             echo "Tags to be deleted:"
-            aws ecr describe-images --region=eu-west-2 \
+            aws ecr describe-images  \
               --repository-name book-a-secure-move/hmpps-book-secure-move-api \
               --image-ids "${TO_DELETE}" --output json  | jq '.[][].imageTags[]'
             echo "Deleting:"
-            aws ecr batch-delete-image --region eu-west-2 \
+            aws ecr batch-delete-image \
             --repository-name book-a-secure-move/hmpps-book-secure-move-api \
             --image-ids ${TO_DELETE}
       - run:
           name: Confirm live latest images
           command: |
             echo "Images tagged latest left behind"
-            aws ecr describe-images --region=eu-west-2 \
+            aws ecr describe-images \
             --repository-name  book-a-secure-move/hmpps-book-secure-move-api \
             --query 'imageDetails[]' --output json | \
             jq 'map(select(any(.imageTags[]? ; contains("latest"))))|map(.imageTags)'


### PR DESCRIPTION
### Jira link

[P4-1476](https://dsdmoj.atlassian.net/browse/P4-1476)

### What?

I have added/removed/altered:

- [ ] Automates the goal of ticket P4-1476 

### Why?

I am doing this because:

- Automate everything™ 
- Apply the process  outlined in [Confluence](https://dsdmoj.atlassian.net/l/c/b0u0ExVQ) automatically every Monday.

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- This was tested on a number of conditions to prevent the current images to being deleted, but there is always a slight change that it could happen do to a bug.
- Only the newest 100 < images < 200 will be left behind.
- Images containing "latest" on its tag designation will be always left behind untouched.
- Up to 100 images will be deleted per run (max aws batch-delete size)
