### PR TITLE
Make fields not required for Patch /move

### DIFF
--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -517,7 +517,7 @@
           required: true
           description: The move object to be modified
           schema:
-            "$ref": "../v2/move.yaml#/Move"
+            "$ref": "../v2/patch_move.yaml#/Move"
         - "$ref": "../v2/move_include_parameter.yaml#/MoveIncludeParameter"
       responses:
         "200":

--- a/swagger/v2/patch_move.yaml
+++ b/swagger/v2/patch_move.yaml
@@ -1,0 +1,142 @@
+Move:
+  type: object
+  required:
+    - type
+    - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: moves
+      enum:
+        - moves
+      description: The type of this object - always `moves`
+    attributes:
+      type: object
+      properties:
+        reference:
+          type: string
+          example: TM7B3A2S
+          description: Unique human-readable identifier for the Move
+          readOnly: true
+        status:
+          type: string
+          enum:
+            - proposed
+            - requested
+            - booked
+            - in_transit
+            - cancelled
+            - completed
+          description: Indicates the stage in it's lifecycle that this move is at
+        move_type:
+          type: string
+          enum:
+            - court_appearance
+            - prison_recall
+            - prison_transfer
+            - police_transfer
+            - video_remand_hearing
+            - hospital
+          description: Indicates the type of move, e.g. prison transfer or court appearance
+        move_agreed:
+          oneOf:
+            - type: boolean
+            - type: "null"
+          example: "true"
+          description: Indicates if the moved has been agreed
+        move_agreed_by:
+          oneOf:
+            - type: string
+            - type: "null"
+          example: John Does
+          description: Indicates the name of the person who agreed the move
+        time_due:
+          type: string
+          format: date-time
+          example: "2020-05-17T15:04:07.632Z"
+          description: Time due at the destination, e.g. court appointment time
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of when the move was last created or updated
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp of when the move was created
+          readOnly: true
+        date:
+          oneOf:
+            - type: string
+              format: date
+            - type: "null"
+          example: "2020-05-17"
+          description:
+            Date on which the move is scheduled (mandatory unless status
+            is proposed)
+        date_from:
+          oneOf:
+            - type: string
+              format: date
+            - type: "null"
+          example: "2020-05-17"
+          description: Start date for potential move (mandatory if status is proposed)
+        date_to:
+          oneOf:
+            - type: string
+              format: date
+            - type: "null"
+          example: "2020-05-17"
+          description: End date for potential move. Must be after date_from
+        additional_information:
+          oneOf:
+            - type: string
+            - type: "null"
+          description:
+            Additional information about the move that the supplier should
+            be made aware of
+        cancellation_reason:
+          oneOf:
+            - type: string
+              enum:
+                - made_in_error
+                - supplier_declined_to_move
+                - rejected
+                - other
+            - type: "null"
+          description: Reason the move has been cancelled
+        cancellation_reason_comment:
+          oneOf:
+            - type: string
+            - type: "null"
+          description:
+            In case 'other' is chosen as cancellation_reason, further details
+            can be specified
+    relationships:
+      type: object
+      properties:
+        profile:
+          $ref: "../v1/profile_reference.yaml#/ProfileReference"
+          description: The profile of the person at a point in time for this move.
+        from_location:
+          $ref: "../v1/location_reference.yaml#/LocationReference"
+          description: The location that the person is being moved from
+        to_location:
+          $ref: "../v1/location_reference.yaml#/LocationReference"
+          description: The location that the person is being moved to
+        allocation:
+          $ref: "../v1/allocation_reference.yaml#/AllocationReference"
+          description: The allocation associated with this move
+        court_hearing:
+          $ref: "../v1/court_hearing_reference.yaml#/CourtHearingReference"
+          description:
+            A court hearing generated when creating a move. May have corresponding
+            hearing in Nomis backend (see nomis fields).
+        prison_transfer_reason:
+          $ref: "../v1/prison_transfer_reason_reference.yaml#/PrisonTransferReasonReference"
+          description: The reason for this prison transfer


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-1929

### What?

Now, in the swagger docs, for patch move, it shows many fields that should not be possible to update.

Separate the example in Post and Patch, instead of using a common YAML to describe both.

### Why?
in the `patch /move` there should not be required attributes, if you don't pass them, the attributes will stay untouched.