### PR TITLE
Ignore move_id in documents

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -3,6 +3,8 @@
 class Document < ApplicationRecord
   include Discard::Model
 
+  self.ignored_columns = %w[move_id]
+
   has_one_attached :file
 
   before_validation :validate_file_presence


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Added ignored_columns to documents

### Why?

To avoid confusion about this field actually being used=