### PR TITLE
P4-1591 Add Person escort record PATCH endpoint

### DIFF
--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -23,16 +23,13 @@ module Api
     end
 
     def update
-      PersonEscortRecords::ParamsValidator.new(update_person_escort_record_attributes).validate!
-      person_escort_record = PersonEscortRecord.find(params[:id])
-      person_escort_record.set_status!(update_person_escort_record_attributes)
+      PersonEscortRecords::ParamsValidator.new(update_person_escort_record_status).validate!
+      person_escort_record.confirm!(update_person_escort_record_status)
 
       render_person_escort_record(person_escort_record, :ok)
     end
 
     def show
-      person_escort_record = PersonEscortRecord.find(params[:id])
-
       render_person_escort_record(person_escort_record, :ok)
     end
 
@@ -46,12 +43,16 @@ module Api
       params.require(:data).permit(UPDATE_PERMITTED_PER_PARAMS)
     end
 
-    def update_person_escort_record_attributes
+    def update_person_escort_record_status
       update_person_escort_record_params.to_h.dig(:attributes, :status)
     end
 
     def supported_relationships
       PersonEscortRecordSerializer::SUPPORTED_RELATIONSHIPS
+    end
+
+    def person_escort_record
+      @person_escort_record ||= PersonEscortRecord.find(params[:id])
     end
 
     def render_person_escort_record(person_escort_record, status)

--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -8,6 +8,11 @@ module Api
       relationships: [profile: {}],
     ].freeze
 
+    UPDATE_PERMITTED_PER_PARAMS = [
+      :type,
+      attributes: [:status],
+    ].freeze
+
     def create
       person_escort_record = PersonEscortRecord.save_with_responses!(
         version: new_person_escort_record_params.dig(:attributes, :version),
@@ -15,6 +20,14 @@ module Api
       )
 
       render_person_escort_record(person_escort_record, :created)
+    end
+
+    def update
+      PersonEscortRecords::ParamsValidator.new(update_person_escort_record_attributes).validate!
+      person_escort_record = PersonEscortRecord.find(params[:id])
+      person_escort_record.set_state!(update_person_escort_record_attributes)
+
+      render_person_escort_record(person_escort_record, :ok)
     end
 
     def show
@@ -27,6 +40,14 @@ module Api
 
     def new_person_escort_record_params
       params.require(:data).permit(NEW_PERMITTED_PER_PARAMS).to_h
+    end
+
+    def update_person_escort_record_params
+      params.require(:data).permit(UPDATE_PERMITTED_PER_PARAMS)
+    end
+
+    def update_person_escort_record_attributes
+      update_person_escort_record_params.to_h.dig(:attributes, :status)
     end
 
     def supported_relationships

--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -25,7 +25,7 @@ module Api
     def update
       PersonEscortRecords::ParamsValidator.new(update_person_escort_record_attributes).validate!
       person_escort_record = PersonEscortRecord.find(params[:id])
-      person_escort_record.set_state!(update_person_escort_record_attributes)
+      person_escort_record.set_status!(update_person_escort_record_attributes)
 
       render_person_escort_record(person_escort_record, :ok)
     end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -80,8 +80,6 @@ class PersonEscortRecord < VersionedModel
   def set_status!(new_status)
     if new_status == PERSON_ESCORT_RECORD_CONFIRMED
       state_machine.confirm!
-    elsif new_status == PERSON_ESCORT_RECORD_PRINTED
-      state_machine.to_print!
     end
 
     save!

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -77,6 +77,19 @@ class PersonEscortRecord < VersionedModel
     save!
   end
 
+  def set_state!(new_state)
+    if new_state == PERSON_ESCORT_RECORD_CONFIRMED
+      state_machine.confirm!
+    elsif new_state == PERSON_ESCORT_RECORD_PRINTED
+      state_machine.to_print!
+    end
+
+    save!
+  rescue FiniteMachine::InvalidStateError
+    errors.add(:state, "can't update to '#{new_state}' from '#{state}'")
+    raise ActiveModel::ValidationError, self
+  end
+
 private
 
   def sections_to_responded

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -77,11 +77,10 @@ class PersonEscortRecord < VersionedModel
     save!
   end
 
-  def set_status!(new_status)
-    if new_status == PERSON_ESCORT_RECORD_CONFIRMED
-      state_machine.confirm!
-    end
+  def confirm!(new_status)
+    return unless new_status == PERSON_ESCORT_RECORD_CONFIRMED
 
+    state_machine.confirm!
     save!
   rescue FiniteMachine::InvalidStateError
     errors.add(:status, "can't update to '#{new_status}' from '#{status}'")

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -77,16 +77,16 @@ class PersonEscortRecord < VersionedModel
     save!
   end
 
-  def set_state!(new_state)
-    if new_state == PERSON_ESCORT_RECORD_CONFIRMED
+  def set_status!(new_status)
+    if new_status == PERSON_ESCORT_RECORD_CONFIRMED
       state_machine.confirm!
-    elsif new_state == PERSON_ESCORT_RECORD_PRINTED
+    elsif new_status == PERSON_ESCORT_RECORD_PRINTED
       state_machine.to_print!
     end
 
     save!
   rescue FiniteMachine::InvalidStateError
-    errors.add(:state, "can't update to '#{new_state}' from '#{state}'")
+    errors.add(:status, "can't update to '#{new_status}' from '#{status}'")
     raise ActiveModel::ValidationError, self
   end
 

--- a/app/services/person_escort_records/params_validator.rb
+++ b/app/services/person_escort_records/params_validator.rb
@@ -6,7 +6,7 @@ module PersonEscortRecords
 
     attr_reader :status
 
-    validates :status, inclusion: { in: [PersonEscortRecord::PERSON_ESCORT_RECORD_CONFIRMED, PersonEscortRecord::PERSON_ESCORT_RECORD_PRINTED] }
+    validates :status, inclusion: { in: [PersonEscortRecord::PERSON_ESCORT_RECORD_CONFIRMED] }
 
     def initialize(status)
       @status = status

--- a/app/services/person_escort_records/params_validator.rb
+++ b/app/services/person_escort_records/params_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PersonEscortRecords
+  class ParamsValidator
+    include ActiveModel::Validations
+
+    attr_reader :status
+
+    validates :status, inclusion: { in: [PersonEscortRecord::PERSON_ESCORT_RECORD_CONFIRMED, PersonEscortRecord::PERSON_ESCORT_RECORD_PRINTED] }
+
+    def initialize(status)
+      @status = status
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :person_escort_records, only: %i[create show]
+    resources :person_escort_records, only: %i[create show update]
     resources :framework_responses, only: %i[update]
 
     namespace :reference do

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -408,22 +408,6 @@ RSpec.describe PersonEscortRecord do
       expect(person_escort_record.confirmed_at).to eq(confirmed_at_timstamp)
     end
 
-    it 'sets status to `printed` if current status is `confirmed`' do
-      person_escort_record = create(:person_escort_record, :confirmed)
-      person_escort_record.set_status!('printed')
-
-      expect(person_escort_record).to be_printed
-    end
-
-    it 'sets `printed` timestamp to `printed_at`' do
-      printed_at_timstamp = Time.zone.now
-      person_escort_record = create(:person_escort_record, :confirmed)
-      allow(Time).to receive(:now).and_return(printed_at_timstamp)
-      person_escort_record.set_status!('printed')
-
-      expect(person_escort_record.printed_at).to eq(printed_at_timstamp)
-    end
-
     it 'does not update status if status is wrong value' do
       person_escort_record = create(:person_escort_record, :completed)
       person_escort_record.set_status!('completed')
@@ -434,8 +418,8 @@ RSpec.describe PersonEscortRecord do
     it 'does not update status if previous status not valid' do
       person_escort_record = create(:person_escort_record, :in_progress)
 
-      expect { person_escort_record.set_status!('printed') }.to raise_error(ActiveModel::ValidationError)
-      expect(person_escort_record.errors.messages[:status]).to contain_exactly("can't update to 'printed' from 'in_progress'")
+      expect { person_escort_record.set_status!('confirmed') }.to raise_error(ActiveModel::ValidationError)
+      expect(person_escort_record.errors.messages[:status]).to contain_exactly("can't update to 'confirmed' from 'in_progress'")
     end
 
     it 'does not update status if current status the same' do

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -391,10 +391,10 @@ RSpec.describe PersonEscortRecord do
     end
   end
 
-  describe '#set_status' do
+  describe '#confirm!' do
     it 'sets status to `confirmed` if current status is `completed`' do
       person_escort_record = create(:person_escort_record, :completed)
-      person_escort_record.set_status!('confirmed')
+      person_escort_record.confirm!('confirmed')
 
       expect(person_escort_record).to be_confirmed
     end
@@ -403,14 +403,14 @@ RSpec.describe PersonEscortRecord do
       confirmed_at_timstamp = Time.zone.now
       person_escort_record = create(:person_escort_record, :completed)
       allow(Time).to receive(:now).and_return(confirmed_at_timstamp)
-      person_escort_record.set_status!('confirmed')
+      person_escort_record.confirm!('confirmed')
 
       expect(person_escort_record.confirmed_at).to eq(confirmed_at_timstamp)
     end
 
     it 'does not update status if status is wrong value' do
       person_escort_record = create(:person_escort_record, :completed)
-      person_escort_record.set_status!('completed')
+      person_escort_record.confirm!('completed')
 
       expect(person_escort_record).to be_completed
     end
@@ -418,14 +418,14 @@ RSpec.describe PersonEscortRecord do
     it 'does not update status if previous status not valid' do
       person_escort_record = create(:person_escort_record, :in_progress)
 
-      expect { person_escort_record.set_status!('confirmed') }.to raise_error(ActiveModel::ValidationError)
+      expect { person_escort_record.confirm!('confirmed') }.to raise_error(ActiveModel::ValidationError)
       expect(person_escort_record.errors.messages[:status]).to contain_exactly("can't update to 'confirmed' from 'in_progress'")
     end
 
     it 'does not update status if current status the same' do
       person_escort_record = create(:person_escort_record, :confirmed)
 
-      expect { person_escort_record.set_status!('confirmed') }.to raise_error(ActiveModel::ValidationError)
+      expect { person_escort_record.confirm!('confirmed') }.to raise_error(ActiveModel::ValidationError)
       expect(person_escort_record.errors.messages[:status]).to contain_exactly("can't update to 'confirmed' from 'confirmed'")
     end
   end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -391,10 +391,10 @@ RSpec.describe PersonEscortRecord do
     end
   end
 
-  describe '#set_state' do
-    it 'sets state to `confirmed` if current state is `completed`' do
+  describe '#set_status' do
+    it 'sets status to `confirmed` if current status is `completed`' do
       person_escort_record = create(:person_escort_record, :completed)
-      person_escort_record.set_state!('confirmed')
+      person_escort_record.set_status!('confirmed')
 
       expect(person_escort_record).to be_confirmed
     end
@@ -403,14 +403,14 @@ RSpec.describe PersonEscortRecord do
       confirmed_at_timstamp = Time.zone.now
       person_escort_record = create(:person_escort_record, :completed)
       allow(Time).to receive(:now).and_return(confirmed_at_timstamp)
-      person_escort_record.set_state!('confirmed')
+      person_escort_record.set_status!('confirmed')
 
       expect(person_escort_record.confirmed_at).to eq(confirmed_at_timstamp)
     end
 
-    it 'sets state to `printed` if current state is `confirmed`' do
+    it 'sets status to `printed` if current status is `confirmed`' do
       person_escort_record = create(:person_escort_record, :confirmed)
-      person_escort_record.set_state!('printed')
+      person_escort_record.set_status!('printed')
 
       expect(person_escort_record).to be_printed
     end
@@ -419,30 +419,30 @@ RSpec.describe PersonEscortRecord do
       printed_at_timstamp = Time.zone.now
       person_escort_record = create(:person_escort_record, :confirmed)
       allow(Time).to receive(:now).and_return(printed_at_timstamp)
-      person_escort_record.set_state!('printed')
+      person_escort_record.set_status!('printed')
 
       expect(person_escort_record.printed_at).to eq(printed_at_timstamp)
     end
 
-    it 'does not update state if state is wrong value' do
+    it 'does not update status if status is wrong value' do
       person_escort_record = create(:person_escort_record, :completed)
-      person_escort_record.set_state!('completed')
+      person_escort_record.set_status!('completed')
 
       expect(person_escort_record).to be_completed
     end
 
-    it 'does not update state if previous state not valid' do
+    it 'does not update status if previous status not valid' do
       person_escort_record = create(:person_escort_record, :in_progress)
 
-      expect { person_escort_record.set_state!('printed') }.to raise_error(ActiveModel::ValidationError)
-      expect(person_escort_record.errors.messages[:state]).to contain_exactly("can't update to 'printed' from 'in_progress'")
+      expect { person_escort_record.set_status!('printed') }.to raise_error(ActiveModel::ValidationError)
+      expect(person_escort_record.errors.messages[:status]).to contain_exactly("can't update to 'printed' from 'in_progress'")
     end
 
-    it 'does not update state if current state the same' do
+    it 'does not update status if current status the same' do
       person_escort_record = create(:person_escort_record, :confirmed)
 
-      expect { person_escort_record.set_state!('confirmed') }.to raise_error(ActiveModel::ValidationError)
-      expect(person_escort_record.errors.messages[:state]).to contain_exactly("can't update to 'confirmed' from 'confirmed'")
+      expect { person_escort_record.set_status!('confirmed') }.to raise_error(ActiveModel::ValidationError)
+      expect(person_escort_record.errors.messages[:status]).to contain_exactly("can't update to 'confirmed' from 'confirmed'")
     end
   end
 

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe Api::PersonEscortRecordsController do
 
         it_behaves_like 'an endpoint that responds with error 422' do
           let(:errors_422) do
-            [{ 'title' => 'Invalid state',
-               'detail' => "Validation failed: State can't update to 'confirmed' from 'in_progress'" }]
+            [{ 'title' => 'Invalid status',
+               'detail' => "Validation failed: Status can't update to 'confirmed' from 'in_progress'" }]
           end
         end
       end

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -39,27 +39,6 @@ RSpec.describe Api::PersonEscortRecordsController do
               "status": 'confirmed',
               "version": person_escort_record.framework.version,
               "confirmed_at": person_escort_record.confirmed_at.iso8601,
-              "printed_at": nil,
-            },
-          })
-        end
-      end
-
-      context 'when status is printed' do
-        let(:person_escort_record) { create(:person_escort_record, :with_responses, :confirmed) }
-        let(:status) { 'printed' }
-
-        it_behaves_like 'an endpoint that responds with success 200'
-
-        it 'returns the correct data' do
-          expect(response_json).to include_json(data: {
-            "id": person_escort_record_id,
-            "type": 'person_escort_records',
-            "attributes": {
-              "status": 'printed',
-              "version": person_escort_record.framework.version,
-              "printed_at": person_escort_record.printed_at.iso8601,
-              "confirmed_at": person_escort_record.confirmed_at.iso8601,
             },
           })
         end

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::PersonEscortRecordsController do
+  describe 'PATCH /person_escort_records/:person_escort_record_id' do
+    include_context 'with supplier with spoofed access token'
+
+    let(:schema) { load_yaml_schema('patch_person_escort_record_responses.yaml') }
+    let(:response_json) { JSON.parse(response.body) }
+    let(:person_escort_record) { create(:person_escort_record, :with_responses, :completed) }
+    let(:person_escort_record_id) { person_escort_record.id }
+    let(:status) { 'confirmed' }
+    let(:person_escort_record_params) do
+      {
+        data: {
+          "type": 'person_escort_records',
+          "attributes": {
+            "status": status,
+          },
+        },
+      }
+    end
+
+    before do
+      patch "/api/v1/person_escort_records/#{person_escort_record_id}", params: person_escort_record_params, headers: headers, as: :json
+      person_escort_record.reload
+    end
+
+    context 'when successful' do
+      context 'when status is confirmed' do
+        it_behaves_like 'an endpoint that responds with success 200'
+
+        it 'returns the correct data' do
+          expect(response_json).to include_json(data: {
+            "id": person_escort_record_id,
+            "type": 'person_escort_records',
+            "attributes": {
+              "status": 'confirmed',
+              "version": person_escort_record.framework.version,
+              "confirmed_at": person_escort_record.confirmed_at.iso8601,
+              "printed_at": nil,
+            },
+          })
+        end
+      end
+
+      context 'when status is printed' do
+        let(:person_escort_record) { create(:person_escort_record, :with_responses, :confirmed) }
+        let(:status) { 'printed' }
+
+        it_behaves_like 'an endpoint that responds with success 200'
+
+        it 'returns the correct data' do
+          expect(response_json).to include_json(data: {
+            "id": person_escort_record_id,
+            "type": 'person_escort_records',
+            "attributes": {
+              "status": 'printed',
+              "version": person_escort_record.framework.version,
+              "printed_at": person_escort_record.printed_at.iso8601,
+              "confirmed_at": person_escort_record.confirmed_at.iso8601,
+            },
+          })
+        end
+      end
+    end
+
+    context 'when unsuccessful' do
+      context 'with a bad request' do
+        let(:person_escort_record_params) { nil }
+
+        it_behaves_like 'an endpoint that responds with error 400'
+      end
+
+      context 'with an invalid status' do
+        let(:status) { 'foo-bar' }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [{ 'title' => 'Invalid status',
+               'detail' => 'Validation failed: Status is not included in the list' }]
+          end
+        end
+      end
+
+      context 'when person_escort_record is wrong starting status' do
+        let(:person_escort_record) { create(:person_escort_record, :with_responses, :in_progress) }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [{ 'title' => 'Invalid state',
+               'detail' => "Validation failed: State can't update to 'confirmed' from 'in_progress'" }]
+          end
+        end
+      end
+
+      context 'when the person_escort_record_id is not found' do
+        let(:person_escort_record_id) { 'foo-bar' }
+        let(:detail_404) { "Couldn't find PersonEscortRecord with 'id'=foo-bar" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+    end
+  end
+end

--- a/spec/services/person_escort_records/params_validator_spec.rb
+++ b/spec/services/person_escort_records/params_validator_spec.rb
@@ -15,10 +15,4 @@ RSpec.describe PersonEscortRecords::ParamsValidator do
 
     expect(params_validator).to be_valid
   end
-
-  it 'does not validate status if value is printed' do
-    params_validator = described_class.new('printed')
-
-    expect(params_validator).to be_valid
-  end
 end

--- a/spec/services/person_escort_records/params_validator_spec.rb
+++ b/spec/services/person_escort_records/params_validator_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonEscortRecords::ParamsValidator do
+  it 'validates status if value is not in list states' do
+    params_validator = described_class.new('in_progress')
+
+    expect(params_validator).not_to be_valid
+    expect(params_validator.errors.messages[:status]).to eq(['is not included in the list'])
+  end
+
+  it 'does not validate status if value is confirmed' do
+    params_validator = described_class.new('confirmed')
+
+    expect(params_validator).to be_valid
+  end
+
+  it 'does not validate status if value is printed' do
+    params_validator = described_class.new('printed')
+
+    expect(params_validator).to be_valid
+  end
+end

--- a/spec/services/person_escort_records/params_validator_spec.rb
+++ b/spec/services/person_escort_records/params_validator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe PersonEscortRecords::ParamsValidator do
-  it 'validates status if value is not in list states' do
+  it 'validates status if value is not in list statuses' do
     params_validator = described_class.new('in_progress')
 
     expect(params_validator).not_to be_valid

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2666,7 +2666,7 @@
       - name: body
         in: body
         required: true
-        description: The `person_escort_record` object to be modified. Sets the current status of the `person_escort_record`, as first `confirmed` then `printed` after a `person_escort_record` is `completed`.
+        description: The `person_escort_record` object to be modified. Sets the current status of the `person_escort_record` as `confirmed` after a `person_escort_record` is `completed`.
         schema:
           "$ref": "../v1/patch_person_escort_record.yaml#/PatchPersonEscortRecord"
       responses:

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2566,13 +2566,13 @@
       consumes:
       - application/vnd.api+json
       parameters:
+      - "$ref": "../v1/person_escort_record_include_parameter.yaml#/PersonEscortRecordIncludeParameter"
       - name: body
         in: body
         required: true
-        description: The person_escort_record object to be created
+        description: The `person_escort_record` object to be created. Requires the `version` of the framework of questions, as well as the `profile` of the person.
         schema:
-          "$ref": "../v1/person_escort_record.yaml#/PersonEscortRecord"
-      - "$ref": "../v1/person_escort_record_include_parameter.yaml#/PersonEscortRecordIncludeParameter"
+          "$ref": "../v1/post_person_escort_record.yaml#/PostPersonEscortRecord"
       responses:
         '201':
           description: created
@@ -2654,6 +2654,58 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/error_responses.yaml#/415"
+    patch:
+      summary: Updates a person_escort_record's status
+      tags:
+      - Person Escort Records
+      consumes:
+      - application/vnd.api+json
+      parameters:
+      - "$ref": "../v1/person_escort_record_id_parameter.yaml#/PersonEscortRecordId"
+      - "$ref": "../v1/person_escort_record_include_parameter.yaml#/PersonEscortRecordIncludeParameter"
+      - name: body
+        in: body
+        required: true
+        description: The `person_escort_record` object to be modified. Sets the current status of the `person_escort_record`, as first `confirmed` then `printed` after a `person_escort_record` is `completed`.
+        schema:
+          "$ref": "../v1/patch_person_escort_record.yaml#/PatchPersonEscortRecord"
+      responses:
+        '200':
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_person_escort_record_responses.yaml#/200"
+        '400':
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_person_escort_record_responses.yaml#/400"
+        '401':
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_person_escort_record_responses.yaml#/401"
+        '404':
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_person_escort_record_responses.yaml#/404"
+        '415':
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_person_escort_record_responses.yaml#/415"
+        '422':
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_person_escort_record_responses.yaml#/422"
   "/reference/allocation_complex_cases":
     get:
       summary: Returns a list of allocation complex cases

--- a/swagger/v1/patch_person_escort_record.yaml
+++ b/swagger/v1/patch_person_escort_record.yaml
@@ -1,0 +1,30 @@
+PatchPersonEscortRecord:
+  type: object
+  required:
+    - id
+    - type
+    - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: person_escort_records
+      enum:
+      - person_escort_records
+      description: The type of this object - always `person_escort_records`
+    attributes:
+      type: object
+      required:
+      - status
+      properties:
+        status:
+          example: confirmed
+          type: string
+          enum:
+            - confirmed
+            - printed
+          description: Sets the current status of the `person_escort_record`

--- a/swagger/v1/patch_person_escort_record.yaml
+++ b/swagger/v1/patch_person_escort_record.yaml
@@ -26,5 +26,4 @@ PatchPersonEscortRecord:
           type: string
           enum:
             - confirmed
-            - printed
           description: Sets the current status of the `person_escort_record`

--- a/swagger/v1/patch_person_escort_record_responses.yaml
+++ b/swagger/v1/patch_person_escort_record_responses.yaml
@@ -1,0 +1,52 @@
+'200':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: person_escort_record.yaml#/PersonEscortRecord
+'400':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError
+'404':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/ResourceNotFound
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnsupportedMediaType
+'422':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnprocessableEntity

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -22,7 +22,6 @@ PersonEscortRecord:
       - version
       properties:
         status:
-          example: in_progress
           type: string
           enum:
             - not_started
@@ -32,9 +31,10 @@ PersonEscortRecord:
           description: Determines the current status of the `person_escort_record`
         version:
           type: string
-          example: '0.1'
+          example: '1.0.1'
           description: Determines the version of framework questions of the `person_escort_record`
         confirmed_at:
+          example: "2020-07-24T17:29:26.338Z"
           oneOf:
           - type: 'null'
           - type: string
@@ -60,7 +60,7 @@ PersonEscortRecord:
                 description: identifier of section
               status:
                 type: string
-                example: in_progress
+                example: not_started
                 enum:
                   - not_started
                   - in_progress

--- a/swagger/v1/post_person_escort_record.yaml
+++ b/swagger/v1/post_person_escort_record.yaml
@@ -1,0 +1,35 @@
+PostPersonEscortRecord:
+  type: object
+  required:
+    - id
+    - type
+    - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: person_escort_records
+      enum:
+      - person_escort_records
+      description: The type of this object - always `person_escort_records`
+    attributes:
+      type: object
+      required:
+      - version
+      properties:
+        version:
+          type: string
+          example: '1.0.1'
+          description: Determines the version of framework questions of the `person_escort_record`
+    relationships:
+      type: object
+      required:
+        - profile
+      properties:
+        profile:
+          $ref: profile_reference.yaml#/ProfileReference
+          description: The profile of the person being moved


### PR DESCRIPTION
### Jira link

[P4-1783](https://dsdmoj.atlassian.net/browse/P4-1783)

### What?

- [x] Added PATCH endpoint for person escort record
- [x] Added param validator for endpoint
- [x] Added state updater in person escort record

### Why?

Add new PATCH endpoint for person escort record, which accepts a status, which could be `confirmed` or `printed`, and updates the person escort record state. It also sets the timestamps for each respectively.

If either the start state is invalid (`completed -> confirmed` or `confirmed -> printed`), or any other params are passed in, it returns an error.

### Have you? (optional)

- [x] Updated API docs if necessary	
