### PR TITLE
P4-1993 Add includes on move endpoint

### DIFF
--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -4,7 +4,7 @@ module Moves
   class Finder
     attr_reader :filter_params, :ability
 
-    MOVE_INCLUDES = [:from_location, :to_location, profile: { person_escort_record: [:framework, :framework_responses, framework_flags: :framework_question] }, person: %i[gender ethnicity]].freeze
+    MOVE_INCLUDES = [:court_hearings, :prison_transfer_reason, :original_move, profile: [documents: { file_attachment: :blob }, person_escort_record: [:framework, :framework_responses, framework_flags: :framework_question]], person: %i[gender ethnicity profiles], from_location: %i[locations_suppliers suppliers], to_location: %i[locations_suppliers suppliers], allocation: %i[to_location from_location]].freeze
 
     def initialize(filter_params, ability, order_params)
       @filter_params = filter_params


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-1993

Add includes when fetching multiple moves. This avoids N+1 queries

### Jira link

[P4-1993]( https://dsdmoj.atlassian.net/browse/P4-1993)

### What?

I have added/removed/altered:

- [x] Added all includes for a move 

### Why?

To avoid N+1 queries, I used the Bullet gem to get a list of N+1 queries on a move. I pulled in the staging database as well to be able to benchmark things properly.

This change does not slow down current queries, and speeds them up:
1) Without `include` in params
2) With `include` in params
3) With all filters and includes in params

### Deployment risks (optional)
- Changes an api that is used in production

