### PR TITLE
Bumps appinsights gem to support disabling log forwarding

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/appinsights.git
-  revision: 93f458fcdfd582fcd331421141194fee063f87ac
+  revision: 4a1cb38a468a8088ae2f4eef1361900aab6b4295
   specs:
     appinsights (0.0.6)
       application_insights (~> 0.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/ministryofjustice/appinsights.git
-  revision: 4a1cb38a468a8088ae2f4eef1361900aab6b4295
+  revision: 5a6c4879b2239f9a0ae337238abd7df81e88621e
   specs:
-    appinsights (0.0.6)
+    appinsights (0.0.7)
       application_insights (~> 0.5.0)
       toml-rb (~> 0.3.0)
 


### PR DESCRIPTION
### Jira link

P4-1982

### What?

I have added/removed/altered:

- [x] Bumps [appinsights gem](https://github.com/ministryofjustice/appinsights/)

### Why?

I am doing this because:

- The updated gem allows disabling the forwarding of logs to Azure AppInsights, which was found causing performance issues.

### Have you? (optional)

- [x] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)  commit [here](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy/commit/b842efe40a3d68cd3ffda95748396b3e58225701)

### Deployment risks (optional)
