### PR TITLE
P4-1945 Clear dependent answers

### DIFF
--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -57,9 +57,11 @@ private
     dependent_ids = dependents.includes(:framework_question).reject { |dependent| option_selected?(dependent.framework_question.dependent_value) }
     return unless dependent_ids.any?
 
-    FrameworkResponse
+    dependent_tree = FrameworkResponse
       .where("framework_responses.id IN (#{recursive_tree})", dependent_ids)
-      .update(value_json: nil, value_text: nil, flags: [])
+
+    dependent_tree.joins(:flags).update(flags: [])
+    dependent_tree.update_all(value_json: nil, value_text: nil, responded: false)
   end
 
   def recursive_tree

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -366,6 +366,25 @@ RSpec.describe FrameworkResponse do
 
         expect(child_response.reload.flags).to contain_exactly(flag)
       end
+
+      it 'sets responded to false on dependent responses if value changed' do
+        parent_response = create(:collection_response, :details)
+        child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, flags: [create(:flag)], responded: true)
+        parent_response.update_with_flags!([option: 'Level 2'])
+
+        expect(child_response.reload.responded).to be(false)
+      end
+
+      it 'does not set responded to false on dependent responses if value not changed' do
+        parent_response = create(:collection_response, :details)
+        child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+        flag = create(:flag)
+        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, flags: [flag], responded: true)
+        parent_response.update_with_flags!([option: 'Level 1'])
+
+        expect(child_response.reload.responded).to be(true)
+      end
     end
   end
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe FrameworkResponse do
       it 'sets responded to false on dependent responses if value changed' do
         parent_response = create(:collection_response, :details)
         child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
-        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, flags: [create(:flag)], responded: true)
+        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, responded: true)
         parent_response.update_with_flags!([option: 'Level 2'])
 
         expect(child_response.reload.responded).to be(false)
@@ -379,8 +379,7 @@ RSpec.describe FrameworkResponse do
       it 'does not set responded to false on dependent responses if value not changed' do
         parent_response = create(:collection_response, :details)
         child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
-        flag = create(:flag)
-        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, flags: [flag], responded: true)
+        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, responded: true)
         parent_response.update_with_flags!([option: 'Level 1'])
 
         expect(child_response.reload.responded).to be(true)

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -233,12 +233,12 @@ RSpec.describe FrameworkResponse do
         parent_response = create(:string_response)
         child1_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
         child2_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
-        create(:string_response, framework_question: child1_question, parent: parent_response)
-        create(:string_response, framework_question: child2_question, parent: parent_response)
+        child_response1 = create(:string_response, framework_question: child1_question, parent: parent_response)
+        child_response2 = create(:string_response, framework_question: child2_question, parent: parent_response)
         parent_response.update_with_flags!('No')
 
-        parent_response.dependents.each do |child_response|
-          expect(child_response.reload.value).to be_nil
+        [child_response1, child_response2].each do |response|
+          expect(response.reload.value).to be_nil
         end
       end
 
@@ -320,12 +320,16 @@ RSpec.describe FrameworkResponse do
       it 'clears all hierarchy of dependent responses' do
         parent_response = create(:string_response)
         child_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
-        grand_child_question = create(:framework_question, dependent_value: 'Yes', parent: child_question)
+        grand_child_question1 = create(:framework_question, dependent_value: 'Yes', parent: child_question)
+        grand_child_question2 = create(:framework_question, dependent_value: 'No', parent: child_question)
         child_response = create(:string_response, framework_question: child_question, parent: parent_response)
-        grand_child_response = create(:string_response, framework_question: grand_child_question, parent: child_response)
+        grand_child_response1 = create(:string_response, framework_question: grand_child_question1, parent: child_response)
+        grand_child_response2 = create(:string_response, framework_question: grand_child_question2, parent: child_response)
         parent_response.update_with_flags!('No')
 
-        expect(grand_child_response.reload.value).to be_nil
+        [grand_child_response1, grand_child_response2].each do |response|
+          expect(response.reload.value).to be_nil
+        end
       end
 
       it 'clears only relevant dependent responses according to dependent value' do


### PR DESCRIPTION
### Jira link

[P4-1945](https://dsdmoj.atlassian.net/browse/P4-1945)

### What?

I have added/removed/altered:

- [x] Added ability to clear dependent responses, flags, and reset responded attribute

### Why?

If the parent answer is changed, we would like to clear all answered dependent values and flags. We should clear
the full tree of dependents and not only the first level down. To determine the correct dependent responses to clear, only
select the responses with dependent values used to match the answered value, this is found
in the framework question attached to the response under `dependent_value`.

I have added a recursive CTE to retrieve a full list of descendants for a list of response ids, rather than recursively attempting to retrieve them as its more efficient. Full explanation can be found [here](https://www.gmarik.info/blog/2012/recursive-data-structures-with-rails/).

To bulk update, I am using the active record import method to avoid any callbacks and to allow associations to be updated.

