### PR TITLE
P4-1783 Add webhook on confirming a person escort record

### DIFF
--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -2,6 +2,8 @@
 
 module Api
   class PersonEscortRecordsController < ApiController
+    after_action :send_notification, only: :update
+
     NEW_PERMITTED_PER_PARAMS = [
       :type,
       attributes: [:version],
@@ -57,6 +59,10 @@ module Api
 
     def render_person_escort_record(person_escort_record, status)
       render json: person_escort_record, status: status, include: included_relationships
+    end
+
+    def send_notification
+      Notifier.prepare_notifications(topic: person_escort_record, action_name: 'update')
     end
   end
 end

--- a/app/jobs/prepare_person_escort_record_notifications_job.rb
+++ b/app/jobs/prepare_person_escort_record_notifications_job.rb
@@ -4,7 +4,8 @@ class PreparePersonEscortRecordNotificationsJob < ApplicationJob
   queue_as :notifications
 
   def perform(topic_id:, action_name:)
-    move = PersonEscortRecord.find(topic_id).profile.move
+    return unless (move = PersonEscortRecord.find(topic_id).profile.move)
+
     PrepareMoveNotificationsJob.perform_now(topic_id: move.id, action_name: action_name)
   end
 end

--- a/app/jobs/prepare_person_escort_record_notifications_job.rb
+++ b/app/jobs/prepare_person_escort_record_notifications_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class PreparePersonEscortRecordNotificationsJob < ApplicationJob
+  queue_as :notifications
+
+  def perform(topic_id:, action_name:)
+    move = PersonEscortRecord.find(topic_id).profile.move
+    PrepareMoveNotificationsJob.perform_now(topic_id: move.id, action_name: action_name)
+  end
+end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -7,6 +7,8 @@ class Notifier
       PrepareMoveNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name)
     when Person
       PreparePersonNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name)
+    when PersonEscortRecord
+      PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name)
     end
   end
 end

--- a/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe PreparePersonEscortRecordNotificationsJob, type: :job do
+  subject(:perform) { described_class.new.perform(topic_id: person_escort_record.id, action_name: 'update') }
+
+  let(:subscription) { create(:subscription) }
+  let(:supplier) { create :supplier, name: 'test', subscriptions: [subscription] }
+  let(:location) { create :location, suppliers: [supplier] }
+  let(:person_escort_record) { create(:person_escort_record) }
+
+  before do
+    create(:notification_type, :webhook)
+    create(:notification_type, :email)
+    create(:move, from_location: location, profile: person_escort_record.profile)
+
+    allow(NotifyWebhookJob).to receive(:perform_later)
+    allow(NotifyEmailJob).to receive(:perform_later)
+  end
+
+  it 'creates a webhook notification' do
+    expect { perform }.to change(Notification.webhooks, :count).by(1)
+  end
+
+  it 'creates an email notification' do
+    expect { perform }.to change(Notification.emails, :count).by(1)
+  end
+
+  it 'schedules a NotifyWebhookJob' do
+    perform
+    expect(NotifyWebhookJob).to have_received(:perform_later).with(Notification.webhooks.last.id)
+  end
+
+  it 'schedules a NotifyEmailJob' do
+    perform
+    expect(NotifyEmailJob).to have_received(:perform_later).with(Notification.emails.last.id)
+  end
+end

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::PersonEscortRecordsController do
     include_context 'with supplier with spoofed access token'
 
     subject(:patch_person_escort_record) do
-      patch "/api/v1/person_escort_records/#{person_escort_record_id}", params: person_escort_record_params, headers: headers, as: :json
+      patch "/api/person_escort_records/#{person_escort_record_id}", params: person_escort_record_params, headers: headers, as: :json
 
       person_escort_record.reload
     end

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Notifier do
     end
   end
 
+  context 'when scheduled with a person_escort_record' do
+    let(:topic) { create(:person_escort_record) }
+
+    it 'queues a job' do
+      expect(PreparePersonEscortRecordNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, action_name: action_name)
+    end
+  end
+
   context 'when called with another object' do
     let(:topic) { Object.new }
 


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-1783

If a person escort record is confirmed, send an update move webhook and email. We have written up a proposal for suppliers,  if using the same `update_move` notification is not preferable we can create a specific action name instead (we will wait for their feedback).