### PR TITLE
P4-1793 Add `ready_for_transit` filter on moves

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -25,7 +25,7 @@ module Api
     end
 
     PERMITTED_FILTER_PARAMS = %i[
-      date_from date_to created_at_from created_at_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason has_relationship_to_allocation
+      date_from date_to created_at_from created_at_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason has_relationship_to_allocation ready_for_transit
     ].freeze
 
     def filter_params

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -120,6 +120,21 @@ FactoryBot.define do
       end
     end
 
+    trait :with_person_escort_record do
+      transient do
+        person_escort_record_status { 'unstarted' }
+      end
+
+      after(:create) do |move, evaluator|
+        create(
+          :person_escort_record,
+          profile: move.profile,
+          status: evaluator.person_escort_record_status,
+          confirmed_at: evaluator.person_escort_record_status == 'confirmed' ? Time.zone.now : nil,
+        )
+      end
+    end
+
     trait :with_date_to do
       date_to { date + 3.days }
     end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -645,6 +645,19 @@
           schema:
             type: boolean
             example: true
+        - name: filter[ready_for_transit]
+          in: query
+          explode: false
+          description:
+            Filters results to either moves which have a confirmed person escort record if set to true,
+            and moves with no person escort record or non confirmed person escort records if set to false.
+            Please note that this filter does not filter by move status, and will include all moves that
+            match the above criteria regardless of status i.e. this filter will include moves which are not
+            necessarily in the `booked` status. Additional filters are necessary to limit the results to the required
+            status of moves (example `booked`).
+          schema:
+            type: boolean
+            example: true
         - name: sort[by]
           description: field to sort results by
           in: query

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -406,6 +406,19 @@
           schema:
             type: boolean
             example: true
+        - name: filter[ready_for_transit]
+          in: query
+          explode: false
+          description:
+            Filters results to either moves which have a confirmed person escort record if set to true,
+            and moves with no person escort record or non confirmed person escort records if set to false.
+            Please note that this filter does not filter by move status, and will include all moves that
+            match the above criteria regardless of status i.e. this filter will include moves which are not
+            necessarily in the `booked` status. Additional filters are necessary to limit the results to the required
+            status of moves (example `booked`).
+          schema:
+            type: boolean
+            example: true
         - name: sort[by]
           description: field to sort results by
           in: query


### PR DESCRIPTION
### Jira link

[P4-1793](https://dsdmoj.atlassian.net/browse/P4-1793)

### What?

I have added/removed/altered:

- [x] Added a new `ready_for_transit` filter on moves endpoint

### Why?

Add new filter to return all moves ready to be in transit if set to true. Moves ready for transit are moves where the person escort record is confirmed.

A move is not ready to be in transit if there is no person escort record attached, or if the status is not confirmed. This filter will be used on the FE dashboard for moves.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Adds a filter to an api that is used in production

