### PR TITLE
2 - P4-2004 Add support for creating `add_multiple_items` responses

### DIFF
--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -23,7 +23,7 @@ class FrameworkQuestion < VersionedModel
 
   def build_responses(question: self, person_escort_record:, questions:)
     response = build_response(question, person_escort_record)
-    return response if question.dependents.empty?
+    return response if question.dependents.empty? || question.question_type == 'add_multiple_items'
 
     question.dependents.each do |dependent_question|
       # NB: to avoid extra queries use original set of questions
@@ -35,8 +35,6 @@ class FrameworkQuestion < VersionedModel
     response
   end
 
-private
-
   def build_response(question, person_escort_record)
     klass =
       case question.question_type
@@ -44,6 +42,8 @@ private
         question.followup_comment ? FrameworkResponse::Object : FrameworkResponse::String
       when 'checkbox'
         question.followup_comment ? FrameworkResponse::Collection : FrameworkResponse::Array
+      when 'add_multiple_items'
+        FrameworkResponse::Collection
       else
         FrameworkResponse::String
       end

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -3,6 +3,7 @@ class FrameworkResponse
     validate :validate_collection_type
     validates :value_text, absence: true
     validate :validate_details_collection, on: :update, if: -> { response_details }
+    validate :validate_multiple_items_collection, on: :update, if: -> { multiple_items? }
 
     def value
       value_json.delete_if(&:empty?) if collection_type_valid?(value_json)
@@ -13,6 +14,8 @@ class FrameworkResponse
       self.value_json =
         if response_details && collection_type_valid?(raw_value)
           details_collection(raw_value).to_a
+        elsif multiple_items? && collection_type_valid?(raw_value)
+          multiple_items_collection(raw_value).to_a
         else
           raw_value.presence || []
         end
@@ -32,6 +35,14 @@ class FrameworkResponse
       )
     end
 
+    def multiple_items_collection(collection)
+      MultipleItemsCollection.new(
+        collection: collection,
+        questions: framework_question.dependents,
+        person_escort_record: person_escort_record
+      )
+    end
+
     def validate_details_collection
       return if errors.present?
 
@@ -41,8 +52,21 @@ class FrameworkResponse
       end
     end
 
+    def validate_multiple_items_collection
+      return if errors.present?
+
+      validated_collection = multiple_items_collection(value)
+      if validated_collection.invalid?
+        errors.merge!(validated_collection.errors)
+      end
+    end
+
     def response_details
       @response_details ||= framework_question.followup_comment
+    end
+
+    def multiple_items?
+      framework_question.question_type == 'add_multiple_items'
     end
 
     def validate_collection_type

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -39,7 +39,7 @@ class FrameworkResponse
       MultipleItemsCollection.new(
         collection: collection,
         questions: framework_question.dependents,
-        person_escort_record: person_escort_record
+        person_escort_record: person_escort_record,
       )
     end
 

--- a/app/models/framework_response/multiple_item_object.rb
+++ b/app/models/framework_response/multiple_item_object.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+class FrameworkResponse
+  class MultipleItemObject
+    include ActiveModel::Validations
+
+    attr_accessor :questions, :item, :responses, :person_escort_record
+
+    validates :item, presence: true, numericality: { only_integer: true }
+    validates :responses, presence: true
+    validate :validate_responses_type
+    validate :multiple_response_objects
+    validate :required_questions
+
+    def initialize(attributes: {}, questions: [], person_escort_record:)
+      attributes = attributes.presence || {}
+      @questions = questions
+      @person_escort_record = person_escort_record
+
+      attributes.deep_symbolize_keys! if attributes.respond_to?(:deep_symbolize_keys!)
+      @item = attributes[:item]
+      @responses = attributes[:responses] || []
+    end
+
+    def as_json(_options = {})
+      return {} unless item.present? && responses.any?
+
+      {
+        item: item,
+        responses: response_objects.map { |response| response_as_json(response) },
+      }
+    end
+
+  private
+
+    def multiple_response_objects
+      return unless responses_type_valid? && response_objects.any? { |object| object.invalid?(:update) }
+
+      response_objects.each_with_index do |object, index|
+        object.errors.each do |key, value|
+          errors.add("responses[#{index}].#{key}", value)
+        end
+      end
+    end
+
+    def response_objects
+      @response_objects ||= responses.map { |response|
+        framework_question = questions.find { |question| question.id == response[:framework_question_id] }
+        next unless framework_question
+
+        framework_response = framework_question.build_response(framework_question, person_escort_record)
+
+        framework_response.value = response[:value]
+        framework_response
+      }.compact
+    end
+
+    def validate_responses_type
+      unless responses_type_valid?
+        errors.add(:responses, 'is incorrect type')
+      end
+    end
+
+    def responses_type_valid?
+      responses.is_a?(::Array) && responses.all?(::Hash)
+    end
+
+    def required_questions
+      return unless responses_type_valid?
+
+      question_ids = responses.map { |response| response[:framework_question_id] }
+      questions.each do |question|
+        next unless question.required
+
+        errors.add(:responses, 'provide a value for all required questions') unless question_ids.include?(question.id)
+      end
+    end
+
+    def response_as_json(response)
+      {
+        value: response.value,
+        framework_question_id: response.framework_question_id,
+      }
+    end
+  end
+end

--- a/app/models/framework_response/multiple_items_collection.rb
+++ b/app/models/framework_response/multiple_items_collection.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class FrameworkResponse
+  class MultipleItemsCollection
+    include ActiveModel::Validations
+
+    attr_reader :collection
+
+    validate :multiple_item_objects
+
+    def initialize(collection:, person_escort_record:, questions: [])
+      @collection = Array(collection).map do |item|
+        MultipleItemObject.new(
+          attributes: item,
+          questions: questions,
+          person_escort_record: person_escort_record,
+        )
+      end
+    end
+
+    def to_a
+      collection
+    end
+
+  private
+
+    def multiple_item_objects
+      return unless collection.any?(&:invalid?)
+
+      collection.each_with_index do |object, index|
+        object.errors.each do |key, value|
+          errors.add("items[#{index}].#{key}", value)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/framework_question.rb
+++ b/spec/factories/framework_question.rb
@@ -22,5 +22,11 @@ FactoryBot.define do
       question_type { 'checkbox' }
       options { ['Level 1', 'Level 2'] }
     end
+
+    trait :add_multiple_items do
+      question_type { 'add_multiple_items' }
+      options { [] }
+      dependents { [build(:framework_question, :checkbox)] }
+    end
   end
 end

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -19,6 +19,16 @@ FactoryBot.define do
       association(:framework_question, :checkbox, followup_comment: true)
       value { [{ 'option' => 'Level 1', 'details' => 'some comment' }, { 'option' => 'Level 2', 'details' => 'another comment' }] }
     end
+
+    trait :multiple_items do
+      association(:framework_question, :add_multiple_items)
+      value do
+        [
+          { 'item' => 1, 'responses' => [{ 'value' => ['Level 1'], 'framework_question_id' => framework_question.dependents.first.id }] },
+          { 'item' => 2, 'responses' => [{ 'value' => ['Level 2'], 'framework_question_id' => framework_question.dependents.first.id }] },
+        ]
+      end
+    end
   end
 
   factory :string_response, parent: :framework_response, class: 'FrameworkResponse::String' do

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -18,72 +18,6 @@ RSpec.describe FrameworkQuestion do
   describe '#build_responses' do
     let(:questions) { described_class.all.index_by(&:id) }
 
-    it 'builds a string response for radio questions' do
-      question = create(:framework_question)
-      person_escort_record = create(:person_escort_record)
-      response = question.build_responses(
-        person_escort_record: person_escort_record,
-        questions: questions,
-      )
-
-      expect(response).to be_a(FrameworkResponse::String)
-    end
-
-    it 'builds an array response for checkbox questions' do
-      question = create(:framework_question, :checkbox)
-      person_escort_record = create(:person_escort_record)
-      response = question.build_responses(
-        person_escort_record: person_escort_record,
-        questions: questions,
-      )
-
-      expect(response).to be_a(FrameworkResponse::Array)
-    end
-
-    it 'builds a string response for text questions' do
-      question = create(:framework_question, :text)
-      person_escort_record = create(:person_escort_record)
-      response = question.build_responses(
-        person_escort_record: person_escort_record,
-        questions: questions,
-      )
-
-      expect(response).to be_a(FrameworkResponse::String)
-    end
-
-    it 'builds a string response for textarea questions' do
-      question = create(:framework_question, :textarea)
-      person_escort_record = create(:person_escort_record)
-      response = question.build_responses(
-        person_escort_record: person_escort_record,
-        questions: questions,
-      )
-
-      expect(response).to be_a(FrameworkResponse::String)
-    end
-
-    it 'builds an object response for radio with followup questions' do
-      question = create(:framework_question, followup_comment: true)
-      person_escort_record = create(:person_escort_record)
-      response = question.build_responses(
-        person_escort_record: person_escort_record,
-        questions: questions,
-      )
-
-      expect(response).to be_a(FrameworkResponse::Object)
-    end
-
-    it 'builds a collection response for checkbox with followup questions' do
-      question = create(:framework_question, :checkbox, followup_comment: true)
-      person_escort_record = create(:person_escort_record)
-      response = question.build_responses(
-        person_escort_record: person_escort_record,
-        questions: questions,
-      )
-
-      expect(response).to be_a(FrameworkResponse::Collection)
-    end
-
     it 'builds response associated to correct question' do
       question1 = create(:framework_question)
       question2 = create(:framework_question)
@@ -144,6 +78,17 @@ RSpec.describe FrameworkQuestion do
       expect(response.dependents.first.framework_question).to eq(dependent_question)
     end
 
+    it 'does not build dependent responses for multiple item questions' do
+      person_escort_record = create(:person_escort_record)
+      question = create(:framework_question, :add_multiple_items)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
+
+      expect(response.dependents).to be_empty
+    end
+
     it 'sets person_escort_record on dependent responses' do
       person_escort_record = create(:person_escort_record)
       question = create(:framework_question)
@@ -185,6 +130,85 @@ RSpec.describe FrameworkQuestion do
 
       dependent_responses = response.dependents
       expect(dependent_responses.first.dependents.size).to eq(2)
+    end
+  end
+
+  describe '#build_response' do
+    it 'builds a string response for radio questions' do
+      question = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_response(
+        question,
+        person_escort_record,
+      )
+
+      expect(response).to be_a(FrameworkResponse::String)
+    end
+
+    it 'builds an array response for checkbox questions' do
+      question = create(:framework_question, :checkbox)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_response(
+        question,
+        person_escort_record,
+      )
+
+      expect(response).to be_a(FrameworkResponse::Array)
+    end
+
+    it 'builds a string response for text questions' do
+      question = create(:framework_question, :text)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_response(
+        question,
+        person_escort_record,
+      )
+
+      expect(response).to be_a(FrameworkResponse::String)
+    end
+
+    it 'builds a string response for textarea questions' do
+      question = create(:framework_question, :textarea)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_response(
+        question,
+        person_escort_record,
+      )
+
+      expect(response).to be_a(FrameworkResponse::String)
+    end
+
+    it 'builds an object response for radio with followup questions' do
+      question = create(:framework_question, followup_comment: true)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_response(
+        question,
+        person_escort_record,
+      )
+
+      expect(response).to be_a(FrameworkResponse::Object)
+    end
+
+    it 'builds a collection response for checkbox with followup questions' do
+      question = create(:framework_question, :checkbox, followup_comment: true)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_response(
+        question,
+        person_escort_record,
+      )
+
+      expect(response).to be_a(FrameworkResponse::Collection)
+    end
+
+    it 'builds a collection response for multiple items questions' do
+      question = create(:framework_question, :add_multiple_items)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_response(
+        question,
+        person_escort_record,
+      )
+
+      expect(response).to be_a(FrameworkResponse::Collection)
     end
   end
 end

--- a/spec/models/framework_response/multiple_item_object_spec.rb
+++ b/spec/models/framework_response/multiple_item_object_spec.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
+  let(:person_escort_record) { create(:person_escort_record) }
+
+  context 'with validations' do
+    it 'ignores other keys passed in' do
+      questions = [create(:framework_question)]
+      attributes = { items: 1, responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:item]).to eq(["can't be blank", 'is not a number'])
+    end
+
+    it 'validates the presence of an item' do
+      questions = [create(:framework_question)]
+      attributes = { responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:item]).to eq(["can't be blank", 'is not a number'])
+    end
+
+    it 'validates that item attribute is a number' do
+      questions = [create(:framework_question)]
+      attributes = { item: 'some-item', responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:item]).to eq(['is not a number'])
+    end
+
+    it 'validates that item attribute is an integer' do
+      questions = [create(:framework_question)]
+      attributes = { item: 1.1, responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:item]).to eq(['must be an integer'])
+    end
+
+    it 'validates the presence of a responses key' do
+      questions = [create(:framework_question)]
+      attributes = { item: 1, response: [{ value: 'Yes', framework_question_id: questions.first.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:responses]).to eq(["can't be blank"])
+    end
+
+    it 'validates responses if an item are not empty' do
+      question1 = create(:framework_question, :checkbox)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = { item: 1, responses: [] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:responses]).to eq(["can't be blank"])
+    end
+
+    it 'validates type of responses key' do
+      questions = [create(:framework_question)]
+      attributes = { item: 1, responses: { value: 'Yes', framework_question_id: questions.first.id } }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:responses]).to eq(['is incorrect type'])
+    end
+
+    it 'validates responses include value key if multiple responses supplied and question required' do
+      question1 = create(:framework_question, :checkbox, required: true)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }, { framework_question_id: question1.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:"responses[1].value"]).to eq(["can't be blank"])
+    end
+
+    it 'does not validate responses include value key if multiple responses supplied and question not required' do
+      question1 = create(:framework_question, :checkbox)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }, { framework_question_id: question1.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).to be_valid
+    end
+
+    it 'validates responses include framework_question_id key if multiple responses supplied and question required' do
+      question1 = create(:framework_question, :checkbox, required: true)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }, { value: ['Level 1'] }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:responses]).to eq(['provide a value for all required questions'])
+    end
+
+    it 'does not validate responses include framework_question_id key if multiple responses supplied and question not required' do
+      question1 = create(:framework_question, :checkbox)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }, { value: ['Level 1'] }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).to be_valid
+    end
+
+    it 'ignores responses with framework_question_id not included in question ids' do
+      question1 = create(:framework_question, :checkbox)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }, { value: ['Level 1'], framework_question_id: 'some-id' }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).to be_valid
+    end
+
+    it 'ignores other keys in responses' do
+      question1 = create(:framework_question, :checkbox)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id, values: 'Some value' }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).to be_valid
+    end
+
+    it 'validates response if value for response is invalid' do
+      questions = [create(:framework_question, :checkbox)]
+      attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:"responses[0].value"]).to eq(['is incorrect type'])
+    end
+
+    it 'does not validate the response if value for response is valid' do
+      questions = [create(:framework_question, :checkbox)]
+      attributes = { item: 1, responses: [{ value: ['Level 1'], framework_question_id: questions.first.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).to be_valid
+    end
+
+    it 'validates response if value for response is required' do
+      questions = [create(:framework_question, :checkbox, required: true)]
+      attributes = { item: 1, responses: [{ value: nil, framework_question_id: questions.first.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:"responses[0].value"]).to eq(["can't be blank"])
+    end
+
+    it 'validates required questions if no response provided for that question' do
+      question1 = create(:framework_question, :checkbox, required: true)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).not_to be_valid
+      expect(object.errors.messages[:responses]).to eq(['provide a value for all required questions'])
+    end
+
+    it 'does not validate optional question if no response provided for that question' do
+      question1 = create(:framework_question, :checkbox)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }] }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object).to be_valid
+    end
+  end
+
+  describe '#as_json' do
+    it 'returns a hash of the item and responses' do
+      question1 = create(:framework_question, :checkbox, required: true)
+      question2 = create(:framework_question, required: true)
+      questions = [question1, question2]
+      attributes = {
+        item: 1,
+        responses: [
+          { value: ['Level 1'], framework_question_id: question1.id },
+          { value: 'No', framework_question_id: question2.id },
+        ],
+      }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object.as_json).to eq(attributes)
+    end
+
+    it 'returns an empty hash if nothing passed in' do
+      questions = [create(:framework_question, :checkbox, required: true)]
+      object = described_class.new(attributes: {}, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object.as_json).to be_empty
+    end
+
+    it 'returns an empty hash if nil option and details passed in' do
+      questions = [create(:framework_question, :checkbox, required: true)]
+      attributes = {
+        item: nil,
+        responses: nil,
+      }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object.as_json).to be_empty
+    end
+
+    it 'ignores invalid responses if no value supplied' do
+      question1 = create(:framework_question, :checkbox, required: true)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = {
+        item: 1,
+        responses: [{ value: ['Level 1'], framework_question_id: question1.id }, { framework_question_id: question2.id }],
+      }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object.as_json).to eq({
+        item: 1,
+        responses: [
+          { value: ['Level 1'], framework_question_id: question1.id },
+          { value: nil, framework_question_id: question2.id },
+        ],
+      })
+    end
+
+    it 'ignores invalid responses if no framework_question_id supplied' do
+      question1 = create(:framework_question, :checkbox, required: true)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = {
+        item: 1,
+        responses: [{ value: ['Level 1'], framework_question_id: question1.id }, { value: 'Yes' }],
+      }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object.as_json).to eq({
+        item: 1,
+        responses: [
+          { value: ['Level 1'], framework_question_id: question1.id },
+        ],
+      })
+    end
+
+    it 'ignores invalid responses if framework_question_id supplied incorrect' do
+      question1 = create(:framework_question, :checkbox, required: true)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      attributes = {
+        item: 1,
+        responses: [{ value: ['Level 1'], framework_question_id: question1.id }, { value: 'Yes', framework_question_id: 'some-id' }],
+      }
+      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+
+      expect(object.as_json).to eq({
+        item: 1,
+        responses: [
+          { value: ['Level 1'], framework_question_id: question1.id },
+        ],
+      })
+    end
+  end
+end

--- a/spec/models/framework_response/multiple_items_collection_spec.rb
+++ b/spec/models/framework_response/multiple_items_collection_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponse::MultipleItemsCollection, type: :model do
+  let(:person_escort_record) { create(:person_escort_record) }
+
+  context 'with validations' do
+    it 'validates the object passed' do
+      question1 = create(:framework_question, :checkbox)
+      question2 = create(:framework_question)
+      questions = [question1, question2]
+      response1 = { value: 'Level 1', framework_question_id: question1.id }
+      response2 = { value: 'Yes', framework_question_id: question2.id }
+      collection = [{ item: 1, responses: [response2] }, { item: 2, responses: [response1, response2] }]
+
+      collection = described_class.new(collection: collection, person_escort_record: person_escort_record, questions: questions)
+
+      expect(collection).not_to be_valid
+      expect(collection.errors.messages[:"items[1].responses[0].value"]).to eq(['is incorrect type'])
+    end
+  end
+
+  describe '#to_a' do
+    it 'returns collection of multiple item objects' do
+      question = create(:framework_question, :checkbox)
+      response = { value: ['Level 1'], framework_question_id: question.id }
+      collection = [{ item: 1, responses: [response] }]
+
+      collection = described_class.new(collection: collection, person_escort_record: person_escort_record, questions: [question])
+      expect(collection.to_a.first).to be_a(FrameworkResponse::MultipleItemObject)
+    end
+
+    it 'maps collection of objects' do
+      question = create(:framework_question, :checkbox)
+      response1 = { value: ['Level 1'], framework_question_id: question.id }
+      response2 = { value: ['Level 2'], framework_question_id: question.id }
+      collection = [{ item: 1, responses: [response2] }, { item: 2, responses: [response1] }]
+
+      collection = described_class.new(collection: collection, person_escort_record: person_escort_record, questions: [question])
+      expect(collection.to_a.count).to eq(2)
+    end
+
+    it 'returns an empty array if collection is empty' do
+      collection = described_class.new(collection: [], person_escort_record: person_escort_record)
+
+      expect(collection.to_a).to be_empty
+    end
+  end
+end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe FrameworkResponse do
       expect(response).to validate_presence_of(:value).on(:update)
     end
 
-    it 'does not validate collection dependent responses if parent response is not correct value' do
+    it 'does not validate multiple item collection dependent responses if parent response is not correct value' do
       question = create(:framework_question, :add_multiple_items, dependent_value: 'Level 3', options: [], required: true)
       response = create(:collection_response, :multiple_items, value: nil, parent: create(:collection_response, :details), framework_question: question)
 

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -74,6 +74,20 @@ RSpec.describe FrameworkResponse do
 
       expect(response).not_to validate_presence_of(:value).on(:update)
     end
+
+    it 'validates multiple item collection dependent responses' do
+      question = create(:framework_question, :add_multiple_items, dependent_value: 'Level 1', options: [], required: true)
+      response = create(:collection_response, :multiple_items, value: nil, parent: create(:collection_response, :details), framework_question: question)
+
+      expect(response).to validate_presence_of(:value).on(:update)
+    end
+
+    it 'does not validate collection dependent responses if parent response is not correct value' do
+      question = create(:framework_question, :add_multiple_items, dependent_value: 'Level 3', options: [], required: true)
+      response = create(:collection_response, :multiple_items, value: nil, parent: create(:collection_response, :details), framework_question: question)
+
+      expect(response).not_to validate_presence_of(:value).on(:update)
+    end
   end
 
   describe '.requires_value?' do
@@ -91,7 +105,7 @@ RSpec.describe FrameworkResponse do
       expect(described_class.requires_value?(response.value, response)).to be(false)
     end
 
-    it 'returns true if question required, value is empty and has is not dependent' do
+    it 'returns true if question required, value is empty and is not dependent' do
       question = create(:framework_question, options: [], required: true)
       response = create(:string_response, value: nil, framework_question: question)
 

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -136,6 +136,15 @@ RSpec.describe PersonEscortRecord do
       expect { person_escort_record.build_responses! }.to change(FrameworkResponse, :count).by(2)
     end
 
+    it 'creates responses for multiple items questions' do
+      framework = create(:framework)
+      create(:framework_question, :add_multiple_items, framework: framework)
+      profile = create(:profile)
+      person_escort_record = build(:person_escort_record, framework: framework, profile: profile)
+
+      expect { person_escort_record.build_responses! }.to change(FrameworkResponse, :count).by(1)
+    end
+
     it 'creates responses for dependent questions' do
       framework = create(:framework)
       parent_question = create(:framework_question, framework: framework)


### PR DESCRIPTION
### Jira link

[P4-2004](https://dsdmoj.atlassian.net/browse/P4-2004)
### What?

- [x] Added new type of collection response for multiple item questions
- [x] Added support for creating multiple item responses when creating the PER

### Why?

Add a new collection response type: multiple items. Each multiple items list contains a multiple item object which encapsulates the item and the corresponding responses. It applies the validations to that object and bubbles them up to the collection appropriately.

This type of question has nested questions which do not have corresponding responses, but rather those responses are encapsulated in the parent question, mapped to the item they are associated to. 

Since the responses provided for the item mirror framework responses, validate those on update (if normal validation added it allows them to be empty which we don't want). Scope validations to an index of the responses and the items to avoid overwriting validation messages. This is similar to `index_errors` on rails associations: https://blog.bigbinary.com/2016/07/07/errors-can-be-indexed-with-nested-attrbutes-in-rails-5.html

When a question is an add multiple items question, create a response of type collection. Do not create dependent responses for multiple items dependent questions, as those will be nested in the parent response.
