### PR TITLE
Add new endpoint /suppliers/:supplier_id/locations 

### DIFF
--- a/app/controllers/api/suppliers_controller.rb
+++ b/app/controllers/api/suppliers_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  class SuppliersController < ApiController
+    def locations
+      paginate locations_from_supplier_moves
+    end
+
+  private
+
+    def locations_from_supplier_moves
+      supplier = Supplier.find(params[:supplier_id])
+
+      Location.joins(:moves_from).where(moves: { supplier_id: supplier.id }).distinct
+    end
+  end
+end

--- a/app/controllers/api/suppliers_controller.rb
+++ b/app/controllers/api/suppliers_controller.rb
@@ -12,6 +12,7 @@ module Api
       supplier = Supplier.find(params[:supplier_id])
 
       Location.joins(:moves_from)
+              .includes(:suppliers)
               .where(moves: { supplier_id: supplier.id })
               .order(key: :asc)
               .distinct

--- a/app/controllers/api/suppliers_controller.rb
+++ b/app/controllers/api/suppliers_controller.rb
@@ -3,7 +3,7 @@
 module Api
   class SuppliersController < ApiController
     def locations
-      paginate locations_from_supplier_moves
+      paginate locations_from_supplier_moves, include: included_relationships
     end
 
   private
@@ -11,7 +11,14 @@ module Api
     def locations_from_supplier_moves
       supplier = Supplier.find(params[:supplier_id])
 
-      Location.joins(:moves_from).where(moves: { supplier_id: supplier.id }).distinct
+      Location.joins(:moves_from)
+              .where(moves: { supplier_id: supplier.id })
+              .order(key: :asc)
+              .distinct
+    end
+
+    def supported_relationships
+      LocationSerializer::SUPPORTED_RELATIONSHIPS
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,5 +73,8 @@ Rails.application.routes.draw do
       resources :regions, only: %i[index show]
       resources :suppliers, only: %i[index show]
     end
+
+    get '/suppliers/:supplier_id/locations', to: 'suppliers#locations'
+
   end
 end

--- a/spec/requests/api/suppliers_controller_locations_spec.rb
+++ b/spec/requests/api/suppliers_controller_locations_spec.rb
@@ -3,28 +3,57 @@
 require 'rails_helper'
 
 RSpec.describe Api::SuppliersController do
+  subject(:get_supplier_locations) { get "/api/v1/suppliers/#{supplier_id}/locations#{query_params}", headers: headers, params: {} }
+
   let(:access_token) { 'spoofed-token' }
-  let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
-  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:headers) { { 'Authorization': "Bearer #{access_token}" } }
   let(:response_json) { JSON.parse(response.body) }
+  let(:query_params) { '' }
 
   describe 'GET /suppliers/:supplier_id/locations' do
+    let(:schema) { load_yaml_schema('get_locations_responses.yaml') }
+
     let(:supplier) { create(:supplier) }
+    let(:supplier_id) { supplier.id }
+    let(:location_a) { create(:location, suppliers: [supplier], key: 'key_aaa') }
+    let(:location_b) { create(:location, suppliers: [supplier], key: 'key_bbb') }
+
+    it_behaves_like 'an endpoint that responds with success 200' do
+      before do
+        create(:move, :requested, supplier: supplier)
+
+        get_supplier_locations
+      end
+    end
 
     it 'returns the locations' do
-      location1 = create(:location, suppliers: [supplier])
-      location2 = create(:location, suppliers: [supplier])
-      create_list(:move, 2, :requested, supplier: supplier, from_location: location1) # to tests that duplicates locations are not shown
-      create(:move, :requested, supplier: supplier, from_location: location2)
+      create_list(:move, 2, :requested, supplier: supplier, from_location: location_a) # to tests that duplicates locations are not shown
+      create(:move, :requested, supplier: supplier, from_location: location_b)
 
-      get "/api/v1/suppliers/#{supplier.id}/locations", headers: headers, params: {}
+      get_supplier_locations
 
       response_location_keys = response_json['data']
                                  .select { |e| e['type'] == 'locations' }
                                  .map { |l| l['attributes']['key'] }
 
-      expect(response).to have_http_status(:success)
-      expect(response_location_keys).to match_array([location1.key, location2.key])
+      expect(response_location_keys).to eq(%w[key_aaa key_bbb])
+    end
+
+    context 'when other locations are present' do
+      it 'does not include those into the response' do
+        another_supplier = create(:supplier)
+        another_location = create(:location, suppliers: [another_supplier])
+        create(:move, :requested, supplier: another_supplier, from_location: another_location)
+        create(:move, :requested, supplier: supplier, from_location: location_a)
+
+        get_supplier_locations
+
+        response_location_keys = response_json['data']
+                                     .select { |e| e['type'] == 'locations' }
+                                     .map { |l| l['attributes']['key'] }
+
+        expect(response_location_keys).to eq(%w[key_aaa])
+      end
     end
   end
 
@@ -35,9 +64,25 @@ RSpec.describe Api::SuppliersController do
     let(:detail_404) { "Couldn't find Supplier with 'id'=invalid-supplier-id" }
 
     before do
-      get "/api/v1/suppliers/#{supplier_id}/locations", headers: headers, params: {}
+      get_supplier_locations
     end
 
     it_behaves_like 'an endpoint that responds with error 404'
+  end
+
+  context 'when including the include query param' do
+    let(:query_params) { '?include=suppliers' }
+    let(:supplier) { create(:supplier) }
+    let(:supplier_id) { supplier.id }
+
+    it 'returns the valid provided includes' do
+      location = create(:location, suppliers: [supplier])
+      create(:move, :requested, supplier: supplier, from_location: location)
+
+      get_supplier_locations
+
+      returned_types = response_json['included'].map { |r| r['type'] }.uniq
+      expect(returned_types).to contain_exactly('suppliers')
+    end
   end
 end

--- a/spec/requests/api/suppliers_controller_locations_spec.rb
+++ b/spec/requests/api/suppliers_controller_locations_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::SuppliersController do
+  let(:access_token) { 'spoofed-token' }
+  let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:response_json) { JSON.parse(response.body) }
+
+  describe 'GET /suppliers/:supplier_id/locations' do
+    let(:supplier) { create(:supplier) }
+
+    it 'returns the locations' do
+      location1 = create(:location, suppliers: [supplier])
+      location2 = create(:location, suppliers: [supplier])
+      create_list(:move, 2, :requested, supplier: supplier, from_location: location1) # to tests that duplicates locations are not shown
+      create(:move, :requested, supplier: supplier, from_location: location2)
+
+      get "/api/v1/suppliers/#{supplier.id}/locations", headers: headers, params: {}
+
+      response_location_keys = response_json['data']
+                                 .select { |e| e['type'] == 'locations' }
+                                 .map { |l| l['attributes']['key'] }
+
+      expect(response).to have_http_status(:success)
+      expect(response_location_keys).to match_array([location1.key, location2.key])
+    end
+  end
+
+  context 'when the supplier_id is not found' do
+    let(:schema) { load_yaml_schema('error_responses.yaml') }
+
+    let(:supplier_id) { 'invalid-supplier-id' }
+    let(:detail_404) { "Couldn't find Supplier with 'id'=invalid-supplier-id" }
+
+    before do
+      get "/api/v1/suppliers/#{supplier_id}/locations", headers: headers, params: {}
+    end
+
+    it_behaves_like 'an endpoint that responds with error 404'
+  end
+end


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-2063

### What?

One of the tasks, before going live, is

to provide an endpoint to get a list of locations for which the suppliers own the moves (from_location)
The locations will be a unique list of the relevant move from_location locations.

I have added a new controller SuppliersController and the action locations.

### Why?

read the https://dsdmoj.atlassian.net/browse/P4-2063 for an extensive explanation

### Have you? (optional)

- [ ] Updated API docs if necessary	

Not necessary, we do not want to make it public for now

### Deployment risks (optional)
No, it does not change the existing endpoints.