### PR TITLE
P4 2038 generate future move notifications

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -29,6 +29,7 @@ class Notification < ApplicationRecord
   scope :kept, -> { undiscarded.joins(:subscription).merge(Subscription.kept) }
   scope :webhooks, -> { where(notification_type: NotificationType::WEBHOOK) }
   scope :emails, -> { where(notification_type: NotificationType::EMAIL) }
+  scope :default_order, -> { order(created_at: :asc) }
 
   def kept?
     # this notification is only kept if it is not discarded and its parent subscription is not discarded

--- a/lib/tasks/notifications.rake
+++ b/lib/tasks/notifications.rake
@@ -1,0 +1,51 @@
+namespace :notifications do
+  desc 'Send webhook and email notifications to the specified supplier for future moves'
+  task :send, %i[supplier from_date send_webhooks send_emails] => :environment do |_, args|
+    abort "Please specify a supplier, e.g. $ rake 'notifications:test_webhook[serco]'" if args[:supplier].blank?
+    supplier = Supplier.find_by(key: args[:supplier]) || Supplier.find_by(id: args[:supplier]) || Supplier.find_by(name: args[:supplier])
+    abort "Unknown supplier: #{args[:supplier]}" if supplier.blank?
+
+    from_date = args[:from_date].present? ? Date.parse(args[:from_date]) : Time.zone.today
+    send_webhooks = args[:send_webhooks].present? ? args[:send_webhooks] == 'true' : true # default to sending webhooks
+    send_emails = args[:send_emails].present? ? args[:send_emails] == 'true' : false # default to not sending emails
+
+    statuses = [Move::MOVE_STATUS_REQUESTED, Move::MOVE_STATUS_BOOKED]
+
+    # moves directly assigned to the supplier
+    moves_assigned = Move
+      .where(supplier: supplier)
+      .where('date >= ?', from_date)
+      .where(status: statuses)
+
+    # moves assumed to belong to the supplier (based on from_location)
+    moves_assumed = Move
+      .where(supplier_id: nil)
+      .where(from_location: Location.supplier(supplier))
+      .where('date >= ?', from_date)
+      .where(status: statuses)
+
+    puts "For moves dated from #{from_date} with statuses of #{statuses}"
+    puts "\tthere are #{moves_assigned.count} assigned moves for #{supplier.name}"
+    puts "\tthere are #{moves_assumed.count} assumed moves for #{supplier.name}"
+
+    puts "Sending webhooks: #{send_webhooks}"
+    puts "Sending emails: #{send_emails}"
+
+    puts "\nAre you sure you want to trigger these notifications? Enter YES to confirm:"
+    print '> '
+    confirm = STDIN.gets.chomp
+
+    abort 'Cancelling' unless confirm =~ /Y(ES)?/i
+
+    puts 'Processing assigned moves...'
+    moves_assigned.find_each do |move|
+      PrepareMoveNotificationsJob.perform_now(topic_id: move.id, action_name: 'update', send_webhooks: send_webhooks, send_emails: send_emails, only_supplier_id: supplier.id)
+    end
+
+    puts 'Processing assumed moves...'
+    moves_assumed.find_each do |move|
+      PrepareMoveNotificationsJob.perform_now(topic_id: move.id, action_name: 'update', send_webhooks: send_webhooks, send_emails: send_emails, only_supplier_id: supplier.id)
+    end
+    puts 'All done.'
+  end
+end


### PR DESCRIPTION
### Jira link

P4-2038

### What?

I have added/removed/altered:

- [x] Added rake task `notifications:send` for seeding suppliers with webhooks, for go-live

### Why?

I am doing this because:

- so that on go live suppliers can synchronise their system with ours

### Deployment risks (optional)

- pretty minimal
