### PR TITLE
Support prison_transfer moves from prison, STC or SCH locations

### DIFF
--- a/app/services/moves/move_type_validator.rb
+++ b/app/services/moves/move_type_validator.rb
@@ -15,7 +15,7 @@ module Moves
       validate_police_to_location if includes? %w[police_transfer]
       validate_police_from_location if includes? %w[police_transfer prison_recall video_remand]
       validate_detained_to_location if includes? %w[prison_remand]
-      validate_prison_from_location if includes? %w[prison_transfer]
+      validate_detained_from_location if includes? %w[prison_transfer]
     end
 
   private
@@ -30,6 +30,10 @@ module Moves
 
     def validate_court_to_location
       record.errors.add(:to_location, "must be a court location for #{human_move_type} move") unless record.to_location&.court?
+    end
+
+    def validate_detained_from_location
+      record.errors.add(:from_location, "must be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.from_location&.detained?
     end
 
     def validate_detained_to_location
@@ -50,10 +54,6 @@ module Moves
 
     def validate_police_to_location
       record.errors.add(:to_location, "must be a police location for #{human_move_type} move") unless record.to_location&.police?
-    end
-
-    def validate_prison_from_location
-      record.errors.add(:from_location, "must be a prison location for #{human_move_type} move") unless record.from_location&.prison?
     end
   end
 end

--- a/spec/services/moves/move_type_validator_spec.rb
+++ b/spec/services/moves/move_type_validator_spec.rb
@@ -167,9 +167,11 @@ RSpec.describe Moves::MoveTypeValidator do
   context 'with prison_transfer `move_type`' do
     let(:move_type) { 'prison_transfer' }
 
-    it 'validates `from_location` is a prison location' do
-      target.from_location = build(:location, :prison)
-      expect(target).to be_valid
+    it 'validates `from_location` is a prison, sch or stc' do
+      %i[prison sch stc].each do |location_type|
+        target.from_location = build(:location, location_type)
+        expect(target).to be_valid
+      end
     end
 
     it 'validates `from_location` is not nil' do
@@ -177,10 +179,10 @@ RSpec.describe Moves::MoveTypeValidator do
       expect(target).not_to be_valid
     end
 
-    it 'has an error if `from_location` is not a prison location' do
+    it 'has an error if `from_location` is not a prison, sch or stc' do
       target.from_location = build(:location, :court)
       expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
-      expect(target.errors[:from_location]).to match_array('must be a prison location for prison transfer move')
+      expect(target.errors[:from_location]).to match_array('must be a prison, secure training centre or secure childrens hospital for prison transfer move')
     end
   end
 


### PR DESCRIPTION
### Jira link

P4-2047

### What?

- [x] Updated business rules and specs for `MoveTypeValidator`

### Why?

- This is to support `prison_transfer` type moves from STC and SCH locations in addition to the existing Prison locations.

### Deployment risks (optional)

- The new rules are more permissive so should not break any existing production use
