### PR TITLE
P4-1778 Add FrameworkResponse patch endpoint

### DIFF
--- a/app/controllers/api/framework_responses_controller.rb
+++ b/app/controllers/api/framework_responses_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Api
+  class FrameworkResponsesController < ApiController
+    PPERMITTED_PARAMS = [
+      :type,
+      attributes: [:value, { value: %i[option details] }, { value: [] }],
+    ].freeze
+
+    def update
+      framework_response.update!(update_attributes)
+
+      render json: framework_response, status: :ok, include: included_relationships
+    end
+
+  private
+
+    def update_params
+      params.require(:data).permit(PPERMITTED_PARAMS)
+    end
+
+    def update_attributes
+      update_params.to_h[:attributes]
+    end
+
+    def supported_relationships
+      FrameworkResponseSerializer::SUPPORTED_RELATIONSHIPS
+    end
+
+    def framework_response
+      @framework_response ||= FrameworkResponse.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/api/framework_responses_controller.rb
+++ b/app/controllers/api/framework_responses_controller.rb
@@ -2,6 +2,8 @@
 
 module Api
   class FrameworkResponsesController < ApiController
+    # NB: permit multiple types of value attributes: array, array of objects,
+    # object with option details fields, and string
     PPERMITTED_PARAMS = [
       :type,
       attributes: [:value, { value: %i[option details] }, { value: [] }],

--- a/app/controllers/api/framework_responses_controller.rb
+++ b/app/controllers/api/framework_responses_controller.rb
@@ -8,19 +8,19 @@ module Api
     ].freeze
 
     def update
-      framework_response.update!(update_attributes)
+      framework_response.update_with_flags!(update_framework_response_attributes)
 
       render json: framework_response, status: :ok, include: included_relationships
     end
 
   private
 
-    def update_params
+    def update_framework_response_params
       params.require(:data).permit(PPERMITTED_PARAMS)
     end
 
-    def update_attributes
-      update_params.to_h[:attributes]
+    def update_framework_response_attributes
+      update_framework_response_params.to_h.dig(:attributes, :value)
     end
 
     def supported_relationships

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -13,4 +13,5 @@ class Flag < VersionedModel
   validates :question_value, presence: true
 
   belongs_to :framework_question
+  has_and_belongs_to_many :framework_responses
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -10,6 +10,7 @@ class FrameworkResponse < VersionedModel
                         foreign_key: 'parent_id'
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
+  has_and_belongs_to_many :flags
   validates_each :value, on: :update do |record, _attr, value|
     record.errors.add(:value, :blank) if requires_value?(value, record)
   end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -10,7 +10,7 @@ class FrameworkResponse < VersionedModel
                         foreign_key: 'parent_id'
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
-  has_and_belongs_to_many :flags
+  has_and_belongs_to_many :flags, autosave: true
   validates_each :value, on: :update do |record, _attr, value|
     record.errors.add(:value, :blank) if requires_value?(value, record)
   end
@@ -25,9 +25,24 @@ class FrameworkResponse < VersionedModel
     record.parent.option_selected?(record.framework_question.dependent_value)
   end
 
+  def update_with_flags!(value)
+    self.value = value
+    update!(flags: build_flags)
+  end
+
 private
 
   def set_responded_value
     self.responded = true
+  end
+
+  def build_flags
+    return [] unless framework_question.flags.any?
+
+    framework_question.flags.each_with_object([]) do |flag, arr|
+      if option_selected?(flag.question_value)
+        arr << flag
+      end
+    end
   end
 end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -15,6 +15,7 @@ class PersonEscortRecord < VersionedModel
 
   belongs_to :framework
   has_many :framework_questions, through: :framework
+  has_many :flags, through: :framework_responses
   belongs_to :profile
   validates :profile, uniqueness: true
 

--- a/app/serializers/flag_serializer.rb
+++ b/app/serializers/flag_serializer.rb
@@ -1,0 +1,9 @@
+class FlagSerializer < ActiveModel::Serializer
+  belongs_to :framework_question, key: :question
+
+  attributes :flag_type, :name, :question_value
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    question
+  ].freeze
+end

--- a/app/serializers/flag_serializer.rb
+++ b/app/serializers/flag_serializer.rb
@@ -1,4 +1,5 @@
 class FlagSerializer < ActiveModel::Serializer
+  type :framework_flags
   belongs_to :framework_question, key: :question
 
   attributes :flag_type, :name, :question_value

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -2,6 +2,7 @@ class FrameworkResponseSerializer < ActiveModel::Serializer
   type 'framework_responses'
   belongs_to :person_escort_record
   belongs_to :framework_question, key: :question
+  has_many :flags
 
   attributes :value, :value_type, :responded
 
@@ -21,5 +22,6 @@ class FrameworkResponseSerializer < ActiveModel::Serializer
   SUPPORTED_RELATIONSHIPS = %w[
     person_escort_record
     question
+    flags
   ].freeze
 end

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -2,6 +2,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   belongs_to :profile, record_type: :profile
   belongs_to :framework, record_type: :framework
   has_many :framework_responses, serializer: FrameworkResponseSerializer, key: :responses
+  has_many :flags
 
   attribute :version
   attribute :state, key: :status
@@ -22,5 +23,6 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
     framework
     profile.person
     responses.question
+    flags
   ].freeze
 end

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -16,7 +16,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   end
 
   def framework_responses
-    object.framework_responses.includes(framework_question: :framework)
+    object.framework_responses.includes(:flags, framework_question: :framework)
   end
 
   SUPPORTED_RELATIONSHIPS = %w[

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     end
 
     resources :person_escort_records, only: %i[create show]
+    resources :framework_responses, only: %i[update]
 
     namespace :reference do
       resources :allocation_complex_cases, only: :index

--- a/db/migrate/20200720063205_create_framework_responses_flags_join_table.rb
+++ b/db/migrate/20200720063205_create_framework_responses_flags_join_table.rb
@@ -1,0 +1,8 @@
+class CreateFrameworkResponsesFlagsJoinTable < ActiveRecord::Migration[6.0]
+  def change
+    create_join_table :framework_responses, :flags, column_options: { type: :uuid } do |t|
+      t.index :framework_response_id
+      t.index :flag_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_15_041742) do
+ActiveRecord::Schema.define(version: 2020_07_20_063205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -132,6 +132,13 @@ ActiveRecord::Schema.define(version: 2020_07_15_041742) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["framework_question_id"], name: "index_flags_on_framework_question_id"
+  end
+
+  create_table "flags_framework_responses", id: false, force: :cascade do |t|
+    t.uuid "framework_response_id", null: false
+    t.uuid "flag_id", null: false
+    t.index ["flag_id"], name: "index_flags_framework_responses_on_flag_id"
+    t.index ["framework_response_id"], name: "index_flags_framework_responses_on_framework_response_id"
   end
 
   create_table "framework_questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe Flag do
   it { is_expected.to validate_presence_of(:flag_type) }
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to belong_to(:framework_question) }
+  it { is_expected.to have_and_belong_to_many(:framework_responses) }
   it { is_expected.to validate_inclusion_of(:flag_type).in_array(%w[information attention warning alert]) }
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe FrameworkResponse do
   it { is_expected.to belong_to(:parent).optional }
 
   it { is_expected.to have_many(:dependents) }
+  it { is_expected.to have_and_belong_to_many(:flags) }
   it { is_expected.to validate_presence_of(:type) }
 
   context 'with validations' do

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -141,4 +141,91 @@ RSpec.describe FrameworkResponse do
       expect(response.responded).to be(true)
     end
   end
+
+  describe '#update_with_flags!' do
+    it 'updates response value' do
+      response = create(:string_response, value: nil)
+      response.update_with_flags!('Yes')
+
+      expect(response.value).to eq('Yes')
+    end
+
+    it 'does not attach flags if no flags attached to question' do
+      create(:flag)
+      response = create(:string_response)
+      response.update_with_flags!('Yes')
+
+      expect(response.flags).to be_empty
+    end
+
+    it 'does not attach flags if answer supplied does not match flag' do
+      flag = create(:flag)
+      response = create(:string_response, value: nil, framework_question: flag.framework_question)
+      response.update_with_flags!('No')
+
+      expect(response.flags).to be_empty
+    end
+
+    it 'attaches flags if answer supplied matches flag for string' do
+      flag = create(:flag)
+      response = create(:string_response, value: nil, framework_question: flag.framework_question)
+      response.update_with_flags!('Yes')
+
+      expect(response.flags).to contain_exactly(flag)
+    end
+
+    it 'attaches flags if answer supplied matches flag for array' do
+      response = create(:array_response, value: nil)
+      flag = create(:flag, question_value: 'Level 1', framework_question: response.framework_question)
+      response.update_with_flags!(['Level 1', 'Level 2'])
+
+      expect(response.flags).to contain_exactly(flag)
+    end
+
+    it 'attaches flags if answer supplied matches flag for object' do
+      response = create(:object_response, :details, value: nil)
+      flag = create(:flag, question_value: 'Yes', framework_question: response.framework_question)
+      response.update_with_flags!({ option: 'Yes', details: 'something' })
+
+      expect(response.flags).to contain_exactly(flag)
+    end
+
+    it 'attaches flags if answer supplied matches flag for collection' do
+      response = create(:collection_response, :details, value: nil)
+      flag = create(:flag, question_value: 'Level 1', framework_question: response.framework_question)
+      response.update_with_flags!([{ option: 'Level 1', details: 'something' }])
+
+      expect(response.flags).to contain_exactly(flag)
+    end
+
+    it 'attaches multiple flags if answer supplied matches flag' do
+      framework_question = create(:framework_question)
+      flag1 = create(:flag, framework_question: framework_question)
+      flag2 = create(:flag, framework_question: framework_question)
+      response = create(:string_response, value: nil, framework_question: framework_question)
+      response.update_with_flags!('Yes')
+
+      expect(response.flags).to contain_exactly(flag1, flag2)
+    end
+
+    it 'detaches flag if answer changed' do
+      framework_question = create(:framework_question)
+      flag1 = create(:flag, framework_question: framework_question)
+      flag2 = create(:flag, framework_question: framework_question)
+      response = create(:string_response, framework_question: framework_question, flags: [flag1, flag2])
+      response.update_with_flags!('No')
+
+      expect(response.reload.flags).to be_empty
+    end
+
+    it 'attaches another flag if answer changed' do
+      framework_question = create(:framework_question)
+      flag1 = create(:flag, framework_question: framework_question)
+      flag2 = create(:flag, question_value: 'No', framework_question: framework_question)
+      response = create(:string_response, framework_question: framework_question, flags: [flag1])
+      response.update_with_flags!('No')
+
+      expect(response.flags).to contain_exactly(flag2)
+    end
+  end
 end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PersonEscortRecord do
   it { is_expected.to validate_inclusion_of(:state).in_array(%w[in_progress completed confirmed]) }
   it { is_expected.to have_many(:framework_responses) }
   it { is_expected.to have_many(:framework_questions).through(:framework) }
+  it { is_expected.to have_many(:flags).through(:framework_responses) }
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:profile) }
 

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -115,6 +115,23 @@ RSpec.describe Api::FrameworkResponsesController do
         end
       end
 
+      context 'when incorrect keys added to object response' do
+        let(:framework_response) { create(:object_response, :details) }
+        let(:value) { { option: 'Yes', detailss: 'Some details' } }
+
+        it 'returns the correct data' do
+          expect(response_json).to include_json(data: {
+            "id": framework_response_id,
+            "type": 'framework_responses',
+            "attributes": {
+              "value": { option: 'Yes' },
+              "value_type": 'object',
+              "responded": true,
+            },
+          })
+        end
+      end
+
       context 'with flags' do
         it 'attaches a flag and returns the correct data' do
           expect(response_json).to include_json(data: {

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Api::FrameworkResponsesController do
                 "data": [
                   {
                     id: flag.id,
-                    type: 'flags',
+                    type: 'framework_flags',
                   },
                 ],
               },

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::FrameworkResponsesController do
 
     let(:response_json) { JSON.parse(response.body) }
     let(:framework_response) { create(:string_response) }
+    let!(:flag) { create(:flag, framework_question: framework_response.framework_question, question_value: 'No') }
     let(:framework_response_id) { framework_response.id }
     let(:value) { 'No' }
 
@@ -109,6 +110,25 @@ RSpec.describe Api::FrameworkResponsesController do
               "value": [{ option: 'Level 1' }],
               "value_type": 'collection',
               "responded": true,
+            },
+          })
+        end
+      end
+
+      context 'with flags' do
+        it 'attaches a flag and returns the correct data' do
+          expect(response_json).to include_json(data: {
+            "id": framework_response_id,
+            "type": 'framework_responses',
+            "relationships": {
+              "flags": {
+                "data": [
+                  {
+                    id: flag.id,
+                    type: 'flags',
+                  },
+                ],
+              },
             },
           })
         end

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::FrameworkResponsesController do
+  describe 'PATCH /framework_responses/:framework_response_id' do
+    include_context 'with supplier with spoofed access token'
+
+    let(:response_json) { JSON.parse(response.body) }
+    let(:framework_response) { create(:string_response) }
+    let(:framework_response_id) { framework_response.id }
+    let(:value) { 'No' }
+
+    let(:framework_response_params) do
+      {
+        data: {
+          "type": 'framework_responses',
+          "attributes": {
+            "value": value,
+          },
+        },
+      }
+    end
+
+    before do
+      patch "/api/v1/framework_responses/#{framework_response_id}", params: framework_response_params, headers: headers, as: :json
+      framework_response.reload
+    end
+
+    context 'when successful' do
+      let(:schema) { load_yaml_schema('patch_framework_response_responses.yaml') }
+
+      context 'when response is a string' do
+        it_behaves_like 'an endpoint that responds with success 200'
+
+        it 'returns the correct data' do
+          expect(response_json).to include_json(data: {
+            "id": framework_response_id,
+            "type": 'framework_responses',
+            "attributes": {
+              "value": value,
+              "value_type": 'string',
+              "responded": true,
+            },
+          })
+        end
+      end
+
+      context 'when response is an array' do
+        let(:framework_response) { create(:array_response) }
+        let(:value) { ['Level 1', 'Level 2'] }
+
+        it 'returns the correct data' do
+          expect(response_json).to include_json(data: {
+            "id": framework_response_id,
+            "type": 'framework_responses',
+            "attributes": {
+              "value": value,
+              "value_type": 'array',
+              "responded": true,
+            },
+          })
+        end
+      end
+
+      context 'when response is an object' do
+        let(:framework_response) { create(:object_response, :details) }
+        let(:value) { { option: 'No', details: 'Some details' } }
+
+        it 'returns the correct data' do
+          expect(response_json).to include_json(data: {
+            "id": framework_response_id,
+            "type": 'framework_responses',
+            "attributes": {
+              "value": value,
+              "value_type": 'object',
+              "responded": true,
+            },
+          })
+        end
+      end
+
+      context 'when response is a collection' do
+        let(:framework_response) { create(:collection_response, :details) }
+        let(:value) { [{ option: 'Level 1', details: 'Some details' }, { option: 'Level 2' }] }
+
+        it 'returns the correct data' do
+          expect(response_json).to include_json(data: {
+            "id": framework_response_id,
+            "type": 'framework_responses',
+            "attributes": {
+              "value": value,
+              "value_type": 'collection',
+              "responded": true,
+            },
+          })
+        end
+      end
+
+      context 'when incorrect keys added to collection response' do
+        let(:framework_response) { create(:collection_response, :details) }
+        let(:value) { [{ option: 'Level 1', detailss: 'Some details' }] }
+
+        it 'returns the correct data' do
+          expect(response_json).to include_json(data: {
+            "id": framework_response_id,
+            "type": 'framework_responses',
+            "attributes": {
+              "value": [{ option: 'Level 1' }],
+              "value_type": 'collection',
+              "responded": true,
+            },
+          })
+        end
+      end
+    end
+
+    context 'when unsuccessful' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+
+      context 'with a bad request' do
+        let(:framework_response_params) { nil }
+
+        it_behaves_like 'an endpoint that responds with error 400'
+      end
+
+      context 'with an invalid value' do
+        let(:value) { 'foo-bar' }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [{ 'title' => 'Unprocessable entity',
+               'detail' => 'Value is not included in the list' }]
+          end
+        end
+      end
+
+      context 'when the framework_response_id is not found' do
+        let(:framework_response_id) { 'foo-bar' }
+        let(:detail_404) { "Couldn't find FrameworkResponse with 'id'=foo-bar" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+    end
+  end
+end

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -74,6 +74,9 @@ RSpec.describe Api::PersonEscortRecordsController do
                 },
               ],
             },
+            "flags": {
+              "data": [],
+            },
           },
         }
       end

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Api::PersonEscortRecordsController do
               "data": [
                 {
                   "id": flag.id,
-                  "type": 'flags',
+                  "type": 'framework_flags',
                 },
               ],
             },

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Api::PersonEscortRecordsController do
 
     let(:response_json) { JSON.parse(response.body) }
     let(:framework_question) { build(:framework_question, section: 'risk-information') }
-    let(:framework_response) { build(:string_response, framework_question: framework_question, responded: true) }
+    let(:flag) { build(:flag, framework_question: framework_question) }
+    let(:framework_response) { build(:string_response, framework_question: framework_question, responded: true, flags: [flag]) }
     let(:framework) { create(:framework, framework_questions: [framework_question]) }
     let(:person_escort_record) { create(:person_escort_record, framework_responses: [framework_response]) }
     let(:person_escort_record_id) { person_escort_record.id }
@@ -53,6 +54,14 @@ RSpec.describe Api::PersonEscortRecordsController do
                 {
                   "id": framework_response.id,
                   "type": 'framework_responses',
+                },
+              ],
+            },
+            "flags": {
+              "data": [
+                {
+                  "id": flag.id,
+                  "type": 'flags',
                 },
               ],
             },

--- a/spec/serializers/flag_serializer_spec.rb
+++ b/spec/serializers/flag_serializer_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlagSerializer do
+  subject(:serializer) { described_class.new(flag) }
+
+  let(:flag) { create(:flag) }
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer, include: includes).serializable_hash }
+  let(:includes) { {} }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('flags')
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eq(flag.id)
+  end
+
+  it 'contains a `name` attribute' do
+    expect(result[:data][:attributes][:name]).to eq(flag.name)
+  end
+
+  it 'contains a `flag_type` attribute' do
+    expect(result[:data][:attributes][:flag_type]).to eq(flag.flag_type)
+  end
+
+  it 'contains a `question_value` attribute' do
+    expect(result[:data][:attributes][:question_value]).to eq(flag.question_value)
+  end
+
+  it 'contains a `question` relationship' do
+    expect(result[:data][:relationships][:question][:data]).to eq(
+      id: flag.framework_question.id,
+      type: 'framework_questions',
+    )
+  end
+
+  context 'with include options' do
+    let(:includes) do
+      {
+        question: :key,
+      }
+    end
+
+    let(:expected_json) do
+      [
+        {
+          id: flag.framework_question.id,
+          type: 'framework_questions',
+          attributes: { key: flag.framework_question.key },
+        },
+      ]
+    end
+
+    it 'contains an included question' do
+      expect(result[:included]).to include_json(expected_json)
+    end
+  end
+end

--- a/spec/serializers/flag_serializer_spec.rb
+++ b/spec/serializers/flag_serializer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FlagSerializer do
   let(:includes) { {} }
 
   it 'contains a `type` property' do
-    expect(result[:data][:type]).to eq('flags')
+    expect(result[:data][:type]).to eq('framework_flags')
   end
 
   it 'contains an `id` property' do

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe FrameworkResponseSerializer do
 
     expect(result[:data][:relationships][:flags][:data]).to contain_exactly(
       id: flag.id,
-      type: 'flags',
+      type: 'framework_flags',
     )
   end
 

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe FrameworkResponseSerializer do
     )
   end
 
+  it 'contains an empty `flags` relationship if no flags present' do
+    expect(result[:data][:relationships][:flags][:data]).to be_empty
+  end
+
+  it 'contains a`flags` relationship when flags present' do
+    flag = create(:flag)
+    framework_response.update(flags: [flag])
+
+    expect(result[:data][:relationships][:flags][:data]).to contain_exactly(
+      id: flag.id,
+      type: 'flags',
+    )
+  end
+
   describe 'value_type' do
     context 'when response is an object response' do
       let(:framework_response) { create(:object_response) }

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe PersonEscortRecordSerializer do
 
     expect(result[:data][:relationships][:flags][:data]).to contain_exactly(
       id: flag.id,
-      type: 'flags',
+      type: 'framework_flags',
     )
   end
 

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -53,6 +53,20 @@ RSpec.describe PersonEscortRecordSerializer do
     )
   end
 
+  it 'contains an empty `flags` relationship if no flags present' do
+    expect(result[:data][:relationships][:flags][:data]).to be_empty
+  end
+
+  it 'contains a`flags` relationship with framework response flags' do
+    flag = create(:flag)
+    create(:string_response, person_escort_record: person_escort_record, flags: [flag])
+
+    expect(result[:data][:relationships][:flags][:data]).to contain_exactly(
+      id: flag.id,
+      type: 'flags',
+    )
+  end
+
   describe 'meta' do
     it 'includes section progress' do
       question = create(:framework_question, framework: person_escort_record.framework, section: 'risk-information')

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -52,6 +52,14 @@
       :$ref: "../v1/document.yaml#/Document"
     :Ethnicity:
       :$ref: "../v1/ethnicity.yaml#/Ethnicity"
+    :Framework:
+      :$ref: "../v1/framework.yaml#/Framework"
+    :FrameworkFlag:
+      :$ref: "../v1/framework_flag.yaml#/FrameworkFlag"
+    :FrameworkQuestion:
+      :$ref: "../v1/framework_question.yaml#/FrameworkQuestion"
+    :FrameworkResponse:
+      :$ref: "../v1/framework_response.yaml#/FrameworkResponse"
     :Gender:
       :$ref: "../v1/gender.yaml#/Gender"
     :Journey:
@@ -448,6 +456,59 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/post_documents_responses.yaml#/422"
+  "/framework_responses/{framework_response_id}":
+    patch:
+      summary: Updates a framework response's value
+      tags:
+      - Framework Responses
+      consumes:
+      - application/vnd.api+json
+      parameters:
+      - "$ref": "../v1/framework_response_id_parameter.yaml#/FrameworkResponseId"
+      - "$ref": "../v1/framework_response_include_parameter.yaml#/FrameworkResponseIncludeParameter"
+      - name: body
+        in: body
+        required: true
+        description: The framework_response object to be modified
+        schema:
+          "$ref": "../v1/framework_response.yaml#/FrameworkResponse"
+      responses:
+        '200':
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_framework_response_responses.yaml#/200"
+        '400':
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_framework_response_responses.yaml#/400"
+        '401':
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_framework_response_responses.yaml#/401"
+        '404':
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_framework_response_responses.yaml#/404"
+        '415':
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_framework_response_responses.yaml#/415"
+        '422':
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_framework_response_responses.yaml#/422"
   "/moves":
     get:
       summary: Returns a list of moves
@@ -2495,7 +2556,7 @@
     post:
       summary: Creates a new person escort record
       tags:
-      - PersonEscortRecord
+      - Person Escort Records
       consumes:
       - application/vnd.api+json
       parameters:
@@ -2543,13 +2604,13 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/post_person_escort_record_responses.yaml#/422"
-  "/person_escort_record/{person_escort_record_id}":
+  "/person_escort_records/{person_escort_record_id}":
     get:
       summary: Gets a person_escort_record
       description:
         "This method gets the specified person_escort_record"
       tags:
-        - PersonEscortRecord
+        - Person Escort Records
       consumes:
         - application/vnd.api+json
       parameters:

--- a/swagger/v1/flag_reference.yaml
+++ b/swagger/v1/flag_reference.yaml
@@ -1,0 +1,29 @@
+FlagReference:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      oneOf:
+      - type: object
+        description:  single object returned if resource is associated to only one flag
+      - type: 'null'
+      - type: array
+        description:  Multiple objects returned if resource is associated to multiple flags
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          example: flags
+          enum:
+            - flags
+          description: The type of this object - always `flags`
+        id:
+          type: string
+          format: uuid
+          example: ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154
+          description:
+            The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v1/framework.yaml
+++ b/swagger/v1/framework.yaml
@@ -1,0 +1,42 @@
+Framework:
+  type: object
+  required:
+  - id
+  - type
+  - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: frameworks
+      enum:
+      - frameworks
+      description: The type of this object - always `frameworks`
+    attributes:
+      type: object
+      required:
+      - name
+      - version
+      properties:
+        name:
+          example: 'person-escort-record'
+          type: string
+          description: the name of the framework
+          readOnly: true
+        version:
+          type: string
+          example: '1.0.1'
+          description: the semantic version of the framework
+          readOnly: true
+    relationships:
+      type: object
+      required:
+      - questions
+      properties:
+        question:
+          $ref: framework_question_reference.yaml#/FrameworkQuestionReference
+          description: The questions for the framework

--- a/swagger/v1/framework_flag.yaml
+++ b/swagger/v1/framework_flag.yaml
@@ -1,0 +1,53 @@
+FrameworkFlag:
+  type: object
+  required:
+  - id
+  - type
+  - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: framework_flags
+      enum:
+      - framework_flags
+      description: The type of this object - always `framework_flags`
+    attributes:
+      type: object
+      required:
+      - flag_type
+      - name
+      - question_value
+      properties:
+        flag_type:
+          type: string
+          example: 'checkbox'
+          enum:
+            - information
+            - attention
+            - warning
+            - alert
+          description: Indicates the type of flag
+          readOnly: true
+        name:
+          example: 'High public interest'
+          type: string
+          description: the name of the flag
+          readOnly: true
+        question_value:
+          type: string
+          example: 'No'
+          description: the option required for the response to display a flag
+          readOnly: true
+    relationships:
+      type: object
+      required:
+      - question
+      properties:
+        question:
+          $ref: framework_question_reference.yaml#/FrameworkQuestionReference
+          description: The question this flag is for

--- a/swagger/v1/framework_flag_reference.yaml
+++ b/swagger/v1/framework_flag_reference.yaml
@@ -1,4 +1,4 @@
-FlagReference:
+FrameworkFlagReference:
   type: object
   required:
     - data
@@ -6,20 +6,23 @@ FlagReference:
     data:
       oneOf:
       - type: object
-        description:  single object returned if resource is associated to only one flag
+        description:  single object returned if resource is associated to only one framework_flag
       - type: 'null'
       - type: array
-        description:  Multiple objects returned if resource is associated to multiple flags
+        description:  Multiple objects returned if resource is associated to multiple framework_flags
+      example:
+        - id: ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154
+          type: framework_flags
       required:
         - type
         - id
       properties:
         type:
           type: string
-          example: flags
+          example: framework_flags
           enum:
-            - flags
-          description: The type of this object - always `flags`
+            - framework_flags
+          description: The type of this object - always `framework_flags`
         id:
           type: string
           format: uuid

--- a/swagger/v1/framework_question.yaml
+++ b/swagger/v1/framework_question.yaml
@@ -1,0 +1,55 @@
+FrameworkQuestion:
+  type: object
+  required:
+  - id
+  - type
+  - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: framework_questions
+      enum:
+      - framework_questions
+      description: The type of this object - always `framework_questions`
+    attributes:
+      type: object
+      required:
+      - key
+      - question_type
+      - options
+      properties:
+        key:
+          example: 'wheelchair-users'
+          type: string
+          description: the unique key for the question
+          readOnly: true
+        question_type:
+          type: string
+          example: 'checkbox'
+          enum:
+            - text
+            - textarea
+            - radio
+            - checkbox
+          description: Indicates the type of question
+          readOnly: true
+        options:
+          type: array
+          example: ['Yes', 'No']
+          items:
+            type: string
+            description: accepted options for a question
+          readOnly: true
+    relationships:
+      type: object
+      required:
+      - framework
+      properties:
+        framework:
+          $ref: framework_reference.yaml#/FrameworkReference
+          description: The framework associated with this question

--- a/swagger/v1/framework_question_reference.yaml
+++ b/swagger/v1/framework_question_reference.yaml
@@ -1,0 +1,24 @@
+FrameworkQuestionReference:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      type: object
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          example: framework_questions
+          enum:
+            - framework_questions
+          description: The type of this object - always `framework_questions`
+        id:
+          type: string
+          format: uuid
+          example: ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154
+          description:
+            The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v1/framework_response.yaml
+++ b/swagger/v1/framework_response.yaml
@@ -1,0 +1,56 @@
+FrameworkResponse:
+  type: object
+  required:
+  - id
+  - type
+  - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: framework_responses
+      enum:
+      - framework_responses
+      description: The type of this object - always `framework_responses`
+    attributes:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          example: 'yes'
+          oneOf:
+          - type: string
+          - type: array
+          - type: object
+          description: the answer value to the person_escort_record question
+        value_type:
+          type: string
+          example: 'array'
+          enum:
+            - string
+            - array
+            - object
+            - collection
+          description: Indicates the type of value for the answer provided
+          readOnly: true
+        responded:
+          type: boolean
+          example: 'true'
+          description: Indicates if response has been answered
+          readOnly: true
+    relationships:
+      type: object
+      required:
+      - person_escort_record
+      properties:
+        person_escort_record:
+          $ref: person_escort_record_reference.yaml#/PersonEscortRecordReference
+          description: The person_escort_record the responses refer to
+        question:
+          $ref: framework_question_reference.yaml#/FrameworkQuestionReference
+          description: The question this response is for

--- a/swagger/v1/framework_response.yaml
+++ b/swagger/v1/framework_response.yaml
@@ -54,3 +54,6 @@ FrameworkResponse:
         question:
           $ref: framework_question_reference.yaml#/FrameworkQuestionReference
           description: The question this response is for
+        flags:
+          $ref: framework_flag_reference.yaml#/FrameworkFlagReference
+          description: The framework flags associated with this framework_response

--- a/swagger/v1/framework_response_id_parameter.yaml
+++ b/swagger/v1/framework_response_id_parameter.yaml
@@ -1,0 +1,9 @@
+FrameworkResponseId:
+  name: framework_response_id
+  in: path
+  required: true
+  description: The ID of the framework_response
+  schema:
+    type: string
+    format: uuid
+  example: 5b61f755-0fd7-4a91-b7a3-a33d751f985f

--- a/swagger/v1/framework_response_include_parameter.yaml
+++ b/swagger/v1/framework_response_include_parameter.yaml
@@ -1,0 +1,13 @@
+FrameworkResponseIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the framework_response
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - flags
+      - person_escort_record
+      - question
+  example: framework

--- a/swagger/v1/patch_framework_response_responses.yaml
+++ b/swagger/v1/patch_framework_response_responses.yaml
@@ -23,15 +23,6 @@
       type: array
       items:
         $ref: errors.yaml#/NotAuthorisedError
-'403':
-  type: object
-  required:
-  - errors
-  properties:
-    errors:
-      type: array
-      items:
-        $ref: errors.yaml#/Forbidden
 '404':
   type: object
   required:

--- a/swagger/v1/patch_framework_response_responses.yaml
+++ b/swagger/v1/patch_framework_response_responses.yaml
@@ -1,0 +1,61 @@
+'200':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: framework_response.yaml#/FrameworkResponse
+'400':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError
+'403':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/Forbidden
+'404':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/ResourceNotFound
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnsupportedMediaType
+'422':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnprocessableEntity

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -85,5 +85,5 @@ PersonEscortRecord:
           $ref: framework_response_reference.yaml#/FrameworkResponseReference
           description: The framework response associated with this person_escort_record
         flags:
-          $ref: flag_reference.yaml#/FlagReference
-          description: The flags associated with this person_escort_record
+          $ref: framework_flag_reference.yaml#/FrameworkFlagReference
+          description: The framework flags associated with this person_escort_record

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -84,3 +84,6 @@ PersonEscortRecord:
         responses:
           $ref: framework_response_reference.yaml#/FrameworkResponseReference
           description: The framework response associated with this person_escort_record
+        flags:
+          $ref: flag_reference.yaml#/FlagReference
+          description: The flags associated with this person_escort_record

--- a/swagger/v1/person_escort_record_include_parameter.yaml
+++ b/swagger/v1/person_escort_record_include_parameter.yaml
@@ -12,4 +12,5 @@ PersonEscortRecordIncludeParameter:
       - profile.person
       - responses
       - responses.question
+      - flags
   example: framework


### PR DESCRIPTION
### Jira link

[P4-1778](https://dsdmoj.atlassian.net/browse/P4-1778)

### What?

I have added/removed/altered:

- [x] Added new framework response patch endpoint
- [x] Add join table for flags/framework responses
- [x] Add ability to attach/detach flags from a response according to it's answer
- [x] Add swagger docs for new endpoint and missing models

### Why?

To allow a client to update a response on a PER, add a new endpoint which accepts a value for the question. According to the answer a flag should be attached/detached from the response if the response matched the value on the flag. Flag should be renamed to `framework_flags` which will be done in a following PR

### Have you? (optional)

- [x] Updated API docs if necessary	