### PR TITLE
Allow filter for /people to be empty

### DIFF
--- a/app/controllers/api/people_controller.rb
+++ b/app/controllers/api/people_controller.rb
@@ -60,6 +60,7 @@ module Api
 
     PERMITTED_COURT_CASE_FILTER_PARAMS = %i[active].freeze
     PERMITTED_TIMETABLE_FILTER_PARAMS = %i[date_from date_to].freeze
+    PERMITTED_FILTER_PARAMS = %i[police_national_computer criminal_records_office prison_number].freeze
     OTHER_SUPPORTED_RELATIONSHIPS = %w[location].freeze
 
     def person
@@ -97,6 +98,10 @@ module Api
       IncludeParamsValidator
         .new(other_included_relationships, OTHER_SUPPORTED_RELATIONSHIPS)
         .fully_validate!
+    end
+
+    def filter_params
+      params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h
     end
   end
 end

--- a/app/controllers/api/v1/people_actions.rb
+++ b/app/controllers/api/v1/people_actions.rb
@@ -62,7 +62,7 @@ module Api::V1
     end
 
     def filter_params
-      params.require(:filter).permit(PERMITTED_FILTER_PARAMS).to_h
+      params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h
     end
 
     def person_params

--- a/app/controllers/api/v1/people_actions.rb
+++ b/app/controllers/api/v1/people_actions.rb
@@ -22,7 +22,6 @@ module Api::V1
       identifiers: [%i[value identifier_type]],
     ].freeze
     PERMITTED_PERSON_PARAMS = [:type, attributes: PERSON_ATTRIBUTES, relationships: {}].freeze
-    PERMITTED_FILTER_PARAMS = %i[police_national_computer prison_number].freeze
 
     def index_and_render
       prison_number = filter_params[:prison_number]&.upcase
@@ -59,10 +58,6 @@ module Api::V1
 
     def updater
       @updater ||= People::Updater.new(person, person_params)
-    end
-
-    def filter_params
-      params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h
     end
 
     def person_params

--- a/app/controllers/api/v2/people_actions.rb
+++ b/app/controllers/api/v2/people_actions.rb
@@ -25,8 +25,6 @@ module Api::V2
 
   private
 
-    PERMITTED_FILTER_PARAMS = %i[police_national_computer criminal_records_office prison_number].freeze
-
     PERSON_ATTRIBUTES = %i[
       first_names
       last_name
@@ -37,10 +35,6 @@ module Api::V2
       gender_additional_information
     ].freeze
     PERMITTED_PERSON_PARAMS = [:type, attributes: PERSON_ATTRIBUTES, relationships: {}].freeze
-
-    def filter_params
-      params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h
-    end
 
     def person_params
       params.require(:data).permit(PERMITTED_PERSON_PARAMS).to_h

--- a/spec/requests/api/people_controller_index_v2_spec.rb
+++ b/spec/requests/api/people_controller_index_v2_spec.rb
@@ -19,9 +19,10 @@ RSpec.describe Api::PeopleController do
   describe 'GET /people' do
     let(:schema) { load_yaml_schema('get_people_responses.yaml', version: 'v2') }
     let!(:people) { create_list :person, 2, prison_number: nil }
-    let(:params) { {} }
 
-    context 'when there are no params' do
+    context 'when there are no filters' do
+      let(:params) { {} }
+
       before { get '/api/people', params: params, headers: headers }
 
       it_behaves_like 'an endpoint that responds with success 200'
@@ -159,6 +160,8 @@ RSpec.describe Api::PeopleController do
     end
 
     describe 'paginating results' do
+      let(:params) { {} }
+
       let!(:people) { create_list :person, 6 }
 
       let(:meta_pagination) do

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2181,7 +2181,7 @@
           description:
             Filters results to only include people identified by that prison_number.
             Either filter[police_national_computer] or filter[prison_number] or both
-            filters are required.
+            filters are supported.
           schema:
             type: string
             example: G1234UT


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-1252

### What?

If you query the GET /people endpoint with no filters it returns a `400` saying a filter is required.

The expected behaviour is:
Without the filter, or without a valid filter, the index people endpoint should return all the entries.

### Why?
Other endpoints (see /moves)  do not expect the filters to be mandatory.


### Have you? (optional)

- [ ] Updated API docs if necessary # WIP
