### PR TITLE
Include dependents in PER serializer to avoid n+1 queries

### DIFF
--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -14,8 +14,12 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
     object.framework.version
   end
 
+  def framework_flags
+    object.framework_flags.includes(framework_question: :dependents)
+  end
+
   def framework_responses
-    object.framework_responses.includes(:framework_flags, framework_question: %i[framework dependents])
+    object.framework_responses.includes(:framework_flags, framework_question: [:framework, dependents: :dependents])
   end
 
   def status


### PR DESCRIPTION
introducing dependents is causing some n+1 queries whilst fetching the PER with questions associating on flags and responses. Double dependents is as fun as it sounds...

```
[active_model_serializers]   ↳ app/controllers/api/person_escort_records_controller.rb:61:in `render_person_escort_record'
[active_model_serializers]   FrameworkQuestion Load (17.2ms)  SELECT "framework_questions".* FROM "framework_questions" WHERE "framework_questions"."parent_id" = $1  [["parent_id", "40c3de38-75db-46fd-826a-0b34fd6fd5a4"]]
[active_model_serializers]   ↳ app/controllers/api/person_escort_records_controller.rb:61:in `render_person_escort_record'
[active_model_serializers]   FrameworkQuestion Load (18.0ms)  SELECT "framework_questions".* FROM "framework_questions" WHERE "framework_questions"."id" = $1 LIMIT $2  [["id", "39f6db13-c724-4b28-ac74-e790f4a47860"], ["LIMIT", 1]]
[active_model_serializers]   ↳ app/controllers/api/person_escort_records_controller.rb:61:in `render_person_escort_record'
[active_model_serializers]   FrameworkQuestion Load (17.5ms)  SELECT "framework_questions".* FROM "framework_questions" WHERE "framework_questions"."id" = $1 LIMIT $2  [["id", "8e409dcf-8a2e-45a3-a3b5-aba0fe43ccc7"], ["LIMIT", 1]]
[active_model_serializers]   ↳ app/controllers/api/person_escort_records_controller.rb:61:in `render_person_escort_record'
[active_model_serializers]   FrameworkQuestion Load (17.5ms)  SELECT "framework_questions".* FROM "framework_questions" WHERE "framework_questions"."id" = $1 LIMIT $2  [["id", "03e97285-f93b-4be8-b527-2cb560266b56"], ["LIMIT", 1]]
[active_model_serializers]   ↳ app/controllers/api/person_escort_records_controller.rb:61:in `render_person_escort_record'
[active_model_serializers]   FrameworkQuestion Load (17.7ms)  SELECT "framework_questions".* FROM "framework_questions" WHERE "framework_questions"."id" = $1 LIMIT $2  [["id", "e63dce3c-8041-435d-af35-357f4faada44"], ["LIMIT", 1]]
[active_model_serializers]   ↳ app/controllers/api/person_escort_records_controller.rb:61:in `render_person_escort_record'
[active_model_serializers]   FrameworkQuestion Load (17.8ms)  SELECT "framework_questions".* FROM "framework_questions" WHERE "framework_questions"."id" = $1 LIMIT $2  [["id", "f40b54b9-77d8-4361-b8d4-e36305b24fc9"], ["LIMIT", 1]]
[active_model_serializers]   ↳ app/controllers/api/person_escort_records_controller.rb:61:in `render_person_escort_record'
[active_model_serializers] Rendered PersonEscortRecordSerializer with ActiveModelSerializers::Adapter::JsonApi (1771.83ms)
Completed 200 OK in 1937ms (Views: 725.1ms | ActiveRecord: 1198.0ms | Allocations: 379984)
```