### PR TITLE
Foreign key names are dynamically generated

### DIFF
--- a/db/migrate/20200729191640_drop_person_id_from_moves.rb
+++ b/db/migrate/20200729191640_drop_person_id_from_moves.rb
@@ -1,6 +1,6 @@
 class DropPersonIdFromMoves < ActiveRecord::Migration[6.0]
   def change
-    remove_foreign_key :moves, column: :person_id, name: 'fk_rails_moves_person_id', to_table: :people
+    remove_foreign_key :moves, column: :person_id, to_table: :people
     remove_column :moves, :person_id, :uuid
   end
 end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Removes reference to name when removing foreign key since the name is dynamically calculated:

### Why?

```sh
│ -- remove_foreign_key(:moves, {:column=>:person_id, :name=>"fk_rails_moves_person_id", :to_table=>:people})
 Caused by:                                                                                                                                                                                                                                                 │
│ ArgumentError: Table 'moves' has no foreign key for people                                                                                                                                                                                                 │
│ /usr/local/bundle/gems/activerecord-6.0.3.2/lib/active_record/connection_adapters/abstract/schema_statements.rb:1382:in `foreign_key_for!'                                                                                                                 │
│ /usr/local/bundle/gems/activerecord-6.0.3.2/lib/active_record/connection_adapters/abstract/schema_statements.rb:1029:in `remove_foreign_key'                                                                                                               │
│ /usr/local/bundle/gems/activerecord-6.0.3.2/lib/active_record/migration.rb:890:in `block in method_missing'                                                                                                                                                │
│ /usr/local/bundle/gems/activerecord-6.0.3.2/lib/active_record/migration.rb:858:in `block in say_with_time'                                                                                                                                                 │
│ /usr/local/bundle/gems/activerecord-6.0.3.2/lib/active_record/migration.rb:858:in `say_with_time'                                                                                                                                                          │
│ /usr/local/bundle/gems/activerecord-6.0.3.2/lib/active_record/migration.rb:879:in `method_missing'                                                                                                                                                         │
│ /app/db/migrate/20200729191640_drop_person_id_from_moves.rb:3:in `change'                                                                                                                                                                                  │
│ /usr/local/bundle/gems/activerecord-6.0.3.2/lib/active
```
