### PR TITLE
P4-1771 Extend PER validations

### DIFF
--- a/app/models/framework_response/array.rb
+++ b/app/models/framework_response/array.rb
@@ -1,7 +1,8 @@
 class FrameworkResponse
   class Array < FrameworkResponse
+    validate :validate_array_type
     validates :value_text, absence: true
-    validates :value_json, on: :update, inclusion: { in: :question_options }, if: :question_options
+    validate :validate_array_values, on: :update
 
     def value
       value_json.presence || []
@@ -17,8 +18,16 @@ class FrameworkResponse
 
   private
 
-    def question_options
-      @question_options ||= framework_question.options.presence
+    def validate_array_values
+      if (invalid_options = value - framework_question.options).any?
+        errors.add(:value, invalid_options.join(', ') + ' are not a valid option')
+      end
+    end
+
+    def validate_array_type
+      unless value.is_a?(::Array)
+        errors.add(:value, 'is incorrect type')
+      end
     end
   end
 end

--- a/app/models/framework_response/array.rb
+++ b/app/models/framework_response/array.rb
@@ -2,7 +2,7 @@ class FrameworkResponse
   class Array < FrameworkResponse
     validate :validate_array_type
     validates :value_text, absence: true
-    validate :validate_array_values, on: :update
+    validate :validate_value_inclusion, on: :update
 
     def value
       value_json.presence || []
@@ -18,9 +18,11 @@ class FrameworkResponse
 
   private
 
-    def validate_array_values
+    def validate_value_inclusion
+      return if errors.present?
+
       if (invalid_options = value - framework_question.options).any?
-        errors.add(:value, invalid_options.join(', ') + ' are not a valid option')
+        errors.add(:value, invalid_options.join(', ') + ' are not valid options')
       end
     end
 

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -1,5 +1,6 @@
 class FrameworkResponse
   class Collection < FrameworkResponse
+    validate :validate_collection_type
     validates :value_text, absence: true
     validate :validate_details_collection, on: :update, if: -> { response_details }
 
@@ -9,7 +10,7 @@ class FrameworkResponse
 
     def value=(raw_value)
       self.value_json =
-        if response_details
+        if response_details && collection_type_valid?(raw_value)
           details_collection(raw_value).to_a
         else
           raw_value.presence || []
@@ -31,11 +32,26 @@ class FrameworkResponse
     end
 
     def validate_details_collection
-      errors.add(:value, :invalid) if details_collection(value).invalid?
+      validated_collection = details_collection(value)
+      if validated_collection.invalid?
+        validated_collection.errors.each do |field, message|
+          errors.add(field, message)
+        end
+      end
     end
 
     def response_details
       @response_details ||= framework_question.followup_comment
+    end
+
+    def validate_collection_type
+      unless collection_type_valid?(value)
+        errors.add(:value, 'is incorrect type')
+      end
+    end
+
+    def collection_type_valid?(collection)
+      collection.is_a?(::Array) && collection.all?(::Hash)
     end
   end
 end

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -5,6 +5,7 @@ class FrameworkResponse
     validate :validate_details_collection, on: :update, if: -> { response_details }
 
     def value
+      value_json.delete_if(&:empty?) if collection_type_valid?(value_json)
       value_json.presence || []
     end
 

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -32,11 +32,11 @@ class FrameworkResponse
     end
 
     def validate_details_collection
+      return if errors.present?
+
       validated_collection = details_collection(value)
       if validated_collection.invalid?
-        validated_collection.errors.each do |field, message|
-          errors.add(field, message)
-        end
+        errors.merge!(validated_collection.errors)
       end
     end
 

--- a/app/models/framework_response/details_collection.rb
+++ b/app/models/framework_response/details_collection.rb
@@ -29,9 +29,7 @@ class FrameworkResponse
       return unless collection.any?(&:invalid?)
 
       collection.each do |detail_object|
-        detail_object.errors.each do |field, message|
-          errors.add(field, message)
-        end
+        errors.merge!(detail_object.errors)
       end
     end
 

--- a/app/models/framework_response/details_collection.rb
+++ b/app/models/framework_response/details_collection.rb
@@ -7,6 +7,7 @@ class FrameworkResponse
     attr_reader :collection
 
     validate :details_objects
+    validate :details_option_uniqueness
 
     def initialize(collection:, question_options: [], details_options: [])
       @collection = Array(collection).map do |item|
@@ -25,7 +26,20 @@ class FrameworkResponse
   private
 
     def details_objects
-      errors.add(:collection, :invalid) if collection.any?(&:invalid?)
+      return unless collection.any?(&:invalid?)
+
+      collection.each do |detail_object|
+        detail_object.errors.each do |field, message|
+          errors.add(field, message)
+        end
+      end
+    end
+
+    def details_option_uniqueness
+      options = collection.map(&:option)
+      if options.size != options.uniq.size
+        errors.add(:option, 'Duplicate options selected')
+      end
     end
   end
 end

--- a/app/models/framework_response/details_object.rb
+++ b/app/models/framework_response/details_object.rb
@@ -7,12 +7,12 @@ class FrameworkResponse
     attr_accessor :question_options, :details_options, :option, :details
 
     validates :option, presence: true, if: :details
-    validates :option, inclusion: { in: :question_options }, if: ->(object) { object.question_options && object.option.present? }
-    validates :details, presence: true, if: :included_in_detail_options
+    validates :option, inclusion: { in: :question_options }, if: :question_options_and_option_present?
+    validates :details, presence: true, if: :included_in_detail_options?
 
     def initialize(attributes: {}, question_options: [], details_options: [])
-      @question_options = question_options.presence
-      @details_options = details_options.presence
+      @question_options = question_options
+      @details_options = details_options
       attributes = attributes.presence || {}
 
       attributes.symbolize_keys! if attributes.respond_to?(:symbolize_keys!)
@@ -31,8 +31,12 @@ class FrameworkResponse
 
   private
 
-    def included_in_detail_options
-      details_options && details_options.include?(option)
+    def included_in_detail_options?
+      details_options.include?(option)
+    end
+
+    def question_options_and_option_present?
+      question_options.any? && option.present?
     end
   end
 end

--- a/app/models/framework_response/details_object.rb
+++ b/app/models/framework_response/details_object.rb
@@ -6,9 +6,9 @@ class FrameworkResponse
 
     attr_accessor :question_options, :details_options, :option, :details
 
-    validates :option, presence: true
-    validates :option, inclusion: { in: :question_options }, if: :question_options
-    validates :details, presence: true, if: :details_options
+    validates :option, presence: true, if: :details
+    validates :option, inclusion: { in: :question_options }, if: ->(object) { object.question_options && object.option.present? }
+    validates :details, presence: true, if: :included_in_detail_options
 
     def initialize(attributes: {}, question_options: [], details_options: [])
       @question_options = question_options.presence
@@ -27,6 +27,12 @@ class FrameworkResponse
         option: option,
         details: details,
       }
+    end
+
+  private
+
+    def included_in_detail_options
+      details_options && details_options.include?(option)
     end
   end
 end

--- a/app/models/framework_response/details_object.rb
+++ b/app/models/framework_response/details_object.rb
@@ -25,7 +25,7 @@ class FrameworkResponse
 
       {
         option: option,
-        details: details,
+        details: details.to_s.presence,
       }
     end
 

--- a/app/models/framework_response/object.rb
+++ b/app/models/framework_response/object.rb
@@ -38,11 +38,11 @@ class FrameworkResponse
     end
 
     def validate_details_object
+      return if errors.present?
+
       validated_object = details_object(attributes: value)
       if validated_object.invalid?
-        validated_object.errors.each do |field, message|
-          errors.add(field, message)
-        end
+        errors.merge!(validated_object.errors)
       end
     end
 

--- a/app/models/framework_response/object.rb
+++ b/app/models/framework_response/object.rb
@@ -1,5 +1,6 @@
 class FrameworkResponse
   class Object < FrameworkResponse
+    validate :validate_object_type
     validates :value_text, absence: true
     validate :validate_details_object, on: :update, if: -> { response_details }
 
@@ -23,6 +24,8 @@ class FrameworkResponse
   private
 
     def details_object(attributes:)
+      return attributes unless attributes.is_a?(::Hash)
+
       DetailsObject.new(
         attributes: attributes,
         question_options: framework_question.options,
@@ -35,8 +38,18 @@ class FrameworkResponse
     end
 
     def validate_details_object
-      # TODO: Add proper validation messages
-      errors.add(:value, :invalid) if details_object(attributes: value).invalid?
+      validated_object = details_object(attributes: value)
+      if validated_object.invalid?
+        validated_object.errors.each do |field, message|
+          errors.add(field, message)
+        end
+      end
+    end
+
+    def validate_object_type
+      unless value.is_a?(::Hash)
+        errors.add(:value, 'is incorrect type')
+      end
     end
   end
 end

--- a/app/models/framework_response/string.rb
+++ b/app/models/framework_response/string.rb
@@ -1,7 +1,7 @@
 class FrameworkResponse
   class String < FrameworkResponse
     validates :value_json, absence: true
-    validates :value_text, on: :update, inclusion: { in: :question_options }, if: :question_options
+    validates :value, inclusion: { in: :question_options }, if: ->(response) { response.question_options && response.value.present? }
 
     def value
       value_text
@@ -14,8 +14,6 @@ class FrameworkResponse
     def option_selected?(option)
       value == option
     end
-
-  private
 
     def question_options
       @question_options ||= framework_question.options.presence

--- a/app/models/framework_response/string.rb
+++ b/app/models/framework_response/string.rb
@@ -1,7 +1,7 @@
 class FrameworkResponse
   class String < FrameworkResponse
     validates :value_json, absence: true
-    validates :value, inclusion: { in: :question_options }, if: ->(response) { response.question_options && response.value.present? }
+    validates :value, inclusion: { in: :question_options }, if: :question_options_and_value_present?
 
     def value
       value_text
@@ -16,7 +16,13 @@ class FrameworkResponse
     end
 
     def question_options
-      @question_options ||= framework_question.options.presence
+      @question_options ||= framework_question.options
+    end
+
+  private
+
+    def question_options_and_value_present?
+      question_options.any? && value.present?
     end
   end
 end

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
   factory :collection_response, parent: :framework_response, class: 'FrameworkResponse::Collection' do
     value { [{ 'name' => 'Foo bar' }, { 'name' => 'Bar baz' }] }
     trait :details do
-      association(:framework_question, followup_comment: true)
+      association(:framework_question, :checkbox, followup_comment: true)
       value { [{ 'option' => 'Level 1', 'details' => 'some comment' }, { 'option' => 'Level 2', 'details' => 'another comment' }] }
     end
   end

--- a/spec/models/framework_response/array_spec.rb
+++ b/spec/models/framework_response/array_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe FrameworkResponse::Array do
       response = create(:array_response, value: ['Level 3', 'Level 4'], framework_question: question)
 
       expect(response).not_to be_valid
-      expect(response.errors.messages[:value]).to eq(['Level 3, Level 4 are not a valid option'])
+      expect(response.errors.messages[:value]).to eq(['Level 3, Level 4 are not valid options'])
     end
 
     it 'does not validate values if value included in options' do
@@ -25,7 +25,8 @@ RSpec.describe FrameworkResponse::Array do
 
     it 'validates correct type is passed in' do
       question = create(:framework_question, :checkbox)
-      response = build(:array_response, value: { 'option' => 'Level 4' }, framework_question: question)
+      response = create(:array_response, framework_question: question)
+      response.update(value: { 'option' => 'Level 4' })
 
       expect(response).not_to be_valid
       expect(response.errors.messages[:value]).to eq(['is incorrect type'])

--- a/spec/models/framework_response/collection_spec.rb
+++ b/spec/models/framework_response/collection_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe FrameworkResponse::Collection do
     it { is_expected.to validate_absence_of(:value_text) }
 
     it 'validates correct type is passed in' do
-      response = build(:collection_response, :details, value: { 'option' => 'Level 4' })
+      response = create(:collection_response, :details)
+      response.update(value: { 'option' => 'Level 4' })
 
       expect(response).not_to be_valid
       expect(response.errors.messages[:value]).to eq(['is incorrect type'])

--- a/spec/models/framework_response/collection_spec.rb
+++ b/spec/models/framework_response/collection_spec.rb
@@ -53,9 +53,17 @@ RSpec.describe FrameworkResponse::Collection do
         expect(response.errors.messages[:value]).to eq(["can't be blank"])
       end
 
+      it 'validates presence of value when empty option and detail supplied' do
+        question = create(:framework_question, :checkbox, followup_comment: true, required: true)
+        response = create(:collection_response, :details, value: [{ details: nil, option: nil }], framework_question: question)
+
+        expect(response).not_to be_valid
+        expect(response.errors.messages[:value]).to eq(["can't be blank"])
+      end
+
       it 'does not validate presence of value when value is provided' do
         question = create(:framework_question, :checkbox, followup_comment: true, required: true)
-        response = create(:collection_response, :details, value: [{ 'option': 'Level 1', details: 'some comment' }], framework_question: question)
+        response = create(:collection_response, :details, value: [{ option: 'Level 1', details: 'some comment' }], framework_question: question)
 
         expect(response).to be_valid
       end
@@ -157,6 +165,19 @@ RSpec.describe FrameworkResponse::Collection do
       expect(response.value.as_json).to contain_exactly(
         { 'details' => 'some comment', 'option' => 'Level 1' },
         { 'details' => 'some comment', 'option' => 'Level 2' },
+      )
+    end
+
+    it 'removes empty hashes in response' do
+      collection = [
+        { details: 'some comment', option: 'Level 1' },
+        {},
+        { details: nil, option: nil },
+      ]
+      response = create(:collection_response, :details, value: collection)
+
+      expect(response.value.as_json).to contain_exactly(
+        { 'details' => 'some comment', 'option' => 'Level 1' },
       )
     end
 

--- a/spec/models/framework_response/details_collection_spec.rb
+++ b/spec/models/framework_response/details_collection_spec.rb
@@ -3,11 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe FrameworkResponse::DetailsCollection, type: :model do
-  it 'validates the details object passed' do
-    collection = [{ option: 'No' }, { option: 'Yes' }]
-    details_collection = described_class.new(collection: collection, question_options: %w[No])
+  context 'with validations' do
+    it 'validates the details object passed' do
+      collection = [{ option: 'No' }, { option: 'Yes' }]
+      details_collection = described_class.new(collection: collection, question_options: %w[No])
 
-    expect(details_collection).not_to be_valid
+      expect(details_collection).not_to be_valid
+      expect(details_collection.errors.messages[:option]).to eq(['is not included in the list'])
+    end
+
+    it 'validates uniqueness of options' do
+      collection = [{ option: 'No', details: 'some detail' }, { option: 'No' }]
+      details_collection = described_class.new(collection: collection, question_options: %w[No])
+
+      expect(details_collection).not_to be_valid
+      expect(details_collection.errors.messages[:option]).to eq(['Duplicate options selected'])
+    end
   end
 
   describe '#to_a' do

--- a/spec/models/framework_response/details_object_spec.rb
+++ b/spec/models/framework_response/details_object_spec.rb
@@ -69,10 +69,30 @@ RSpec.describe FrameworkResponse::DetailsObject, type: :model do
       expect(details_object.as_json).to eq(attributes)
     end
 
-    it 'returns a empty hash if nothing passed in' do
+    it 'returns an empty hash if nothing passed in' do
       details_object = described_class.new(attributes: {})
 
       expect(details_object.as_json).to be_empty
+    end
+
+    it 'returns an empty hash if nil option and details passed in' do
+      attributes = {
+        option: nil,
+        details: nil,
+      }
+      details_object = described_class.new(attributes: attributes)
+
+      expect(details_object.as_json).to be_empty
+    end
+
+    it 'returns details as a string if different type passed in' do
+      attributes = {
+        option: nil,
+        details: ['Level 1', { "option": 'details' }],
+      }
+      details_object = described_class.new(attributes: attributes)
+
+      expect(details_object.as_json).to eq(details: '["Level 1", {:option=>"details"}]', option: nil)
     end
   end
 end

--- a/spec/models/framework_response/details_object_spec.rb
+++ b/spec/models/framework_response/details_object_spec.rb
@@ -3,39 +3,59 @@
 require 'rails_helper'
 
 RSpec.describe FrameworkResponse::DetailsObject, type: :model do
-  it 'validates the presence of an option' do
-    attributes = { details: 'some comment' }
-    details_object = described_class.new(attributes: attributes)
+  context 'with validations' do
+    it 'ignores other keys passed in' do
+      attributes = { options: 'No', details: 'some comment' }
+      details_object = described_class.new(attributes: attributes, question_options: %w[No])
 
-    expect(details_object).to validate_presence_of(:option)
-  end
+      expect(details_object).not_to be_valid
+      expect(details_object.errors.messages[:option]).to eq(["can't be blank"])
+    end
 
-  it 'validates the inclusion of an option if question options are supplied' do
-    attributes = { option: 'Yes' }
-    details_object = described_class.new(attributes: attributes, question_options: %w[No])
+    it 'validates the presence of an option' do
+      attributes = { details: 'some comment' }
+      details_object = described_class.new(attributes: attributes)
 
-    expect(details_object).to validate_inclusion_of(:option).in_array(%w[No])
-  end
+      expect(details_object).not_to be_valid
+      expect(details_object.errors.messages[:option]).to eq(["can't be blank"])
+    end
 
-  it 'does not validate the inclusion of an option if no question options supplied' do
-    attributes = { option: 'Yes' }
-    details_object = described_class.new(attributes: attributes)
+    it 'validates values included in option if question options are supplied' do
+      attributes = { option: 'Yes' }
+      details_object = described_class.new(attributes: attributes, question_options: %w[No])
 
-    expect(details_object).not_to validate_inclusion_of(:option).in_array([])
-  end
+      expect(details_object).not_to be_valid
+      expect(details_object.errors.messages[:option]).to eq(['is not included in the list'])
+    end
 
-  it 'validates the presence of details if detail options are supplied' do
-    attributes = { option: 'No' }
-    details_object = described_class.new(attributes: attributes, details_options: %w[No])
+    it 'does not validate the inclusion of an option if no question options supplied' do
+      attributes = { option: 'Yes' }
+      details_object = described_class.new(attributes: attributes)
 
-    expect(details_object).to validate_presence_of(:details)
-  end
+      expect(details_object).to be_valid
+    end
 
-  it 'does not validate the presence of details if no detail options supplied' do
-    attributes = { option: 'No' }
-    details_object = described_class.new(attributes: attributes, question_options: %w[No])
+    it 'validates the presence of details if detail options are supplied' do
+      attributes = { option: 'No' }
+      details_object = described_class.new(attributes: attributes, details_options: %w[No])
 
-    expect(details_object).not_to validate_presence_of(:details)
+      expect(details_object).not_to be_valid
+      expect(details_object.errors.messages[:details]).to eq(["can't be blank"])
+    end
+
+    it 'does not validate the presence of details if no detail options supplied' do
+      attributes = { option: 'No' }
+      details_object = described_class.new(attributes: attributes, question_options: %w[No])
+
+      expect(details_object).to be_valid
+    end
+
+    it 'does not validate the presence of details if detail options supplied but option is answered different' do
+      attributes = { option: 'Yes' }
+      details_object = described_class.new(attributes: attributes, details_options: %w[No])
+
+      expect(details_object).to be_valid
+    end
   end
 
   describe '#as_json' do

--- a/spec/models/framework_response/object_spec.rb
+++ b/spec/models/framework_response/object_spec.rb
@@ -5,45 +5,119 @@ require 'rails_helper'
 RSpec.describe FrameworkResponse::Object do
   subject { create(:object_response) }
 
-  it { is_expected.to validate_absence_of(:value_text) }
+  context 'with validations' do
+    it { is_expected.to validate_absence_of(:value_text) }
 
-  it 'validates presence of value when a record is updated if question is required' do
-    question = create(:framework_question, required: true, options: [])
-    response = create(:object_response, value: nil, framework_question: question)
+    it 'validates correct type is passed in' do
+      response = build(:object_response, :details, value: [{ 'option' => 'Level 4' }])
 
-    expect(response).to validate_presence_of(:value)
-  end
+      expect(response).not_to be_valid
+      expect(response.errors.messages[:value]).to eq(['is incorrect type'])
+    end
 
-  it 'does not validate presence of value when a record is updated if question is required and dependent' do
-    question = create(:framework_question, required: true, options: [])
-    response = create(:object_response, value: nil, framework_question: question, parent: create(:string_response))
+    it 'validates details object' do
+      question = create(
+        :framework_question,
+        followup_comment: true,
+        followup_comment_options: %w[Yes],
+      )
+      response = create(:object_response, :details, value: { 'option' => 'Yes' }, framework_question: question)
 
-    expect(response).not_to validate_presence_of(:value)
-  end
+      expect(response).not_to be_valid
+      expect(response.errors.messages[:details]).to eq(["can't be blank"])
+    end
 
-  it 'does not validate presence of value when a record is updated if question is not required' do
-    question = create(:framework_question, options: [])
-    response = create(:object_response, value: nil, framework_question: question)
+    it 'validates details object missing keys' do
+      question = create(
+        :framework_question,
+        followup_comment: true,
+        followup_comment_options: %w[Yes],
+      )
+      response = create(:object_response, :details, value: { 'options' => 'Yes', 'details' => 'something' }, framework_question: question)
 
-    expect(response).not_to validate_presence_of(:value)
-  end
+      expect(response).not_to be_valid
+      expect(response.errors.messages[:option]).to eq(["can't be blank"])
+    end
 
-  it 'validates presence of value when a record is updated if question and details are required' do
-    question = create(:framework_question, required: true, options: [], followup_comment: true)
-    response = create(:object_response, value: nil, framework_question: question)
+    context 'when question required' do
+      it 'validates presence of value when value is empty' do
+        question = create(:framework_question, followup_comment: true, required: true)
+        response = create(:object_response, value: {}, framework_question: question)
 
-    expect(response).to validate_presence_of(:value)
-  end
+        expect(response).not_to be_valid
+        expect(response.errors.messages[:value]).to eq(["can't be blank"])
+      end
 
-  it 'validates details object' do
-    question = create(
-      :framework_question,
-      followup_comment: true,
-      followup_comment_options: %w[Yes],
-    )
-    response = create(:object_response, :details, value: { 'option' => 'Yes' }, framework_question: question)
+      it 'validates presence of value when value is nil' do
+        question = create(:framework_question, followup_comment: true, required: true)
+        response = create(:object_response, value: nil, framework_question: question)
 
-    expect(response).not_to be_valid
+        expect(response).not_to be_valid
+        expect(response.errors.messages[:value]).to eq(["can't be blank"])
+      end
+
+      it 'does not validate presence of value when value is provided' do
+        question = create(:framework_question, followup_comment: true, required: true)
+        response = create(:object_response, :details, value: { option: 'Yes', details: 'some comment' }, framework_question: question)
+
+        expect(response).to be_valid
+      end
+    end
+
+    context 'when question not required' do
+      it 'does not validate presence of value when value is empty' do
+        response = create(:object_response, :details, value: {})
+
+        expect(response).to be_valid
+      end
+
+      it 'does not validate presence of value when value is nil' do
+        response = create(:object_response, :details, value: nil)
+
+        expect(response).to be_valid
+      end
+
+      it 'does not validate presence of value when value is provided' do
+        response = create(:object_response, :details, value: { option: 'Yes', details: 'some comment' })
+
+        expect(response).to be_valid
+      end
+    end
+
+    context 'when dependent question' do
+      it 'does not validate presence of value if parent not answered' do
+        question = create(:framework_question, followup_comment: true, required: true, dependent_value: 'Yes')
+        parent_response = create(:string_response, value: nil)
+        response = create(:object_response, value: nil, framework_question: question, parent: parent_response)
+
+        expect(response).to be_valid
+      end
+
+      it 'does not validate presence of value if parent answered with different answer' do
+        question = create(:framework_question, followup_comment: true, required: true, dependent_value: 'Yes')
+        parent_response = create(:string_response, value: 'No')
+        response = create(:object_response, value: nil, framework_question: question, parent: parent_response)
+
+        expect(response).to be_valid
+      end
+
+      it 'validates presence of value if parent answered with dependent value' do
+        question = create(:framework_question, followup_comment: true, required: true, dependent_value: 'Yes')
+        parent_response = create(:string_response, value: 'Yes')
+        response = create(:object_response, value: {}, framework_question: question, parent: parent_response)
+
+        expect(response).not_to be_valid
+        expect(response.errors.messages[:value]).to eq(["can't be blank"])
+      end
+
+      it 'does not validate presence of value if parent answered with dependent value but question not required' do
+        question = create(:framework_question, followup_comment: true, dependent_value: 'Yes')
+        parent_response = create(:string_response, value: 'Yes')
+        response = create(:object_response, value: nil, framework_question: question, parent: parent_response)
+
+        expect(response).to be_valid
+      end
+    end
   end
 
   describe '#value' do

--- a/spec/models/framework_response/object_spec.rb
+++ b/spec/models/framework_response/object_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe FrameworkResponse::Object do
     it { is_expected.to validate_absence_of(:value_text) }
 
     it 'validates correct type is passed in' do
-      response = build(:object_response, :details, value: [{ 'option' => 'Level 4' }])
+      response = create(:object_response, :details)
+      response.update(value: ['Level 4'])
 
       expect(response).not_to be_valid
       expect(response.errors.messages[:value]).to eq(['is incorrect type'])

--- a/spec/models/framework_response/string_spec.rb
+++ b/spec/models/framework_response/string_spec.rb
@@ -5,28 +5,103 @@ require 'rails_helper'
 RSpec.describe FrameworkResponse::String do
   subject { create(:string_response) }
 
-  it { is_expected.to validate_absence_of(:value_json) }
-  it { is_expected.to validate_inclusion_of(:value_text).in_array(%w[Yes No]) }
+  context 'with validations' do
+    it { is_expected.to validate_absence_of(:value_json) }
 
-  it 'validates value text presence when a record is updated if question required' do
-    question = create(:framework_question, required: true)
-    response = create(:string_response, value: nil, framework_question: question)
+    it 'validates values included in options' do
+      response = build(:string_response, value: 'Some other value')
 
-    expect(response).to validate_presence_of(:value).on(:update)
-  end
+      expect(response).not_to be_valid
+      expect(response.errors.messages[:value]).to eq(['is not included in the list'])
+    end
 
-  it 'does not validate value text presence when a record is updated if question required and dependent' do
-    question = create(:framework_question, required: true)
-    response = create(:string_response, value: nil, framework_question: question, parent: create(:string_response))
+    it 'does not validate values if value included in options' do
+      response = create(:string_response, value: 'No')
 
-    expect(response).not_to validate_presence_of(:value_text).on(:update)
-  end
+      expect(response).to be_valid
+    end
 
-  it 'does not validates value text inclusion if no options present on question' do
-    question = create(:framework_question, required: true, options: [])
-    response = create(:string_response, value: 'Some value', framework_question: question)
+    it 'does not validate values if no options available' do
+      question = create(:framework_question, :text)
+      response = create(:string_response, value: 'Some value', framework_question: question)
 
-    expect(response).not_to validate_inclusion_of(:value_text).in_array([])
+      expect(response).to be_valid
+    end
+
+    it 'validates type as not included in options since it is converted to a string' do
+      response = build(:string_response, value: { 'option' => 'some option' })
+
+      expect(response).not_to be_valid
+      expect(response.errors.messages[:value]).to eq(['is not included in the list'])
+    end
+
+    context 'when question required' do
+      it 'validates presence of value when value is nil with options' do
+        question = create(:framework_question, required: true)
+        response = create(:string_response, value: nil, framework_question: question)
+
+        expect(response).not_to be_valid
+        expect(response.errors.messages[:value]).to eq(["can't be blank"])
+      end
+
+      it 'validates presence of value when value is nil with no options' do
+        question = create(:framework_question, :text, required: true)
+        response = create(:string_response, value: nil, framework_question: question)
+
+        expect(response).not_to be_valid
+        expect(response.errors.messages[:value]).to eq(["can't be blank"])
+      end
+    end
+
+    context 'when question not required' do
+      it 'does not validate presence of value when value is nil with options' do
+        response = create(:string_response, value: nil)
+
+        expect(response).to be_valid
+      end
+
+      it 'does not validate presence of value when value is nil with no options' do
+        question = create(:framework_question, :text)
+        response = create(:string_response, value: nil, framework_question: question)
+
+        expect(response).to be_valid
+      end
+    end
+
+    context 'when dependent question' do
+      it 'does not validate presence of value if parent not answered' do
+        question = create(:framework_question, required: true, dependent_value: 'Yes')
+        parent_response = create(:string_response, value: nil)
+        response = create(:string_response, value: nil, framework_question: question, parent: parent_response)
+
+        expect(response).to be_valid
+      end
+
+      it 'does not validate presence of value if parent answered with different answer' do
+        question = create(:framework_question, required: true, dependent_value: 'Yes')
+        parent_response = create(:string_response, value: 'No')
+        response = create(:string_response, value: nil, framework_question: question, parent: parent_response)
+
+        expect(response).to be_valid
+      end
+
+      it 'validates presence of value if parent answered with dependent value' do
+        question = create(:framework_question, required: true, dependent_value: 'Yes')
+        parent_response = create(:string_response, value: 'Yes')
+        response = create(:string_response, value: nil, framework_question: question, parent: parent_response)
+
+        expect(response).not_to be_valid
+        expect(response.errors.messages[:value]).to eq(["can't be blank"])
+      end
+
+      it 'does not validate presence of value if parent answered with dependent value but question not required' do
+        question = create(:framework_question, dependent_value: 'Yes')
+        parent_response = create(:string_response, value: 'Yes')
+        response = create(:string_response, value: nil, framework_question: question, parent: parent_response)
+
+        expect(response).to be_valid
+      end
+    end
   end
 
   describe '#value' do

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -10,67 +10,69 @@ RSpec.describe FrameworkResponse do
   it { is_expected.to have_many(:dependents) }
   it { is_expected.to validate_presence_of(:type) }
 
-  it 'validates string dependent responses' do
-    question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
-    response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
+  context 'with validations' do
+    it 'validates string dependent responses' do
+      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
+      response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
 
-    expect(response).to validate_presence_of(:value).on(:update)
-  end
+      expect(response).to validate_presence_of(:value).on(:update)
+    end
 
-  it 'does not validate string dependent responses if parent response is not correct value' do
-    question = create(:framework_question, dependent_value: 'No', options: [], required: true)
-    response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
+    it 'does not validate string dependent responses if parent response is not correct value' do
+      question = create(:framework_question, dependent_value: 'No', options: [], required: true)
+      response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
 
-    expect(response).not_to validate_presence_of(:value).on(:update)
-  end
+      expect(response).not_to validate_presence_of(:value).on(:update)
+    end
 
-  it 'does not validate dependent responses if parent response is correct value but not required' do
-    question = create(:framework_question, dependent_value: 'Yes', options: [], required: false)
-    response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
+    it 'does not validate dependent responses if parent response is correct value but not required' do
+      question = create(:framework_question, dependent_value: 'Yes', options: [], required: false)
+      response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
 
-    expect(response).not_to validate_presence_of(:value).on(:update)
-  end
+      expect(response).not_to validate_presence_of(:value).on(:update)
+    end
 
-  it 'validates array dependent responses' do
-    question = create(:framework_question, dependent_value: 'Level 1', options: [], required: true)
-    response = create(:string_response, value: nil, parent: create(:array_response), framework_question: question)
+    it 'validates array dependent responses' do
+      question = create(:framework_question, dependent_value: 'Level 1', options: [], required: true)
+      response = create(:string_response, value: nil, parent: create(:array_response), framework_question: question)
 
-    expect(response).to validate_presence_of(:value).on(:update)
-  end
+      expect(response).to validate_presence_of(:value).on(:update)
+    end
 
-  it 'does not validate array dependent responses if parent response is not correct value' do
-    question = create(:framework_question, dependent_value: 'Level 2', options: [], required: true)
-    response = create(:string_response, value: nil, parent: create(:array_response), framework_question: question)
+    it 'does not validate array dependent responses if parent response is not correct value' do
+      question = create(:framework_question, dependent_value: 'Level 2', options: [], required: true)
+      response = create(:string_response, value: nil, parent: create(:array_response), framework_question: question)
 
-    expect(response).not_to validate_presence_of(:value).on(:update)
-  end
+      expect(response).not_to validate_presence_of(:value).on(:update)
+    end
 
-  it 'validates object dependent responses' do
-    question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
-    response = create(:string_response, value: nil, parent: create(:object_response, :details), framework_question: question)
+    it 'validates object dependent responses' do
+      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
+      response = create(:string_response, value: nil, parent: create(:object_response, :details), framework_question: question)
 
-    expect(response).to validate_presence_of(:value).on(:update)
-  end
+      expect(response).to validate_presence_of(:value).on(:update)
+    end
 
-  it 'does not validate object dependent responses if parent response is not correct value' do
-    question = create(:framework_question, dependent_value: 'No', options: [], required: true)
-    response = create(:string_response, value: nil, parent: create(:object_response, :details), framework_question: question)
+    it 'does not validate object dependent responses if parent response is not correct value' do
+      question = create(:framework_question, dependent_value: 'No', options: [], required: true)
+      response = create(:string_response, value: nil, parent: create(:object_response, :details), framework_question: question)
 
-    expect(response).not_to validate_presence_of(:value).on(:update)
-  end
+      expect(response).not_to validate_presence_of(:value).on(:update)
+    end
 
-  it 'validates collection dependent responses' do
-    question = create(:framework_question, dependent_value: 'Level 1', options: [], required: true)
-    response = create(:string_response, value: nil, parent: create(:collection_response, :details), framework_question: question)
+    it 'validates collection dependent responses' do
+      question = create(:framework_question, dependent_value: 'Level 1', options: [], required: true)
+      response = create(:string_response, value: nil, parent: create(:collection_response, :details), framework_question: question)
 
-    expect(response).to validate_presence_of(:value).on(:update)
-  end
+      expect(response).to validate_presence_of(:value).on(:update)
+    end
 
-  it 'does not validate collection dependent responses if parent response is not correct value' do
-    question = create(:framework_question, dependent_value: 'Level 3', options: [], required: true)
-    response = create(:string_response, value: nil, parent: create(:collection_response, :details), framework_question: question)
+    it 'does not validate collection dependent responses if parent response is not correct value' do
+      question = create(:framework_question, dependent_value: 'Level 3', options: [], required: true)
+      response = create(:string_response, value: nil, parent: create(:collection_response, :details), framework_question: question)
 
-    expect(response).not_to validate_presence_of(:value).on(:update)
+      expect(response).not_to validate_presence_of(:value).on(:update)
+    end
   end
 
   describe '.requires_value?' do


### PR DESCRIPTION
### Jira link

[P4-1771](https://dsdmoj.atlassian.net/browse/P4-1771)

### What?

I have added/removed/altered:

- [x] Added type validation across responses
- [x] Fixed error validations
- [x] Bubble up errors from nested detail objects and collections
- [x] Added extra testing for posterity

### Why?

Correct the following validations:
- Array responses inclusion: inclusion validation works on strings not arrays use custom validation instead
- Validate option inclusion if option present to allow empty responses to be valid if response optional
- Validate details presence only if question answered with dependent answer

Added the following validations:
- Type validation for each response type
- Uniqueness validation on collection options incase someone sends a checklist response more than once
- Move option presence to only be required if details sent, as presence is done in main object class