### PR TITLE
add UAT URL to swagger

### DIFF
--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -14,6 +14,8 @@
     :description: Dev API
   - :url: https://hmpps-book-secure-move-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/api/v1
     :description: Staging API
+  - :url: https://hmpps-book-secure-move-api-uat.apps.live-1.cloud-platform.service.justice.gov.uk/api/v1
+    :description: UAT API
   - :url: https://hmpps-book-secure-move-api-preprod.apps.live-1.cloud-platform.service.justice.gov.uk/api/v1
     :description: PreProd API
   - :url: https://api.bookasecuremove.service.justice.gov.uk/api/v1

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -22,6 +22,8 @@
     :description: Dev API
   - :url: https://hmpps-book-secure-move-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/api
     :description: Staging API
+  - :url: https://hmpps-book-secure-move-api-uat.apps.live-1.cloud-platform.service.justice.gov.uk/api
+    :description: UAT API
   - :url: https://hmpps-book-secure-move-api-preprod.apps.live-1.cloud-platform.service.justice.gov.uk/api
     :description: PreProd API
   - :url: https://api.bookasecuremove.service.justice.gov.uk/api


### PR DESCRIPTION
### Jira link

P4-1986

### What?

I have added/removed/altered:

- [x] Added UAT URL to swagger docs

### Why?

I am doing this because:

- suppliers download the swagger.yaml specification in order to easily import URLs into their system

### Have you? (optional)

- [X] Updated API docs if necessary	


