### PR TITLE
Add additional STC and SCH locations to Youth region

### DIFF
--- a/lib/tasks/data/regions.yml
+++ b/lib/tasks/data/regions.yml
@@ -149,3 +149,13 @@
     - CKI
     - WNI
     - WYI
+    - STC1
+    - STC3
+    - SCH1
+    - SCH2
+    - SCH3
+    - SCH4
+    - SCH5
+    - SCH6
+    - SCH8
+    - SCH9


### PR DESCRIPTION
### Jira link

P4-1931

### What?

- [x] Map additional existing SCH and STC locations to the Youth region (for use with allocations)

### Why?

- This allows moves for these locations to be viewed as part of the youth region. The Nomis agency id's for these are as follows (note - there is no STC7):

#### YOI
Wetherby - WYI
Werrington - WNI
Parc - PRI
Feltham YOI - FMI
Cookham Wood - CKI

#### STC
Rainsbrook - STC1
Oakhill - STC3

#### SCH
Vinney Green - SCH9
Hillside - SCH6
Barton Moss - SCH4
Aycliffe - SCH3
Aldine House - SCH2
Lincolnshire - SCH8
Adel Beck - SCH1
Clayfields - SCH5
