### PR TITLE
Enforce move_type attribute to be specified for v2 move creation

### DIFF
--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -69,6 +69,7 @@ module Api::V2
         attributes[:supplier] = SupplierChooser.new(doorkeeper_application_owner, from_location).call unless from_location_attributes.nil?
         attributes[:from_location] = from_location unless from_location_attributes.nil?
         attributes[:to_location] = to_location unless to_location_attributes.nil?
+        attributes[:version] = 2
       end
     end
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -90,6 +90,13 @@ class Move < VersionedModel
 
   scope :not_cancelled, -> { where.not(status: MOVE_STATUS_CANCELLED) }
 
+  attr_accessor :version
+
+  # TODO: Temporary method to apply correct validation rules when creating v2 move
+  def v2?
+    version == 2
+  end
+
   def rebooked
     self.class.find_by(original_move_id: id)
   end
@@ -146,7 +153,7 @@ private
   end
 
   def set_move_type
-    return if move_type.present?
+    return if move_type.present? || v2?
 
     # TODO: The order is not important, here.
     #       Remove this from the model when we migrate to mandatory move_type under v2

--- a/app/services/moves/move_type_validator.rb
+++ b/app/services/moves/move_type_validator.rb
@@ -9,10 +9,13 @@ module Moves
       return if record.move_type.blank?
 
       # Apply more complex validation rules for specific move types
-      validate_police_from_location if includes? %w[video_remand]
-      validate_hospital_to_location if includes? %w[hospital]
-      validate_detained_to_location if includes? %w[prison_remand]
+      validate_court_to_location if includes? %w[court_appearance]
       validate_not_detained_to_location if includes? %w[court_other]
+      validate_hospital_to_location if includes? %w[hospital]
+      validate_police_to_location if includes? %w[police_transfer]
+      validate_police_from_location if includes? %w[police_transfer prison_recall video_remand]
+      validate_detained_to_location if includes? %w[prison_remand]
+      validate_prison_from_location if includes? %w[prison_transfer]
     end
 
   private
@@ -25,20 +28,32 @@ module Moves
       record.move_type.to_s.humanize(capitalize: false)
     end
 
-    def validate_police_from_location
-      record.errors.add(:from_location, "must be a police location for #{human_move_type} move") unless record.from_location&.police?
-    end
-
-    def validate_hospital_to_location
-      record.errors.add(:to_location, "must be a high security hospital location for #{human_move_type} move") unless record.to_location&.high_security_hospital?
+    def validate_court_to_location
+      record.errors.add(:to_location, "must be a court location for #{human_move_type} move") unless record.to_location&.court?
     end
 
     def validate_detained_to_location
       record.errors.add(:to_location, "must be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.to_location&.detained?
     end
 
+    def validate_hospital_to_location
+      record.errors.add(:to_location, "must be a high security hospital location for #{human_move_type} move") unless record.to_location&.high_security_hospital?
+    end
+
     def validate_not_detained_to_location
       record.errors.add(:to_location, "must not be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.to_location&.not_detained?
+    end
+
+    def validate_police_from_location
+      record.errors.add(:from_location, "must be a police location for #{human_move_type} move") unless record.from_location&.police?
+    end
+
+    def validate_police_to_location
+      record.errors.add(:to_location, "must be a police location for #{human_move_type} move") unless record.to_location&.police?
+    end
+
+    def validate_prison_from_location
+      record.errors.add(:from_location, "must be a prison location for #{human_move_type} move") unless record.from_location&.prison?
     end
   end
 end

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
     time_due { Time.now }
     status { 'requested' }
     additional_information { 'some more info about the move that the supplier might need to know' }
-    move_type { 'court_appearance' }
     sequence(:created_at) { |n| Time.now - n.minutes }
     sequence(:date_from) { |n| Date.today - n.days }
 
@@ -41,6 +40,8 @@ FactoryBot.define do
 
     trait :police_transfer do
       move_type { 'police_transfer' }
+      association(:from_location, :police, factory: :location)
+      association(:to_location, :police, factory: :location)
     end
 
     trait :video_remand do
@@ -150,10 +151,10 @@ FactoryBot.define do
     end
   end
 
-  factory :from_court_to_prison, class: 'Move' do
+  factory :from_prison_to_court, class: 'Move' do
     association(:profile)
-    association(:from_location, :court, factory: :location)
-    association(:to_location, :prison, factory: :location)
+    association(:from_location, :prison, factory: :location)
+    association(:to_location, :court, factory: :location)
     date { Date.today }
     time_due { Time.now }
     status { 'requested' }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -229,11 +229,36 @@ RSpec.describe Move do
   end
 
   describe '#move_type' do
-    subject(:move) { build :move, from_location: from_location, to_location: to_location, move_type: nil }
+    subject(:move) { build :move, from_location: from_location, to_location: to_location, move_type: move_type, version: version }
 
     let(:from_location) { build :location, :police }
+    let(:move_type) { nil }
+    let(:version) { nil }
 
     before { move.valid? }
+
+    context 'when creating a v2 move' do
+      let(:version) { 2 }
+      let(:to_location) { nil }
+
+      context 'without specifying move_type' do
+        it 'does not set move_type' do
+          expect(move.move_type).to be_nil
+        end
+
+        it 'is not valid' do
+          expect(move).not_to be_valid
+        end
+      end
+
+      context 'when specifying move_type' do
+        let(:move_type) { 'prison_recall' }
+
+        it 'is valid' do
+          expect(move).to be_valid
+        end
+      end
+    end
 
     context 'when to_location is empty' do
       let(:to_location) { nil }

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::MoveEventsController do
     let(:response_json) { JSON.parse(response.body) }
     let(:schema) { load_yaml_schema('post_move_events_responses.yaml') }
     let(:from_location) { create(:location, suppliers: [supplier]) }
-    let(:move) { create(:move, from_location: from_location) }
+    let(:move) { create(:move, :prison_transfer, from_location: from_location) }
     let(:move_id) { move.id }
     let(:new_location) { create(:location) }
     let(:redirect_params) do

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe Api::MovesController do
       end
 
       context 'without a `to_location`' do
+        let(:from_location) { create :location, :police, suppliers: [supplier] }
         let(:to_location) { nil }
         let(:data) do
           {

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Api::MovesController do
       let(:data) do
         {
           type: 'moves',
-          attributes: move_attributes.merge(move_type: nil),
+          attributes: move_attributes.merge(move_type: 'prison_recall'),
           relationships: {
             profile: { data: { type: 'profiles', id: profile.id } },
             from_location: { data: { type: 'locations', id: from_location.id } },
@@ -236,7 +236,7 @@ RSpec.describe Api::MovesController do
             time_due: Time.now,
             status: 'requested',
             additional_information: 'some more info',
-            move_type: nil,
+            move_type: 'court_appearance',
           },
           relationships: {
             profile: { data: { type: 'profiles', id: profile.id } },
@@ -266,6 +266,7 @@ RSpec.describe Api::MovesController do
           move_agreed_by: 'John Doe',
           date_from: date_from,
           date_to: date_to,
+          move_type: 'court_appearance',
         }
       end
 
@@ -417,9 +418,23 @@ RSpec.describe Api::MovesController do
         }
       end
 
-      let(:detail_404) {  "Couldn't find Location with 'id'=foo" }
+      let(:detail_404) { "Couldn't find Location with 'id'=foo" }
 
       it_behaves_like 'an endpoint that responds with error 404' do
+        before { do_post }
+      end
+    end
+
+    context 'when omitting move_type attribute' do
+      let(:move_attributes) { attributes_for(:move).except(:move_type) }
+
+      let(:errors_422) do
+        [
+          { 'title' => 'Unprocessable entity', 'detail' => 'Move type is not included in the list', 'source' => { 'pointer' => '/data/attributes/move_type' }, 'code' => 'inclusion' },
+        ]
+      end
+
+      it_behaves_like 'an endpoint that responds with error 422' do
         before { do_post }
       end
     end

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe Api::MovesController do
     end
 
     context 'without a `to_location`' do
+      let(:from_location) { create :location, :police, suppliers: [another_supplier] }
       let(:to_location) { nil }
       let(:data) do
         {
@@ -218,7 +219,7 @@ RSpec.describe Api::MovesController do
     end
 
     context 'with a proposed move' do
-      let(:move_attributes) { attributes_for(:move).except(:date).merge(status: 'proposed') }
+      let(:move_attributes) { attributes_for(:move).except(:date).merge(move_type: 'court_appearance', status: 'proposed') }
 
       it_behaves_like 'an endpoint that responds with success 201' do
         before { do_post }
@@ -440,7 +441,7 @@ RSpec.describe Api::MovesController do
     end
 
     context 'when specifying invalid attributes' do
-      let(:move_attributes) { attributes_for(:move).except(:date).merge(status: 'invalid') }
+      let(:move_attributes) { attributes_for(:move).except(:date).merge(move_type: 'court_appearance', status: 'invalid') }
 
       let(:errors_422) do
         [
@@ -455,10 +456,10 @@ RSpec.describe Api::MovesController do
     end
 
     context 'when a move is a duplicate' do
-      let(:move_attributes) { attributes_for(:move).merge(date: move.date) }
+      let(:move_attributes) { attributes_for(:move).merge(move_type: 'court_appearance', date: move.date) }
 
       context 'when there are cancelled duplicates' do
-        let!(:move) { create(:move, :cancelled, profile: profile, from_location: from_location, to_location: to_location) }
+        let!(:move) { create(:move, :cancelled, :court_appearance, profile: profile, from_location: from_location, to_location: to_location) }
 
         it_behaves_like 'an endpoint that responds with success 201' do
           before { do_post }
@@ -466,7 +467,7 @@ RSpec.describe Api::MovesController do
       end
 
       context 'when the Move has been already created' do
-        let!(:move) { create(:move, profile: profile, from_location: from_location, to_location: to_location) }
+        let!(:move) { create(:move, :court_appearance, profile: profile, from_location: from_location, to_location: to_location) }
         let(:errors_422) do
           [
             {

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Api::MovesController do
   describe 'PATCH /moves' do
     let(:schema) { load_yaml_schema('patch_move_responses.yaml') }
     let(:supplier) { create(:supplier) }
-    let!(:from_location) { create :location, suppliers: [supplier] }
+    let!(:from_location) { create :location, :police, suppliers: [supplier] }
     let(:profile) { create(:profile, documents: before_documents) }
-    let!(:move) { create :move, :proposed, move_type: 'prison_recall', from_location: from_location, profile: profile }
+    let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile }
     let(:move_id) { move.id }
     let(:date_from) { Date.yesterday }
     let(:date_to) { Date.tomorrow }

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Api::MovesController do
   end
 
   describe 'PATCH /moves' do
-    let!(:move) { create :move, :proposed, move_type: 'prison_recall', from_location: from_location, profile: profile }
+    let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile }
 
-    let(:from_location) { create :location, suppliers: [supplier] }
+    let(:from_location) { create :location, :police, suppliers: [supplier] }
     let(:move_id) { move.id }
     let(:profile) { create(:profile) }
     let(:date_from) { Date.yesterday }
@@ -40,7 +40,6 @@ RSpec.describe Api::MovesController do
           additional_information: 'some more info',
           cancellation_reason: nil,
           cancellation_reason_comment: nil,
-          move_type: 'court_appearance',
           move_agreed: true,
           move_agreed_by: 'Fred Bloggs',
           date_from: date_from,
@@ -59,7 +58,6 @@ RSpec.describe Api::MovesController do
         'date_to' => date_to,
         'move_agreed' => true,
         'move_agreed_by' => 'Fred Bloggs',
-        'move_type' => 'court_appearance',
         'status' => 'requested',
       }
     end

--- a/spec/services/allocations/create_in_nomis_spec.rb
+++ b/spec/services/allocations/create_in_nomis_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Allocations::CreateInNomis do
   context 'when move is valid' do
     subject(:create_transfer_in_nomis) { described_class.call(move) }
 
-    let(:from_location) { create(:location, nomis_agency_id: from_nomis_agency_id) }
-    let(:to_location) { create(:location, nomis_agency_id: to_nomis_agency_id) }
+    let(:from_location) { create(:location, :police, nomis_agency_id: from_nomis_agency_id) }
+    let(:to_location) { create(:location, :prison, nomis_agency_id: to_nomis_agency_id) }
     let(:move) do
       create(
         :move,

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Moves::Finder do
       end
 
       context 'with two location filters' do
-        let!(:second_move) { create :from_court_to_prison }
+        let!(:second_move) { create :from_prison_to_court }
         let(:filter_params) { { from_location_id: [move.from_location_id, second_move.from_location_id] } }
 
         it 'returns moves matching multiple locations' do
@@ -221,7 +221,7 @@ RSpec.describe Moves::Finder do
       let!(:court_appearance_move) { create :move, :court_appearance }
       let!(:prison_recall_move) { create :move, :prison_recall }
       let!(:prison_transfer_move) { create :move, :prison_transfer }
-      let!(:police_transfer_move) { create :move, move_type: :police_transfer }
+      let!(:police_transfer_move) { create :move, :police_transfer }
 
       context 'with matching move_type' do
         let(:filter_params) { { move_type: 'court_appearance' } }

--- a/spec/services/moves/move_type_validator_spec.rb
+++ b/spec/services/moves/move_type_validator_spec.rb
@@ -24,6 +24,26 @@ RSpec.describe Moves::MoveTypeValidator do
     it { is_expected.to be_valid }
   end
 
+  context 'with court_appearance `move_type`' do
+    let(:move_type) { 'court_appearance' }
+
+    it 'validates `to_location` is a court' do
+      target.to_location = build(:location, :court)
+      expect(target).to be_valid
+    end
+
+    it 'validates `to_location` is not nil' do
+      target.to_location = nil
+      expect(target).not_to be_valid
+    end
+
+    it 'has an error if `to_location` is not a court' do
+      target.to_location = build(:location, :prison)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:to_location]).to match_array('must be a court location for court appearance move')
+    end
+  end
+
   context 'with court_other `move_type`' do
     let(:move_type) { 'court_other' }
 
@@ -38,7 +58,7 @@ RSpec.describe Moves::MoveTypeValidator do
     end
 
     it 'has an error if `to_location` is not a prison, sch or stc' do
-      %i[prison stc stc].each do |location_type|
+      %i[prison sch stc].each do |location_type|
         target.to_location = build(:location, location_type)
         expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
         expect(target.errors[:to_location]).to match_array('must not be a prison, secure training centre or secure childrens hospital for court other move')
@@ -66,11 +86,67 @@ RSpec.describe Moves::MoveTypeValidator do
     end
   end
 
+  context 'with police_transfer `move_type`' do
+    let(:move_type) { 'police_transfer' }
+
+    it 'validates `from_location` and `to_location` is a police location' do
+      target.from_location = build(:location, :police)
+      target.to_location = build(:location, :police)
+      expect(target).to be_valid
+    end
+
+    it 'validates `from_location` is not nil' do
+      target.from_location = nil
+      target.to_location = build(:location, :police)
+      expect(target).not_to be_valid
+    end
+
+    it 'validates `to_location` is not nil' do
+      target.from_location = build(:location, :police)
+      target.to_location = nil
+      expect(target).not_to be_valid
+    end
+
+    it 'has an error if `from_location` is not a police location' do
+      target.from_location = build(:location, :court)
+      target.to_location = build(:location, :police)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:from_location]).to match_array('must be a police location for police transfer move')
+    end
+
+    it 'has an error if `to_location` is not a police location' do
+      target.from_location = build(:location, :police)
+      target.to_location = build(:location, :court)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:to_location]).to match_array('must be a police location for police transfer move')
+    end
+  end
+
+  context 'with prison_recall `move_type`' do
+    let(:move_type) { 'prison_recall' }
+
+    it 'validates `from_location` is a police location' do
+      target.from_location = build(:location, :police)
+      expect(target).to be_valid
+    end
+
+    it 'validates `from_location` is not nil' do
+      target.from_location = nil
+      expect(target).not_to be_valid
+    end
+
+    it 'has an error if `from_location` is not a police location' do
+      target.from_location = build(:location, :court)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:from_location]).to match_array('must be a police location for prison recall move')
+    end
+  end
+
   context 'with prison_remand `move_type`' do
     let(:move_type) { 'prison_remand' }
 
     it 'validates `to_location` is a prison, sch or stc' do
-      %i[prison stc stc].each do |location_type|
+      %i[prison sch stc].each do |location_type|
         target.to_location = build(:location, location_type)
         expect(target).to be_valid
       end
@@ -85,6 +161,26 @@ RSpec.describe Moves::MoveTypeValidator do
       target.from_location = build(:location, :court)
       expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
       expect(target.errors[:to_location]).to match_array('must be a prison, secure training centre or secure childrens hospital for prison remand move')
+    end
+  end
+
+  context 'with prison_transfer `move_type`' do
+    let(:move_type) { 'prison_transfer' }
+
+    it 'validates `from_location` is a prison location' do
+      target.from_location = build(:location, :prison)
+      expect(target).to be_valid
+    end
+
+    it 'validates `from_location` is not nil' do
+      target.from_location = nil
+      expect(target).not_to be_valid
+    end
+
+    it 'has an error if `from_location` is not a prison location' do
+      target.from_location = build(:location, :court)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:from_location]).to match_array('must be a prison location for prison transfer move')
     end
   end
 

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Moves::Updater do
   subject(:updater) { described_class.new(move, move_params) }
 
   let(:before_documents) { create_list(:document, 2) }
-  let!(:from_location) { create(:location) }
-  let!(:move) { create(:move, :proposed, move_type: 'prison_recall', from_location: from_location, profile: profile) }
+  let!(:from_location) { create(:location, :police) }
+  let!(:move) { create(:move, :proposed, :prison_recall, from_location: from_location, profile: profile) }
   let(:profile) { create(:profile, documents: before_documents) }
   let(:date_from) { Date.yesterday }
   let(:date_to) { Date.tomorrow }
@@ -22,7 +22,6 @@ RSpec.describe Moves::Updater do
         additional_information: 'some more info',
         cancellation_reason: cancellation_reason,
         cancellation_reason_comment: nil,
-        move_type: 'court_appearance',
         move_agreed: true,
         move_agreed_by: 'Fred Bloggs',
         date_from: date_from,
@@ -37,7 +36,6 @@ RSpec.describe Moves::Updater do
       expect(updater.move).to have_attributes(
         status: 'requested',
         additional_information: 'some more info',
-        move_type: 'court_appearance',
         move_agreed: true,
         move_agreed_by: 'Fred Bloggs',
         date_from: date_from,

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -19,7 +19,6 @@ Move:
       type: object
       required:
       - status
-      - move_type
       properties:
         reference:
           type: string


### PR DESCRIPTION
### Jira link

P4-1851

### What?

- [x] Added a new transient `version` attribute on `Move` model to avoid automatically setting a `move_type` for moves created via v2 `POST /moves` endpoint
- [x] Enforce specification of `move_type` when creating a move via v2 `POST /moves` endpoint (by disabling behaviour described above)
- [x] Added validation rules for original move types that were previously derived automatically - reflecting existing rules for these so that moves created under `v1` endpoint without specifying `move_type` are still valid

### Why?

- We need to support a richer set of move types (already implemented in previous PR's) so cannot rely on move type being derived automatically in the back end API. Instead clients (front end and suppliers) must specify the `move_type` explicitly when creating a move under v2 `POST /moves` endpoint. v1 endpoint will still allow `move_type` to be omitted.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- This is a breaking change for v2 - which is in use now, so needs collaboration with front end devs and communication with suppliers before this can be merged. Will also require end to end test suite to pass successfully (currently this will break as `move_type` is not specified by front end code).
