### PR TITLE
Remove unused/confusing YOI location type

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -6,7 +6,6 @@ class Location < ApplicationRecord
   LOCATION_TYPE_PRISON = 'prison'
   LOCATION_TYPE_SECURE_TRAINING_CENTRE = 'secure_training_centre'
   LOCATION_TYPE_SECURE_CHILDRENS_HOME = 'secure_childrens_home'
-  LOCATION_TYPE_YOUTH_OFFENDING_INSTITUTE = 'youth_offending_institute'
   LOCATION_TYPE_APPROVED_PREMISES = 'approved_premises'
   LOCATION_TYPE_PROBATION_OFFICE = 'probation_office'
   LOCATION_TYPE_COMMUNITY_REHABILITATION_COMPANY = 'community_rehabilitation_company'
@@ -21,7 +20,6 @@ class Location < ApplicationRecord
     prison: LOCATION_TYPE_PRISON,
     secure_training_centre: LOCATION_TYPE_SECURE_TRAINING_CENTRE,
     secure_childrens_home: LOCATION_TYPE_SECURE_CHILDRENS_HOME,
-    youth_offending_institute: LOCATION_TYPE_YOUTH_OFFENDING_INSTITUTE,
     approved_premises: LOCATION_TYPE_APPROVED_PREMISES,
     probation_office: LOCATION_TYPE_PROBATION_OFFICE,
     community_rehabilitation_company: LOCATION_TYPE_COMMUNITY_REHABILITATION_COMPANY,
@@ -37,7 +35,6 @@ class Location < ApplicationRecord
     'POLICE' => LOCATION_TYPE_POLICE,
     'STC' => LOCATION_TYPE_SECURE_TRAINING_CENTRE,
     'SCH' => LOCATION_TYPE_SECURE_CHILDRENS_HOME,
-    'YOI' => LOCATION_TYPE_YOUTH_OFFENDING_INSTITUTE,
     'APPR' => LOCATION_TYPE_APPROVED_PREMISES,
     'COMM' => LOCATION_TYPE_PROBATION_OFFICE,
     'CRC' => LOCATION_TYPE_COMMUNITY_REHABILITATION_COMPANY,

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     end
     # Move types
     trait :court_appearance do
-      # NB: Police / Prison / STC / SCH, YOI --> Court
+      # NB: Police / Prison / STC / SCH --> Court
       move_type { 'court_appearance' }
       association(:from_location, :police, factory: :location)
       association(:to_location, :court, factory: :location)

--- a/swagger/v1/location.yaml
+++ b/swagger/v1/location.yaml
@@ -36,7 +36,6 @@ Location:
           - prison
           - secure_training_centre
           - secure_childrens_home
-          - youth_offending_institute
           - approved_premises
           - probation_office
           - community_rehabilitation_company


### PR DESCRIPTION
### Jira link

P4-2048

### What?

- [x] Remove `youth_offending_institute` from supported `Location` types (affects v1 and v2 API)

### Why?

- Whilst this seems reckless and controversial, the YOI type is never actually used. We have no locations of this type on any environment; instead all YOI locations are held within Nomis (and hence imported to PECS) as `prison` type. This change does not remove or affect any existing data, but does clear up some confusion by appearing to support a location type that is not actually supported. We should align with Nomis data and treat YOI locations as prisons.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- This location type is not used in production as we do not have (and have never had) any locations with a type of `youth_offending_institute`. As we have no YOI type locations, there are no moves created with YOI type locations, as moves cannot be created without specifying valid locations. Other than updating the Swagger docs, this change should have no visible effect to consumers of the API.
