### PR TITLE
Add support for prison_recall and court_other move types

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -62,4 +62,12 @@ class Location < ApplicationRecord
   scope :supplier, ->(supplier_id) { joins(:suppliers).where(locations_suppliers: { supplier_id: supplier_id }) }
   scope :ordered_by_title, ->(direction) { order('locations.title' => direction) }
   scope :search_by_title, ->(search) { select(:id).where('title ILIKE :search', search: "%#{search}%") }
+
+  def detained?
+    prison? || secure_training_centre? || secure_childrens_home?
+  end
+
+  def not_detained?
+    !detained?
+  end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -25,11 +25,13 @@ class Move < VersionedModel
 
   enum move_type: {
     court_appearance: 'court_appearance',
-    prison_recall: 'prison_recall',
-    prison_transfer: 'prison_transfer',
-    police_transfer: 'police_transfer',
-    video_remand_hearing: 'video_remand_hearing',
+    court_other: 'court_other',
     hospital: 'hospital',
+    police_transfer: 'police_transfer',
+    prison_recall: 'prison_recall',
+    prison_remand: 'prison_remand',
+    prison_transfer: 'prison_transfer',
+    video_remand_hearing: 'video_remand_hearing',
   }
 
   self.ignored_columns = %w[person_id]

--- a/app/services/moves/move_type_validator.rb
+++ b/app/services/moves/move_type_validator.rb
@@ -11,6 +11,8 @@ module Moves
       # Apply more complex validation rules for specific move types
       validate_police_from_location if includes? %w[video_remand_hearing]
       validate_hospital_to_location if includes? %w[hospital]
+      validate_detained_to_location if includes? %w[prison_remand]
+      validate_not_detained_to_location if includes? %w[court_other]
     end
 
   private
@@ -29,6 +31,14 @@ module Moves
 
     def validate_hospital_to_location
       record.errors.add(:to_location, "must be a high security hospital location for #{human_move_type} move") unless record.to_location&.high_security_hospital?
+    end
+
+    def validate_detained_to_location
+      record.errors.add(:to_location, "must be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.to_location&.detained?
+    end
+
+    def validate_not_detained_to_location
+      record.errors.add(:to_location, "must not be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.to_location&.not_detained?
     end
   end
 end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -24,6 +24,13 @@ FactoryBot.define do
       nomis_agency_id { 'GUICCT' }
     end
 
+    trait :hospital do
+      sequence(:key) { |x| "secure_hospital_#{x}" }
+      title { "#{Faker::Address.city} Secure Hospital" }
+      location_type { Location::LOCATION_TYPE_HIGH_SECURITY_HOSPITAL }
+      nomis_agency_id { 'GUISH' }
+    end
+
     trait :police do
       sequence(:key) { |x| "police_station_#{x}" }
       title { "#{Faker::Address.city} Police Station" }
@@ -31,11 +38,18 @@ FactoryBot.define do
       nomis_agency_id { 'GUIPS' }
     end
 
-    trait :hospital do
-      sequence(:key) { |x| "secure_hospital_#{x}" }
-      title { "#{Faker::Address.city} Secure Hospital" }
-      location_type { Location::LOCATION_TYPE_HIGH_SECURITY_HOSPITAL }
-      nomis_agency_id { 'GUISH' }
+    trait :sch do
+      sequence(:key) { |x| "secure_childrens_home_#{x}" }
+      title { "#{Faker::Address.city} Secure Childrens Home" }
+      location_type { Location::LOCATION_TYPE_SECURE_CHILDRENS_HOME }
+      nomis_agency_id { 'GUISCH' }
+    end
+
+    trait :stc do
+      sequence(:key) { |x| "secure_training_centre_#{x}" }
+      title { "#{Faker::Address.city} Secure Training Centre" }
+      location_type { Location::LOCATION_TYPE_SECURE_TRAINING_CENTRE }
+      nomis_agency_id { 'GUISTC' }
     end
 
     trait :with_suppliers do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe Location do
   it { is_expected.to validate_presence_of(:location_type) }
   it { is_expected.to define_enum_for(:location_type).backed_by_column_of_type(:string) }
 
-  context 'when location is a prison' do
-    subject(:location) { build :location }
+  context 'when location is a court' do
+    subject(:location) { build :location, :court }
 
-    it { expect(location.prison?).to be true }
+    it { expect(location.prison?).to be false }
     it { expect(location.police?).to be false }
-    it { expect(location.court?).to be false }
+    it { expect(location.court?).to be true }
+    it { expect(location.detained?).to be false }
+    it { expect(location.not_detained?).to be true }
   end
 
   context 'when location is a police custody unit' do
@@ -25,14 +27,38 @@ RSpec.describe Location do
     it { expect(location.prison?).to be false }
     it { expect(location.police?).to be true }
     it { expect(location.court?).to be false }
+    it { expect(location.detained?).to be false }
+    it { expect(location.not_detained?).to be true }
   end
 
-  context 'when location is a court' do
-    subject(:location) { build :location, :court }
+  context 'when location is a prison' do
+    subject(:location) { build :location }
+
+    it { expect(location.prison?).to be true }
+    it { expect(location.police?).to be false }
+    it { expect(location.court?).to be false }
+    it { expect(location.detained?).to be true }
+    it { expect(location.not_detained?).to be false }
+  end
+
+  context 'when location is a secure childrens hospital' do
+    subject(:location) { build :location, :sch }
 
     it { expect(location.prison?).to be false }
     it { expect(location.police?).to be false }
-    it { expect(location.court?).to be true }
+    it { expect(location.court?).to be false }
+    it { expect(location.detained?).to be true }
+    it { expect(location.not_detained?).to be false }
+  end
+
+  context 'when location is a secure training centre' do
+    subject(:location) { build :location, :stc }
+
+    it { expect(location.prison?).to be false }
+    it { expect(location.police?).to be false }
+    it { expect(location.court?).to be false }
+    it { expect(location.detained?).to be true }
+    it { expect(location.not_detained?).to be false }
   end
 
   describe '#supplier' do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -14,9 +14,6 @@ RSpec.describe Location do
   context 'when location is a court' do
     subject(:location) { build :location, :court }
 
-    it { expect(location.prison?).to be false }
-    it { expect(location.police?).to be false }
-    it { expect(location.court?).to be true }
     it { expect(location.detained?).to be false }
     it { expect(location.not_detained?).to be true }
   end
@@ -24,9 +21,6 @@ RSpec.describe Location do
   context 'when location is a police custody unit' do
     subject(:location) { build :location, :police }
 
-    it { expect(location.prison?).to be false }
-    it { expect(location.police?).to be true }
-    it { expect(location.court?).to be false }
     it { expect(location.detained?).to be false }
     it { expect(location.not_detained?).to be true }
   end
@@ -34,9 +28,6 @@ RSpec.describe Location do
   context 'when location is a prison' do
     subject(:location) { build :location }
 
-    it { expect(location.prison?).to be true }
-    it { expect(location.police?).to be false }
-    it { expect(location.court?).to be false }
     it { expect(location.detained?).to be true }
     it { expect(location.not_detained?).to be false }
   end
@@ -44,9 +35,6 @@ RSpec.describe Location do
   context 'when location is a secure childrens hospital' do
     subject(:location) { build :location, :sch }
 
-    it { expect(location.prison?).to be false }
-    it { expect(location.police?).to be false }
-    it { expect(location.court?).to be false }
     it { expect(location.detained?).to be true }
     it { expect(location.not_detained?).to be false }
   end
@@ -54,9 +42,6 @@ RSpec.describe Location do
   context 'when location is a secure training centre' do
     subject(:location) { build :location, :stc }
 
-    it { expect(location.prison?).to be false }
-    it { expect(location.police?).to be false }
-    it { expect(location.court?).to be false }
     it { expect(location.detained?).to be true }
     it { expect(location.not_detained?).to be false }
   end

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Api::MovesController do
   include ActiveJob::TestHelper
 
+  subject(:post_moves) { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
+
   let(:response_json) { JSON.parse(response.body) }
 
   describe 'POST /moves' do
@@ -41,29 +43,27 @@ RSpec.describe Api::MovesController do
     let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
     let(:content_type) { ApiController::CONTENT_TYPE }
 
-    before do
-      next if RSpec.current_example.metadata[:skip_before]
-
-      post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
-    end
-
     context 'when successful' do
       let(:move) { Move.find_by(from_location_id: from_location.id) }
 
-      it_behaves_like 'an endpoint that responds with success 201'
+      it_behaves_like 'an endpoint that responds with success 201' do
+        before { post_moves }
+      end
 
-      it 'creates a move', skip_before: true do
-        expect { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
-          .to change(Move, :count).by(1)
+      it 'creates a move' do
+        expect { post_moves }.to change(Move, :count).by(1)
       end
 
       it 'sets the from_location supplier as the supplier on the move' do
+        post_moves
         expect(move.supplier).to eq(move.from_location.suppliers.first)
       end
 
       context 'with a real access token' do
         let(:application) { create(:application, owner: supplier) }
         let(:access_token) { create(:access_token, application: application).token }
+
+        before { post_moves }
 
         it 'audits the supplier' do
           expect(move.versions.map(&:whodunnit)).to eq([supplier.id])
@@ -75,14 +75,18 @@ RSpec.describe Api::MovesController do
       end
 
       it 'associates the documents with the newly created move' do
+        post_moves
         expect(move.profile.documents).to eq([document])
       end
 
       it 'associates a reason with the newly created move' do
+        post_moves
         expect(move.prison_transfer_reason).to eq(reason)
       end
 
       context 'when it includes all supported relationship' do
+        before { post_moves }
+
         it 'returns the correct data' do
           ActiveStorage::Current.host = 'http://www.example.com' # This is used in the serializer
           expected_response_json = JSON.parse(ActionController::Base.render(json: move, include: MoveSerializer::SUPPORTED_RELATIONSHIPS))
@@ -98,14 +102,16 @@ RSpec.describe Api::MovesController do
       end
 
       it 'does not provide a default value for move_agreed' do
+        post_moves
         expect(response_json.dig('data', 'attributes', 'move_agreed')).to eq nil
       end
 
       it 'sets the additional_information' do
+        post_moves
         expect(response_json.dig('data', 'attributes', 'additional_information')).to match 'some more info'
       end
 
-      context 'when the supplier has a webhook subscription', :skip_before do
+      context 'when the supplier has a webhook subscription' do
         let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
         let!(:notification_type_webhook) { create(:notification_type, :webhook) }
         let(:notification) { subscription.notifications.last }
@@ -121,7 +127,7 @@ RSpec.describe Api::MovesController do
         before do
           allow(Faraday).to receive(:new).and_return(faraday_client)
           perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
-            post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
+            post_moves
           end
         end
 
@@ -136,7 +142,7 @@ RSpec.describe Api::MovesController do
         end
       end
 
-      context 'when the supplier has an email subscription', :skip_before do
+      context 'when the supplier has an email subscription' do
         let!(:subscription) { create(:subscription, :no_callback_url, supplier: supplier) }
         let!(:notification_type_email) { create(:notification_type, :email) }
         let(:notification) { subscription.notifications.last }
@@ -156,7 +162,7 @@ RSpec.describe Api::MovesController do
         before do
           allow(MoveMailer).to receive(:notify).and_return(notify_response)
           perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyEmailJob]) do
-            post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
+            post_moves
           end
         end
 
@@ -184,14 +190,16 @@ RSpec.describe Api::MovesController do
           }
         end
 
-        it_behaves_like 'an endpoint that responds with success 201'
+        it_behaves_like 'an endpoint that responds with success 201' do
+          before { post_moves }
+        end
 
-        it 'creates a move', skip_before: true do
-          expect { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
-            .to change(Move, :count).by(1)
+        it 'creates a move' do
+          expect { post_moves }.to change(Move, :count).by(1)
         end
 
         it 'sets the move_type to `prison_recall`' do
+          post_moves
           expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'prison_recall'
         end
       end
@@ -199,10 +207,12 @@ RSpec.describe Api::MovesController do
       context 'with a proposed move' do
         let(:move_attributes) { attributes_for(:move).except(:date).merge(status: 'proposed') }
 
+        before { post_moves }
+
         it_behaves_like 'an endpoint that responds with success 201'
       end
 
-      context 'when a court hearing relationship is passed', skip_before: true do
+      context 'when a court hearing relationship is passed' do
         let(:court_hearing) { create(:court_hearing) }
 
         let(:data) do
@@ -225,7 +235,7 @@ RSpec.describe Api::MovesController do
         end
 
         it 'returns the hearing in the json body' do
-          post '/api/v1/moves', params: { data: data }, headers: headers, as: :json
+          post_moves
 
           court_hearings_response = response_json['included'].select { |entry| entry['type'] == 'court_hearings' }
           expect(court_hearings_response.count).to be 1
@@ -244,6 +254,8 @@ RSpec.describe Api::MovesController do
             date_to: date_to,
           }
         end
+
+        before { post_moves }
 
         it 'sets date_from' do
           expect(response_json.dig('data', 'attributes', 'date_from')).to eq date_from.to_s
@@ -264,20 +276,21 @@ RSpec.describe Api::MovesController do
         end
       end
 
-      context 'with explicit video_remand_hearing `move_type`' do
-        let(:move_attributes) { attributes_for(:move, move_type: 'video_remand_hearing') }
-        let(:from_location) { create :location, :police, suppliers: [supplier] }
-        let(:to_location) { nil }
+      context 'with explicit court_other `move_type`' do
+        let(:move_attributes) { attributes_for(:move, move_type: 'court_other') }
+        let(:to_location) { create :location, :hospital, suppliers: [supplier] }
 
-        it_behaves_like 'an endpoint that responds with success 201'
-
-        it 'creates a move', skip_before: true do
-          expect { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
-            .to change(Move, :count).by(1)
+        it_behaves_like 'an endpoint that responds with success 201' do
+          before { post_moves }
         end
 
-        it 'sets the move_type to `video_remand_hearing`' do
-          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand_hearing'
+        it 'creates a move' do
+          expect { post_moves }.to change(Move, :count).by(1)
+        end
+
+        it 'sets the move_type to `court_other`' do
+          post_moves
+          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'court_other'
         end
       end
 
@@ -285,15 +298,54 @@ RSpec.describe Api::MovesController do
         let(:move_attributes) { attributes_for(:move, move_type: 'hospital') }
         let(:to_location) { create :location, :hospital, suppliers: [supplier] }
 
-        it_behaves_like 'an endpoint that responds with success 201'
+        it_behaves_like 'an endpoint that responds with success 201' do
+          before { post_moves }
+        end
 
-        it 'creates a move', skip_before: true do
-          expect { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
-            .to change(Move, :count).by(1)
+        it 'creates a move' do
+          expect { post_moves }.to change(Move, :count).by(1)
         end
 
         it 'sets the move_type to `hospital`' do
+          post_moves
           expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'hospital'
+        end
+      end
+
+      context 'with explicit prison_remand `move_type`' do
+        let(:move_attributes) { attributes_for(:move, move_type: 'prison_remand') }
+        let(:to_location) { create :location, :stc, suppliers: [supplier] }
+
+        it_behaves_like 'an endpoint that responds with success 201' do
+          before { post_moves }
+        end
+
+        it 'creates a move' do
+          expect { post_moves }.to change(Move, :count).by(1)
+        end
+
+        it 'sets the move_type to `prison_remand`' do
+          post_moves
+          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'prison_remand'
+        end
+      end
+
+      context 'with explicit video_remand_hearing `move_type`' do
+        let(:move_attributes) { attributes_for(:move, move_type: 'video_remand_hearing') }
+        let(:from_location) { create :location, :police, suppliers: [supplier] }
+        let(:to_location) { nil }
+
+        it_behaves_like 'an endpoint that responds with success 201' do
+          before { post_moves }
+        end
+
+        it 'creates a move' do
+          expect { post_moves }.to change(Move, :count).by(1)
+        end
+
+        it 'sets the move_type to `video_remand_hearing`' do
+          post_moves
+          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand_hearing'
         end
       end
 
@@ -312,6 +364,8 @@ RSpec.describe Api::MovesController do
             },
           }
         end
+
+        before { post_moves }
 
         it 'associates the profile with the newly created move' do
           expect(move.profile).to eq(profile)
@@ -350,6 +404,8 @@ RSpec.describe Api::MovesController do
           }
         end
 
+        before { post_moves }
+
         it 'favours the profile passed in with the newly created move' do
           expect(move.profile).to eq(profile)
         end
@@ -365,12 +421,16 @@ RSpec.describe Api::MovesController do
     context 'with a bad request' do
       let(:data) { nil }
 
+      before { post_moves }
+
       it_behaves_like 'an endpoint that responds with error 400'
     end
 
     context 'with a reference to a missing relationship' do
       let(:from_location) { build(:location) }
       let(:detail_404) { "Couldn't find Location without an ID" }
+
+      before { post_moves }
 
       it_behaves_like 'an endpoint that responds with error 404'
     end
@@ -394,6 +454,8 @@ RSpec.describe Api::MovesController do
           },
         ]
       end
+
+      before { post_moves }
 
       it_behaves_like 'an endpoint that responds with error 422'
     end

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -288,10 +288,9 @@ RSpec.describe Api::MovesController do
       end
     end
 
-    context 'with explicit video_remand_hearing `move_type`' do
-      let(:move_attributes) { attributes_for(:move, move_type: 'video_remand_hearing') }
-      let(:from_location) { create :location, :police, suppliers: [supplier] }
-      let(:to_location) { nil }
+    context 'with explicit court_other `move_type`' do
+      let(:move_attributes) { attributes_for(:move, move_type: 'court_other') }
+      let(:to_location) { create :location, :hospital, suppliers: [supplier] }
 
       it_behaves_like 'an endpoint that responds with success 201' do
         before { do_post }
@@ -301,10 +300,10 @@ RSpec.describe Api::MovesController do
         expect { do_post }.to change(Move, :count).by(1)
       end
 
-      it 'sets the move_type to `video_remand_hearing`' do
+      it 'sets the move_type to `court_other`' do
         do_post
 
-        expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand_hearing'
+        expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'court_other'
       end
     end
 
@@ -324,6 +323,45 @@ RSpec.describe Api::MovesController do
         do_post
 
         expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'hospital'
+      end
+    end
+
+    context 'with explicit prison_remand `move_type`' do
+      let(:move_attributes) { attributes_for(:move, move_type: 'prison_remand') }
+      let(:to_location) { create :location, :stc, suppliers: [supplier] }
+
+      it_behaves_like 'an endpoint that responds with success 201' do
+        before { do_post }
+      end
+
+      it 'creates a move' do
+        expect { do_post }.to change(Move, :count).by(1)
+      end
+
+      it 'sets the move_type to `prison_remand`' do
+        do_post
+
+        expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'prison_remand'
+      end
+    end
+
+    context 'with explicit video_remand_hearing `move_type`' do
+      let(:move_attributes) { attributes_for(:move, move_type: 'video_remand_hearing') }
+      let(:from_location) { create :location, :police, suppliers: [supplier] }
+      let(:to_location) { nil }
+
+      it_behaves_like 'an endpoint that responds with success 201' do
+        before { do_post }
+      end
+
+      it 'creates a move' do
+        expect { do_post }.to change(Move, :count).by(1)
+      end
+
+      it 'sets the move_type to `video_remand_hearing`' do
+        do_post
+
+        expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand_hearing'
       end
     end
 

--- a/spec/services/moves/move_type_validator_spec.rb
+++ b/spec/services/moves/move_type_validator_spec.rb
@@ -24,23 +24,25 @@ RSpec.describe Moves::MoveTypeValidator do
     it { is_expected.to be_valid }
   end
 
-  context 'with video remand hearing `move_type`' do
-    let(:move_type) { 'video_remand_hearing' }
+  context 'with court_other `move_type`' do
+    let(:move_type) { 'court_other' }
 
-    it 'validates `from_location` is a police location' do
-      target.from_location = build(:location, :police)
+    it 'validates `to_location` is not a prison, sch or stc' do
+      target.to_location = build(:location, :court)
       expect(target).to be_valid
     end
 
-    it 'validates `from_location` is not nil' do
-      target.from_location = nil
+    it 'validates `to_location` is not nil' do
+      target.to_location = nil
       expect(target).not_to be_valid
     end
 
-    it 'has an error if `from_location` is not a police location' do
-      target.from_location = build(:location, :court)
-      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
-      expect(target.errors[:from_location]).to match_array('must be a police location for video remand hearing move')
+    it 'has an error if `to_location` is not a prison, sch or stc' do
+      %i[prison stc stc].each do |location_type|
+        target.to_location = build(:location, location_type)
+        expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+        expect(target.errors[:to_location]).to match_array('must not be a prison, secure training centre or secure childrens hospital for court other move')
+      end
     end
   end
 
@@ -58,9 +60,51 @@ RSpec.describe Moves::MoveTypeValidator do
     end
 
     it 'has an error if `to_location` is not a high security hospital' do
-      target.from_location = build(:location, :court)
+      target.to_location = build(:location, :court)
       expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
       expect(target.errors[:to_location]).to match_array('must be a high security hospital location for hospital move')
+    end
+  end
+
+  context 'with prison_remand `move_type`' do
+    let(:move_type) { 'prison_remand' }
+
+    it 'validates `to_location` is a prison, sch or stc' do
+      %i[prison stc stc].each do |location_type|
+        target.to_location = build(:location, location_type)
+        expect(target).to be_valid
+      end
+    end
+
+    it 'validates `to_location` is not nil' do
+      target.to_location = nil
+      expect(target).not_to be_valid
+    end
+
+    it 'has an error if `to_location` is not a prison, sch or stc' do
+      target.from_location = build(:location, :court)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:to_location]).to match_array('must be a prison, secure training centre or secure childrens hospital for prison remand move')
+    end
+  end
+
+  context 'with video remand hearing `move_type`' do
+    let(:move_type) { 'video_remand_hearing' }
+
+    it 'validates `from_location` is a police location' do
+      target.from_location = build(:location, :police)
+      expect(target).to be_valid
+    end
+
+    it 'validates `from_location` is not nil' do
+      target.from_location = nil
+      expect(target).not_to be_valid
+    end
+
+    it 'has an error if `from_location` is not a police location' do
+      target.from_location = build(:location, :court)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:from_location]).to match_array('must be a police location for video remand hearing move')
     end
   end
 end

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -40,11 +40,13 @@ Move:
           type: string
           enum:
           - court_appearance
-          - prison_recall
-          - prison_transfer
-          - police_transfer
-          - video_remand_hearing
+          - court_other
           - hospital
+          - police_transfer
+          - prison_recall
+          - prison_remand
+          - prison_transfer
+          - video_remand_hearing
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
           oneOf:

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -40,11 +40,13 @@ Move:
           type: string
           enum:
             - court_appearance
-            - prison_recall
-            - prison_transfer
-            - police_transfer
-            - video_remand_hearing
+            - court_other
             - hospital
+            - police_transfer
+            - prison_recall
+            - prison_remand
+            - prison_transfer
+            - video_remand_hearing
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
           oneOf:


### PR DESCRIPTION
### Jira link

P4-1873 P4-1860

### What?

- [x] Added new `court_other` and `prison_remand` move types
- [x] Added new helper methods to Location model to determine prison/STC/SCH types
- [x] Refactored existing create moves request spec (v1) to avoid use of `skip_before` tag

### Why?

- We want to support additional move types in the near future.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Adds support for new types in move type param but these are not currently used, so no risk

