### PR TITLE
Add support for filtering moves by person date_of_birth attribute

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -25,7 +25,7 @@ module Api
     end
 
     PERMITTED_FILTER_PARAMS = %i[
-      date_from date_to created_at_from created_at_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason has_relationship_to_allocation ready_for_transit
+      date_from date_to created_at_from created_at_to date_of_birth_from date_of_birth_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason has_relationship_to_allocation ready_for_transit
     ].freeze
 
     def filter_params

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -46,6 +46,7 @@ module Moves
       scope = scope.accessible_by(ability)
       scope = scope.includes(MOVE_INCLUDES)
       scope = apply_date_range_filters(scope)
+      scope = apply_date_of_birth_filters(scope)
       scope = apply_location_type_filters(scope)
       scope = apply_allocation_relationship_filters(scope)
       scope = apply_ready_for_transit_filters(scope)
@@ -69,9 +70,19 @@ module Moves
     def apply_date_range_filters(scope)
       scope = scope.where('date >= ?', filter_params[:date_from]) if filter_params.key?(:date_from)
       scope = scope.where('date <= ?', filter_params[:date_to]) if filter_params.key?(:date_to)
-      # created_at is a date/time, so inclusive filtering has to be subtlely different
+      # created_at is a date/time, so inclusive filtering has to be subtly different
       scope = scope.where('moves.created_at >= ?', filter_params[:created_at_from]) if filter_params.key?(:created_at_from)
       scope = scope.where('moves.created_at < ?', Date.parse(filter_params[:created_at_to]) + 1) if filter_params.key?(:created_at_to)
+      scope
+    end
+
+    def apply_date_of_birth_filters(scope)
+      return scope unless filter_params.key?(:date_of_birth_from) || filter_params.key?(:date_of_birth_to)
+
+      # only join on person if necessary, otherwise moves without people are not included
+      scope = scope.joins(:person)
+      scope = scope.where('people.date_of_birth >= ?', filter_params[:date_of_birth_from]) if filter_params.key?(:date_of_birth_from)
+      scope = scope.where('people.date_of_birth <= ?', filter_params[:date_of_birth_to]) if filter_params.key?(:date_of_birth_to)
       scope
     end
 

--- a/app/services/moves/params_validator.rb
+++ b/app/services/moves/params_validator.rb
@@ -4,9 +4,9 @@ module Moves
   class ParamsValidator
     include ActiveModel::Validations
 
-    attr_reader :date_from, :date_to, :created_at_from, :created_at_to, :sort_by, :sort_direction, :move_type, :cancellation_reason
+    attr_reader :date_from, :date_to, :created_at_from, :created_at_to, :date_of_birth_from, :date_of_birth_to, :sort_by, :sort_direction, :move_type, :cancellation_reason
 
-    validates_each :date_from, :date_to, :created_at_from, :created_at_to, allow_nil: true do |record, attr, value|
+    validates_each :date_from, :date_to, :created_at_from, :created_at_to, :date_of_birth_from, :date_of_birth_to, allow_nil: true do |record, attr, value|
       Date.strptime(value, '%Y-%m-%d')
     rescue ArgumentError
       record.errors.add attr, 'is not a valid date.'
@@ -25,6 +25,8 @@ module Moves
       @date_to = filter_params[:date_to]
       @created_at_from = filter_params[:created_at_from]
       @created_at_to = filter_params[:created_at_to]
+      @date_of_birth_from = filter_params[:date_of_birth_from]
+      @date_of_birth_to = filter_params[:date_of_birth_to]
       @move_type = filter_params[:move_type]
       @cancellation_reason = filter_params[:cancellation_reason]
 

--- a/db/migrate/20200805154106_add_index_to_people_date_of_birth.rb
+++ b/db/migrate/20200805154106_add_index_to_people_date_of_birth.rb
@@ -1,0 +1,7 @@
+class AddIndexToPeopleDateOfBirth < ActiveRecord::Migration[6.0]
+  def change
+    change_table :people do |t|
+      t.index :date_of_birth
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_29_191640) do
+ActiveRecord::Schema.define(version: 2020_08_05_154106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -394,6 +394,7 @@ ActiveRecord::Schema.define(version: 2020_07_29_191640) do
     t.datetime "last_synced_with_nomis"
     t.integer "latest_nomis_booking_id"
     t.index ["criminal_records_office"], name: "index_people_on_criminal_records_office"
+    t.index ["date_of_birth"], name: "index_people_on_date_of_birth"
     t.index ["ethnicity_id"], name: "index_people_on_ethnicity_id"
     t.index ["gender_id"], name: "index_people_on_gender_id"
     t.index ["nomis_prison_number"], name: "index_people_on_nomis_prison_number"

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Moves::Finder do
         end
       end
 
-      context 'with mis-matching mismatched date range in past' do
+      context 'with mis-matching date range in past' do
         let(:filter_params) { { date_from: (move.date - 5.days).to_s, date_to: (move.date - 2.days).to_s } }
 
         it 'returns empty results set' do
@@ -112,8 +112,55 @@ RSpec.describe Moves::Finder do
         end
       end
 
-      context 'with mis-matching mismatched date range in future' do
+      context 'with mis-matching date range in future' do
         let(:filter_params) { { date_from: (move.date + 2.days).to_s, date_to: (move.date + 5.days).to_s } }
+
+        it 'returns empty results set' do
+          expect(results).to be_empty
+        end
+      end
+    end
+
+    describe 'by date of birth' do
+      let(:date_of_birth) { 18.years.ago }
+      let!(:person) { create :person, date_of_birth: date_of_birth }
+      let!(:profile) { create :profile, person: person }
+      let!(:move) { create :move, profile: profile }
+
+      context 'with matching date range' do
+        let(:filter_params) { { date_of_birth_from: (date_of_birth - 2.days).to_s, date_of_birth_to: (date_of_birth + 1.day).to_s } }
+
+        it 'returns moves matching date of birth range' do
+          expect(results).to contain_exactly(move)
+        end
+      end
+
+      context 'with matching date of birth from only' do
+        let(:filter_params) { { date_of_birth_from: (date_of_birth - 1.day).to_s } }
+
+        it 'returns moves matching date of birth range' do
+          expect(results).to contain_exactly(move)
+        end
+      end
+
+      context 'with matching date of birth to only' do
+        let(:filter_params) { { date_of_birth_to: (date_of_birth + 1.day).to_s } }
+
+        it 'returns moves matching date of birth range' do
+          expect(results).to contain_exactly(move)
+        end
+      end
+
+      context 'with mis-matching date of birth range in past' do
+        let(:filter_params) { { date_of_birth_from: (date_of_birth - 5.days).to_s, date_of_birth_to: (date_of_birth - 3.days).to_s } }
+
+        it 'returns empty results set' do
+          expect(results).to be_empty
+        end
+      end
+
+      context 'with mis-matching date of birth range in future' do
+        let(:filter_params) { { date_of_birth_from: (date_of_birth + 2.days).to_s, date_of_birth_to: (date_of_birth + 5.days).to_s } }
 
         it 'returns empty results set' do
           expect(results).to be_empty

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -135,6 +135,14 @@ RSpec.describe Moves::Finder do
         end
       end
 
+      context 'with matching exact date' do
+        let(:filter_params) { { date_of_birth_from: date_of_birth.to_s, date_of_birth_to: date_of_birth.to_s } }
+
+        it 'returns moves matching date of birth range' do
+          expect(results).to contain_exactly(move)
+        end
+      end
+
       context 'with matching date of birth from only' do
         let(:filter_params) { { date_of_birth_from: (date_of_birth - 1.day).to_s } }
 
@@ -161,6 +169,14 @@ RSpec.describe Moves::Finder do
 
       context 'with mis-matching date of birth range in future' do
         let(:filter_params) { { date_of_birth_from: (date_of_birth + 2.days).to_s, date_of_birth_to: (date_of_birth + 5.days).to_s } }
+
+        it 'returns empty results set' do
+          expect(results).to be_empty
+        end
+      end
+
+      context 'with nil values' do
+        let(:filter_params) { { date_of_birth_from: nil, date_of_birth_to: nil } }
 
         it 'returns empty results set' do
           expect(results).to be_empty

--- a/spec/services/moves/params_validator_spec.rb
+++ b/spec/services/moves/params_validator_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Moves::ParamsValidator do
   subject(:params_validator) { described_class.new(filter_params, {}) }
 
-  let(:filter_params) { { date_from: date_from, date_to: date_to } }
+  let(:filter_params) { { date_from: date_from, date_to: date_to, date_of_birth_from: date_from, date_of_birth_to: date_to } }
   let(:good_date) { '2019-05-05' }
 
   context 'with correct dates' do

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -563,6 +563,24 @@
             type: string
             example: "2019-05-09"
           format: date
+        - name: filter[date_of_birth_from]
+          in: query
+          description:
+            Filters results to only include moves with people born on or after the
+            given date, e.g. `2009-05-02`
+          schema:
+            type: string
+            example: "2009-05-09"
+          format: date
+        - name: filter[date_of_birth_to]
+          in: query
+          description:
+            Filters results to only include moves with people born on or before
+            the given date, e.g. `2009-05-09`
+          schema:
+            type: string
+            example: "2009-05-09"
+          format: date
         - name: filter[status]
           in: query
           explode: false

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -324,6 +324,24 @@
             type: string
             example: "2019-05-09"
           format: date
+        - name: filter[date_of_birth_from]
+          in: query
+          description:
+            Filters results to only include moves with people born on or after the
+            given date, e.g. `2009-05-02`
+          schema:
+            type: string
+            example: "2009-05-09"
+          format: date
+        - name: filter[date_of_birth_to]
+          in: query
+          description:
+            Filters results to only include moves with people born on or before
+            the given date, e.g. `2009-05-09`
+          schema:
+            type: string
+            example: "2009-05-09"
+          format: date
         - name: filter[status]
           in: query
           explode: false


### PR DESCRIPTION
### Jira link

P4-1995

### What?

I have added/removed/altered:

- [x] Added support for additional `date_of_birth_from` and `date_of_birth_to` filters for `GET /moves` endpoint
- [x] Updated `Moves::Finder` and `Moves::ParamsValidator` services to permit/validate additional params

### Why?

- We wish to support showing moves only for people with specific age ranges. Rather than pass in an age (which could include a number of years and/or months), this requires the front end to determine a specific date based on the current date and pass corresponding date range. Agreed this approach during refinement as it is more flexible and avoids having to invent a new mechanism for passing age in year and month parameters.

### Have you? (optional)

- [x] Updated API docs if necessary - new filter is supported in both v1 and v2 API

### Deployment risks (optional)

- Includes support for additional filters, but these do not affect returned moves if not specified
