### PR TITLE
Allow move_type to be updated when redirecting a move

### DIFF
--- a/app/controllers/api/move_events_controller.rb
+++ b/app/controllers/api/move_events_controller.rb
@@ -11,7 +11,7 @@ module Api
     APPROVE_PARAMS = [:type, attributes: %i[timestamp date create_in_nomis]].freeze
     CANCEL_PARAMS = [:type, attributes: %i[timestamp cancellation_reason cancellation_reason_comment notes]].freeze
     LOCKOUT_PARAMS = [:type, attributes: %i[timestamp notes], relationships: { from_location: {} }].freeze
-    REDIRECT_PARAMS = [:type, attributes: %i[timestamp notes], relationships: { to_location: {} }].freeze
+    REDIRECT_PARAMS = [:type, attributes: %i[timestamp notes move_type], relationships: { to_location: {} }].freeze
     REJECT_PARAMS = [:type, attributes: %i[timestamp rejection_reason cancellation_reason_comment rebook]].freeze
 
     COMMON_PARAMS = [:type, attributes: %i[timestamp notes]].freeze # for accept, complete and start move events

--- a/app/models/move_event.rb
+++ b/app/models/move_event.rb
@@ -25,6 +25,10 @@ class MoveEvent < Event
     @cancellation_reason_comment ||= event_params.dig(:attributes, :cancellation_reason_comment)
   end
 
+  def move_type
+    @move_type ||= event_params.dig(:attributes, :move_type)
+  end
+
 private
 
   def option_selected?(attribute_name)

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -28,6 +28,7 @@ module EventLog
           # no action to perform when a move is locked out, this event is purely for auditing
         when Event::REDIRECT
           move.to_location = event.to_location
+          move.move_type = event.move_type if event.move_type.present?
         when Event::REJECT
           move.status = Move::MOVE_STATUS_CANCELLED
           move.rejection_reason = event.rejection_reason

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -36,17 +36,7 @@ Move:
           - completed
           description: Indicates the stage in its lifecycle that this move is at
         move_type:
-          type: string
-          enum:
-          - court_appearance
-          - court_other
-          - hospital
-          - police_transfer
-          - prison_recall
-          - prison_remand
-          - prison_transfer
-          - video_remand
-          description: Indicates the type of move, e.g. prison transfer or court appearance
+          $ref: move_type_attribute.yaml#/MoveType
         move_agreed:
           oneOf:
           - type: boolean

--- a/swagger/v1/move_type_attribute.yaml
+++ b/swagger/v1/move_type_attribute.yaml
@@ -1,0 +1,12 @@
+MoveType:
+  type: string
+  enum:
+    - court_appearance
+    - court_other
+    - hospital
+    - police_transfer
+    - prison_recall
+    - prison_remand
+    - prison_transfer
+    - video_remand
+  description: Indicates the type of move, e.g. prison transfer or court appearance

--- a/swagger/v1/post_move_redirect.yaml
+++ b/swagger/v1/post_move_redirect.yaml
@@ -17,6 +17,8 @@ PostMoveRedirect:
       properties:
         timestamp:
           $ref: timestamp_attribute.yaml#/Timestamp
+        move_type:
+          $ref: move_type_attribute.yaml#/MoveType
         notes:
           $ref: notes_attribute.yaml#/Notes
     relationships:

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -37,17 +37,7 @@ Move:
             - completed
           description: Indicates the stage in its lifecycle that this move is at
         move_type:
-          type: string
-          enum:
-            - court_appearance
-            - court_other
-            - hospital
-            - police_transfer
-            - prison_recall
-            - prison_remand
-            - prison_transfer
-            - video_remand
-          description: Indicates the type of move, e.g. prison transfer or court appearance
+          $ref: "../v1/move_type_attribute.yaml#/MoveType"
         move_agreed:
           oneOf:
             - type: boolean


### PR DESCRIPTION
### Jira link

P4-2031

### What?

- [x] Add new optional `move_type` param for move redirection event
- [x] Cleaned up swagger docs to avoid repeated definition of `move_type` attribute

### Why?

- If a move is redirected to a location which requires a new `move_type` then currently it's not possible to so as the move type cannot be changed after the move is created. This limits the flexibility for some move scenarios. This PR adds support for an extra `move_type` parameter to be passed in the redirect event (if not passed then existing move_type is retained). Existing move type validation logic ensures that the specified to_location and move_type combination remains valid. 

### Have you? (optional)

- [x] Updated API docs if necessary

### Deployment risks (optional)

- Existing API behaviour is unchanged if new parameter is not specified, so low risk

