### PR TITLE
P4-1944 Require framework on creating a person escort record

### DIFF
--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -7,6 +7,4 @@ class Framework < ApplicationRecord
 
   has_many :framework_questions
   has_many :person_escort_records
-
-  scope :ordered_by_latest_version, -> { order(Arel.sql('cast(version as double precision) desc')) }
 end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -36,8 +36,7 @@ class PersonEscortRecord < VersionedModel
 
   def self.save_with_responses!(profile_id:, version: nil)
     profile = Profile.find(profile_id)
-    # TODO: remove default framework, getting the last framework is temporary until versioning is finalised
-    framework = version.present? ? Framework.find_by!(version: version) : Framework.ordered_by_latest_version.first
+    framework = Framework.find_by!(version: version)
 
     record = new(profile: profile, framework: framework)
     record.build_responses!

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -10,16 +10,4 @@ RSpec.describe Framework do
   it { is_expected.to validate_uniqueness_of(:name).scoped_to(:version) }
   it { is_expected.to have_many(:person_escort_records) }
   it { is_expected.to have_many(:framework_questions) }
-
-  describe '.ordered_by_latest_version' do
-    it 'orders frameworks by descending order of versions' do
-      framework1 = create(:framework, version: '1.01')
-      framework2 = create(:framework, version: '0.1')
-      framework3 = create(:framework, version: '1.12')
-
-      expect(described_class.ordered_by_latest_version).to eq(
-        [framework3, framework1, framework2],
-      )
-    end
-  end
 end

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Api::PersonEscortRecordsController do
       end
 
       context 'with a reference to a missing framework' do
-        let(:framework_version) { '0.2' }
+        let(:framework_version) { '0.2.1' }
         let(:detail_404) { "Couldn't find Framework" }
 
         it_behaves_like 'an endpoint that responds with error 404'
@@ -128,13 +128,9 @@ RSpec.describe Api::PersonEscortRecordsController do
             },
           }
         end
+        let(:detail_404) { "Couldn't find Framework" }
 
-        it_behaves_like 'an endpoint that responds with error 422' do
-          let(:errors_422) do
-            [{ 'title' => 'Unprocessable entity',
-               'detail' => 'Framework must exist' }]
-          end
-        end
+        it_behaves_like 'an endpoint that responds with error 404'
       end
     end
   end


### PR DESCRIPTION
### Jira link

[P4-1944](https://dsdmoj.atlassian.net/browse/P4-1944)

### What?

I have added/removed/altered:

- [x] Remove scope to find latest framework
- [x] Remove default framework fallback on creating a person escort record

### Why?

Remove default framework version and always expect a framework version to be passed when creating a person escort record, otherwise raise an error. This avoids any unexpected behaviour or using frameworks that might include questions with breaking changes

### Have you? (optional)

- [x] API docs already require a framework

