### PR TITLE
Expose dependents on move endpoint for PER questions

### DIFF
--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -41,6 +41,7 @@ class MoveSerializer < ActiveModel::Serializer
     profile.person_escort_record.framework
     profile.person_escort_record.responses
     profile.person_escort_record.responses.question
+    profile.person_escort_record.responses.question.descendants.**
     from_location
     from_location.suppliers
     to_location

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -34,7 +34,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
     framework
     profile.person
     responses.question
-    responses.question.descendants
+    responses.question.descendants.**
     flags
   ].freeze
 end

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -37,6 +37,7 @@ module V2
       profile.person_escort_record.framework
       profile.person_escort_record.responses
       profile.person_escort_record.responses.question
+      profile.person_escort_record.responses.question.descendants.**
       from_location
       from_location.suppliers
       to_location

--- a/swagger/v1/move_include_parameter.yaml
+++ b/swagger/v1/move_include_parameter.yaml
@@ -29,4 +29,5 @@ MoveIncludeParameter:
       - profile.person_escort_record.framework
       - profile.person_escort_record.responses
       - profile.person_escort_record.responses.question
+      - profile.person_escort_record.responses.question.descendants.**
   example: from_location

--- a/swagger/v1/person_escort_record_include_parameter.yaml
+++ b/swagger/v1/person_escort_record_include_parameter.yaml
@@ -12,6 +12,6 @@ PersonEscortRecordIncludeParameter:
       - profile.person
       - responses
       - responses.question
-      - responses.question.descendants
+      - responses.question.descendants.**
       - flags
   example: framework

--- a/swagger/v2/move_include_parameter.yaml
+++ b/swagger/v2/move_include_parameter.yaml
@@ -24,4 +24,5 @@ MoveIncludeParameter:
       - profile.person_escort_record.framework
       - profile.person_escort_record.responses
       - profile.person_escort_record.responses.question
+      - profile.person_escort_record.responses.question.descendants.**
   example: from_location


### PR DESCRIPTION
To expose the descendant questions resource on a Move, add to include list.
Update since descendants are nested and hierarchical we need to use `**` to allow includes for more than one level: https://github.com/rails-api/active_model_serializers/blob/v0.10.6/docs/general/adapters.md#include-option 

I kept the response at a single level as we will never need to support multiple nested resources at that level, this is only on the PER or Move