### PR TITLE
Add support for returning GET /moves endpoint in CSV format

### DIFF
--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -3,10 +3,14 @@ module Api::V2
     def index_and_render
       moves = Moves::Finder.new(filter_params, current_ability, params[:sort] || {}).call
 
-      paginate moves,
-               each_serializer: ::V2::MoveSerializer,
-               include: included_relationships,
-               fields: ::V2::MoveSerializer::INCLUDED_FIELDS
+      if csv?
+        send_file(Moves::Exporter.new(moves).call, type: 'text/csv', disposition: :inline)
+      else
+        paginate moves,
+                 each_serializer: ::V2::MoveSerializer,
+                 include: included_relationships,
+                 fields: ::V2::MoveSerializer::INCLUDED_FIELDS
+      end
     end
 
     def show_and_render

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -14,6 +14,7 @@ class ApiController < ApplicationController
   before_action :validate_include_params
 
   CONTENT_TYPE = 'application/vnd.api+json'
+  REGEXP_CSV = /(application|text)\/csv/i.freeze
   REGEXP_API_VERSION = %r{.*version=(?<version>\d+)}.freeze
 
   rescue_from ActionController::ParameterMissing, with: :render_bad_request_error
@@ -231,6 +232,10 @@ private
 
   def supported_relationships
     []
+  end
+
+  def csv?
+    request.headers['Accept']&.match?(REGEXP_CSV)
   end
 
   def api_version

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -83,7 +83,6 @@ class Move < VersionedModel
   has_many :journeys, -> { default_order }, dependent: :restrict_with_exception, inverse_of: :move
   has_many :court_hearings, dependent: :restrict_with_exception
   has_many :move_events, as: :eventable, dependent: :destroy # NB: polymorphic association
-  has_many :documents
 
   validates :from_location, presence: true
   validates :to_location, presence: true, unless: -> { prison_recall? || video_remand? }

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -83,6 +83,7 @@ class Move < VersionedModel
   has_many :journeys, -> { default_order }, dependent: :restrict_with_exception, inverse_of: :move
   has_many :court_hearings, dependent: :restrict_with_exception
   has_many :move_events, as: :eventable, dependent: :destroy # NB: polymorphic association
+  has_many :documents
 
   validates :from_location, presence: true
   validates :to_location, presence: true, unless: -> { prison_recall? || video_remand? }

--- a/app/services/moves/exporter.rb
+++ b/app/services/moves/exporter.rb
@@ -63,7 +63,7 @@ module Moves
       'Requires special vehicle',
       'Requires special vehicle details',
       'Uploaded documents',
-    ]
+    ].freeze
 
     MOVE_INCLUDES = [:from_location, :to_location, :profile, :documents, person: %i[gender ethnicity]].freeze
 
@@ -131,7 +131,7 @@ module Moves
       ].flatten
     end
 
-   def answer_details(answers, key)
+    def answer_details(answers, key)
       selected_answers = answers&.select { |answer| answer.key == key }
       comments = selected_answers&.collect do |answer|
         description = answer.nomis_alert_description
@@ -139,6 +139,6 @@ module Moves
       end
 
       [comments.present?.to_s.upcase, comments&.join("\n\n")]
-    end
+     end
   end
 end

--- a/app/services/moves/exporter.rb
+++ b/app/services/moves/exporter.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module Moves
+  class Exporter
+    attr_reader :moves
+
+    HEADINGS = [
+      'Status',
+      'Reference',
+      'Move type',
+      'Created at',
+      'Last updated',
+      'From location name',
+      'From location code',
+      'To location name',
+      'To location code',
+      'Additional information',
+      'Date of travel',
+      'PNC number',
+      'Prison number',
+      'Last name',
+      'First name(s)',
+      'Date of birth',
+      'Gender',
+      'Ethnicity',
+      'Ethnicity code',
+      'Violent',
+      'Violent details',
+      'Escape',
+      'Escape details',
+      'Must be held separately',
+      'Must be held separately details',
+      'Self harm',
+      'Self harm details',
+      'Concealed items',
+      'Concealed items details',
+      'Any other risks',
+      'Any other risks details',
+      'Special diet or allergy',
+      'Special diet or allergy details',
+      'Health issue',
+      'Health issue details',
+      'Medication',
+      'Medication details',
+      'Wheelchair user',
+      'Wheelchair user details',
+      'Pregnant',
+      'Pregnant details',
+      'Any other requirements',
+      'Any other requirements details',
+      'Solicitor or other legal representation',
+      'Solicitor or other legal representation details',
+      'Sign or other language interpreter',
+      'Sign or other language interpreter details',
+      'Any other information',
+      'Any other information details',
+      'Not for release',
+      'Not for release details',
+      'Not to be released',
+      'Not to be released details',
+      'Requires special vehicle',
+      'Requires special vehicle details',
+      'Uploaded documents',
+    ]
+
+    MOVE_INCLUDES = [:from_location, :to_location, :profile, :documents, person: %i[gender ethnicity]].freeze
+
+    def initialize(moves)
+      @moves = moves
+    end
+
+    def call
+      Tempfile.new('export', Rails.root.join('tmp')).tap do |file|
+        csv = CSV.new(file)
+        csv << HEADINGS
+        moves.includes(MOVE_INCLUDES).find_in_batches do |batched_moves|
+          batched_moves.each do |move|
+            csv << attributes_row(move)
+          end
+        end
+      end
+    end
+
+  private
+
+    def attributes_row(move)
+      person = move.person
+      answers = move.profile&.assessment_answers
+
+      [
+        move.status, # Status
+        move.reference, # Reference
+        move.move_type, # Move type
+        move.created_at.iso8601, # Created at
+        move.updated_at.iso8601, # Last updated
+        move.from_location&.title, # From location name
+        move.from_location&.nomis_agency_id, # From location code
+        move.to_location&.title, # To location name
+        move.to_location&.nomis_agency_id, # To location code
+        move.additional_information, # Additional information
+        move.date&.strftime('%d/%m/%Y'), # Date of travel
+        person&.police_national_computer, # PNC number
+        person&.prison_number, # Prison number
+        person&.last_name, # Last name
+        person&.first_names, # First name(s)
+        person&.date_of_birth&.strftime('%d/%m/%Y'), # Date of birth
+        person&.gender&.title, # Gender
+        person&.ethnicity&.title, # Ethnicity
+        person&.ethnicity&.key, # Ethnicity code
+        answer_details(answers, 'violent'), # Violent details
+        answer_details(answers, 'escape'), # Escape details
+        answer_details(answers, 'hold_separately'), # Must be held separately details
+        answer_details(answers, 'self_harm'), # Self harm details
+        answer_details(answers, 'concealed_items'), # Concealed items details
+        answer_details(answers, 'other_risks'), # Any other risks details
+        answer_details(answers, 'special_diet_or_allergy'), # Special diet or allergy details
+        answer_details(answers, 'health_issue'), # Health issue details
+        answer_details(answers, 'medication'), # Medication details
+        answer_details(answers, 'wheelchair'), # Wheelchair user details
+        answer_details(answers, 'pregnant'), # Pregnant details
+        answer_details(answers, 'other_health'), # Any other details
+        answer_details(answers, 'solicitor'), # Solicitor or other legal representation details
+        answer_details(answers, 'interpreter'), # Sign or other language interpreter details
+        answer_details(answers, 'other_court'), # Any other information details
+        answer_details(answers, 'not_for_release'), # Not for release details
+        answer_details(answers, 'not_to_be_released'), # Not to be released details
+        answer_details(answers, 'special_vehicle'), # Requires special vehicle details
+        move.documents.size, # 'Uploaded documents',
+      ].flatten
+    end
+
+   def answer_details(answers, key)
+      selected_answers = answers&.select { |answer| answer.key == key }
+      comments = selected_answers&.collect do |answer|
+        description = answer.nomis_alert_description
+        description.present? ? "#{description}: #{answer.comments}" : answer.comments
+      end
+
+      [comments.present?.to_s.upcase, comments&.join("\n\n")]
+    end
+  end
+end

--- a/spec/services/moves/exporter_spec.rb
+++ b/spec/services/moves/exporter_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Moves::Exporter do
+  subject(:file) { described_class.new(moves).call }
+  let(:content) { file.rewind && file.read }
+  let(:csv) { CSV.parse(content) }
+  let(:header) { csv.first }
+  let(:row) { csv.last }
+
+  let(:question) { create(:assessment_question) }
+  let(:from_location) { create(:location, title: 'From Location', nomis_agency_id: 'FROM1') }
+  let(:to_location) { create(:location, title: 'To Location', nomis_agency_id: 'TO1') }
+  let(:person) { create(:person) }
+  let!(:move) { create(:move, from_location: from_location, to_location: to_location, person: person) }
+  let(:moves) { Move.all }
+
+  it 'includes correct header names' do
+    expect(header).to eq(described_class::HEADINGS)
+  end
+
+  it 'has correct number of header columns' do
+    expect(header.count).to eq(56)
+  end
+
+  it 'has correct number of body columns' do
+    expect(row.count).to eq(56)
+  end
+
+  it 'includes move details' do
+    expect(row).to include(move.status, move.reference, move.move_type, move.additional_information)
+  end
+
+  it 'includes move timestamps and date' do
+    expect(row).to include(move.created_at.iso8601, move.updated_at.iso8601, move.date.strftime('%d/%m/%Y'))
+  end
+
+  it 'includes from location details' do
+    expect(row).to include(from_location.title, from_location.nomis_agency_id)
+  end
+
+  it 'includes to location details' do
+    expect(row).to include(to_location.title, to_location.nomis_agency_id)
+  end
+
+  it 'includes person details' do
+    expect(row).to include(person.police_national_computer, person.prison_number, person.last_name, person.first_names)
+  end
+
+  it 'includes person date of birth' do
+    expect(row).to include(person.date_of_birth&.strftime('%d/%m/%Y'))
+  end
+
+  it 'includes person gender' do
+    expect(row).to include(person.gender.title)
+  end
+
+  it 'includes ethnicity details' do
+    expect(row).to include(person.ethnicity.title, person.ethnicity.key)
+  end
+
+  %w[violent escape hold_separately self_harm concealed_items other_risks special_diet_or_allergy health_issue medication wheelchair pregnant other_health solicitor interpreter other_court not_for_release not_to_be_released special_vehicle].each do |alert_type|
+    it "includes TRUE flag when #{alert_type} is present" do
+      question.update(key: alert_type)
+      move.profile.update(assessment_answers: [{ assessment_question_id: question.id, comments: 'Yikes!' }])
+      expect(row).to include('TRUE')
+    end
+
+    it "includes comments when #{alert_type} is present" do
+      question.update(key: alert_type)
+      move.profile.update(assessment_answers: [{ assessment_question_id: question.id, comments: 'Yikes!' }])
+      expect(row).to include('Yikes!')
+    end
+
+    it "includes description prefix on comments for Nomis #{alert_type} alerts" do
+      question.update(key: alert_type)
+      move.profile.update(assessment_answers: [{ nomis_alert_description: 'Foo', assessment_question_id: question.id, comments: 'Yikes!' }])
+      expect(row).to include('Foo: Yikes!')
+    end
+
+    it "includes multiple comment lines for multiple #{alert_type} alerts" do
+      question.update(key: alert_type)
+      move.profile.update(assessment_answers: [{ assessment_question_id: question.id, comments: 'Yikes!' }, { assessment_question_id: question.id, comments: 'Bam!'}])
+      expect(row).to include("Yikes!\n\nBam!")
+    end
+  end
+
+  it 'includes move documents count' do
+    expect(row.last).to eq '0'
+  end
+end
+

--- a/swagger/v2/accept_type_parameter.yaml
+++ b/swagger/v2/accept_type_parameter.yaml
@@ -5,6 +5,8 @@ Accept:
 
     We currently support `application/vnd.api+json` and `version` 1 and 2.
 
+    Additionally, the `GET /moves` endpoint only supports content type of `application/csv` or `text/csv`; this will return a CSV file rather than JSONAPI. When specifying a CSV content type pagination parameters are ignored and all relevant records are returned.
+
     You don't have to supply the media type. `version` _must_ be provided.
   in: header
   required: true


### PR DESCRIPTION
### Jira link

P4-2028

### What?

- [x] Add support for specifying 'text/csv' or 'application/csv' type in 'Accept' header on 'GET /moves' v2 endpoint
- [x] Add new `Moves::Exporter` service to render found moves in CSV file format (matching the existing front end format)

### Why?

- The existing approach for downloading CSV files in the front end uses the API to retrieve all of the relevant moves (normally 1 weeks worth for a given location) in JSONAPI format, and then reformats to a second JSON representation, then serializes that to a CSV format. This is far from efficient, so this new approach generates the CSV in the backend without involving any unnecessary JSON conversion - it simply uses ActiveRecord relationships and writes to a temporary file.
- Adding an additional content type to the existing v2 endpoint means that we can leverage all of the existing filters on the `GET /moves` endpoint - these are already well tested, so clients can obtain exactly the required moves.
- The simple synchronous approach adopted means we only require a `Tempfile` on the API server serving the request; nothing needs to be shared across servers and the temporary files are automatically removed when garbage collection is performed. The server load and response time should be the same or lower than returning the same data in JSONAPI format too. Local testing using a snapshot of the entire staging database (11,470 moves) returns the file in around 15 seconds. A more representative example of 1,000 moves (1 weeks worth across all locations) takes around 1 - 1.5 seconds. If this is scoped to a single location then this should be sub second.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Extends the existing `GET /moves` endpoint to support new `Accept` header value - no change to behaviour if this is not specified
