### PR TITLE
P4-1993 Include resources in move endpoint to improve performance

### DIFF
--- a/app/controllers/api/v1/moves_actions.rb
+++ b/app/controllers/api/v1/moves_actions.rb
@@ -109,7 +109,9 @@ module Api::V1
     def move
       @move ||= Move
         .accessible_by(current_ability)
-        .includes(:from_location, :to_location, profile: { person: %i[gender ethnicity] })
+        .includes(
+          :from_location, :to_location, profile: { person: %i[gender ethnicity], person_escort_record: { framework_flags: :framework_question } }
+        )
         .find(params[:id])
     end
 

--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -144,7 +144,9 @@ module Api::V2
     def move
       @move ||= Move
         .accessible_by(current_ability)
-        .includes(:from_location, :to_location, profile: { person: %i[gender ethnicity] })
+        .includes(
+          :from_location, :to_location, profile: { person: %i[gender ethnicity], person_escort_record: { framework_flags: :framework_question } }
+        )
         .find(params[:id])
     end
 


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-1993

* Add PER includes in single Move endpoint to avoid N+1 queries
* Include all other resources in multiple moves GET endpoint
This list was compiled from the Bullet gem

### Jira link

[P4-1993]( https://dsdmoj.atlassian.net/browse/P4-1993)

### What?
- [x] Added includes to v1/v2 single Move GET endpoint for PER records
- [x] Added includes to multiple Move GET endpoint  for all resources
### Why?

To avoid N+1 queries add the required includes on a Move Endpoint. I used the [Bullet gem](https://github.com/flyerhzm/bullet) to flush out the full list of required includes. I tested this with the following variations to make sure we don't cause any performance issues with/without Includes:

Single Move with/without includes

Multiple Moves
- with filters with time range
- with filters without time range
- with one include
- with no includes
- with all includes
### Deployment risks (optional)

- Changes an api and performance that is used in production

