### PR TITLE
Automatically cancel Nomis prison transfer events when cancelling move

### DIFF
--- a/app/lib/nomis_client/allocations.rb
+++ b/app/lib/nomis_client/allocations.rb
@@ -12,6 +12,16 @@ module NomisClient
 
         e.response
       end
+
+      def put(booking_id:, event_id:, body_params: {})
+        allocations_path = "/bookings/#{booking_id}/prison-to-prison/#{event_id}/cancel"
+
+        NomisClient::Base.put(allocations_path, body: body_params.to_json)
+      rescue OAuth2::Error => e
+        log_exception('Allocations::RemoveFromNomis Error!', allocations_path, body_params, e)
+
+        e.response
+      end
     end
   end
 end

--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -7,23 +7,29 @@ module NomisClient
 
     class << self
       def get(path, params = {})
-        token.get("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
-      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
-        Rails.logger.warn "Nomis Connection Error: #{e.message}"
-        raise e
+        token_request(:get, path, params)
       end
 
       def post(path, params = {})
         params = update_json_headers(params)
-        token.post("#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
-      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
-        Rails.logger.warn "Nomis Connection Error: #{e.message}"
-        raise e
+        token_request(:post, path, params)
+      end
+
+      def put(path, params = {})
+        params = update_json_headers(params)
+        token_request(:put, path, params)
       end
 
     private
 
       REFRESH_TOKEN_TIMEFRAME_IN_SECONDS = 5
+
+      def token_request(method, path, params)
+        token.send(method, "#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+        Rails.logger.warn "Nomis Connection Error: #{e.message}"
+        raise e
+      end
 
       def token
         return @token if @token && !token_expired_or_to_expire?

--- a/app/services/allocations/create_in_nomis.rb
+++ b/app/services/allocations/create_in_nomis.rb
@@ -2,7 +2,7 @@ module Allocations
   class CreateInNomis
     def self.call(move)
       booking_id = move.person&.latest_nomis_booking_id
-      return unless booking_id.present? && move.to_location.present?
+      return unless booking_id.present? && move.to_location_id?
 
       body = {
         booking_id: booking_id,

--- a/app/services/allocations/create_in_nomis.rb
+++ b/app/services/allocations/create_in_nomis.rb
@@ -2,7 +2,7 @@ module Allocations
   class CreateInNomis
     def self.call(move)
       booking_id = move.person&.latest_nomis_booking_id
-      return unless booking_id.present? && move.to_location_id?
+      return unless booking_id.present? && move.to_location_id? && move.nomis_event_id.nil?
 
       body = {
         booking_id: booking_id,

--- a/app/services/allocations/remove_from_nomis.rb
+++ b/app/services/allocations/remove_from_nomis.rb
@@ -1,0 +1,26 @@
+module Allocations
+  class RemoveFromNomis
+    def self.call(move)
+      booking_id = move.person&.latest_nomis_booking_id
+      return unless booking_id.present? && move.nomis_event_id?
+
+      body = {
+        booking_id: booking_id,
+        event_id: move.nomis_event_id,
+        body_params: {
+          reasonCode: 'ADMI',
+        },
+      }
+
+      response = NomisClient::Allocations.put(body)
+
+      if response&.status == 200
+        move.update(nomis_event_id: nil)
+      end
+
+      { response_status: response&.status, response_body: response&.body, request_params: body }.tap do |log_attributes|
+        Rails.logger.info("Tried to remove a prison to prison transfer from nomis #{log_attributes.to_json}")
+      end
+    end
+  end
+end

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -21,6 +21,7 @@ module EventLog
           move.status = Move::MOVE_STATUS_CANCELLED
           move.cancellation_reason = event.cancellation_reason
           move.cancellation_reason_comment = event.cancellation_reason_comment
+          Allocations::RemoveFromNomis.call(move)
         when Event::COMPLETE
           move.status = Move::MOVE_STATUS_COMPLETED
         when Event::LOCKOUT

--- a/spec/fixtures/files/nomis_put_bookings_400.json
+++ b/spec/fixtures/files/nomis_put_bookings_400.json
@@ -1,0 +1,5 @@
+{
+  "status": 400,
+  "userMessage": "Move with id 123456789 is not in a scheduled state.",
+  "developerMessage": "Move with id 123456789 is not in a scheduled state."}>,
+}

--- a/spec/fixtures/files/nomis_put_bookings_400.json
+++ b/spec/fixtures/files/nomis_put_bookings_400.json
@@ -1,5 +1,5 @@
 {
   "status": 400,
   "userMessage": "Move with id 123456789 is not in a scheduled state.",
-  "developerMessage": "Move with id 123456789 is not in a scheduled state."}>,
+  "developerMessage": "Move with id 123456789 is not in a scheduled state."
 }

--- a/spec/fixtures/files/nomis_put_bookings_404.json
+++ b/spec/fixtures/files/nomis_put_bookings_404.json
@@ -1,0 +1,5 @@
+{
+  "status": 404,
+  "userMessage": "Resource not found.",
+  "developerMessage": "Resource not found."
+}

--- a/spec/fixtures/files/nomis_put_bookings_500.json
+++ b/spec/fixtures/files/nomis_put_bookings_500.json
@@ -1,0 +1,5 @@
+{
+  "status": 500,
+  "userMessage": "Unrecoverable error occurred whilst processing request.",
+  "developerMessage": "Unrecoverable error occurred whilst processing request."
+}

--- a/spec/requests/api/move_events_controller_cancel_spec.rb
+++ b/spec/requests/api/move_events_controller_cancel_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Api::MoveEventsController do
     end
 
     before do
+      allow(Allocations::RemoveFromNomis).to receive(:call)
       allow(Notifier).to receive(:prepare_notifications)
       post "/api/v1/moves/#{move_id}/cancel", params: cancel_params, headers: headers, as: :json
     end
@@ -44,6 +45,10 @@ RSpec.describe Api::MoveEventsController do
 
       it 'updates the move cancellation_reason_comment' do
         expect(move.reload.cancellation_reason_comment).to eql('no room on the bus')
+      end
+
+      it 'removes a prison transfer event from Nomis' do
+        expect(Allocations::RemoveFromNomis).to have_received(:call).with(move)
       end
 
       describe 'webhook and email notifications' do

--- a/spec/services/allocations/create_in_nomis_spec.rb
+++ b/spec/services/allocations/create_in_nomis_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Allocations::CreateInNomis do
         :move,
         :prison_recall,
         date: move_date,
+        nomis_event_id: nomis_event_id,
         from_location: from_location,
         to_location: to_location,
       )
@@ -20,6 +21,7 @@ RSpec.describe Allocations::CreateInNomis do
     let(:from_nomis_agency_id) { 'PVI' }
     let(:to_nomis_agency_id) { 'HLI' }
     let(:booking_id) { 123 }
+    let(:nomis_event_id) { nil }
     let(:response_body) { { 'id' => 123 }.to_json }
 
     before do
@@ -76,6 +78,15 @@ RSpec.describe Allocations::CreateInNomis do
         expect(create_transfer_in_nomis).to include(
           response_status: 400,
         )
+      end
+    end
+
+    context 'when nomis_event_id is already present' do
+      let(:nomis_response_status) { nil }
+      let(:nomis_event_id) { '123456' }
+
+      it 'is nil' do
+        expect(create_transfer_in_nomis).to be_nil
       end
     end
 

--- a/spec/services/allocations/remove_from_nomis_spec.rb
+++ b/spec/services/allocations/remove_from_nomis_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe Allocations::RemoveFromNomis do
+  context 'when move is valid' do
+    subject(:remove_transfer_from_nomis) { described_class.call(move) }
+
+    let(:from_location) { create(:location, :prison) }
+    let(:to_location) { create(:location, :prison) }
+    let(:move) do
+      create(
+        :move,
+        :prison_transfer,
+        nomis_event_id: nomis_event_id,
+        from_location: from_location,
+        to_location: to_location,
+      )
+    end
+
+    let(:booking_id) { 123 }
+    let(:nomis_event_id) { 456 }
+    let(:response_body) { '' }
+
+    before do
+      allow(NomisClient::Allocations).to receive(:put)
+                                     .and_return(instance_double('OAuth2::Response', status: nomis_response_status, body: response_body))
+      move.person.update(latest_nomis_booking_id: booking_id)
+    end
+
+    context 'when Nomis return 200 success' do
+      let(:nomis_response_status) { 200 }
+      let(:nomis_client_args) do
+        {
+          booking_id: booking_id,
+          event_id: nomis_event_id,
+          body_params: {
+            'reasonCode': 'ADMI',
+          },
+        }
+      end
+
+      it 'removes the prison transfer event from Nomis' do
+        remove_transfer_from_nomis
+
+        expect(NomisClient::Allocations).to have_received(:put).with(nomis_client_args)
+      end
+
+      it 'clears the nomis_event_id' do
+        remove_transfer_from_nomis
+
+        expect(move.nomis_event_id).to be_nil
+      end
+
+      it 'returns debugging information' do
+        expect(remove_transfer_from_nomis).to include(
+          request_params: nomis_client_args,
+          response_body: response_body,
+          response_status: 200,
+        )
+      end
+    end
+
+    context 'when Nomis returns an error' do
+      let(:nomis_response_status) { 400 }
+
+      it 'does NOT clear nomis_event_id' do
+        remove_transfer_from_nomis
+
+        expect(move.nomis_event_id).to eq(nomis_event_id)
+      end
+
+      it 'returns debugging information' do
+        expect(remove_transfer_from_nomis).to include(
+          response_status: 400,
+        )
+      end
+    end
+
+    context 'when latest_booking_id is missing' do
+      let(:nomis_response_status) { nil }
+      let(:booking_id) { nil }
+
+      it 'is nil' do
+        expect(remove_transfer_from_nomis).to be_nil
+      end
+    end
+
+    context 'when nomis_event_id is missing' do
+      let(:nomis_response_status) { nil }
+      let(:nomis_event_id) { nil }
+
+      it 'is nil' do
+        expect(remove_transfer_from_nomis).to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/with_nomis_client_auth_context.rb
+++ b/spec/support/with_nomis_client_auth_context.rb
@@ -10,6 +10,7 @@ RSpec.shared_context 'with NomisClient authentication', shared_context: :metadat
       'OAuth2::AccessToken',
       get: oauth2_response,
       post: oauth2_response,
+      put: oauth2_response,
       expires?: true,
       refresh!: true,
       expires_at: token_expires_at,


### PR DESCRIPTION

### Jira link

P4-1950

### What?
- [x] Extended Nomis base client to support `put` method and refactored to DRY things up.
- [x] Added new `Allocations::RemoveFromNomis` service to complement previous `CreateInNomis` service.

### Why?

- When moves are cancelled any corresponding transfer in event should be removed to keep Nomis in sync. The new service uses the persisted `nomis_event_id` attribute to determine if there is an existing Nomis transfer event (this is assigned when calling `Allocations::CreateInNomis` service). On success the `nomis_event_id` is cleared so that calling the service again has no effect. This cancellation behaviour is automatically applied for all move cancellations but only calls Nomis when an event id is stored on the move.

### Deployment risks (optional)

- Changes behaviour for an existing API (cancelling move), but has no effect unless event was previously created