### PR TITLE
Rename video_remand_hearing to video_remand

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -31,7 +31,7 @@ class Move < VersionedModel
     prison_recall: 'prison_recall',
     prison_remand: 'prison_remand',
     prison_transfer: 'prison_transfer',
-    video_remand_hearing: 'video_remand_hearing',
+    video_remand: 'video_remand',
   }
 
   self.ignored_columns = %w[person_id]
@@ -64,7 +64,7 @@ class Move < VersionedModel
   has_many :move_events, as: :eventable, dependent: :destroy # NB: polymorphic association
 
   validates :from_location, presence: true
-  validates :to_location, presence: true, unless: -> { prison_recall? || video_remand_hearing? }
+  validates :to_location, presence: true, unless: -> { prison_recall? || video_remand? }
   validates :move_type, inclusion: { in: move_types }
   validates_with Moves::MoveTypeValidator
 

--- a/app/services/moves/move_type_validator.rb
+++ b/app/services/moves/move_type_validator.rb
@@ -9,7 +9,7 @@ module Moves
       return if record.move_type.blank?
 
       # Apply more complex validation rules for specific move types
-      validate_police_from_location if includes? %w[video_remand_hearing]
+      validate_police_from_location if includes? %w[video_remand]
       validate_hospital_to_location if includes? %w[hospital]
       validate_detained_to_location if includes? %w[prison_remand]
       validate_not_detained_to_location if includes? %w[court_other]

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -43,10 +43,10 @@ FactoryBot.define do
       move_type { 'police_transfer' }
     end
 
-    trait :video_remand_hearing do
-      move_type { 'video_remand_hearing' }
+    trait :video_remand do
+      move_type { 'video_remand' }
       association(:from_location, :police, factory: :location)
-      to_location { nil } # NB: to_location is always nil for a video_remand_hearing
+      to_location { nil } # NB: to_location is always nil for a video_remand
     end
 
     trait :hospital do

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Move do
     end
   end
 
-  it 'validates presence of `to_location` if `move_type` is NOT prison_recall or video_remand_hearing' do
+  it 'validates presence of `to_location` if `move_type` is NOT prison_recall or video_remand' do
     expect(build(:move, move_type: 'prison_transfer')).to(
       validate_presence_of(:to_location),
     )
@@ -70,8 +70,8 @@ RSpec.describe Move do
     )
   end
 
-  it 'does NOT validate presence of `to_location` if `move_type` is video_remand_hearing' do
-    expect(build(:move, move_type: 'video_remand_hearing')).not_to(
+  it 'does NOT validate presence of `to_location` if `move_type` is video_remand' do
+    expect(build(:move, move_type: 'video_remand')).not_to(
       validate_presence_of(:to_location),
     )
   end

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Api::MoveEventsController do
     end
 
     context 'with a video remand hearing' do
-      let(:move) { create(:move, :video_remand_hearing) }
+      let(:move) { create(:move, :video_remand) }
 
       it 'populates the move to_location' do
         expect { move.reload }.to change(move, :to_location).from(nil).to(new_location)

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -330,8 +330,8 @@ RSpec.describe Api::MovesController do
         end
       end
 
-      context 'with explicit video_remand_hearing `move_type`' do
-        let(:move_attributes) { attributes_for(:move, move_type: 'video_remand_hearing') }
+      context 'with explicit video_remand `move_type`' do
+        let(:move_attributes) { attributes_for(:move, move_type: 'video_remand') }
         let(:from_location) { create :location, :police, suppliers: [supplier] }
         let(:to_location) { nil }
 
@@ -343,9 +343,9 @@ RSpec.describe Api::MovesController do
           expect { post_moves }.to change(Move, :count).by(1)
         end
 
-        it 'sets the move_type to `video_remand_hearing`' do
+        it 'sets the move_type to `video_remand`' do
           post_moves
-          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand_hearing'
+          expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand'
         end
       end
 

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -345,8 +345,8 @@ RSpec.describe Api::MovesController do
       end
     end
 
-    context 'with explicit video_remand_hearing `move_type`' do
-      let(:move_attributes) { attributes_for(:move, move_type: 'video_remand_hearing') }
+    context 'with explicit video_remand `move_type`' do
+      let(:move_attributes) { attributes_for(:move, move_type: 'video_remand') }
       let(:from_location) { create :location, :police, suppliers: [supplier] }
       let(:to_location) { nil }
 
@@ -358,10 +358,10 @@ RSpec.describe Api::MovesController do
         expect { do_post }.to change(Move, :count).by(1)
       end
 
-      it 'sets the move_type to `video_remand_hearing`' do
+      it 'sets the move_type to `video_remand`' do
         do_post
 
-        expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand_hearing'
+        expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'video_remand'
       end
     end
 

--- a/spec/services/moves/move_type_validator_spec.rb
+++ b/spec/services/moves/move_type_validator_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Moves::MoveTypeValidator do
   end
 
   context 'with video remand hearing `move_type`' do
-    let(:move_type) { 'video_remand_hearing' }
+    let(:move_type) { 'video_remand' }
 
     it 'validates `from_location` is a police location' do
       target.from_location = build(:location, :police)
@@ -104,7 +104,7 @@ RSpec.describe Moves::MoveTypeValidator do
     it 'has an error if `from_location` is not a police location' do
       target.from_location = build(:location, :court)
       expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
-      expect(target.errors[:from_location]).to match_array('must be a police location for video remand hearing move')
+      expect(target.errors[:from_location]).to match_array('must be a police location for video remand move')
     end
   end
 end

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -46,7 +46,7 @@ Move:
           - prison_recall
           - prison_remand
           - prison_transfer
-          - video_remand_hearing
+          - video_remand
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
           oneOf:

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -46,7 +46,7 @@ Move:
             - prison_recall
             - prison_remand
             - prison_transfer
-            - video_remand_hearing
+            - video_remand
           description: Indicates the type of move, e.g. prison transfer or court appearance
         move_agreed:
           oneOf:


### PR DESCRIPTION
### Jira link

P4-1816

### What?

- [x] Rename the `video_remand_hearing` move type enum member to `video_remand`

### Why?

- This is consistent with the naming for `prison_remand` and matches the value for front end work that's already been started. It's not yet been used to create any production moves so is safe to change at this point.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Not yet used in production, so safe to change now

