### PR TITLE
[P4-2015] Adds feed for Notification model

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,6 +3,21 @@
 class Notification < ApplicationRecord
   include Discard::Model
 
+  FEED_ATTRIBUTES = %w[
+    id
+    event_type
+    topic_id
+    topic_type
+    delivery_attempts
+    delivery_attempted_at
+    delivered_at
+    discarded_at
+    created_at
+    updated_at
+    response_id
+    notification_type_id
+  ].freeze
+
   belongs_to :subscription
   belongs_to :notification_type # NB: should be either NotificationType::WEBHOOK or NotificationType::EMAIL
   belongs_to :topic, polymorphic: true, touch: true # NB: polymorphic association because topic could be associated with a Move or a Profile
@@ -15,8 +30,17 @@ class Notification < ApplicationRecord
   scope :webhooks, -> { where(notification_type: NotificationType::WEBHOOK) }
   scope :emails, -> { where(notification_type: NotificationType::EMAIL) }
 
+  scope :updated_at_range, lambda { |from, to|
+    includes(:notification_type)
+      .where(updated_at: from..to)
+  }
+
   def kept?
     # this notification is only kept if it is not discarded and its parent subscription is not discarded
     !discarded? && subscription.kept?
+  end
+
+  def for_feed
+    attributes.slice(*FEED_ATTRIBUTES)
   end
 end

--- a/app/services/feeds/notification.rb
+++ b/app/services/feeds/notification.rb
@@ -1,0 +1,18 @@
+module Feeds
+  class Notification
+    def initialize(updated_at_from = nil, updated_at_to = nil)
+      @updated_at_from = updated_at_from || Time.zone.yesterday.beginning_of_day
+      @updated_at_to = updated_at_to || Time.zone.yesterday.end_of_day
+
+      @feed = []
+    end
+
+    def call
+      ::Notification.updated_at_range(@updated_at_from, @updated_at_to).find_each do |notification|
+        @feed << notification.for_feed.to_json
+      end
+
+      @feed.join("\n")
+    end
+  end
+end

--- a/db/migrate/20200813104335_adds_index_on_updated_at_to_notification.rb
+++ b/db/migrate/20200813104335_adds_index_on_updated_at_to_notification.rb
@@ -1,0 +1,7 @@
+class AddsIndexOnUpdatedAtToNotification < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :notifications, :updated_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_11_110024) do
+ActiveRecord::Schema.define(version: 2020_08_13_104335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -332,6 +332,7 @@ ActiveRecord::Schema.define(version: 2020_08_11_110024) do
     t.index ["topic_id"], name: "index_notifications_on_topic_id"
     t.index ["topic_type", "topic_id"], name: "index_notifications_on_topic_type_and_topic_id"
     t.index ["topic_type"], name: "index_notifications_on_topic_type"
+    t.index ["updated_at"], name: "index_notifications_on_updated_at"
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|

--- a/lib/tasks/feeds/notification.rake
+++ b/lib/tasks/feeds/notification.rake
@@ -1,0 +1,8 @@
+namespace :feeds do
+  desc 'Exports a JSON feed of all profiles to s3'
+  task notification: :environment do
+    feed = Feeds::Notification.new.call
+
+    CloudDataFeed.new.write(feed, 'notifications.json')
+  end
+end

--- a/spec/factories/notification.rb
+++ b/spec/factories/notification.rb
@@ -1,7 +1,11 @@
 FactoryBot.define do
   factory :notification do
     association :subscription
-    association :notification_type, :webhook # defaults to webhook
+
+    notification_type do
+      NotificationType.find_or_create_by(id: 'webhook', title: 'Webhook')
+    end
+
     event_type { 'move_created' }
     association :topic, factory: :move
     delivery_attempts { 0 }
@@ -10,10 +14,14 @@ FactoryBot.define do
   end
 
   trait(:email) do
-    association :notification_type, :email
+    notification_type do
+      NotificationType.find_or_create_by(id: 'email', title: 'Email')
+    end
   end
 
   trait(:webhook) do
-    association :notification_type, :webhook
+    notification_type do
+      NotificationType.find_or_create_by(id: 'webhook', title: 'Webhook')
+    end
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -58,4 +58,47 @@ RSpec.describe Notification, type: :model do
       expect { create(:notification, topic: topic) }.to change { topic.reload.updated_at }
     end
   end
+
+  describe '#for_feed' do
+    subject(:notification) { create(:notification, :email) }
+
+    let(:expected_json) do
+      {
+        'id' => notification.id,
+        'event_type' => 'move_created',
+        'topic_id' => notification.topic_id,
+        'topic_type' => notification.topic_type,
+        'delivery_attempts' => 0,
+        'delivery_attempted_at' => be_a(Time),
+        'delivered_at' => be_a(Time),
+        'discarded_at' => nil,
+        'created_at' => be_a(Time),
+        'updated_at' => be_a(Time),
+        'response_id' => nil,
+        'notification_type_id' => 'email',
+      }
+    end
+
+    it 'generates a feed document' do
+      expect(notification.for_feed).to include_json(expected_json)
+    end
+  end
+
+  describe '.updated_at_range' do
+    let(:updated_at_from) { Time.zone.now.beginning_of_day - 1.day }
+    let(:updated_at_to) { Time.zone.now.end_of_day - 1.day }
+
+    it 'returns the expected notifications' do
+      create(:notification, updated_at: updated_at_from - 1.second)
+      create(:notification, updated_at: updated_at_to + 1.second)
+      on_start_notification = create(:notification, updated_at: updated_at_from)
+      on_end_notification = create(:notification, updated_at: updated_at_to)
+
+      actual_notifications = described_class.updated_at_range(
+        updated_at_from,
+        updated_at_to,
+      )
+      expect(actual_notifications).to eq([on_start_notification, on_end_notification])
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

P4-2015

### What?

I have added/removed/altered:

- [x] Adds feed service implementation
- [x] Adds feed presenter implementation
- [x] Adds feed tasks
- [x] Adds feed unit tests
- [x] Adds updated_at index
- [x] Refactors notifications factory to add flexibility for creating multiple notifications of the same type

### Why?

See epic