### PR TITLE
1 - P4-2004 Add support for importing `add_multiple_items` questions

### DIFF
--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -6,6 +6,7 @@ class FrameworkQuestion < VersionedModel
     checkbox: 'checkbox',
     text: 'text',
     textarea: 'textarea',
+    add_multiple_items: 'add_multiple_items',
   }
 
   validates :key, presence: true

--- a/app/services/frameworks/question.rb
+++ b/app/services/frameworks/question.rb
@@ -15,7 +15,9 @@ module Frameworks
     def call
       question.question_type = source['type']
       question.required = true if required?(source.fetch('validations', []))
+
       build_options(source.fetch('options', []))
+      build_followup_questions(followups: source.fetch('questions', []), value: nil)
 
       questions
     end

--- a/spec/fixtures/files/frameworks/person-escort-record-1/manifests/property-information.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/manifests/property-information.yml
@@ -1,0 +1,7 @@
+name: Property information
+steps:
+  -
+    name: Property details
+    slug: property-details
+    questions:
+      - property-bags

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/property-bag-seal-number.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/property-bag-seal-number.yml
@@ -1,0 +1,6 @@
+type: text
+question: Seal number
+validations:
+  -
+    type: required
+    message: Enter the seal number

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/property-bag-type.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/property-bag-type.yml
@@ -1,0 +1,32 @@
+type: checkbox
+question: What type of property is in this bag?
+description: Property type
+options:
+  -
+    label: Medication
+    value: Medication
+    followup_comment:
+      label: Give details
+  -
+    label: UK currency
+    value: UK currency
+    followup_comment:
+      label: Total amount
+      validations:
+        -
+          type: required
+          message: Enter the total amount
+  -
+    label: Other currency
+    value: Other currency
+    followup_comment:
+      label: Give details of currencies and amounts
+  -
+    label: Valuables
+    value: Valuables
+    followup_comment:
+      label: Give details
+validations:
+  -
+    type: required
+    message: Select property types

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/property-bags.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/property-bags.yml
@@ -1,0 +1,10 @@
+type: add_multiple_items
+question: Bags of property
+list_item_name: Bag
+questions:
+  - property-bag-seal-number
+  - property-bag-type
+validations:
+  -
+    type: required
+    message: Add at least one bag of property

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FrameworkQuestion do
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_presence_of(:section) }
   it { is_expected.to validate_presence_of(:question_type) }
-  it { is_expected.to validate_inclusion_of(:question_type).in_array(%w[radio checkbox text textarea]) }
+  it { is_expected.to validate_inclusion_of(:question_type).in_array(%w[radio checkbox text textarea add_multiple_items]) }
 
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:parent).optional }

--- a/spec/services/frameworks/importer_spec.rb
+++ b/spec/services/frameworks/importer_spec.rb
@@ -56,6 +56,9 @@ RSpec.describe Frameworks::Importer do
           'regular-medication',
           'sensitive-medication',
           'wheelchair-users',
+          'property-bags',
+          'property-bag-type',
+          'property-bag-seal-number',
         )
       end
 
@@ -63,7 +66,7 @@ RSpec.describe Frameworks::Importer do
         described_class.new(filepath: filepath, version: '0.1').call
         framework = Framework.find_by(name: 'person-escort-record-1')
 
-        expect(framework.framework_questions.pluck(:section).uniq).to contain_exactly('offence-details', 'health-information')
+        expect(framework.framework_questions.pluck(:section).uniq).to contain_exactly('offence-details', 'health-information', 'property-information')
       end
 
       it 'maps the correct section to a question' do

--- a/spec/services/frameworks/question_spec.rb
+++ b/spec/services/frameworks/question_spec.rb
@@ -127,5 +127,41 @@ RSpec.describe Frameworks::Question do
         question_value: 'Yes',
       )
     end
+
+    context 'when question type is add_multiple_items' do
+      it 'sets a question as required if required validation available' do
+        filepath = Rails.root.join(fixture_path, 'property-bags.yml')
+        question = FrameworkQuestion.new(section: 'property-information', key: 'property-bags')
+        described_class.new(filepath: filepath, questions: { 'property-bags' => question }).call
+
+        expect(question.required).to eq(true)
+      end
+
+      it 'does not set dependent questions values' do
+        filepath = Rails.root.join(fixture_path, 'property-bags.yml')
+        question = FrameworkQuestion.new(section: 'property-information', key: 'property-bags')
+        dependent_question = FrameworkQuestion.new(section: 'property-information', key: 'property-bag-type')
+        questions = {
+          'property-bags' => question,
+          'property-bag-type' => dependent_question,
+        }
+        described_class.new(filepath: filepath, questions: questions).call
+
+        expect(dependent_question.dependent_value).to be_nil
+      end
+
+      it 'sets dependent questions parents' do
+        filepath = Rails.root.join(fixture_path, 'property-bags.yml')
+        question = FrameworkQuestion.new(section: 'property-information', key: 'property-bags')
+        dependent_question = FrameworkQuestion.new(section: 'property-information', key: 'property-bag-type')
+        questions = {
+          'property-bags' => question,
+          'property-bag-type' => dependent_question,
+        }
+        described_class.new(filepath: filepath, questions: questions).call
+
+        expect(dependent_question.parent).to eq(question)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[P4-2004](https://dsdmoj.atlassian.net/browse/P4-2004)

### What?

- [x] Add new type to framework questions
- [x] Link child questions on a add_multiple_items question without dependent values

### Why?

To support importing questions which require multiple items, add new type of question which allows multiple questions to exist grouped by this question. The child questions are created without a dependent value.  
