### PR TITLE
Expose PER in profile and update swagger docs

### DIFF
--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -20,6 +20,6 @@ class FrameworkResponseSerializer < ActiveModel::Serializer
 
   SUPPORTED_RELATIONSHIPS = %w[
     person_escort_record
-    framework_question
+    question
   ].freeze
 end

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -35,6 +35,7 @@ class MoveSerializer < ActiveModel::Serializer
     person.gender
     profile.person.ethnicity
     profile.person.gender
+    profile.person_escort_record
     from_location
     from_location.suppliers
     to_location

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -7,6 +7,7 @@ class ProfileSerializer < ActiveModel::Serializer
 
   belongs_to :person, serializer: PersonSerializer
   has_many :documents, serializer: DocumentSerializer
+  has_one :person_escort_record, serializer: PersonEscortRecordSerializer
 
   SUPPORTED_RELATIONSHIPS = %w[documents person].freeze
 end

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -32,6 +32,7 @@ module V2
       profile.documents
       profile.person.ethnicity
       profile.person.gender
+      profile.person_escort_record
       from_location
       from_location.suppliers
       to_location

--- a/app/serializers/v2/profile_serializer.rb
+++ b/app/serializers/v2/profile_serializer.rb
@@ -7,6 +7,7 @@ class V2::ProfileSerializer < ActiveModel::Serializer
 
   belongs_to :person, serializer: V2::PersonSerializer
   has_many :documents, serializer: DocumentSerializer
+  has_one :person_escort_record, serializer: PersonEscortRecordSerializer
 
   SUPPORTED_RELATIONSHIPS = %w[documents person].freeze
 end

--- a/spec/serializers/framework_question_serializer_spec.rb
+++ b/spec/serializers/framework_question_serializer_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe FrameworkQuestionSerializer do
   subject(:serializer) { described_class.new(framework_question) }
 
   let(:framework_question) { create :framework_question }
-  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer, include: includes).serializable_hash }
+  let(:includes) { {} }
 
   it 'contains a `type` property' do
     expect(result[:data][:type]).to eq('framework_questions')
@@ -33,5 +34,23 @@ RSpec.describe FrameworkQuestionSerializer do
       id: framework_question.framework.id,
       type: 'frameworks',
     )
+  end
+
+  context 'with include options' do
+    let(:includes) { { framework: :name } }
+
+    let(:expected_json) do
+      [
+        {
+          id: framework_question.framework.id,
+          type: 'frameworks',
+          attributes: { name: framework_question.framework.name },
+        },
+      ]
+    end
+
+    it 'contains an included framework' do
+      expect(result[:included]).to include_json(expected_json)
+    end
   end
 end

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe PersonEscortRecordSerializer do
   subject(:serializer) { described_class.new(person_escort_record) }
 
   let(:person_escort_record) { create(:person_escort_record) }
-  let(:result) { ActiveModelSerializers::Adapter.create(serializer).serializable_hash }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer, include: includes).serializable_hash }
+  let(:includes) { {} }
 
   it 'contains a `type` property' do
     expect(result[:data][:type]).to eq('person_escort_records')
@@ -67,6 +68,33 @@ RSpec.describe PersonEscortRecordSerializer do
       it 'does not include includes section progress' do
         expect(result[:data][:meta][:section_progress]).to be_empty
       end
+    end
+  end
+
+  context 'with include options' do
+    let(:includes) { { responses: [:value, question: :key] } }
+    let(:framework_response) { build(:object_response) }
+    let(:person_escort_record) do
+      create(:person_escort_record, framework_responses: [framework_response])
+    end
+
+    let(:expected_json) do
+      [
+        {
+          id: framework_response.id,
+          type: 'framework_responses',
+          attributes: { value: framework_response.value },
+        },
+        {
+          id: framework_response.framework_question.id,
+          type: 'framework_questions',
+          attributes: { key: framework_response.framework_question.key },
+        },
+      ]
+    end
+
+    it 'contains an included responses and question' do
+      expect(result[:included]).to include_json(expected_json)
     end
   end
 end

--- a/spec/serializers/profile_serializer_spec.rb
+++ b/spec/serializers/profile_serializer_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe ProfileSerializer do
           documents: {
             data: [],
           },
+          person_escort_record: {
+            data: nil,
+          },
         },
       },
     }

--- a/spec/serializers/v2/profile_serializer_spec.rb
+++ b/spec/serializers/v2/profile_serializer_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe V2::ProfileSerializer do
           documents: {
             data: [],
           },
+          person_escort_record: {
+            data: nil,
+          },
         },
       },
     }

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2505,6 +2505,7 @@
         description: The person_escort_record object to be created
         schema:
           "$ref": "../v1/person_escort_record.yaml#/PersonEscortRecord"
+      - "$ref": "../v1/person_escort_record_include_parameter.yaml#/PersonEscortRecordIncludeParameter"
       responses:
         '201':
           description: created
@@ -2554,6 +2555,7 @@
       parameters:
         - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
         - "$ref": "../v1/person_escort_record_id_parameter.yaml#/PersonEscortRecordId"
+        - "$ref": "../v1/person_escort_record_include_parameter.yaml#/PersonEscortRecordIncludeParameter"
       responses:
         "200":
           description: success

--- a/swagger/v1/move_include_parameter.yaml
+++ b/swagger/v1/move_include_parameter.yaml
@@ -24,4 +24,5 @@ MoveIncludeParameter:
       - profile.person
       - profile.person.gender
       - profile.person.ethnicity
+      - profile.person_escort_record
   example: from_location

--- a/swagger/v1/person_escort_record_include_parameter.yaml
+++ b/swagger/v1/person_escort_record_include_parameter.yaml
@@ -1,0 +1,15 @@
+PersonEscortRecordIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the person_escort_record
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - framework
+      - profile
+      - profile.person
+      - responses
+      - responses.question
+  example: framework

--- a/swagger/v1/person_escort_record_reference.yaml
+++ b/swagger/v1/person_escort_record_reference.yaml
@@ -1,0 +1,26 @@
+PersonEscortRecordReference:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      oneOf:
+      - type: object
+      - type: 'null'
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          example: person_escort_records
+          enum:
+            - person_escort_records
+          description: The type of this object - always `person_escort_records`
+        id:
+          type: string
+          format: uuid
+          example: ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154
+          description:
+            The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v1/profile.yaml
+++ b/swagger/v1/profile.yaml
@@ -31,3 +31,6 @@ Profile:
         documents:
           $ref: document_reference.yaml#/DocumentReference
           description: The documents associated with this Move
+        person_escort_record:
+          $ref: person_escort_record_reference.yaml#/PersonEscortRecordReference
+          description: The person_escort_record associated with this Move

--- a/swagger/v2/move_include_parameter.yaml
+++ b/swagger/v2/move_include_parameter.yaml
@@ -19,4 +19,5 @@ MoveIncludeParameter:
       - profile.person
       - profile.person.gender
       - profile.person.ethnicity
+      - profile.person_escort_record
   example: from_location


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [x] Added PER include in profile
- [x] Added PER relationship in profile
- [x] Updated swagger docs for move includes and PER endpoints
- [x] Added tests for includes in PER serializers as they are keyed differently

### Why?

To allow the FE to access the PER from the moves detail dashboard, expose PER relationship in profile. I also updated swagger documentation as it was missing includes. I added some tests for serializers as we are keying questions/responses differently 

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

