### PR TITLE
Allow prison to prison transfers (allocations) to be created in Nomis

### DIFF
--- a/app/controllers/api/move_events_controller.rb
+++ b/app/controllers/api/move_events_controller.rb
@@ -8,7 +8,7 @@ module Api
     before_action :validate_idempotency_key
     around_action :idempotent_action
 
-    APPROVE_PARAMS = [:type, attributes: %i[timestamp date]].freeze
+    APPROVE_PARAMS = [:type, attributes: %i[timestamp date create_in_nomis]].freeze
     CANCEL_PARAMS = [:type, attributes: %i[timestamp cancellation_reason cancellation_reason_comment notes]].freeze
     LOCKOUT_PARAMS = [:type, attributes: %i[timestamp notes], relationships: { from_location: {} }].freeze
     REDIRECT_PARAMS = [:type, attributes: %i[timestamp notes], relationships: { to_location: {} }].freeze

--- a/app/lib/nomis_client/allocations.rb
+++ b/app/lib/nomis_client/allocations.rb
@@ -8,18 +8,7 @@ module NomisClient
 
         NomisClient::Base.post(allocations_path, body: body_params.to_json)
       rescue OAuth2::Error => e
-        Raven.capture_message(
-          'Allocations::CreateInNomis Error!',
-          extra: {
-            allocations_route: allocations_path,
-            body_params: body_params,
-            nomis_response: {
-              status: e.response.status,
-              body: e.response.body,
-            },
-          },
-          level: 'error',
-        )
+        log_exception('Allocations::CreateInNomis Error!', allocations_path, body_params, e)
 
         e.response
       end

--- a/app/lib/nomis_client/allocations.rb
+++ b/app/lib/nomis_client/allocations.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module NomisClient
+  class Allocations < NomisClient::Base
+    class << self
+      def post(booking_id:, body_params: {})
+        allocations_path = "/bookings/#{booking_id}/prison-to-prison"
+
+        NomisClient::Base.post(allocations_path, body: body_params.to_json)
+      rescue OAuth2::Error => e
+        Raven.capture_message(
+          'Allocations::CreateInNomis Error!',
+          extra: {
+            allocations_route: allocations_path,
+            body_params: body_params,
+            nomis_response: {
+              status: e.response.status,
+              body: e.response.body,
+            },
+          },
+          level: 'error',
+        )
+
+        e.response
+      end
+    end
+  end
+end

--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -59,6 +59,19 @@ module NomisClient
           },
         }.deep_merge(params)
       end
+
+      def log_exception(description, path, params, exception)
+        Raven.capture_message(description,
+                              extra: {
+                                route: path,
+                                body_params: params,
+                                nomis_response: {
+                                  status: exception.response.status,
+                                  body: exception.response.body,
+                                },
+                              },
+                              level: 'error')
+      end
     end
   end
 end

--- a/app/lib/nomis_client/court_hearings.rb
+++ b/app/lib/nomis_client/court_hearings.rb
@@ -19,18 +19,7 @@ module NomisClient
 
         NomisClient::Base.post(court_hearings_path, body: body_params.to_json)
       rescue OAuth2::Error => e
-        Raven.capture_message(
-          'CourtHearings::CreateInNomis Error!',
-          extra: {
-            court_cases_route: court_hearings_path,
-            body_params: body_params,
-            nomis_response: {
-              status: e.response.status,
-              body: e.response.body,
-            },
-          },
-          level: 'error',
-        )
+        log_exception('CourtHearings::CreateInNomis Error!', court_hearings_path, body_params, e)
 
         e.response
       end

--- a/app/lib/nomis_client/court_hearings.rb
+++ b/app/lib/nomis_client/court_hearings.rb
@@ -20,7 +20,7 @@ module NomisClient
         NomisClient::Base.post(court_hearings_path, body: body_params.to_json)
       rescue OAuth2::Error => e
         Raven.capture_message(
-          'CourtHearings:CreateInNomis Error!',
+          'CourtHearings::CreateInNomis Error!',
           extra: {
             court_cases_route: court_hearings_path,
             body_params: body_params,

--- a/app/models/move_event.rb
+++ b/app/models/move_event.rb
@@ -1,8 +1,12 @@
 class MoveEvent < Event
   # NB: this class exposes a few methods specific to moves to the Event model
 
+  def create_in_nomis?
+    @create_in_nomis ||= option_selected?(:create_in_nomis)
+  end
+
   def rebook?
-    @rebook ||= event_params.dig(:attributes, :rebook).to_s == 'true'
+    @rebook ||= option_selected?(:rebook)
   end
 
   def date
@@ -19,5 +23,11 @@ class MoveEvent < Event
 
   def cancellation_reason_comment
     @cancellation_reason_comment ||= event_params.dig(:attributes, :cancellation_reason_comment)
+  end
+
+private
+
+  def option_selected?(attribute_name)
+    event_params.dig(:attributes, attribute_name).to_s == 'true'
   end
 end

--- a/app/services/allocations/create_in_nomis.rb
+++ b/app/services/allocations/create_in_nomis.rb
@@ -1,0 +1,28 @@
+module Allocations
+  class CreateInNomis
+    def self.call(move)
+      booking_id = move.person.latest_nomis_booking_id
+
+      body = {
+        booking_id: booking_id,
+        body_params: {
+          fromPrisonLocation: move.from_location.nomis_agency_id,
+          toPrisonLocation: move.to_location.nomis_agency_id,
+          escortType: 'PECS',
+          scheduledMoveDateTime: move.date.to_s(:nomis),
+        },
+      }
+
+      response = NomisClient::Allocations.post(body)
+
+      if response&.status == 201
+        new_event_id = JSON.parse(response.body)['id']
+        move.update(nomis_event_id: new_event_id)
+      end
+
+      { response_status: response&.status, response_body: response&.body, request_params: body }.tap do |log_attributes|
+        Rails.logger.info("Tried to create a prison to prison transfer in nomis #{log_attributes.to_json}")
+      end
+    end
+  end
+end

--- a/app/services/allocations/create_in_nomis.rb
+++ b/app/services/allocations/create_in_nomis.rb
@@ -1,7 +1,8 @@
 module Allocations
   class CreateInNomis
     def self.call(move)
-      booking_id = move.person.latest_nomis_booking_id
+      booking_id = move.person&.latest_nomis_booking_id
+      return unless booking_id.present? && move.to_location.present?
 
       body = {
         booking_id: booking_id,

--- a/app/services/court_hearings/create_in_nomis.rb
+++ b/app/services/court_hearings/create_in_nomis.rb
@@ -4,8 +4,8 @@ module CourtHearings
       booking_id = move.person.latest_nomis_booking_id
 
       body_locations = {
-        "fromPrisonLocation": move.from_location.nomis_agency_id,
-        "toCourtLocation": move.to_location.nomis_agency_id,
+        fromPrisonLocation: move.from_location.nomis_agency_id,
+        toCourtLocation: move.to_location.nomis_agency_id,
       }
 
       log_attributes = []
@@ -15,13 +15,13 @@ module CourtHearings
           booking_id: booking_id,
           court_case_id: hearing.nomis_case_id,
           body_params: {
-            'courtHearingDateTime': hearing.start_time.to_s(:nomis),
-            'comments': hearing.comments,
+            courtHearingDateTime: hearing.start_time.to_s(:nomis),
+            comments: hearing.comments,
           }.merge(body_locations),
         }
         response = NomisClient::CourtHearings.post(body)
 
-        log_attributes << { response_sttus: response&.status, response_body: response&.body, request_body: body }
+        log_attributes << { response_status: response&.status, response_body: response&.body, request_params: body }
 
         next unless response&.status == 201
 

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -16,6 +16,7 @@ module EventLog
         when Event::APPROVE
           move.status = Move::MOVE_STATUS_REQUESTED
           move.date = event.date
+          Allocations::CreateInNomis.call(move) if event.create_in_nomis?
         when Event::CANCEL
           move.status = Move::MOVE_STATUS_CANCELLED
           move.cancellation_reason = event.cancellation_reason

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -127,6 +127,18 @@ FactoryBot.define do
         end
       end
 
+      trait :approve_with_nomis do
+        event_name { 'approve' }
+        details do
+          { event_params: {
+            attributes: {
+              date: Date.tomorrow,
+              create_in_nomis: true,
+            },
+          } }
+        end
+      end
+
       trait :reject do
         event_name { 'reject' }
         details do

--- a/spec/lib/nomis_client/allocations_spec.rb
+++ b/spec/lib/nomis_client/allocations_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true do
+  describe '.post' do
+    subject(:prison_transfer_post) do
+      described_class.post(booking_id: booking_id, body_params: {})
+    end
+
+    let(:booking_id) { 1111 }
+    let(:response_status) { 201 }
+    let(:response_body) { '{}' }
+
+    it 'creates prison-to-prison transfer in Nomis ' do
+      prison_transfer_post
+
+      expect(token)
+        .to have_received(:post)
+        .with('/elite2api/api/bookings/1111/prison-to-prison', body: '{}', headers: { Accept: 'application/json', 'Content-Type': 'application/json' })
+    end
+
+    context 'when Nomis returns an error' do
+      before do
+        allow(oauth2_response).to receive(:error=)
+        allow(token).to receive(:post).and_raise(OAuth2::Error.new(oauth2_response))
+      end
+
+      let(:response_status) { 500 }
+
+      let(:raven_args) do
+        [
+          'Allocations::CreateInNomis Error!',
+          extra: {
+            body_params: {},
+            allocations_route: '/bookings/1111/prison-to-prison',
+            nomis_response: { body: '{}', status: 500 },
+          },
+          level: 'error',
+        ]
+      end
+
+      it 'pushes an error warning to Sentry' do
+        allow(Raven).to receive(:capture_message)
+
+        prison_transfer_post
+
+        expect(Raven).to have_received(:capture_message).with(*raven_args)
+      end
+    end
+  end
+end

--- a/spec/lib/nomis_client/allocations_spec.rb
+++ b/spec/lib/nomis_client/allocations_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
     let(:response_status) { 201 }
     let(:response_body) { '{}' }
 
-    it 'creates prison-to-prison transfer in Nomis ' do
+    it 'creates prison-to-prison transfer in Nomis' do
       prison_transfer_post
 
       expect(token)
@@ -33,7 +33,7 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
           'Allocations::CreateInNomis Error!',
           extra: {
             body_params: {},
-            allocations_route: '/bookings/1111/prison-to-prison',
+            route: '/bookings/1111/prison-to-prison',
             nomis_response: { body: '{}', status: 500 },
           },
           level: 'error',

--- a/spec/lib/nomis_client/court_hearings_spec.rb
+++ b/spec/lib/nomis_client/court_hearings_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe NomisClient::CourtHearings, with_nomis_client_authentication: tru
           'CourtHearings::CreateInNomis Error!',
           extra: {
             body_params: {},
-            court_cases_route: '/bookings/1111/court-cases/2222/prison-to-court-hearings',
+            route: '/bookings/1111/court-cases/2222/prison-to-court-hearings',
             nomis_response: { body: '{}', status: 500 },
           },
           level: 'error',

--- a/spec/lib/nomis_client/court_hearings_spec.rb
+++ b/spec/lib/nomis_client/court_hearings_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe NomisClient::CourtHearings, with_nomis_client_authentication: tru
 
       let(:raven_args) do
         [
-          'CourtHearings:CreateInNomis Error!',
+          'CourtHearings::CreateInNomis Error!',
           extra: {
             body_params: {},
             court_cases_route: '/bookings/1111/court-cases/2222/prison-to-court-hearings',

--- a/spec/requests/api/move_events_controller_approve_spec.rb
+++ b/spec/requests/api/move_events_controller_approve_spec.rb
@@ -19,12 +19,14 @@ RSpec.describe Api::MoveEventsController do
           attributes: {
             timestamp: '2020-04-23T18:25:43.511Z',
             date: approved_date,
+            create_in_nomis: 'true',
           },
         },
       }
     end
 
     before do
+      allow(Allocations::CreateInNomis).to receive(:call)
       allow(Notifier).to receive(:prepare_notifications)
       post "/api/v1/moves/#{move_id}/approve", params: approve_params, headers: headers, as: :json
     end
@@ -38,6 +40,10 @@ RSpec.describe Api::MoveEventsController do
 
       it 'updates the move date' do
         expect(move.reload.date).to eql(approved_date)
+      end
+
+      it 'creates a prison transfer event in Nomis' do
+        expect(Allocations::CreateInNomis).to have_received(:call).with(move)
       end
 
       describe 'webhook and email notifications' do

--- a/spec/services/allocations/create_in_nomis_spec.rb
+++ b/spec/services/allocations/create_in_nomis_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe Allocations::CreateInNomis do
+  context 'when move is valid' do
+    subject(:create_transfer_in_nomis) { described_class.call(move) }
+
+    let(:move) do
+      create(
+        :move,
+        date: move_date,
+        from_location: create(:location, nomis_agency_id: from_nomis_agency_id),
+        to_location: create(:location, nomis_agency_id: to_nomis_agency_id),
+      )
+    end
+
+    let(:move_date) { Date.parse('2099-07-27') }
+    let(:from_nomis_agency_id) { 'PVI' }
+    let(:to_nomis_agency_id) { 'HLI' }
+    let(:booking_id) { 123 }
+    let(:response_body) { { 'id' => 123 }.to_json }
+
+    before do
+      allow(NomisClient::Allocations).to receive(:post)
+                                     .and_return(instance_double('OAuth2::Response', status: nomis_response_status, body: response_body))
+      move.person.update(latest_nomis_booking_id: booking_id)
+    end
+
+    context 'when Nomis return 201 success' do
+      let(:nomis_response_status) { 201 }
+      let(:nomis_client_args) do
+        {
+          booking_id: booking_id,
+          body_params: {
+            'fromPrisonLocation': from_nomis_agency_id,
+            'toPrisonLocation': to_nomis_agency_id,
+            'escortType': 'PECS',
+            'scheduledMoveDateTime': '2099-07-27T00:00:00',
+          },
+        }
+      end
+
+      it 'creates the prison transfer event in Nomis' do
+        create_transfer_in_nomis
+
+        expect(NomisClient::Allocations).to have_received(:post).with(nomis_client_args)
+      end
+
+      it 'updates the nomis_event_id' do
+        create_transfer_in_nomis
+
+        expect(move.nomis_event_id).to eq 123
+      end
+
+      it 'returns debugging information' do
+        expect(create_transfer_in_nomis).to include(
+          request_params: nomis_client_args,
+          response_body: response_body,
+          response_status: 201,
+        )
+      end
+    end
+
+    context 'when Nomis returns an error' do
+      let(:nomis_response_status) { 400 }
+
+      it 'does NOT set nomis_event_id' do
+        create_transfer_in_nomis
+
+        expect(move.nomis_event_id).to be_nil
+      end
+
+      it 'returns debugging information' do
+        expect(create_transfer_in_nomis).to include(
+          response_status: 400,
+        )
+      end
+    end
+  end
+end

--- a/spec/services/allocations/create_in_nomis_spec.rb
+++ b/spec/services/allocations/create_in_nomis_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe Allocations::CreateInNomis do
   context 'when move is valid' do
     subject(:create_transfer_in_nomis) { described_class.call(move) }
 
+    let(:from_location) { create(:location, nomis_agency_id: from_nomis_agency_id) }
+    let(:to_location) { create(:location, nomis_agency_id: to_nomis_agency_id) }
     let(:move) do
       create(
         :move,
+        :prison_recall,
         date: move_date,
-        from_location: create(:location, nomis_agency_id: from_nomis_agency_id),
-        to_location: create(:location, nomis_agency_id: to_nomis_agency_id),
+        from_location: from_location,
+        to_location: to_location,
       )
     end
 
@@ -73,6 +76,24 @@ RSpec.describe Allocations::CreateInNomis do
         expect(create_transfer_in_nomis).to include(
           response_status: 400,
         )
+      end
+    end
+
+    context 'when latest_booking_id is missing' do
+      let(:nomis_response_status) { nil }
+      let(:booking_id) { nil }
+
+      it 'is nil' do
+        expect(create_transfer_in_nomis).to be_nil
+      end
+    end
+
+    context 'when to_location_id is missing' do
+      let(:nomis_response_status) { nil }
+      let(:to_location) { nil }
+
+      it 'is nil' do
+        expect(create_transfer_in_nomis).to be_nil
       end
     end
   end

--- a/swagger/v1/post_move_approve.yaml
+++ b/swagger/v1/post_move_approve.yaml
@@ -23,3 +23,9 @@ PostMoveApprove:
           format: date
           example: '2020-05-17'
           description: Date on which the move is scheduled
+        create_in_nomis:
+          oneOf:
+          - type: boolean
+          - type: 'null'
+          example: 'true'
+          description: Indicates if the move should be automatically created in NOMIS


### PR DESCRIPTION

### Jira link

P4-1949

### What?

- [x] Add new `create_in_nomis` parameter to existing `POST /move_events/approve' endpoint
- [x] Add new `Allocations::CreateInNomis` service
- [x] Add new `NomisClient::Allocations` client service

### Why?

- This is to support creating prison to prison transfers (aka allocations) in Nomis automatically when the singleton move request is approved in the front end. Further PR's will do the same when updating existing allocation profiles.

- Note that the front end always receives a success response regardless of the Nomis response. We do not wish to block front end in the event of Nomis failure, so must return a success response. Unfortunately we do not have a mechanism to return a success response with associated warnings (e.g. the move was approved but Nomis was not updated).

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Integrates with a new (or at least not used yet) Nomis endpoint, so will require end to end testing
- Introduces a new optional attribute to existing API endpoint, so does not affect production API