### PR TITLE
Bump up maximum pagination limit for Kaminari

### DIFF
--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -2,5 +2,5 @@
 
 Kaminari.configure do |config|
   config.default_per_page = 20
-  config.max_per_page = 100
+  config.max_per_page = 2000
 end

--- a/swagger/v1/pagination_parameters.yaml
+++ b/swagger/v1/pagination_parameters.yaml
@@ -11,9 +11,9 @@ PerPage:
   name: per_page
   in: query
   description: Number of records to return in a single response, defaults to 20, maximum
-    value is 100.
+    value is 2000.
   schema:
     type: integer
     default: 20
-    maximum: 100
+    maximum: 2000
   example: 20


### PR DESCRIPTION
### Jira link

P4-2027

### What?

- [x] Increased maximum page size in Kaminari to 2000

### Why?

- This allows the front end to request a larger page size if required (currently maximum is 100 rows). This doesn't change the default page size if pagination params are not specified. We also need to do some real world testing (maybe on staging) to see at what point the back end API starts to break down with larger page sizes.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- No risk unless passing larger page size params from front end or suppliers
- There is a significant risk performance will degrade with larger page sizes, but this needs to be tested on a realistic environment such as staging.
