### PR TITLE
log number of moves exported

### DIFF
--- a/lib/tasks/journeys_report.rake
+++ b/lib/tasks/journeys_report.rake
@@ -78,6 +78,7 @@ namespace :journeys do
           journeys: journeys,
         }
       end
+      print " #{moves.length} moves exported. "
       puts 'done.'
 
       File.open(filename, 'w') do |file|


### PR DESCRIPTION
### Jira link

n/a

### What?

I have added/removed/altered:

- [ ] Outputting the number of exported moves per supplier 


### Why?

I am doing this because:
- So that we can keep track of the report evolution without having to open the actual reports. 

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

