### PR TITLE
Create prison to prison transfer in Nomis when adding person to allocation

### DIFF
--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -29,6 +29,7 @@ module Api::V2
       move.save!
       move.allocation&.refresh_status_and_moves_count!
 
+      Allocations::CreateInNomis.call(move) if create_in_nomis?
       Notifier.prepare_notifications(topic: move, action_name: action_name)
 
       render_move(move, :ok)
@@ -54,6 +55,10 @@ module Api::V2
       ],
       relationships: {},
     ].freeze
+
+    def create_in_nomis?
+      move.allocation_id? && params[:create_in_nomis].to_s == 'true'
+    end
 
     def move_params
       @move_params ||= params.require(:data).permit(PERMITTED_MOVE_PARAMS).to_h

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -9,6 +9,7 @@ class MoveSerializer < ActiveModel::Serializer
              :time_due,
              :date,
              :move_type,
+             :nomis_event_id,
              :additional_information,
              :rejection_reason,
              :cancellation_reason,

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe MoveSerializer do
       expect(attributes[:move_type]).to eql move.move_type
     end
 
+    it 'contains a nomis_event_id attribute' do
+      expect(attributes[:nomis_event_id]).to eql move.nomis_event_id
+    end
+
     it 'contains a rejection_reason attribute' do
       expect(attributes[:rejection_reason]).to eql move.rejection_reason
     end

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -537,6 +537,13 @@
           schema:
             "$ref": "../v2/patch_move.yaml#/Move"
         - "$ref": "../v2/move_include_parameter.yaml#/MoveIncludeParameter"
+        - name: create_in_nomis
+          in: query
+          oneOf:
+          - type: boolean
+          - type: 'null'
+          example: 'true'
+          description: Indicates if the move should be automatically created in NOMIS
       responses:
         "200":
           description: success


### PR DESCRIPTION
### Jira link

P4-1942

### What?

- [x] When patching a move in v2 via `PATCH /moves/:id` and also including an optional `?create_in_nomis=true` query parameter for a move that's part of an allocation, automatically create a corresponding prison to prison transfer event in Nomis

### Why?

- OCA users can view the moves within an allocation, and choose an appropriate person to be moved. This updated person relationship is sent via a PATCH to the move. The front end can now include the additional param when the corresponding checkbox is ticked and have the move created in Nomis.
- The front can check that the Nomis event was created by checking presence of `nomis_event_id` attribute. If present the Nomis event was created, if `nil` it was not created; Nomis can return an error if e.g. the prisoner is not currently booked into the same from location - we still want to return a success response to the front end.
- A query parameter makes more sense in this instance as the included attributes in the body are all attributes of a move.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Adds an extra query string param, but API behaviour is unchanged without this param

