### PR TITLE
Improve error message for webhook notifications

### DIFF
--- a/app/jobs/notify_webhook_job.rb
+++ b/app/jobs/notify_webhook_job.rb
@@ -18,7 +18,9 @@ class NotifyWebhookJob < ApplicationJob
       client = get_client(subscription)
       response = client.post(subscription.callback_url, data, 'PECS-SIGNATURE': hmac, 'PECS-NOTIFICATION-ID': notification_id)
 
-      raise "non-success status received from #{subscription.callback_url} (#{response.status} #{response.reason_phrase})" unless response.success?
+      unless response.success?
+        raise "non-success status received from #{subscription.callback_url}. Status: #{response.status}, Reason: #{response.reason_phrase}, Response body: '#{response.body}'"
+      end
 
       notification.update(
         delivered_at: Time.zone.now,

--- a/spec/jobs/notify_webhook_job_spec.rb
+++ b/spec/jobs/notify_webhook_job_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe NotifyWebhookJob, type: :job do
       end
 
       context 'when the callback response is a failure' do
-        let(:response) { instance_double(Faraday::Response, success?: false, status: 503, reason_phrase: 'Server error') }
+        let(:response) { instance_double(Faraday::Response, success?: false, status: 503, reason_phrase: 'Server error', body: { message: 'some message', error: 'some error' }.to_json) }
 
         it 'raises Notification failed error' do
           expect { perform! }.to raise_error(RuntimeError, /non-success status received/)


### PR DESCRIPTION
Parse response and extract error message from body, to help debugging of webhook errors. The raw response with an error coming from the server has the following structure:

```
{"resource"=>"/suite/webapi/getMOJEvents", "error"=>"APNX-1-4187-005", "message"=>"User password has expired. Please sign in using a web browser to change your password.", "title"=>"An Error Has Occurred"}
```
If the structure is different we should get empty values
