### PR TITLE
Fix nomis_agency_id for Rainsbrook STC in Youth Region

### DIFF
--- a/lib/tasks/data/regions.yml
+++ b/lib/tasks/data/regions.yml
@@ -149,7 +149,7 @@
     - CKI
     - WNI
     - WYI
-    - STC1
+    - STC2
     - STC3
     - SCH1
     - SCH2


### PR DESCRIPTION
### Jira link

P4-1931

### What?

- [x] Use correct `nomis_agency_id` for Rainsbrook STC in Youth region mapping

### Why?

- On testing this against dev environment, only 14 locations got mapped rather than the expected 15. The missing one was Rainsbook which has `nomis_agency_id` of `STC2` rather than `STC1`.