### PR TITLE
Remove dead nomis_event_ids attribute from moves

### DIFF
--- a/app/controllers/api/v1/moves_actions.rb
+++ b/app/controllers/api/v1/moves_actions.rb
@@ -25,8 +25,6 @@ module Api::V1
     end
 
     def update_and_render
-      raise ActiveRecord::ReadOnlyRecord, 'Can\'t change moves coming from Nomis' if move.from_nomis?
-
       updater.call
 
       Notifier.prepare_notifications(topic: updater.move, action_name: updater.status_changed ? 'update_status' : 'update')

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -87,7 +87,6 @@ class Move < VersionedModel
 
   before_validation :set_reference
   before_validation :set_move_type
-  before_validation :ensure_event_nomis_ids_uniqueness
 
   delegate :suppliers, to: :from_location
 
@@ -117,14 +116,6 @@ class Move < VersionedModel
 
   def rejected?
     cancellation_reason == CANCELLATION_REASON_REJECTED
-  end
-
-  def nomis_event_id=(event_id)
-    nomis_event_ids << event_id
-  end
-
-  def from_nomis?
-    !nomis_event_ids.empty?
   end
 
   def existing
@@ -170,10 +161,6 @@ private
                      else
                        'prison_transfer'
                      end
-  end
-
-  def ensure_event_nomis_ids_uniqueness
-    nomis_event_ids.uniq!
   end
 
   def is_a_police_tranfer?

--- a/db/migrate/20200728090010_remove_nomis_event_ids_from_moves.rb
+++ b/db/migrate/20200728090010_remove_nomis_event_ids_from_moves.rb
@@ -1,0 +1,9 @@
+class RemoveNomisEventIdsFromMoves < ActiveRecord::Migration[6.0]
+  def up
+    remove_column :moves, :nomis_event_ids
+  end
+
+  def down
+    add_column :moves, :nomis_event_ids, :integer, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_074625) do
+ActiveRecord::Schema.define(version: 2020_07_28_090010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -270,7 +270,6 @@ ActiveRecord::Schema.define(version: 2020_07_28_074625) do
     t.datetime "time_due"
     t.string "cancellation_reason"
     t.text "cancellation_reason_comment"
-    t.integer "nomis_event_ids", default: [], null: false, array: true
     t.uuid "profile_id"
     t.uuid "prison_transfer_reason_id"
     t.text "reason_comment"

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -19,29 +19,6 @@ namespace :data_maintenance do
     end
   end
 
-  desc 'cancel all NOMIS synched moves from prisons'
-  task cancel_synched_prison_moves: :environment do
-    Location.prison.each do |prison|
-      from_moves = prison.moves_from.requested.select(&:from_nomis?).each do |move|
-        move.update!(
-          status: Move::MOVE_STATUS_CANCELLED,
-          cancellation_reason: Move::CANCELLATION_REASON_MADE_IN_ERROR,
-        )
-      end
-
-      puts "Prison #{prison.title} cancelled #{from_moves.size} moves" if from_moves.any?
-    end
-  end
-
-  desc 'move old nomis_event_id to nomis_event_ids'
-  task move_event_id_to_event_ids: :environment do
-    Move.where.not(nomis_event_id: nil).each do |move|
-      # rubocop:disable Rails/SkipsModelValidations
-      move.update_attribute(:nomis_event_ids, [move.nomis_event_id])
-      # rubocop:enable Rails/SkipsModelValidations
-    end
-  end
-
   desc 'fix incorrect move_agreed for all moves except prison transfers'
   task fix_move_agreed_for_non_prison_transfers: :environment do
     Move.where(move_agreed: false).where.not(move_type: 'prison_transfer').update_all(move_agreed: nil)

--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -187,8 +187,6 @@ namespace :fake_data do
       profile = profiles.sample
       from_location = prisons.sample
       to_location = courts.sample
-      nomis_event_ids = []
-      nomis_event_ids << (1_000_000..1_500_000).to_a.sample if rand(2).zero?
       next if Move.find_by(date: date, profile: profile, from_location: from_location, to_location: to_location)
 
       move = Move.create!(
@@ -199,7 +197,6 @@ namespace :fake_data do
         from_location: from_location,
         to_location: to_location,
         status: %w[proposed requested booked in_transit completed].sample,
-        nomis_event_ids: nomis_event_ids,
       )
       document = Document.new(move: move)
       document.file.attach(io: file, filename: 'file-sample_100kB.doc')

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -162,13 +162,6 @@ RSpec.describe Move do
     expect(build(:move, date_from: '2020-03-04', date_to: '2020-03-04')).to be_valid
   end
 
-  it 'does NOT permit duplicate nomis_event_ids' do
-    move = create(:move, nomis_event_ids: [123_456])
-    move.nomis_event_ids << 123_456
-    move.save
-    expect(move.nomis_event_ids).to eq([123_456])
-  end
-
   context 'when a Move for a Person has already been created' do
     let(:move) { create(:move) }
 
@@ -217,28 +210,6 @@ RSpec.describe Move do
     end
 
     it { is_expected.to validate_presence_of(:reference) }
-  end
-
-  describe '#nomis_event_id=' do
-    subject(:move) { create :move }
-
-    context 'when nomis_event_id is not present' do
-      it 'assigns the nomis_event_id to the nomis_event_ids array' do
-        move.nomis_event_id = 123_456
-        expect(move.nomis_event_ids).to eq([123_456])
-      end
-    end
-
-    context 'when nomis_event_id is present' do
-      before do
-        move.nomis_event_id = 123_456
-      end
-
-      it 'assigns the nomis_event_id to the nomis_event_ids array without losing the old nomis_event_id' do
-        move.nomis_event_id = 654_321
-        expect(move.nomis_event_ids).to eq([123_456, 654_321])
-      end
-    end
   end
 
   describe '#reference' do
@@ -292,28 +263,6 @@ RSpec.describe Move do
 
       it 'sets move_type to `police_transfer`' do
         expect(move.move_type).to eq 'police_transfer'
-      end
-    end
-  end
-
-  describe '#from_nomis?' do
-    subject(:move) { build :move }
-
-    context 'with nomis_event_ids' do
-      let(:nomis_event_id) { 12_345_678 }
-
-      before { move.nomis_event_ids = [nomis_event_id] }
-
-      it 'is truthy' do
-        expect(move).to be_from_nomis
-      end
-    end
-
-    context 'without nomis_event_ids' do
-      before { move.nomis_event_ids = [] }
-
-      it 'is falsy' do
-        expect(move).not_to be_from_nomis
       end
     end
   end

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -664,25 +664,6 @@ RSpec.describe Api::MovesController do
         it_behaves_like 'an endpoint that responds with error 400'
       end
 
-      context 'when from nomis' do
-        let(:nomis_event_id) { 12_345_678 }
-        let!(:move) { create :move, nomis_event_ids: [nomis_event_id] }
-        let(:detail_403) { 'Can\'t change moves coming from Nomis' }
-
-        let(:move_params) do
-          {
-            type: 'moves',
-            attributes: {
-              status: 'cancelled',
-              cancellation_reason: 'supplier_declined_to_move',
-              reference: 'new reference',
-            },
-          }
-        end
-
-        it_behaves_like 'an endpoint that responds with error 403'
-      end
-
       context 'with a missing move' do
         let(:move_id) { 'null' }
         let(:detail_404) { "Couldn't find Move with 'id'=null" }

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -460,27 +460,6 @@ RSpec.describe Api::MovesController do
       end
     end
 
-    context 'when from nomis' do
-      let(:nomis_event_id) { 12_345_678 }
-      let!(:move) { create :move, nomis_event_ids: [nomis_event_id] }
-      let(:detail_403) { 'Can\'t change moves coming from Nomis' }
-
-      let(:move_params) do
-        {
-          type: 'moves',
-          attributes: {
-            status: 'cancelled',
-            cancellation_reason: 'supplier_declined_to_move',
-            reference: 'new reference',
-          },
-        }
-      end
-
-      it_behaves_like 'an endpoint that responds with error 403' do
-        before { do_patch }
-      end
-    end
-
     context 'when the move does not exist' do
       let(:move_id) { 'foo' }
       let(:move_params) { nil }

--- a/spec/services/alerts/importer_spec.rb
+++ b/spec/services/alerts/importer_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe Alerts::Importer do
       date: '2019-08-19',
       time_due: '2019-08-19T17:00:00',
       status: 'requested',
-      nomis_event_id: 123_456,
     }]
   end
 


### PR DESCRIPTION
### Jira link

P4-1949 P4-1499

### What?
- [x] Removed `nomis_event_ids` from Move model
- [x] Removed overridden assignment of `nomis_event_id` attribute on same model
- [x] Removed `from_nomis?` method and associated checks for read only moves

### Why?

It seems that in the distant past, Nomis events were imported from Nomis and used to create associated moves in PECS. When first implemented, the original Nomis event id was stored in the move `nomis_event_id` attribute as these have a 1:1 mapping with moves. Also these imported moves were treated as read only so that they could not be modified via the API (which would presumably be a bad thing).

Time passed...

Subsequently it was discovered that court hearings break the original 1:1 mapping approach with the same prisoner potentially having multiple court hearings (for different offences) on the same date and location, which means a move cannot be created for each event. Nomis stores each individual court hearing as a separate event; so at that point `nomis_event_ids` was added to store an array of all associated Nomis events for the move. A rake task was added to back fill this array attribute on existing data, and the `nomis_event_ids` array was then used to determine if a move originated from Nomis.

Time passed...

At some point it was further decided not to import events from Nomis to create moves any longer. This meant that in production a number of unwanted moves were left that needed to be cancelled. Another rake task was built for this. There is no remaining evidence of the Nomis event importer in the code base so presumably this was removed, although the legacy `nomis_event_id` and `nomis_event_ids` attributes plus checks for enforcing read only access to moves from Nomis were left behind. This looks to be an oversight as there is no reference to these attributes in the code which means they are not exposed via the API.

In an attempt to clean up the residual mess I have removed the `nomis_event_ids` attribute. There will be ancient cancelled moves in production that were from Nomis originally that will hence lose the association with the original Nomis event - however this data is unwanted and probably should have been deleted completely instead. The original `nomis_event_id` attribute however does have some future use, as it will be repurposed to store the created prison to prison transfer event id. This means that the custom accessor code for this attribute can be removed and it can revert to a simple integer type.

### Deployment risks (optional)

- Drops a redundant attribute of production data (which was never exposed in the API). The only potential knock on impact from this would be that it may now be possible to modify legacy cancelled Nomis moves (but perhaps the front end prevents amendments to cancelled moves - unsure on that).
