### PR TITLE
3 - P4-2004 Add support for PATCHing `add_multiple_items` responses

### DIFF
--- a/app/controllers/api/framework_responses_controller.rb
+++ b/app/controllers/api/framework_responses_controller.rb
@@ -4,9 +4,13 @@ module Api
   class FrameworkResponsesController < ApiController
     # NB: permit multiple types of value attributes: array, array of objects,
     # object with option details fields, and string
-    PPERMITTED_PARAMS = [
+    PERMITTED_PARAMS = [
       :type,
-      attributes: [:value, { value: %i[option details] }, { value: [] }],
+      attributes: [
+        :value,
+        { value: [:option, :details, :item, responses: [:framework_question_id, :value, { value: %i[option details] }, { value: [] }]] },
+        { value: [] },
+      ],
     ].freeze
 
     def update
@@ -18,7 +22,7 @@ module Api
   private
 
     def update_framework_response_params
-      params.require(:data).permit(PPERMITTED_PARAMS)
+      params.require(:data).permit(PERMITTED_PARAMS)
     end
 
     def update_framework_response_attributes

--- a/app/serializers/framework_question_serializer.rb
+++ b/app/serializers/framework_question_serializer.rb
@@ -1,9 +1,24 @@
 class FrameworkQuestionSerializer < ActiveModel::Serializer
   belongs_to :framework
 
-  attributes :key, :section, :question_type, :options
+  attributes :key, :section, :question_type, :options, :response_type
+  has_many :dependents, key: :descendants
+
+  def response_type
+    case object.question_type
+    when 'radio'
+      object.followup_comment ? 'object' : 'string'
+    when 'checkbox'
+      object.followup_comment ? 'collection' : 'array'
+    when 'add_multiple_items'
+      'collection::add_multiple_items'
+    else
+      'string'
+    end
+  end
 
   SUPPORTED_RELATIONSHIPS = %w[
     framework
+    descendants
   ].freeze
 end

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -15,13 +15,13 @@ class FrameworkResponseSerializer < ActiveModel::Serializer
     when 'FrameworkResponse::Object'
       'object'
     when 'FrameworkResponse::Collection'
-      'collection'
+      object.framework_question.question_type == 'add_multiple_items' ? 'collection::add_multiple_items' : 'collection'
     end
   end
 
   SUPPORTED_RELATIONSHIPS = %w[
     person_escort_record
-    question
+    question.descendants
     flags
   ].freeze
 end

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -15,7 +15,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   end
 
   def framework_responses
-    object.framework_responses.includes(:framework_flags, framework_question: [:framework, :dependents])
+    object.framework_responses.includes(:framework_flags, framework_question: %i[framework dependents])
   end
 
   def status

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -15,7 +15,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   end
 
   def framework_responses
-    object.framework_responses.includes(:framework_flags, framework_question: :framework)
+    object.framework_responses.includes(:framework_flags, framework_question: [:framework, :dependents])
   end
 
   def status
@@ -30,6 +30,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
     framework
     profile.person
     responses.question
+    responses.question.descendants
     flags
   ].freeze
 end

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Api::FrameworkResponsesController do
             "type": 'framework_responses',
             "attributes": {
               "value": value,
-              "value_type": 'collection',
+              "value_type": 'collection::add_multiple_items',
               "responded": true,
             },
           })
@@ -160,7 +160,7 @@ RSpec.describe Api::FrameworkResponsesController do
             "type": 'framework_responses',
             "attributes": {
               "value": [{ item: 2, responses: [{ value: ['Level 2'], framework_question_id: framework_question.id }] }],
-              "value_type": 'collection',
+              "value_type": 'collection::add_multiple_items',
               "responded": true,
             },
           })

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -70,11 +70,19 @@ RSpec.describe FrameworkResponseSerializer do
       end
     end
 
-    context 'when response is an collection response' do
+    context 'when response is a collection response' do
       let(:framework_response) { create(:collection_response) }
 
       it 'returns value_type `collection`' do
         expect(result[:data][:attributes][:value_type]).to eq('collection')
+      end
+    end
+
+    context 'when response is a collection response and question type is add multiple items' do
+      let(:framework_response) { create(:collection_response, :multiple_items) }
+
+      it 'returns value_type `collection`' do
+        expect(result[:data][:attributes][:value_type]).to eq('collection::add_multiple_items')
       end
     end
 

--- a/swagger/v1/framework_question.yaml
+++ b/swagger/v1/framework_question.yaml
@@ -21,6 +21,7 @@ FrameworkQuestion:
       required:
       - key
       - question_type
+      - response_type
       - options
       properties:
         key:
@@ -37,6 +38,17 @@ FrameworkQuestion:
             - radio
             - checkbox
           description: Indicates the type of question
+          readOnly: true
+        response_type:
+          type: string
+          example: 'string'
+          enum:
+            - string
+            - array
+            - object
+            - collection
+            - collection::add_multiple_items
+          description: Indicates the type of response for the question
           readOnly: true
         section:
           example: 'risk-information'

--- a/swagger/v1/framework_response.yaml
+++ b/swagger/v1/framework_response.yaml
@@ -47,11 +47,10 @@ FrameworkResponse:
                       type: string
                     details:
                       type: string
-                  example:
-                    - option: Level 1
-                      details: Some details about Level 1
-                    - option: Level 2
-                      details: Some details about Level 2
+                    item:
+                      type: integer
+                    responses:
+                      type: array
         value_type:
           type: string
           example: 'array'
@@ -60,6 +59,7 @@ FrameworkResponse:
             - array
             - object
             - collection
+            - collection::add_multiple_items
           description: Indicates the type of value for the answer provided
           readOnly: true
         responded:

--- a/swagger/v1/framework_response_include_parameter.yaml
+++ b/swagger/v1/framework_response_include_parameter.yaml
@@ -10,4 +10,5 @@ FrameworkResponseIncludeParameter:
       - flags
       - person_escort_record
       - question
+      - question.descendants
   example: framework

--- a/swagger/v1/person_escort_record_include_parameter.yaml
+++ b/swagger/v1/person_escort_record_include_parameter.yaml
@@ -12,5 +12,6 @@ PersonEscortRecordIncludeParameter:
       - profile.person
       - responses
       - responses.question
+      - responses.question.descendants
       - flags
   example: framework


### PR DESCRIPTION
### Jira link

[P4-2004](https://dsdmoj.atlassian.net/browse/P4-2004)

### What?

- [x] Added support in framework responses controller to permit new values for add multiple items
- [x] Expose dependent questions in framework question serializer
- [x] Expose response type in framework question serializer

### Why?

To allow multiple item responses to be updated, permit nested `item` and `responses` attributes for framework responses.
Since value supports multiple types we have to mirror that in the permitted attributes by supporting both a nested string and object.

Since we are allowing the client to build the nested responses, they require the response type to be exposed. We can do this on the framework questions, which now have both `question_type` as well as `response_type`.

Expose a different response type for add multiple items, since this will indicate that this type of response is structured differently. Since migrating existing types is more involved, we are deferring it for later.

### Have you? (optional)

- [x] Updated API docs if necessary	


### Deployment risks (optional)

- Changes an api that is used in production

