### PR TITLE
Rename `flags` to `framework_flags`

### DIFF
--- a/app/models/framework_flag.rb
+++ b/app/models/framework_flag.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Flag < VersionedModel
+class FrameworkFlag < VersionedModel
   enum flag_type: {
     information: 'information',
     attention: 'attention',

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -17,7 +17,7 @@ class FrameworkQuestion < VersionedModel
                         foreign_key: 'parent_id'
   belongs_to :parent, class_name: 'FrameworkQuestion', optional: true
 
-  has_many :flags
+  has_many :framework_flags
   has_many :framework_responses
 
   def build_responses(question: self, person_escort_record:, questions:)

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -10,7 +10,7 @@ class FrameworkResponse < VersionedModel
                         foreign_key: 'parent_id'
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
-  has_and_belongs_to_many :flags, autosave: true
+  has_and_belongs_to_many :framework_flags, autosave: true
   validates_each :value, on: :update do |record, _attr, value|
     record.errors.add(:value, :blank) if requires_value?(value, record)
   end
@@ -30,7 +30,7 @@ class FrameworkResponse < VersionedModel
       old_value = self.value
       self.value = value
 
-      update!(flags: build_flags)
+      update!(framework_flags: build_flags)
       clear_dependent_values_and_flags!(old_value)
 
       # lock the status update to avoid race condition on multiple response patches
@@ -49,9 +49,9 @@ private
   end
 
   def build_flags
-    return [] unless framework_question.flags.any?
+    return [] unless framework_question.framework_flags.any?
 
-    framework_question.flags.each_with_object([]) do |flag, arr|
+    framework_question.framework_flags.each_with_object([]) do |flag, arr|
       if option_selected?(flag.question_value)
         arr << flag
       end
@@ -69,11 +69,11 @@ private
   def update_dependent_responses!(dependent_ids)
     return unless dependent_ids.any?
 
-    descendants = descendants_tree(dependent_ids).includes(:framework_question, :flags).map do |descendant|
+    descendants = descendants_tree(dependent_ids).includes(:framework_question, :framework_flags).map do |descendant|
       descendant.assign_attributes(
         value: nil,
         responded: false,
-        flags: [],
+        framework_flags: [],
       )
 
       descendant

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -21,7 +21,7 @@ class PersonEscortRecord < VersionedModel
 
   belongs_to :framework
   has_many :framework_questions, through: :framework
-  has_many :flags, through: :framework_responses
+  has_many :framework_flags, through: :framework_responses
   belongs_to :profile
 
   has_state_machine PersonEscortRecordStateMachine, on: :status

--- a/app/serializers/framework_flag_serializer.rb
+++ b/app/serializers/framework_flag_serializer.rb
@@ -1,5 +1,4 @@
-class FlagSerializer < ActiveModel::Serializer
-  type :framework_flags
+class FrameworkFlagSerializer < ActiveModel::Serializer
   belongs_to :framework_question, key: :question
 
   attributes :flag_type, :title, :question_value

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -2,7 +2,7 @@ class FrameworkResponseSerializer < ActiveModel::Serializer
   type 'framework_responses'
   belongs_to :person_escort_record
   belongs_to :framework_question, key: :question
-  has_many :flags
+  has_many :framework_flags, key: :flags
 
   attributes :value, :value_type, :responded
 

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -2,7 +2,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   belongs_to :profile, record_type: :profile
   belongs_to :framework, record_type: :framework
   has_many :framework_responses, serializer: FrameworkResponseSerializer, key: :responses
-  has_many :flags
+  has_many :framework_flags, key: :flags
 
   attributes :version, :status, :confirmed_at
 
@@ -15,7 +15,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   end
 
   def framework_responses
-    object.framework_responses.includes(:flags, framework_question: :framework)
+    object.framework_responses.includes(:framework_flags, framework_question: :framework)
   end
 
   def status

--- a/app/services/frameworks/question.rb
+++ b/app/services/frameworks/question.rb
@@ -61,7 +61,7 @@ module Frameworks
 
     def build_flags(flags:, value:)
       flags.each do |flag|
-        question.flags.new(
+        question.framework_flags.new(
           flag_type: flag['type'],
           title: flag['label'],
           question_value: value,

--- a/db/migrate/20200729080731_rename_flags_to_framework_flags.rb
+++ b/db/migrate/20200729080731_rename_flags_to_framework_flags.rb
@@ -1,0 +1,7 @@
+class RenameFlagsToFrameworkFlags < ActiveRecord::Migration[6.0]
+  def change
+    rename_table :flags, :framework_flags
+    rename_table :flags_framework_responses, :framework_flags_responses
+    rename_column :framework_flags_responses, :flag_id, :framework_flag_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_090010) do
+ActiveRecord::Schema.define(version: 2020_07_29_080731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -125,21 +125,21 @@ ActiveRecord::Schema.define(version: 2020_07_28_090010) do
     t.index ["eventable_id", "eventable_type"], name: "index_events_on_eventable_id_and_eventable_type"
   end
 
-  create_table "flags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "framework_flags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "framework_question_id", null: false
     t.string "flag_type", null: false
     t.string "title", null: false
     t.string "question_value", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["framework_question_id"], name: "index_flags_on_framework_question_id"
+    t.index ["framework_question_id"], name: "index_framework_flags_on_framework_question_id"
   end
 
-  create_table "flags_framework_responses", id: false, force: :cascade do |t|
+  create_table "framework_flags_responses", id: false, force: :cascade do |t|
     t.uuid "framework_response_id", null: false
-    t.uuid "flag_id", null: false
-    t.index ["flag_id"], name: "index_flags_framework_responses_on_flag_id"
-    t.index ["framework_response_id"], name: "index_flags_framework_responses_on_framework_response_id"
+    t.uuid "framework_flag_id", null: false
+    t.index ["framework_flag_id"], name: "index_framework_flags_responses_on_framework_flag_id"
+    t.index ["framework_response_id"], name: "index_framework_flags_responses_on_framework_response_id"
   end
 
   create_table "framework_questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -484,7 +484,7 @@ ActiveRecord::Schema.define(version: 2020_07_28_090010) do
   add_foreign_key "allocations", "locations", column: "to_location_id", name: "fk_rails_allocations_to_location_id"
   add_foreign_key "court_hearings", "moves"
   add_foreign_key "documents", "moves"
-  add_foreign_key "flags", "framework_questions"
+  add_foreign_key "framework_flags", "framework_questions"
   add_foreign_key "framework_questions", "frameworks"
   add_foreign_key "framework_responses", "framework_questions"
   add_foreign_key "framework_responses", "person_escort_records"

--- a/spec/factories/framework_flag.rb
+++ b/spec/factories/framework_flag.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :flag do
+  factory :framework_flag do
     sequence(:title) { |x| "High public interest #{x}" }
     sequence(:flag_type) { 'warning' }
     sequence(:question_value) { 'Yes' }

--- a/spec/models/framework_flag_spec.rb
+++ b/spec/models/framework_flag_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe Flag do
-  subject { create(:flag) }
+RSpec.describe FrameworkFlag do
+  subject { create(:framework_flag) }
 
   it { is_expected.to validate_presence_of(:flag_type) }
   it { is_expected.to validate_presence_of(:title) }

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FrameworkQuestion do
   it { is_expected.to belong_to(:parent).optional }
 
   it { is_expected.to have_many(:dependents) }
-  it { is_expected.to have_many(:flags) }
+  it { is_expected.to have_many(:framework_flags) }
   it { is_expected.to have_many(:framework_responses) }
 
   describe '#build_responses' do

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FrameworkResponse do
   it { is_expected.to belong_to(:parent).optional }
 
   it { is_expected.to have_many(:dependents) }
-  it { is_expected.to have_and_belong_to_many(:flags) }
+  it { is_expected.to have_and_belong_to_many(:framework_flags) }
   it { is_expected.to validate_presence_of(:type) }
 
   context 'with validations' do
@@ -151,81 +151,81 @@ RSpec.describe FrameworkResponse do
     end
 
     it 'does not attach flags if no flags attached to question' do
-      create(:flag)
+      create(:framework_flag)
       response = create(:string_response)
       response.update_with_flags!('Yes')
 
-      expect(response.flags).to be_empty
+      expect(response.framework_flags).to be_empty
     end
 
     it 'does not attach flags if answer supplied does not match flag' do
-      flag = create(:flag)
+      flag = create(:framework_flag)
       response = create(:string_response, value: nil, framework_question: flag.framework_question)
       response.update_with_flags!('No')
 
-      expect(response.flags).to be_empty
+      expect(response.framework_flags).to be_empty
     end
 
     it 'attaches flags if answer supplied matches flag for string' do
-      flag = create(:flag)
+      flag = create(:framework_flag)
       response = create(:string_response, value: nil, framework_question: flag.framework_question)
       response.update_with_flags!('Yes')
 
-      expect(response.flags).to contain_exactly(flag)
+      expect(response.framework_flags).to contain_exactly(flag)
     end
 
     it 'attaches flags if answer supplied matches flag for array' do
       response = create(:array_response, value: nil)
-      flag = create(:flag, question_value: 'Level 1', framework_question: response.framework_question)
+      flag = create(:framework_flag, question_value: 'Level 1', framework_question: response.framework_question)
       response.update_with_flags!(['Level 1', 'Level 2'])
 
-      expect(response.flags).to contain_exactly(flag)
+      expect(response.framework_flags).to contain_exactly(flag)
     end
 
     it 'attaches flags if answer supplied matches flag for object' do
       response = create(:object_response, :details, value: nil)
-      flag = create(:flag, question_value: 'Yes', framework_question: response.framework_question)
+      flag = create(:framework_flag, question_value: 'Yes', framework_question: response.framework_question)
       response.update_with_flags!({ option: 'Yes', details: 'something' })
 
-      expect(response.flags).to contain_exactly(flag)
+      expect(response.framework_flags).to contain_exactly(flag)
     end
 
     it 'attaches flags if answer supplied matches flag for collection' do
       response = create(:collection_response, :details, value: nil)
-      flag = create(:flag, question_value: 'Level 1', framework_question: response.framework_question)
+      flag = create(:framework_flag, question_value: 'Level 1', framework_question: response.framework_question)
       response.update_with_flags!([{ option: 'Level 1', details: 'something' }])
 
-      expect(response.flags).to contain_exactly(flag)
+      expect(response.framework_flags).to contain_exactly(flag)
     end
 
     it 'attaches multiple flags if answer supplied matches flag' do
       framework_question = create(:framework_question)
-      flag1 = create(:flag, framework_question: framework_question)
-      flag2 = create(:flag, framework_question: framework_question)
+      flag1 = create(:framework_flag, framework_question: framework_question)
+      flag2 = create(:framework_flag, framework_question: framework_question)
       response = create(:string_response, value: nil, framework_question: framework_question)
       response.update_with_flags!('Yes')
 
-      expect(response.flags).to contain_exactly(flag1, flag2)
+      expect(response.framework_flags).to contain_exactly(flag1, flag2)
     end
 
     it 'detaches flag if answer changed' do
       framework_question = create(:framework_question)
-      flag1 = create(:flag, framework_question: framework_question)
-      flag2 = create(:flag, framework_question: framework_question)
-      response = create(:string_response, framework_question: framework_question, flags: [flag1, flag2])
+      flag1 = create(:framework_flag, framework_question: framework_question)
+      flag2 = create(:framework_flag, framework_question: framework_question)
+      response = create(:string_response, framework_question: framework_question, framework_flags: [flag1, flag2])
       response.update_with_flags!('No')
 
-      expect(response.reload.flags).to be_empty
+      expect(response.reload.framework_flags).to be_empty
     end
 
     it 'attaches another flag if answer changed' do
       framework_question = create(:framework_question)
-      flag1 = create(:flag, framework_question: framework_question)
-      flag2 = create(:flag, question_value: 'No', framework_question: framework_question)
-      response = create(:string_response, framework_question: framework_question, flags: [flag1])
+      flag1 = create(:framework_flag, framework_question: framework_question)
+      flag2 = create(:framework_flag, question_value: 'No', framework_question: framework_question)
+      response = create(:string_response, framework_question: framework_question, framework_flags: [flag1])
       response.update_with_flags!('No')
 
-      expect(response.flags).to contain_exactly(flag2)
+      expect(response.framework_flags).to contain_exactly(flag2)
     end
 
     context 'when dependent responses' do
@@ -355,20 +355,20 @@ RSpec.describe FrameworkResponse do
       it 'clears flags on dependent responses if value changed' do
         parent_response = create(:collection_response, :details)
         child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
-        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, flags: [create(:flag)])
+        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, framework_flags: [create(:framework_flag)])
         parent_response.update_with_flags!([option: 'Level 2'])
 
-        expect(child_response.reload.flags).to be_empty
+        expect(child_response.reload.framework_flags).to be_empty
       end
 
       it 'does not clear flags on dependent responses if value not changed' do
         parent_response = create(:collection_response, :details)
         child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
-        flag = create(:flag)
-        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, flags: [flag])
+        flag = create(:framework_flag)
+        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, framework_flags: [flag])
         parent_response.update_with_flags!([option: 'Level 1'])
 
-        expect(child_response.reload.flags).to contain_exactly(flag)
+        expect(child_response.reload.framework_flags).to contain_exactly(flag)
       end
 
       it 'sets responded to false on dependent responses if value changed' do

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PersonEscortRecord do
   it { is_expected.to validate_inclusion_of(:status).in_array(%w[unstarted in_progress completed confirmed]) }
   it { is_expected.to have_many(:framework_responses) }
   it { is_expected.to have_many(:framework_questions).through(:framework) }
-  it { is_expected.to have_many(:flags).through(:framework_responses) }
+  it { is_expected.to have_many(:framework_flags).through(:framework_responses) }
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:profile) }
 

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::FrameworkResponsesController do
     let(:schema) { load_yaml_schema('patch_framework_response_responses.yaml') }
     let(:response_json) { JSON.parse(response.body) }
     let(:framework_response) { create(:string_response) }
-    let!(:flag) { create(:flag, framework_question: framework_response.framework_question, question_value: 'No') }
+    let!(:flag) { create(:framework_flag, framework_question: framework_response.framework_question, question_value: 'No') }
     let(:framework_response_id) { framework_response.id }
     let(:value) { 'No' }
 

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Api::PersonEscortRecordsController do
 
     let(:response_json) { JSON.parse(response.body) }
     let(:framework_question) { build(:framework_question, section: 'risk-information') }
-    let(:flag) { build(:flag, framework_question: framework_question) }
-    let(:framework_response) { build(:string_response, framework_question: framework_question, responded: true, flags: [flag]) }
+    let(:flag) { build(:framework_flag, framework_question: framework_question) }
+    let(:framework_response) { build(:string_response, framework_question: framework_question, responded: true, framework_flags: [flag]) }
     let(:framework) { create(:framework, framework_questions: [framework_question]) }
     let(:person_escort_record) { create(:person_escort_record, framework_responses: [framework_response]) }
     let(:person_escort_record_id) { person_escort_record.id }

--- a/spec/serializers/framework_flag_serializer_spec.rb
+++ b/spec/serializers/framework_flag_serializer_spec.rb
@@ -2,10 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe FlagSerializer do
-  subject(:serializer) { described_class.new(flag) }
+RSpec.describe FrameworkFlagSerializer do
+  subject(:serializer) { described_class.new(framework_flag) }
 
-  let(:flag) { create(:flag) }
+  let(:framework_flag) { create(:framework_flag) }
   let(:result) { ActiveModelSerializers::Adapter.create(serializer, include: includes).serializable_hash }
   let(:includes) { {} }
 
@@ -14,24 +14,24 @@ RSpec.describe FlagSerializer do
   end
 
   it 'contains an `id` property' do
-    expect(result[:data][:id]).to eq(flag.id)
+    expect(result[:data][:id]).to eq(framework_flag.id)
   end
 
   it 'contains a `title` attribute' do
-    expect(result[:data][:attributes][:title]).to eq(flag.title)
+    expect(result[:data][:attributes][:title]).to eq(framework_flag.title)
   end
 
   it 'contains a `flag_type` attribute' do
-    expect(result[:data][:attributes][:flag_type]).to eq(flag.flag_type)
+    expect(result[:data][:attributes][:flag_type]).to eq(framework_flag.flag_type)
   end
 
   it 'contains a `question_value` attribute' do
-    expect(result[:data][:attributes][:question_value]).to eq(flag.question_value)
+    expect(result[:data][:attributes][:question_value]).to eq(framework_flag.question_value)
   end
 
   it 'contains a `question` relationship' do
     expect(result[:data][:relationships][:question][:data]).to eq(
-      id: flag.framework_question.id,
+      id: framework_flag.framework_question.id,
       type: 'framework_questions',
     )
   end
@@ -46,9 +46,9 @@ RSpec.describe FlagSerializer do
     let(:expected_json) do
       [
         {
-          id: flag.framework_question.id,
+          id: framework_flag.framework_question.id,
           type: 'framework_questions',
-          attributes: { key: flag.framework_question.key },
+          attributes: { key: framework_flag.framework_question.key },
         },
       ]
     end

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe FrameworkResponseSerializer do
   end
 
   it 'contains a`flags` relationship when flags present' do
-    flag = create(:flag)
-    framework_response.update(flags: [flag])
+    flag = create(:framework_flag)
+    framework_response.update(framework_flags: [flag])
 
     expect(result[:data][:relationships][:flags][:data]).to contain_exactly(
       id: flag.id,

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe PersonEscortRecordSerializer do
   end
 
   it 'contains a`flags` relationship with framework response flags' do
-    flag = create(:flag)
-    create(:string_response, person_escort_record: person_escort_record, flags: [flag])
+    flag = create(:framework_flag)
+    create(:string_response, person_escort_record: person_escort_record, framework_flags: [flag])
 
     expect(result[:data][:relationships][:flags][:data]).to contain_exactly(
       id: flag.id,

--- a/spec/services/frameworks/importer_spec.rb
+++ b/spec/services/frameworks/importer_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Frameworks::Importer do
         described_class.new(filepath: filepath, version: '0.1').call
         framework_question = FrameworkQuestion.find_by(key: 'medical-professional-referral')
 
-        expect(framework_question.flags.pluck(:title)).to contain_exactly(
+        expect(framework_question.framework_flags.pluck(:title)).to contain_exactly(
           'Physical Health',
           'Medication',
         )

--- a/spec/services/frameworks/question_spec.rb
+++ b/spec/services/frameworks/question_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Frameworks::Question do
       questions = { 'medical-professional-referral' => question }
       described_class.new(filepath: filepath, questions: questions).call
 
-      expect(question.flags.size).to eq(2)
+      expect(question.framework_flags.size).to eq(2)
     end
 
     it 'sets attributes on flag as well as question answer to conditionally surface the flag' do
@@ -121,7 +121,7 @@ RSpec.describe Frameworks::Question do
       questions = { 'medical-professional-referral' => question }
       described_class.new(filepath: filepath, questions: questions).call
 
-      expect(question.flags.first).to have_attributes(
+      expect(question.framework_flags.first).to have_attributes(
         flag_type: 'alert',
         title: 'Physical Health',
         question_value: 'Yes',


### PR DESCRIPTION
### What?

- [x] Renamed `flag` and `flag/response` join table to `framework_flags`
- [x] change all relationships/model names to `framework_flags` 

### Why?

Currently all framework entities have `framework` prepended to the name like `framework_questions` and `framework_responses`. For consistency prepend `framework` to `flags`. 

The keys on the API responses have been set already to `flags` but the name of the resource is called `framework_flags`. This is consistent with other framework resources.

### Have you? (optional)

- The documentation has already been changed to framework flag previously

### Deployment risks (optional)

- There is no data currently in this table so should not affect anything in prod

