### PR TITLE
Overriding existing method needs an argument

### DIFF
--- a/app/models/profile/assessment_answer.rb
+++ b/app/models/profile/assessment_answer.rb
@@ -39,7 +39,7 @@ class Profile
       assessment_question_id.blank?
     end
 
-    def as_json
+    def as_json(_options = {})
       {
         title: title,
         comments: comments,


### PR DESCRIPTION
We got the following error whilst creating the PER with a profile with assessment answers:

```
ArgumentError (wrong number of arguments (given 1, expected 0)):

app/models/profile/assessment_answer.rb:42:in `as_json'
```
We should be allowing an argument to be passed to `as_json` method to mimic original method