### PR TITLE
[P4-1973] Adds swagger documentation for events endpoints

### DIFF
--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -648,7 +648,7 @@
           required: true
           description: The event object to be created
           schema:
-            "$ref": "../v2/event.yaml#/Event"
+            "$ref": "../v2/event.yaml#/EventRequestPostBody"
       responses:
         "201":
           description: created

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -636,7 +636,7 @@
                 "$ref": "../v1/error_responses.yaml#/415"
   "/events":
     post:
-      summary: Creates a new event for a given eventable
+      summary: DRAFT Creates a new event for a given eventable DRAFT
       tags:
         - Events
       consumes:
@@ -681,7 +681,7 @@
               schema:
                 "$ref": "../v2/post_event_responses.yaml#/422"
     get:
-      summary: Returns a list of events
+      summary: DRAFT Returns a list of events DRAFT
       description: |
         Returns a list of events that by default are sorted by their client supplied timestamp.
 

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -634,3 +634,49 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/error_responses.yaml#/415"
+  "/events":
+    post:
+      summary: Creates a new event for a given eventable
+      tags:
+        - Events
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": "../v2/accept_type_parameter.yaml#/Accept"
+        - name: body
+          in: body
+          required: true
+          description: The event object to be created
+          schema:
+            "$ref": "../v2/event.yaml#/Event"
+      responses:
+        "201":
+          description: created
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/post_event_responses.yaml#/201"
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/post_event_responses.yaml#/400"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/post_event_responses.yaml#/401"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/post_event_responses.yaml#/415"
+        "422":
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/post_event_responses.yaml#/422"

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -540,9 +540,9 @@
         - name: create_in_nomis
           in: query
           oneOf:
-          - type: boolean
-          - type: 'null'
-          example: 'true'
+            - type: boolean
+            - type: "null"
+          example: "true"
           description: Indicates if the move should be automatically created in NOMIS
       responses:
         "200":
@@ -680,3 +680,106 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v2/post_event_responses.yaml#/422"
+    get:
+      summary: Returns a list of events
+      description: |
+        Returns a list of events that by default are sorted by their client supplied timestamp.
+
+        This api is paginated using our standard pagination query params.
+      tags:
+        - Events
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": "../v2/accept_type_parameter.yaml#/Accept"
+        - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - name: filter[timestamp_from]
+          in: query
+          description: |
+            A [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) timestamp string
+
+            Filters results to only include events on and after the given
+            date-time.
+
+            This filter runs against the client supplied timestamp field.
+          schema:
+            type: string
+            format: date-time
+            example: "filter[timestamp_to]=2020-06-16T00:00:00+01:00"
+          format: date
+          explode: false
+        - name: filter[timestamp_to]
+          in: query
+          description: |
+            A [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) timestamp string
+
+            Filters results to only include events up to and including the given
+            date-time.
+
+            This filter runs against the client supplied timestamp field.
+          schema:
+            type: string
+            format: date-time
+            example: "filter[timestamp_to]=2020-06-17T23:59:59+01:00"
+          explode: false
+        - name: filter[eventable_type]
+          in: query
+          description: |
+            Filters results to only include events of the provided eventable_type/s.
+
+            This filter has a single- and a multiple- eventable mode.
+
+            In multiple mode the filter will filter events of the eventable_type (e.g. filter[eventable_type]=moves,people will return all events that are about moves or people).
+
+            In single eventable mode the filter will check to see whether the eventable_id filter is supplied.
+            When the eventable_id is supplied it will return all events for that single eventable. Otherwise it will return eventables of the supplied type.
+
+            For example:
+              `?filter[eventable_type]=moves&filter[eventable_id]=3561f372-9f1c-4e13-997e-b11e1647cce1`
+
+            Will return the events for the Move indicated by the eventable_id filter.
+
+            Whereas:
+              `?filter[eventable_type]=moves`
+
+            Will return all events with an eventable_type of `moves`
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - people
+                - moves
+                - journeys
+            example: "filter[eventable_type]=people,moves"
+        - name: filter[eventable_id]
+          in: query
+          description: |
+            Filters results to only include events of the provided eventable.
+
+            Must be supplied with an eventable_type filter in single mode (see eventable_type filter description) to uniquely identify a common subject for events.
+          schema:
+            type: string
+            example: "?filter[eventable_id]=3561f372-9f1c-4e13-997e-b11e1647cce1&filter[eventable_type]=moves"
+            explode: false
+        - "$ref": "../v1/pagination_parameters.yaml#/Page"
+        - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
+      responses:
+        "200":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/get_events_responses.yaml#/200"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/get_events_responses.yaml#/401"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/get_events_responses.yaml#/415"

--- a/swagger/v1/journey_reference.yaml
+++ b/swagger/v1/journey_reference.yaml
@@ -1,4 +1,4 @@
-MoveReference:
+JourneyReference:
   type: object
   required:
     - data
@@ -14,10 +14,10 @@ MoveReference:
       properties:
         type:
           type: string
-          example: moves
+          example: journeys
           enum:
-            - moves
-          description: The type of this object - always `moves`
+            - journeys
+          description: The type of this object - always `journeys`
         id:
           type: string
           format: uuid

--- a/swagger/v2/event.yaml
+++ b/swagger/v2/event.yaml
@@ -1,0 +1,70 @@
+Event:
+  type: object
+  required:
+    - type
+    - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: moves
+      enum:
+        - moves
+      description: The type of this object - always `moves`
+    attributes:
+      type: object
+      required:
+        - event_name
+        - timestamp
+      properties:
+        event_name:
+          type: string
+          example: cancel_move
+          description: |
+            Events have many forms which determine their accepted payload shape and validations. The event_name indicates which form the payload, validations and any relevant event actions take.
+
+            An invalid (non-existing) event_name field triggers a validation error.
+
+            See our [wiki](https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki) for specific event validations/expected json payloads and lengthy descriptions.
+
+            This is **mandatory** and specific to each event.
+          readOnly: true
+        timestamp:
+          type: string
+          description: |
+            A [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) timestamp string indicating when the event was recorded to have occurred (or at least as close as feasible to when the event is thought to have occurred). Please always include the zone to be most accurate (e.g. ‘2020-06-16T10:20:30+01:00’).
+
+            This is **mandatory**.
+          format: date-time
+        notes:
+          type: string
+          description: |
+            An arbitary, event-specific and optional field for any additional notes about an event that might be useful for other humans to be informed about.
+        details:
+          type: object
+          description: |
+            A optional json object that is optional and usually different for each event. Custom event validations are run against the values in this object.
+
+            See our [wiki](https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki) for specific event validations/expected json payloads and lengthy descriptions.
+    relationships:
+      type: object
+      required:
+        - eventable
+      properties:
+        eventable:
+          oneOf:
+            - $ref: "../v1/person_reference.yaml#/PersonReference"
+            - $ref: "../v1/move_reference.yaml#/MoveReference"
+            - $ref: "../v1/journey_reference.yaml#/JourneyReference"
+          description: |
+            The subject that the event relates too.
+
+            We validate for each specific event that the eventable is one of the resource types we expect.
+
+            For example, we validate that the cancel_move event's eventable is a move object.
+
+            See our [wiki](https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki) for specific event validations/expected json payloads and lengthy descriptions.

--- a/swagger/v2/event.yaml
+++ b/swagger/v2/event.yaml
@@ -1,4 +1,4 @@
-Event:
+EventResponseBody:
   type: object
   required:
     - type
@@ -11,10 +11,10 @@ Event:
       description: The unique identifier (UUID) of this object
     type:
       type: string
-      example: moves
+      example: events
       enum:
-        - moves
-      description: The type of this object - always `moves`
+        - events
+      description: The type of this object - always `events`
     attributes:
       type: object
       required:
@@ -23,7 +23,6 @@ Event:
       properties:
         event_name:
           type: string
-          example: cancel_move
           description: |
             Events have many forms which determine their accepted payload shape and validations. The event_name indicates which form the payload, validations and any relevant event actions take.
 
@@ -32,7 +31,7 @@ Event:
             See our [wiki](https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki) for specific event validations/expected json payloads and lengthy descriptions.
 
             This is **mandatory** and specific to each event.
-          readOnly: true
+          example: cancel_move
         timestamp:
           type: string
           description: |
@@ -47,9 +46,12 @@ Event:
         details:
           type: object
           description: |
-            A optional json object that is optional and usually different for each event. Custom event validations are run against the values in this object.
+            JSON object that is optional and usually different for each event. Custom event validations are run against the values in this object.
 
             See our [wiki](https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki) for specific event validations/expected json payloads and lengthy descriptions.
+          example:
+            cancellation_reason: "made_in_error"
+            cancellation_reason_comment: "cancelled because the prisoner refused to move"
     relationships:
       type: object
       required:
@@ -68,3 +70,76 @@ Event:
             For example, we validate that the cancel_move event's eventable is a move object.
 
             See our [wiki](https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki) for specific event validations/expected json payloads and lengthy descriptions.
+          example:
+            id: "ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154"
+            type: "moves"
+EventRequestPostBody:
+  type: object
+  required:
+    - type
+    - attributes
+  properties:
+    type:
+      type: string
+      example: events
+      enum:
+        - events
+      description: The type of this object - always `events`
+    attributes:
+      type: object
+      required:
+        - event_name
+        - timestamp
+      properties:
+        event_name:
+          type: string
+          description: |
+            Events have many forms which determine their accepted payload shape and validations. The event_name indicates which form the payload, validations and any relevant event actions take.
+
+            An invalid (non-existing) event_name field triggers a validation error.
+
+            See our [wiki](https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki) for specific event validations/expected json payloads and lengthy descriptions.
+
+            This is **mandatory** and specific to each event.
+          example: cancel_move
+        timestamp:
+          type: string
+          description: |
+            A [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) timestamp string indicating when the event was recorded to have occurred (or at least as close as feasible to when the event is thought to have occurred). Please always include the zone to be most accurate (e.g. ‘2020-06-16T10:20:30+01:00’).
+
+            This is **mandatory**.
+          format: date-time
+        notes:
+          type: string
+          description: |
+            An arbitary, event-specific and optional field for any additional notes about an event that might be useful for other humans to be informed about.
+        details:
+          type: object
+          description: |
+            JSON object that is optional and usually different for each event. Custom event validations are run against the values in this object.
+
+            See our [wiki](https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki) for specific event validations/expected json payloads and lengthy descriptions.
+          example:
+            cancellation_reason: "made_in_error"
+            cancellation_reason_comment: "cancelled because the prisoner refused to move"
+    relationships:
+      type: object
+      required:
+        - eventable
+      properties:
+        eventable:
+          oneOf:
+            - $ref: "../v1/person_reference.yaml#/PersonReference"
+            - $ref: "../v1/move_reference.yaml#/MoveReference"
+            - $ref: "../v1/journey_reference.yaml#/JourneyReference"
+          description: |
+            The subject that the event relates too.
+
+            We validate for each specific event that the eventable is one of the resource types we expect.
+
+            For example, we validate that the cancel_move event's eventable is a move object.
+
+            See our [wiki](https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki) for specific event validations/expected json payloads and lengthy descriptions.
+          example:
+            id: "ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154"
+            type: "moves"

--- a/swagger/v2/event.yaml
+++ b/swagger/v2/event.yaml
@@ -35,10 +35,11 @@ EventResponseBody:
         timestamp:
           type: string
           description: |
-            A [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) timestamp string indicating when the event was recorded to have occurred (or at least as close as feasible to when the event is thought to have occurred). Please always include the zone to be most accurate (e.g. ‘2020-06-16T10:20:30+01:00’).
+            A [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) timestamp string indicating when the event was recorded to have occurred (or at least as close as feasible to when the event is thought to have occurred). Please always include the zone to be most accurate (e.g. '2020-06-16T10:20:30+01:00').
 
             This is **mandatory**.
           format: date-time
+          example: "2020-06-16T10:20:30+01:00"
         notes:
           type: string
           description: |
@@ -109,6 +110,7 @@ EventRequestPostBody:
 
             This is **mandatory**.
           format: date-time
+          example: "2020-06-16T10:20:30+01:00"
         notes:
           type: string
           description: |

--- a/swagger/v2/get_events_responses.yaml
+++ b/swagger/v2/get_events_responses.yaml
@@ -1,0 +1,53 @@
+"200":
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      type: array
+      items:
+        $ref: "../v2/event.yaml#/EventResponseBody"
+    links:
+      $ref: "../v1/pagination_links.yaml#/PaginationLinks"
+    meta:
+      type: object
+      properties:
+        pagination:
+          $ref: "../v1/pagination.yaml#/Pagination"
+
+"400":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/BadRequest"
+"401":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/NotAuthorisedError"
+"415":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/UnsupportedMediaType"
+"422":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/UnprocessableEntity"

--- a/swagger/v2/post_event_responses.yaml
+++ b/swagger/v2/post_event_responses.yaml
@@ -4,15 +4,7 @@
     - data
   properties:
     data:
-      $ref: "../v2/event.yaml#/Event"
-    included:
-      description: If requested, the included eventable
-      type: array
-      items:
-        oneOf:
-          - $ref: "../v2/person.yaml#/Person"
-          - $ref: "../v2/move.yaml#/Move"
-          - $ref: "../v1/journey.yaml#/Journey"
+      $ref: "../v2/event.yaml#/EventResponseBody"
 "400":
   type: object
   required:

--- a/swagger/v2/post_event_responses.yaml
+++ b/swagger/v2/post_event_responses.yaml
@@ -1,0 +1,51 @@
+"201":
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      $ref: "../v2/event.yaml#/Event"
+    included:
+      description: If requested, the included eventable
+      type: array
+      items:
+        oneOf:
+          - $ref: "../v2/person.yaml#/Person"
+          - $ref: "../v2/move.yaml#/Move"
+          - $ref: "../v1/journey.yaml#/Journey"
+"400":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/BadRequest"
+"401":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/NotAuthorisedError"
+"415":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/UnsupportedMediaType"
+"422":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/UnprocessableEntity"


### PR DESCRIPTION
### Jira link

P4-1973

### What?

I have added documentation for:

- [x] POST /events
- [x] GET /events
- [x] GET /events?filter[eventable_type]=people,moves,journeys
- [x] GET /events?filter[eventable_id]=3561f372-9f1c-4e13-997e-b11e1647cce1
- [x] GET /events?filter[timestamp_to]=2020-06-16T00:00:00+01:00
- [x] GET /events?filter[timestamp_from]=2020-06-16T00:00:00+01:00

### Why?

We need this to flag implementation detail early on to suppliers.