### PR TITLE
Revert "Bump prometheus_exporter from 0.4.13 to 0.5.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     parser (2.7.1.4)
       ast (~> 2.4.1)
     pg (1.0.0)
-    prometheus_exporter (0.5.3)
+    prometheus_exporter (0.4.13)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-api#808