### PR TITLE
P4-1792 Fix progress section for the PER

### DIFF
--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -59,7 +59,7 @@ class PersonEscortRecord < VersionedModel
 private
 
   def sections_to_responded
-    @sections_to_responded ||= framework_responses.joins(:framework_question).select('DISTINCT responded, framework_questions.section').group_by(&:section)
+    @sections_to_responded ||= FrameworkResponse.where(id: required_responses.map(&:id)).joins(:framework_question).select('DISTINCT responded, framework_questions.section').group_by(&:section)
   end
 
   def set_progress(responses)
@@ -69,5 +69,11 @@ private
     return PERSON_ESCORT_RECORD_NOT_STARTED if responded.all?(false)
 
     PERSON_ESCORT_RECORD_IN_PROGRESS
+  end
+
+  def required_responses
+    framework_responses.includes(:framework_question, :parent).select do |framework_response|
+      framework_response.parent ? framework_response.parent.option_selected?(framework_response.framework_question.dependent_value) : framework_response
+    end
   end
 end


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-1792

The previous implementation of the progress section included all responses and only looked at a response having responded
true or false. This is an issue with dependent questions, where they are valid remaining unanswered if a parent question is answered differently and doesn't lead to them, meaning they will always remain unanswered.

Add a filter to only select and check nodes which are not dependent responses, or dependent responses where the parent has been answered with the correct dependent response to include them.

