### PR TITLE
Add APPINSIGHTS_LOGGING_ENABLED env var 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ GOVUK_NOTIFY_TEMPLATE_ID=8f2e5473-15f2-4db8-a2de-153f26a0524c
 DEV_DISABLE_AUTH=false
 
 ELASTIC_APM_ENABLED=false
+
+# This allow to disable the logging for AppInsights.
+# We do not need to log on AI since we use Kibana.
+APPINSIGHTS_LOGGING_ENABLED=false


### PR DESCRIPTION
### Jira link
P4-1982

### What?

We need to be able to disable logging on Appinsights.

### Why?

Logging is causing some timeout issues and also it is not used, since the main logging tools we use is Kibana.

### Deployment risks (optional)
No risk.