### PR TITLE
Add Person Escort Record state machine

### DIFF
--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -32,7 +32,11 @@ class FrameworkResponse < VersionedModel
 
       update!(flags: build_flags)
       clear_dependent_values_and_flags!(old_value)
-      person_escort_record.update_state!
+
+      # lock the state update to avoid race condition on multiple response patches
+      person_escort_record.with_lock do
+        person_escort_record.update_state!
+      end
     end
   rescue FiniteMachine::InvalidStateError
     raise ActiveRecord::ReadOnlyRecord, "Can't update framework_responses because person_escort_record is #{person_escort_record.state}"

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -33,13 +33,13 @@ class FrameworkResponse < VersionedModel
       update!(flags: build_flags)
       clear_dependent_values_and_flags!(old_value)
 
-      # lock the state update to avoid race condition on multiple response patches
+      # lock the status update to avoid race condition on multiple response patches
       person_escort_record.with_lock do
-        person_escort_record.update_state!
+        person_escort_record.update_status!
       end
     end
   rescue FiniteMachine::InvalidStateError
-    raise ActiveRecord::ReadOnlyRecord, "Can't update framework_responses because person_escort_record is #{person_escort_record.state}"
+    raise ActiveRecord::ReadOnlyRecord, "Can't update framework_responses because person_escort_record is #{person_escort_record.status}"
   end
 
 private

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -32,7 +32,10 @@ class FrameworkResponse < VersionedModel
 
       update!(flags: build_flags)
       clear_dependent_values_and_flags!(old_value)
+      person_escort_record.update_state!
     end
+  rescue FiniteMachine::InvalidStateError
+    raise ActiveRecord::ReadOnlyRecord, "Can't update framework_responses because person_escort_record is #{person_escort_record.state}"
   end
 
 private

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -46,7 +46,7 @@ class PersonEscortRecord < VersionedModel
     framework = version.present? ? Framework.find_by!(version: version) : Framework.ordered_by_latest_version.first
 
     # TODO: add state machine
-    record = new(profile: profile, framework: framework, state: PERSON_ESCORT_RECORD_IN_PROGRESS)
+    record = new(profile: profile, framework: framework)
     record.build_responses!
   end
 

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -5,20 +5,17 @@ class PersonEscortRecord < VersionedModel
   PERSON_ESCORT_RECORD_IN_PROGRESS = 'in_progress'.freeze
   PERSON_ESCORT_RECORD_COMPLETED = 'completed'.freeze
   PERSON_ESCORT_RECORD_CONFIRMED = 'confirmed'.freeze
-  PERSON_ESCORT_RECORD_PRINTED = 'printed'.freeze
 
   enum statuses: {
     unstarted: PERSON_ESCORT_RECORD_NOT_STARTED,
     in_progress: PERSON_ESCORT_RECORD_IN_PROGRESS,
     completed: PERSON_ESCORT_RECORD_COMPLETED,
     confirmed: PERSON_ESCORT_RECORD_CONFIRMED,
-    printed: PERSON_ESCORT_RECORD_PRINTED,
   }
 
   validates :status, presence: true, inclusion: { in: statuses }
   validates :profile, uniqueness: true
   validates :confirmed_at, presence: { if: :confirmed? }
-  validates :printed_at, presence: { if: :printed? }
 
   has_many :framework_responses, dependent: :destroy
 
@@ -32,12 +29,10 @@ class PersonEscortRecord < VersionedModel
   delegate :complete,
            :uncomplete,
            :confirm,
-           :to_print,
            :unstarted?,
            :in_progress?,
            :completed?,
            :confirmed?,
-           :printed?,
            to: :state_machine
 
   def self.save_with_responses!(profile_id:, version: nil)

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -26,8 +26,7 @@ class PersonEscortRecord < VersionedModel
 
   has_state_machine PersonEscortRecordStateMachine, on: :status
 
-  delegate :complete,
-           :uncomplete,
+  delegate :calculate,
            :confirm,
            :unstarted?,
            :in_progress?,
@@ -73,11 +72,7 @@ class PersonEscortRecord < VersionedModel
 
   def update_status!
     progress = set_progress(sections_to_responded)
-    if progress == PERSON_ESCORT_RECORD_IN_PROGRESS
-      state_machine.uncomplete!
-    elsif progress == PERSON_ESCORT_RECORD_COMPLETED
-      state_machine.complete!
-    end
+    state_machine.calculate!(progress)
 
     save!
   end

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -4,7 +4,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   has_many :framework_responses, serializer: FrameworkResponseSerializer, key: :responses
   has_many :flags
 
-  attributes :version, :status, :confirmed_at, :printed_at
+  attributes :version, :status, :confirmed_at
 
   meta do
     { section_progress: object.section_progress }

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -4,8 +4,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   has_many :framework_responses, serializer: FrameworkResponseSerializer, key: :responses
   has_many :flags
 
-  attributes :version, :confirmed_at, :printed_at
-  attribute :state, key: :status
+  attributes :version, :status, :confirmed_at, :printed_at
 
   meta do
     { section_progress: object.section_progress }
@@ -17,6 +16,14 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
 
   def framework_responses
     object.framework_responses.includes(:flags, framework_question: :framework)
+  end
+
+  def status
+    if object.state == 'unstarted'
+      'not_started'
+    else
+      object.state
+    end
   end
 
   SUPPORTED_RELATIONSHIPS = %w[

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -4,7 +4,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   has_many :framework_responses, serializer: FrameworkResponseSerializer, key: :responses
   has_many :flags
 
-  attribute :version
+  attributes :version, :confirmed_at, :printed_at
   attribute :state, key: :status
 
   meta do

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -19,10 +19,10 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   end
 
   def status
-    if object.state == 'unstarted'
+    if object.status == 'unstarted'
       'not_started'
     else
-      object.state
+      object.status
     end
   end
 

--- a/app/state_machines/person_escort_record_state_machine.rb
+++ b/app/state_machines/person_escort_record_state_machine.rb
@@ -1,8 +1,8 @@
 class PersonEscortRecordStateMachine < FiniteMachine::Definition
   initial :unstarted
 
-  event :complete, %i[unstarted in_progress completed] => :completed
-  event :uncomplete, %i[unstarted in_progress completed] => :in_progress
+  event :calculate, %i[unstarted in_progress completed] => :completed, if: ->(_context, progress) { progress == PersonEscortRecord::PERSON_ESCORT_RECORD_COMPLETED }
+  event :calculate, %i[unstarted in_progress completed] => :in_progress, if: ->(_context, progress) { progress == PersonEscortRecord::PERSON_ESCORT_RECORD_IN_PROGRESS }
   event :confirm, completed: :confirmed
 
   terminal :confirmed

--- a/app/state_machines/person_escort_record_state_machine.rb
+++ b/app/state_machines/person_escort_record_state_machine.rb
@@ -1,0 +1,14 @@
+class PersonEscortRecordStateMachine < FiniteMachine::Definition
+  initial :unstarted
+
+  event :complete, %i[unstarted in_progress] => :completed
+  event :uncomplete, %i[unstarted completed] => :in_progress
+  event :confirm, completed: :confirmed
+  event :to_print, confirmed: :printed
+
+  terminal :printed
+
+  on_enter do |event|
+    target.state = event.to
+  end
+end

--- a/app/state_machines/person_escort_record_state_machine.rb
+++ b/app/state_machines/person_escort_record_state_machine.rb
@@ -9,7 +9,7 @@ class PersonEscortRecordStateMachine < FiniteMachine::Definition
   terminal :printed
 
   on_enter do |event|
-    target.state = event.to
+    target.status = event.to
   end
 
   on_after :confirm do

--- a/app/state_machines/person_escort_record_state_machine.rb
+++ b/app/state_machines/person_escort_record_state_machine.rb
@@ -4,9 +4,8 @@ class PersonEscortRecordStateMachine < FiniteMachine::Definition
   event :complete, %i[unstarted in_progress completed] => :completed
   event :uncomplete, %i[unstarted in_progress completed] => :in_progress
   event :confirm, completed: :confirmed
-  event :to_print, confirmed: :printed
 
-  terminal :printed
+  terminal :confirmed
 
   on_enter do |event|
     target.status = event.to
@@ -14,9 +13,5 @@ class PersonEscortRecordStateMachine < FiniteMachine::Definition
 
   on_after :confirm do
     target.confirmed_at = Time.zone.now
-  end
-
-  on_after :to_print do
-    target.printed_at = Time.zone.now
   end
 end

--- a/app/state_machines/person_escort_record_state_machine.rb
+++ b/app/state_machines/person_escort_record_state_machine.rb
@@ -11,4 +11,12 @@ class PersonEscortRecordStateMachine < FiniteMachine::Definition
   on_enter do |event|
     target.state = event.to
   end
+
+  on_after :confirm do
+    target.confirmed_at = Time.zone.now
+  end
+
+  on_after :to_print do
+    target.printed_at = Time.zone.now
+  end
 end

--- a/app/state_machines/person_escort_record_state_machine.rb
+++ b/app/state_machines/person_escort_record_state_machine.rb
@@ -1,8 +1,8 @@
 class PersonEscortRecordStateMachine < FiniteMachine::Definition
   initial :unstarted
 
-  event :complete, %i[unstarted in_progress] => :completed
-  event :uncomplete, %i[unstarted completed] => :in_progress
+  event :complete, %i[unstarted in_progress completed] => :completed
+  event :uncomplete, %i[unstarted in_progress completed] => :in_progress
   event :confirm, completed: :confirmed
   event :to_print, confirmed: :printed
 

--- a/db/migrate/20200724071959_add_state_timestamps_to_person_escort_records.rb
+++ b/db/migrate/20200724071959_add_state_timestamps_to_person_escort_records.rb
@@ -1,0 +1,6 @@
+class AddStateTimestampsToPersonEscortRecords < ActiveRecord::Migration[6.0]
+  def change
+    add_column :person_escort_records, :confirmed_at, :datetime
+    add_column :person_escort_records, :printed_at, :datetime
+  end
+end

--- a/db/migrate/20200724071959_add_state_timestamps_to_person_escort_records.rb
+++ b/db/migrate/20200724071959_add_state_timestamps_to_person_escort_records.rb
@@ -1,6 +1,5 @@
 class AddStateTimestampsToPersonEscortRecords < ActiveRecord::Migration[6.0]
   def change
     add_column :person_escort_records, :confirmed_at, :datetime
-    add_column :person_escort_records, :printed_at, :datetime
   end
 end

--- a/db/migrate/20200727043305_rename_state_on_person_escort_record.rb
+++ b/db/migrate/20200727043305_rename_state_on_person_escort_record.rb
@@ -1,0 +1,5 @@
+class RenameStateOnPersonEscortRecord < ActiveRecord::Migration[6.0]
+    def change
+    rename_column :person_escort_records, :state, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_20_063205) do
+ActiveRecord::Schema.define(version: 2020_07_24_071959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -408,6 +408,8 @@ ActiveRecord::Schema.define(version: 2020_07_20_063205) do
     t.string "state", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "confirmed_at"
+    t.datetime "printed_at"
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
     t.index ["profile_id"], name: "index_person_escort_records_on_profile_id", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_24_071959) do
+ActiveRecord::Schema.define(version: 2020_07_27_043305) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -405,7 +405,7 @@ ActiveRecord::Schema.define(version: 2020_07_24_071959) do
   create_table "person_escort_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "framework_id", null: false
     t.uuid "profile_id", null: false
-    t.string "state", null: false
+    t.string "status", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "confirmed_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -409,7 +409,6 @@ ActiveRecord::Schema.define(version: 2020_07_27_043305) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "confirmed_at"
-    t.datetime "printed_at"
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
     t.index ["profile_id"], name: "index_person_escort_records_on_profile_id", unique: true
   end

--- a/spec/factories/person_escort_record.rb
+++ b/spec/factories/person_escort_record.rb
@@ -4,7 +4,8 @@ FactoryBot.define do
   factory :person_escort_record do
     association(:framework)
     association(:profile)
-    state { 'in_progress' }
+
+    after(:build, &:initialize_state)
 
     trait :with_responses do
       association(:framework, :with_questions)
@@ -17,6 +18,24 @@ FactoryBot.define do
           )
         end
       end
+    end
+
+    trait :in_progress do
+      state { PersonEscortRecord::PERSON_ESCORT_RECORD_IN_PROGRESS }
+    end
+
+    trait :completed do
+      state { PersonEscortRecord::PERSON_ESCORT_RECORD_COMPLETED }
+    end
+
+    trait :confirmed do
+      state { PersonEscortRecord::PERSON_ESCORT_RECORD_CONFIRMED }
+      confirmed_at { Time.zone.now }
+    end
+
+    trait :printed do
+      state { PersonEscortRecord::PERSON_ESCORT_RECORD_PRINTED }
+      printed_at { Time.zone.now }
     end
   end
 end

--- a/spec/factories/person_escort_record.rb
+++ b/spec/factories/person_escort_record.rb
@@ -32,10 +32,5 @@ FactoryBot.define do
       status { PersonEscortRecord::PERSON_ESCORT_RECORD_CONFIRMED }
       confirmed_at { Time.zone.now }
     end
-
-    trait :printed do
-      status { PersonEscortRecord::PERSON_ESCORT_RECORD_PRINTED }
-      printed_at { Time.zone.now }
-    end
   end
 end

--- a/spec/factories/person_escort_record.rb
+++ b/spec/factories/person_escort_record.rb
@@ -21,20 +21,20 @@ FactoryBot.define do
     end
 
     trait :in_progress do
-      state { PersonEscortRecord::PERSON_ESCORT_RECORD_IN_PROGRESS }
+      status { PersonEscortRecord::PERSON_ESCORT_RECORD_IN_PROGRESS }
     end
 
     trait :completed do
-      state { PersonEscortRecord::PERSON_ESCORT_RECORD_COMPLETED }
+      status { PersonEscortRecord::PERSON_ESCORT_RECORD_COMPLETED }
     end
 
     trait :confirmed do
-      state { PersonEscortRecord::PERSON_ESCORT_RECORD_CONFIRMED }
+      status { PersonEscortRecord::PERSON_ESCORT_RECORD_CONFIRMED }
       confirmed_at { Time.zone.now }
     end
 
     trait :printed do
-      state { PersonEscortRecord::PERSON_ESCORT_RECORD_PRINTED }
+      status { PersonEscortRecord::PERSON_ESCORT_RECORD_PRINTED }
       printed_at { Time.zone.now }
     end
   end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -390,15 +390,15 @@ RSpec.describe FrameworkResponse do
       end
     end
 
-    context 'with person_escort_record states' do
-      it 'does not change person escort record state if no answers provided invalid' do
+    context 'with person_escort_record status' do
+      it 'does not change person escort record status if no answers provided invalid' do
         response = create(:string_response, value: nil)
 
         expect { response.update_with_flags!(%w[Yes]) }.to raise_error(ActiveRecord::RecordInvalid)
         expect(response.person_escort_record).to be_unstarted
       end
 
-      it 'updates person escort record state if some answers provided' do
+      it 'updates person escort record status if some answers provided' do
         response1 = create(:string_response, value: nil)
         create(:string_response, value: nil, person_escort_record: response1.person_escort_record)
         response1.update_with_flags!('Yes')
@@ -406,7 +406,7 @@ RSpec.describe FrameworkResponse do
         expect(response1.person_escort_record).to be_in_progress
       end
 
-      it 'does not allow updating responses if person_escort_record state is confirmed' do
+      it 'does not allow updating responses if person_escort_record status is confirmed' do
         person_escort_record = create(:person_escort_record, :confirmed, :with_responses)
         response = person_escort_record.framework_responses.first
 
@@ -414,7 +414,7 @@ RSpec.describe FrameworkResponse do
         expect(response.reload.value).to eq('Yes')
       end
 
-      it 'does not allow updating responses if person_escort_record state is printed' do
+      it 'does not allow updating responses if person_escort_record status is printed' do
         person_escort_record = create(:person_escort_record, :printed, :with_responses)
         response = person_escort_record.framework_responses.first
 

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -413,14 +413,6 @@ RSpec.describe FrameworkResponse do
         expect { response.update_with_flags!('No') }.to raise_error(ActiveRecord::ReadOnlyRecord)
         expect(response.reload.value).to eq('Yes')
       end
-
-      it 'does not allow updating responses if person_escort_record status is printed' do
-        person_escort_record = create(:person_escort_record, :printed, :with_responses)
-        response = person_escort_record.framework_responses.first
-
-        expect { response.update_with_flags!('No') }.to raise_error(ActiveRecord::ReadOnlyRecord)
-        expect(response.reload.value).to eq('Yes')
-      end
     end
   end
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -389,5 +389,38 @@ RSpec.describe FrameworkResponse do
         expect(child_response.reload.responded).to be(true)
       end
     end
+
+    context 'with person_escort_record states' do
+      it 'does not change person escort record state if no answers provided invalid' do
+        response = create(:string_response, value: nil)
+
+        expect { response.update_with_flags!(%w[Yes]) }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(response.person_escort_record).to be_unstarted
+      end
+
+      it 'updates person escort record state if some answers provided' do
+        response1 = create(:string_response, value: nil)
+        create(:string_response, value: nil, person_escort_record: response1.person_escort_record)
+        response1.update_with_flags!('Yes')
+
+        expect(response1.person_escort_record).to be_in_progress
+      end
+
+      it 'does not allow updating responses if person_escort_record state is confirmed' do
+        person_escort_record = create(:person_escort_record, :confirmed, :with_responses)
+        response = person_escort_record.framework_responses.first
+
+        expect { response.update_with_flags!('No') }.to raise_error(ActiveRecord::ReadOnlyRecord)
+        expect(response.reload.value).to eq('Yes')
+      end
+
+      it 'does not allow updating responses if person_escort_record state is printed' do
+        person_escort_record = create(:person_escort_record, :printed, :with_responses)
+        response = person_escort_record.framework_responses.first
+
+        expect { response.update_with_flags!('No') }.to raise_error(ActiveRecord::ReadOnlyRecord)
+        expect(response.reload.value).to eq('Yes')
+      end
+    end
   end
 end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -363,9 +363,27 @@ RSpec.describe PersonEscortRecord do
       expect(person_escort_record).to be_completed
     end
 
+    it 'sets state to `completed` from itself if response changed' do
+      person_escort_record = create(:person_escort_record, :completed)
+      create(:string_response, responded: true, person_escort_record: person_escort_record)
+      create(:string_response, responded: true, person_escort_record: person_escort_record)
+      person_escort_record.update_state!
+
+      expect(person_escort_record).to be_completed
+    end
+
     it 'sets state back to `in_progress` from `completed` if response cleared' do
       person_escort_record = create(:person_escort_record, :completed)
       create(:string_response, responded: true, person_escort_record: person_escort_record)
+      create(:string_response, value: nil, responded: false, person_escort_record: person_escort_record)
+      person_escort_record.update_state!
+
+      expect(person_escort_record).to be_in_progress
+    end
+
+    it 'sets state to `in_progress` from itself if response changed' do
+      person_escort_record = create(:person_escort_record, :in_progress)
+      create(:string_response, value: 'No', responded: true, person_escort_record: person_escort_record)
       create(:string_response, value: nil, responded: false, person_escort_record: person_escort_record)
       person_escort_record.update_state!
 

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PersonEscortRecord do
   subject { create(:person_escort_record) }
 
   it { is_expected.to validate_presence_of(:status) }
-  it { is_expected.to validate_inclusion_of(:status).in_array(%w[unstarted in_progress completed confirmed printed]) }
+  it { is_expected.to validate_inclusion_of(:status).in_array(%w[unstarted in_progress completed confirmed]) }
   it { is_expected.to have_many(:framework_responses) }
   it { is_expected.to have_many(:framework_questions).through(:framework) }
   it { is_expected.to have_many(:flags).through(:framework_responses) }
@@ -21,11 +21,6 @@ RSpec.describe PersonEscortRecord do
   it 'validates presence of confirmed_at if person_escort_record confirmed' do
     person_escort_record = build(:person_escort_record, :confirmed)
     expect(person_escort_record).to validate_presence_of(:confirmed_at)
-  end
-
-  it 'validates presence of printed_at if person_escort_record printed' do
-    person_escort_record = build(:person_escort_record, :printed)
-    expect(person_escort_record).to validate_presence_of(:printed_at)
   end
 
   describe '.save_with_responses!' do
@@ -392,11 +387,6 @@ RSpec.describe PersonEscortRecord do
 
     it 'raises error if status is `confirmed`' do
       person_escort_record = create(:person_escort_record, :confirmed)
-      expect { person_escort_record.update_status! }.to raise_error(FiniteMachine::InvalidStateError)
-    end
-
-    it 'raises error if status is `printed`' do
-      person_escort_record = create(:person_escort_record, :printed)
       expect { person_escort_record.update_status! }.to raise_error(FiniteMachine::InvalidStateError)
     end
   end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -70,11 +70,11 @@ RSpec.describe PersonEscortRecord do
       expect { described_class.save_with_responses!(profile_id: profile.id) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
-    it 'sets initial state to in_progress' do
+    it 'sets initial state to unstarted' do
       profile = create(:profile)
       create(:framework)
 
-      expect(described_class.save_with_responses!(profile_id: profile.id).state).to eq('in_progress')
+      expect(described_class.save_with_responses!(profile_id: profile.id).state).to eq('unstarted')
     end
 
     it 'creates responses for framework questions' do

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Api::FrameworkResponsesController do
   describe 'PATCH /framework_responses/:framework_response_id' do
     include_context 'with supplier with spoofed access token'
 
+    let(:schema) { load_yaml_schema('patch_framework_response_responses.yaml') }
     let(:response_json) { JSON.parse(response.body) }
     let(:framework_response) { create(:string_response) }
     let!(:flag) { create(:flag, framework_question: framework_response.framework_question, question_value: 'No') }
@@ -29,8 +30,6 @@ RSpec.describe Api::FrameworkResponsesController do
     end
 
     context 'when successful' do
-      let(:schema) { load_yaml_schema('patch_framework_response_responses.yaml') }
-
       context 'when response is a string' do
         it_behaves_like 'an endpoint that responds with success 200'
 
@@ -153,8 +152,6 @@ RSpec.describe Api::FrameworkResponsesController do
     end
 
     context 'when unsuccessful' do
-      let(:schema) { load_yaml_schema('error_responses.yaml') }
-
       context 'with a bad request' do
         let(:framework_response_params) { nil }
 
@@ -170,6 +167,16 @@ RSpec.describe Api::FrameworkResponsesController do
                'detail' => 'Value is not included in the list' }]
           end
         end
+      end
+
+      context 'when person_escort_record confirmed' do
+        let(:person_escort_record) { create(:person_escort_record, :confirmed) }
+        let(:framework_response) { create(:string_response, person_escort_record: person_escort_record) }
+        let(:detail_403) do
+          "Can't update framework_responses because person_escort_record is confirmed"
+        end
+
+        it_behaves_like 'an endpoint that responds with error 403'
       end
 
       context 'when the framework_response_id is not found' do

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Api::PersonEscortRecordsController do
           "type": 'person_escort_records',
           "attributes": {
             "version": framework_version,
-            "status": 'in_progress',
+            "status": 'not_started',
             "confirmed_at": nil,
             "printed_at": nil,
           },

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe Api::PersonEscortRecordsController do
             "version": framework_version,
             "status": 'not_started',
             "confirmed_at": nil,
-            "printed_at": nil,
           },
           "meta": {
             'section_progress' => [

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe Api::PersonEscortRecordsController do
           "attributes": {
             "version": framework_version,
             "status": 'in_progress',
+            "confirmed_at": nil,
+            "printed_at": nil,
           },
           "meta": {
             'section_progress' => [

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Api::PersonEscortRecordsController do
           "type": 'person_escort_records',
           "attributes": {
             "version": person_escort_record.framework.version,
-            "status": 'in_progress',
+            "status": 'not_started',
           },
           "meta": {
             'section_progress' => [

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe FrameworkResponseSerializer do
         {
           id: framework_response.person_escort_record.id,
           type: 'person_escort_records',
-          attributes: { status: 'in_progress' },
+          attributes: { status: 'not_started' },
         },
         {
           id: framework_response.framework_question.id,

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe PersonEscortRecordSerializer do
   end
 
   it 'contains a `status` attribute' do
-    expect(result[:data][:attributes][:status]).to eq('in_progress')
+    expect(result[:data][:attributes][:status]).to eq('not_started')
   end
 
   it 'contains a `version` attribute' do

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe PersonEscortRecordSerializer do
     expect(result[:data][:attributes][:version]).to eq(person_escort_record.framework.version)
   end
 
+  it 'contains a `confirmed_at` attribute' do
+    expect(result[:data][:attributes][:confirmed_at]).to eq(person_escort_record.confirmed_at)
+  end
+
+  it 'contains a `printed_at` attribute' do
+    expect(result[:data][:attributes][:printed_at]).to eq(person_escort_record.printed_at)
+  end
+
   it 'contains a `profile` relationship' do
     expect(result[:data][:relationships][:profile][:data]).to eq(
       id: person_escort_record.profile.id,

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -29,10 +29,6 @@ RSpec.describe PersonEscortRecordSerializer do
     expect(result[:data][:attributes][:confirmed_at]).to eq(person_escort_record.confirmed_at)
   end
 
-  it 'contains a `printed_at` attribute' do
-    expect(result[:data][:attributes][:printed_at]).to eq(person_escort_record.printed_at)
-  end
-
   it 'contains a `profile` relationship' do
     expect(result[:data][:relationships][:profile][:data]).to eq(
       id: person_escort_record.profile.id,

--- a/spec/state_machines/allocation_state_machine_spec.rb
+++ b/spec/state_machines/allocation_state_machine_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe AllocationStateMachine do
 
   before { machine.restore!(initial_state) }
 
-  shared_examples 'state_machine target status' do |expected_status|
-    describe 'machine status' do
-      it { expect(machine.current).to eql expected_status }
-    end
-
-    describe 'target status' do
-      it { expect(target.status).to eql expected_status }
-    end
-  end
-
   it { is_expected.to respond_to(:fill, :unfill, :cancel) }
 
   context 'when in the unfilled status' do

--- a/spec/state_machines/journey_state_machine_spec.rb
+++ b/spec/state_machines/journey_state_machine_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe JourneyStateMachine do
 
   before { machine.restore!(initial_state) }
 
-  shared_examples 'state_machine target state' do |expected_state|
-    describe 'machine state' do
-      it { expect(machine.current).to eql expected_state }
-    end
-
-    describe 'target state' do
-      it { expect(target.state).to eql expected_state }
-    end
-  end
-
   it { is_expected.to respond_to(:start, :reject, :cancel, :uncancel, :complete, :uncomplete, :restore!, :current) }
 
   context 'when in the proposed state' do

--- a/spec/state_machines/journey_state_machine_spec.rb
+++ b/spec/state_machines/journey_state_machine_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe JourneyStateMachine do
 
   before { machine.restore!(initial_state) }
 
+  shared_examples 'state_machine target state' do |expected_state|
+    describe 'machine state' do
+      it { expect(machine.current).to eql expected_state }
+    end
+
+    describe 'target state' do
+      it { expect(target.state).to eql expected_state }
+    end
+  end
+
   it { is_expected.to respond_to(:start, :reject, :cancel, :uncancel, :complete, :uncomplete, :restore!, :current) }
 
   context 'when in the proposed state' do

--- a/spec/state_machines/person_escort_record_state_machine_spec.rb
+++ b/spec/state_machines/person_escort_record_state_machine_spec.rb
@@ -9,19 +9,19 @@ RSpec.describe PersonEscortRecordStateMachine do
 
   before { machine.restore!(initial_status) }
 
-  it { is_expected.to respond_to(:complete, :uncomplete, :confirm) }
+  it { is_expected.to respond_to(:calculate, :confirm) }
 
   context 'when in the unstarted status' do
     it_behaves_like 'state_machine target status', :unstarted
 
-    context 'when the uncomplete event is fired' do
-      before { machine.uncomplete }
+    context 'when the calculate event is fired and it is in progress' do
+      before { machine.calculate(PersonEscortRecord::PERSON_ESCORT_RECORD_IN_PROGRESS) }
 
       it_behaves_like 'state_machine target status', :in_progress
     end
 
-    context 'when the complete event is fired' do
-      before { machine.complete }
+    context 'when the complete event is fired and it is completed' do
+      before { machine.calculate(PersonEscortRecord::PERSON_ESCORT_RECORD_COMPLETED) }
 
       it_behaves_like 'state_machine target status', :completed
     end
@@ -32,16 +32,16 @@ RSpec.describe PersonEscortRecordStateMachine do
 
     it_behaves_like 'state_machine target status', :in_progress
 
-    context 'when the complete event is fired' do
-      before { machine.complete }
-
-      it_behaves_like 'state_machine target status', :completed
-    end
-
-    context 'when the uncomplete event is fired' do
-      before { machine.uncomplete }
+    context 'when the calculate event is fired and it is in progress' do
+      before { machine.calculate(PersonEscortRecord::PERSON_ESCORT_RECORD_IN_PROGRESS) }
 
       it_behaves_like 'state_machine target status', :in_progress
+    end
+
+    context 'when the complete event is fired and it is completed' do
+      before { machine.calculate(PersonEscortRecord::PERSON_ESCORT_RECORD_COMPLETED) }
+
+      it_behaves_like 'state_machine target status', :completed
     end
   end
 
@@ -50,14 +50,14 @@ RSpec.describe PersonEscortRecordStateMachine do
 
     it_behaves_like 'state_machine target status', :completed
 
-    context 'when the uncomplete event is fired' do
-      before { machine.uncomplete }
+    context 'when the calculate event is fired and it is in progress' do
+      before { machine.calculate(PersonEscortRecord::PERSON_ESCORT_RECORD_IN_PROGRESS) }
 
       it_behaves_like 'state_machine target status', :in_progress
     end
 
-    context 'when the complete event is fired' do
-      before { machine.complete }
+    context 'when the complete event is fired and it is completed' do
+      before { machine.calculate(PersonEscortRecord::PERSON_ESCORT_RECORD_COMPLETED) }
 
       it_behaves_like 'state_machine target status', :completed
     end

--- a/spec/state_machines/person_escort_record_state_machine_spec.rb
+++ b/spec/state_machines/person_escort_record_state_machine_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe PersonEscortRecordStateMachine do
   let(:machine) { described_class.new(target) }
-  let(:target) { Struct.new(:state).new(initial_state) }
+  let(:target) { Struct.new(:state, :confirmed_at, :printed_at).new(initial_state) }
   let(:initial_state) { :unstarted }
 
   before { machine.restore!(initial_state) }
@@ -51,21 +51,38 @@ RSpec.describe PersonEscortRecordStateMachine do
     end
 
     context 'when the confirm event is fired' do
-      before { machine.confirm }
+      let(:confirmed_at_timstamp) { Time.zone.now }
+
+      before do
+        allow(Time).to receive(:now).and_return(confirmed_at_timstamp)
+        machine.confirm
+      end
 
       it_behaves_like 'state_machine target state', :confirmed
+
+      it 'sets the current timestamp to confirmed_at' do
+        expect(target.confirmed_at).to eq(confirmed_at_timstamp)
+      end
     end
   end
 
   context 'when in the confirmed state' do
     let(:initial_state) { :confirmed }
+    let(:printed_at_timstamp) { Time.zone.now }
 
     it_behaves_like 'state_machine target state', :confirmed
 
     context 'when the to_print event is fired' do
-      before { machine.to_print }
+      before do
+        allow(Time).to receive(:now).and_return(printed_at_timstamp)
+        machine.to_print
+      end
 
       it_behaves_like 'state_machine target state', :printed
+
+      it 'sets the current timestamp to printed_at' do
+        expect(target.printed_at).to eq(printed_at_timstamp)
+      end
     end
   end
 

--- a/spec/state_machines/person_escort_record_state_machine_spec.rb
+++ b/spec/state_machines/person_escort_record_state_machine_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe PersonEscortRecordStateMachine do
 
       it_behaves_like 'state_machine target state', :completed
     end
+
+    context 'when the uncomplete event is fired' do
+      before { machine.uncomplete }
+
+      it_behaves_like 'state_machine target state', :in_progress
+    end
   end
 
   context 'when in the completed state' do
@@ -48,6 +54,12 @@ RSpec.describe PersonEscortRecordStateMachine do
       before { machine.uncomplete }
 
       it_behaves_like 'state_machine target state', :in_progress
+    end
+
+    context 'when the complete event is fired' do
+      before { machine.complete }
+
+      it_behaves_like 'state_machine target state', :completed
     end
 
     context 'when the confirm event is fired' do

--- a/spec/state_machines/person_escort_record_state_machine_spec.rb
+++ b/spec/state_machines/person_escort_record_state_machine_spec.rb
@@ -4,62 +4,62 @@ require 'rails_helper'
 
 RSpec.describe PersonEscortRecordStateMachine do
   let(:machine) { described_class.new(target) }
-  let(:target) { Struct.new(:state, :confirmed_at, :printed_at).new(initial_state) }
-  let(:initial_state) { :unstarted }
+  let(:target) { Struct.new(:status, :confirmed_at, :printed_at).new(initial_status) }
+  let(:initial_status) { :unstarted }
 
-  before { machine.restore!(initial_state) }
+  before { machine.restore!(initial_status) }
 
   it { is_expected.to respond_to(:complete, :uncomplete, :confirm, :to_print) }
 
-  context 'when in the unstarted state' do
-    it_behaves_like 'state_machine target state', :unstarted
+  context 'when in the unstarted status' do
+    it_behaves_like 'state_machine target status', :unstarted
 
     context 'when the uncomplete event is fired' do
       before { machine.uncomplete }
 
-      it_behaves_like 'state_machine target state', :in_progress
+      it_behaves_like 'state_machine target status', :in_progress
     end
 
     context 'when the complete event is fired' do
       before { machine.complete }
 
-      it_behaves_like 'state_machine target state', :completed
+      it_behaves_like 'state_machine target status', :completed
     end
   end
 
-  context 'when in the in_progress state' do
-    let(:initial_state) { :in_progress }
+  context 'when in the in_progress status' do
+    let(:initial_status) { :in_progress }
 
-    it_behaves_like 'state_machine target state', :in_progress
+    it_behaves_like 'state_machine target status', :in_progress
 
     context 'when the complete event is fired' do
       before { machine.complete }
 
-      it_behaves_like 'state_machine target state', :completed
+      it_behaves_like 'state_machine target status', :completed
     end
 
     context 'when the uncomplete event is fired' do
       before { machine.uncomplete }
 
-      it_behaves_like 'state_machine target state', :in_progress
+      it_behaves_like 'state_machine target status', :in_progress
     end
   end
 
-  context 'when in the completed state' do
-    let(:initial_state) { :completed }
+  context 'when in the completed status' do
+    let(:initial_status) { :completed }
 
-    it_behaves_like 'state_machine target state', :completed
+    it_behaves_like 'state_machine target status', :completed
 
     context 'when the uncomplete event is fired' do
       before { machine.uncomplete }
 
-      it_behaves_like 'state_machine target state', :in_progress
+      it_behaves_like 'state_machine target status', :in_progress
     end
 
     context 'when the complete event is fired' do
       before { machine.complete }
 
-      it_behaves_like 'state_machine target state', :completed
+      it_behaves_like 'state_machine target status', :completed
     end
 
     context 'when the confirm event is fired' do
@@ -70,7 +70,7 @@ RSpec.describe PersonEscortRecordStateMachine do
         machine.confirm
       end
 
-      it_behaves_like 'state_machine target state', :confirmed
+      it_behaves_like 'state_machine target status', :confirmed
 
       it 'sets the current timestamp to confirmed_at' do
         expect(target.confirmed_at).to eq(confirmed_at_timstamp)
@@ -78,11 +78,11 @@ RSpec.describe PersonEscortRecordStateMachine do
     end
   end
 
-  context 'when in the confirmed state' do
-    let(:initial_state) { :confirmed }
+  context 'when in the confirmed status' do
+    let(:initial_status) { :confirmed }
     let(:printed_at_timstamp) { Time.zone.now }
 
-    it_behaves_like 'state_machine target state', :confirmed
+    it_behaves_like 'state_machine target status', :confirmed
 
     context 'when the to_print event is fired' do
       before do
@@ -90,7 +90,7 @@ RSpec.describe PersonEscortRecordStateMachine do
         machine.to_print
       end
 
-      it_behaves_like 'state_machine target state', :printed
+      it_behaves_like 'state_machine target status', :printed
 
       it 'sets the current timestamp to printed_at' do
         expect(target.printed_at).to eq(printed_at_timstamp)
@@ -98,9 +98,9 @@ RSpec.describe PersonEscortRecordStateMachine do
     end
   end
 
-  context 'when in the printed state' do
-    let(:initial_state) { :printed }
+  context 'when in the printed status' do
+    let(:initial_status) { :printed }
 
-    it_behaves_like 'state_machine target state', :printed
+    it_behaves_like 'state_machine target status', :printed
   end
 end

--- a/spec/state_machines/person_escort_record_state_machine_spec.rb
+++ b/spec/state_machines/person_escort_record_state_machine_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonEscortRecordStateMachine do
+  let(:machine) { described_class.new(target) }
+  let(:target) { Struct.new(:state).new(initial_state) }
+  let(:initial_state) { :unstarted }
+
+  before { machine.restore!(initial_state) }
+
+  it { is_expected.to respond_to(:complete, :uncomplete, :confirm, :to_print) }
+
+  context 'when in the unstarted state' do
+    it_behaves_like 'state_machine target state', :unstarted
+
+    context 'when the uncomplete event is fired' do
+      before { machine.uncomplete }
+
+      it_behaves_like 'state_machine target state', :in_progress
+    end
+
+    context 'when the complete event is fired' do
+      before { machine.complete }
+
+      it_behaves_like 'state_machine target state', :completed
+    end
+  end
+
+  context 'when in the in_progress state' do
+    let(:initial_state) { :in_progress }
+
+    it_behaves_like 'state_machine target state', :in_progress
+
+    context 'when the complete event is fired' do
+      before { machine.complete }
+
+      it_behaves_like 'state_machine target state', :completed
+    end
+  end
+
+  context 'when in the completed state' do
+    let(:initial_state) { :completed }
+
+    it_behaves_like 'state_machine target state', :completed
+
+    context 'when the uncomplete event is fired' do
+      before { machine.uncomplete }
+
+      it_behaves_like 'state_machine target state', :in_progress
+    end
+
+    context 'when the confirm event is fired' do
+      before { machine.confirm }
+
+      it_behaves_like 'state_machine target state', :confirmed
+    end
+  end
+
+  context 'when in the confirmed state' do
+    let(:initial_state) { :confirmed }
+
+    it_behaves_like 'state_machine target state', :confirmed
+
+    context 'when the to_print event is fired' do
+      before { machine.to_print }
+
+      it_behaves_like 'state_machine target state', :printed
+    end
+  end
+
+  context 'when in the printed state' do
+    let(:initial_state) { :printed }
+
+    it_behaves_like 'state_machine target state', :printed
+  end
+end

--- a/spec/state_machines/person_escort_record_state_machine_spec.rb
+++ b/spec/state_machines/person_escort_record_state_machine_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 
 RSpec.describe PersonEscortRecordStateMachine do
   let(:machine) { described_class.new(target) }
-  let(:target) { Struct.new(:status, :confirmed_at, :printed_at).new(initial_status) }
+  let(:target) { Struct.new(:status, :confirmed_at).new(initial_status) }
   let(:initial_status) { :unstarted }
 
   before { machine.restore!(initial_status) }
 
-  it { is_expected.to respond_to(:complete, :uncomplete, :confirm, :to_print) }
+  it { is_expected.to respond_to(:complete, :uncomplete, :confirm) }
 
   context 'when in the unstarted status' do
     it_behaves_like 'state_machine target status', :unstarted
@@ -80,27 +80,7 @@ RSpec.describe PersonEscortRecordStateMachine do
 
   context 'when in the confirmed status' do
     let(:initial_status) { :confirmed }
-    let(:printed_at_timstamp) { Time.zone.now }
 
     it_behaves_like 'state_machine target status', :confirmed
-
-    context 'when the to_print event is fired' do
-      before do
-        allow(Time).to receive(:now).and_return(printed_at_timstamp)
-        machine.to_print
-      end
-
-      it_behaves_like 'state_machine target status', :printed
-
-      it 'sets the current timestamp to printed_at' do
-        expect(target.printed_at).to eq(printed_at_timstamp)
-      end
-    end
-  end
-
-  context 'when in the printed status' do
-    let(:initial_status) { :printed }
-
-    it_behaves_like 'state_machine target status', :printed
   end
 end

--- a/spec/support/state_machine_target_state.rb
+++ b/spec/support/state_machine_target_state.rb
@@ -1,9 +1,0 @@
-RSpec.shared_examples 'state_machine target state' do |expected_state|
-  describe 'machine state' do
-    it { expect(machine.current).to eql expected_state }
-  end
-
-  describe 'target state' do
-    it { expect(target.state).to eql expected_state }
-  end
-end

--- a/spec/support/state_machine_target_state.rb
+++ b/spec/support/state_machine_target_state.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples 'state_machine target state' do |expected_state|
+  describe 'machine state' do
+    it { expect(machine.current).to eql expected_state }
+  end
+
+  describe 'target state' do
+    it { expect(target.state).to eql expected_state }
+  end
+end

--- a/spec/support/state_machine_target_status.rb
+++ b/spec/support/state_machine_target_status.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples 'state_machine target status' do |expected_status|
+  describe 'machine status' do
+    it { expect(machine.current).to eql expected_status }
+  end
+
+  describe 'target status' do
+    it { expect(target.status).to eql expected_status }
+  end
+end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -491,6 +491,12 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/patch_framework_response_responses.yaml#/401"
+        '403':
+          description: forbidden
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_framework_response_responses.yaml#/403"
         '404':
           description: resource not found
           content:

--- a/swagger/v1/patch_framework_response_responses.yaml
+++ b/swagger/v1/patch_framework_response_responses.yaml
@@ -23,6 +23,15 @@
       type: array
       items:
         $ref: errors.yaml#/NotAuthorisedError
+'403':
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/Forbidden
 '404':
   type: object
   required:

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -29,7 +29,6 @@ PersonEscortRecord:
             - in_progress
             - completed
             - confirmed
-            - printed
           description: Determines the current status of the `person_escort_record`
         version:
           type: string
@@ -41,22 +40,7 @@ PersonEscortRecord:
           - type: string
             format: date-time
             description: Timestamp of when the person_escort_record was confirmed
-        printed_at:
-          oneOf:
-          - type: 'null'
-          - type: string
-            format: date-time
-            description: Timestamp of when the person_escort_record was printed
-        updated_at:
-          type: string
-          format: date-time
-          description: Timestamp of when the person_escort_record was last created or updated
-          readOnly: true
-        created_at:
-          type: string
-          format: date-time
-          description: Timestamp of when the person_escort_record was created
-          readOnly: true
+            readOnly: true
     meta:
       readOnly: true
       type: object

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -25,9 +25,11 @@ PersonEscortRecord:
           example: in_progress
           type: string
           enum:
+            - not_started
             - in_progress
             - completed
             - confirmed
+            - printed
           description: Determines the current status of the `person_escort_record`
         version:
           type: string

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -33,6 +33,18 @@ PersonEscortRecord:
           type: string
           example: '0.1'
           description: Determines the version of framework questions of the `person_escort_record`
+        confirmed_at:
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of when the person_escort_record was confirmed
+        printed_at:
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of when the person_escort_record was printed
         updated_at:
           type: string
           format: date-time


### PR DESCRIPTION
### Jira link

[P4-1591](https://dsdmoj.atlassian.net/browse/P4-1783)

### What?

I have added/removed/altered:

- [x] Added person escort record state machine
- [x] Added two new timestamp fields to person escort record for confirmed and printed state changes
- [x] Added ability to calculate state of person escort record on response update


### Why?

- The PersonEscortRecord state machine has been added to handle the different transitions of the PER, as well as add two new states: `not_started` and `printed`. Since we cannot have `not_started` in the enum values due to it overlapping with the negation generated methods `not_`, only expose that value in the serializer.

- To track when a PER is confirmed and printed, timestamps for each event have been added. After a state is changed to either set the timestamps respectively in the after callback.

- To calculate the state changes on a person escort record, utilise the same query for sections, but do not group them to the specified section to calculate the general state. If the person escort record is confirmed/printed, this method will
throw an error to stop the ability to calculate the state, as this is no longer editable and can only be done by the patch endpoint.

- When a response is updated, the PER state should be recalculated. If the PER is either confirmed/printed, it should not be updated, and returns a forbidden error instead.

### Have you? (optional)

- [x] Updated API docs if necessary	
