### PR TITLE
P4-2008 simple rake task for printing out a move

### DIFF
--- a/lib/tasks/inspect_move.rake
+++ b/lib/tasks/inspect_move.rake
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+namespace :inspect do
+  desc 'Inspects a move, rake inspect:move '
+  task :move, [:id_or_ref] => :environment do |_, args|
+    abort "Please specify a move id or move reference, e.g. $ rake 'inspect:move[ABC1234X]'" if args[:id_or_ref].blank?
+    move = Move.find_by(id: args[:id_or_ref]) || Move.find_by(reference: args[:id_or_ref])
+    abort "Could not find move record with id or reference: #{args[:id_or_ref]}" if move.blank?
+
+    puts 'MOVE RECORD'
+    puts '-----------'
+    puts "id:\t\t#{move.id}"
+    puts "reference:\t#{move.reference}"
+    puts "date:\t\t#{move.date}"
+    puts "date-from:\t#{move.date_from}" if move.date_from.present?
+    puts "date-to:\t#{move.date_to}" if move.date_to.present?
+    puts "time due:\t#{move.time_due}" if move.time_due.present?
+    puts "status:\t\t#{move.status}"
+    if move.cancelled?
+      puts "cancel reason:\t#{move.cancellation_reason}"
+      puts "cancel comment:\t#{move.cancellation_reason_comment}"
+    end
+    puts "move type:\t#{move.move_type}"
+    puts "from location:\t#{move.from_location&.title}"
+    puts "to location:\t#{move.to_location&.title}"
+    puts "created at:\t#{move.created_at}"
+    puts "updated at:\t#{move.created_at}"
+    puts "additional information: #{move.additional_information}"
+
+    puts "\n"
+    puts 'MOVE EVENTS'
+    puts '-----------'
+    if move.move_events.any?
+      puts "EVENT\t\tTIMESTAMP\t\t\tPARAMS"
+      move.move_events.default_order.each do |event| # NB use each to preserve sort order
+        puts "#{event.event_name.ljust(15, ' ')}\t#{event.client_timestamp}\t#{event.event_params}"
+      end
+    else
+      puts '(no events recorded)'
+    end
+
+    puts "\n"
+    puts 'JOURNEYS'
+    puts '--------'
+    if move.journeys.any?
+      puts "ID\t\t\t\t\tTIMESTAMP\t\t\tSTATE\t\tFROM --> TO"
+      move.journeys.default_order.each do |journey| # NB use each to preserve sort order
+        puts "#{journey.id}\t#{journey.client_timestamp}\t#{journey.state}\t#{journey.from_location.title} --> #{journey.to_location.title}"
+      end
+    else
+      puts '(no events recorded)'
+    end
+
+    puts "\n"
+    puts 'JOURNEY EVENTS'
+    puts '--------------'
+    if move.journeys.any?
+      move.journeys.default_order.each do |journey| # NB use each to preserve sort order
+        puts "#{journey.from_location.title} --> #{journey.to_location.title} (#{journey.id})"
+        if journey.events.any?
+          puts "\s\sEVENT\t\t\tTIMESTAMP\t\t\tPARAMS"
+          journey.events.default_order.each do |event| # NB use each to preserve sort order
+            puts "\s\s#{event.event_name.ljust(15, ' ')}\t#{event.client_timestamp}\t#{event.event_params}"
+          end
+        else
+          puts "\s\s(no events recorded)"
+        end
+        puts ''
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

P4-2008
### What?

I have added/removed/altered:

- [x] rake task for printing out a move


### Why?

I am doing this because:

- to help with supplier testing and assurance


# example output
```
$ rake 'inspect:move[PXJ2479F]'

MOVE RECORD
-----------
id:		a8c06937-475b-4342-a5e2-5586cb28eecd
reference:	PXJ2479F
date:		2020-04-27
status:		requested
move type:	court_appearance
from location:	Oakhill Secure Training Centre
to location:	Houghton-le-Spring Youth Court
created at:	2020-04-27 12:46:06 +0100
updated at:	2020-04-27 12:46:06 +0100
additional information: 

MOVE EVENTS
-----------
(no events recorded)

JOURNEYS
--------
ID					TIMESTAMP			STATE		FROM --> TO
855923bf-9cfd-4e53-a12c-1065d05ee954	2020-04-27 05:00:00 +0100	completed	Oakhill Secure Training Centre --> Yarls Wood AIT
9b4b6c18-a6c0-454e-b9b4-c0534f14e885	2020-04-27 05:43:00 +0100	completed	Yarls Wood AIT --> Weymouth Crown Court
bfbd65c4-8cbc-4918-8ce1-639af8a4ff38	2020-04-28 05:43:00 +0100	completed	Weymouth Crown Court --> Yarls Wood AIT
4cc4e9a6-3f30-4fbc-b267-d5a32f4401ea	2020-04-28 06:47:00 +0100	completed	Yarls Wood AIT --> Houghton-le-Spring Youth Court

JOURNEY EVENTS
--------------
Oakhill Secure Training Centre --> Yarls Wood AIT (855923bf-9cfd-4e53-a12c-1065d05ee954)
  EVENT			TIMESTAMP			PARAMS
  lockout        	2020-04-27 05:43:00 +0100	{"attributes"=>{"notes"=>"delayed by driver unavailable"}, "relationships"=>{"from_location"=>{"data"=>{"id"=>"f470e18a-40fe-4751-8196-5125d169d2b6"}}}}

Yarls Wood AIT --> Weymouth Crown Court (9b4b6c18-a6c0-454e-b9b4-c0534f14e885)
  EVENT			TIMESTAMP			PARAMS
  redirect       	2020-04-27 05:43:00 +0100	{"attributes"=>{"notes"=>"redirecting because of lockout"}, "relationships"=>{"to_location"=>{"data"=>{"id"=>"f97e9452-b492-4317-9f09-92479ae61d99"}}}}

Weymouth Crown Court --> Yarls Wood AIT (bfbd65c4-8cbc-4918-8ce1-639af8a4ff38)
  EVENT			TIMESTAMP			PARAMS
  redirect       	2020-04-28 05:43:00 +0100	{"attributes"=>{"notes"=>"redirecting back because of lockout previous day"}, "relationships"=>{"to_location"=>{"data"=>{"id"=>"f470e18a-40fe-4751-8196-5125d169d2b6"}}}}

Yarls Wood AIT --> Houghton-le-Spring Youth Court (4cc4e9a6-3f30-4fbc-b267-d5a32f4401ea)
  (no events recorded)
```


