### PR TITLE
Fix fake_data.rake

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -189,7 +189,7 @@ namespace :fake_data do
       to_location = courts.sample
       next if Move.find_by(date: date, profile: profile, from_location: from_location, to_location: to_location)
 
-      move = Move.create!(
+      Move.create!(
         date: date,
         date_from: date,
         time_due: time,

--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -198,7 +198,7 @@ namespace :fake_data do
         to_location: to_location,
         status: %w[proposed requested booked in_transit completed].sample,
       )
-      document = Document.new(move: move)
+      document = Document.new(documentable: profile)
       document.file.attach(io: file, filename: 'file-sample_100kB.doc')
       document.save!
     ensure
@@ -240,7 +240,7 @@ namespace :fake_data do
   task drop_all: :environment do
     puts 'drop_all...'
     if Rails.env.development? || Rails.env.test?
-      [Allocation, Event, Journey, Move, Document, Location, Profile, Person, AssessmentQuestion, Ethnicity, Gender, IdentifierType, Supplier].each(&:destroy_all)
+      [Allocation, Event, Document, Journey, Move, Location, Profile, Person, AssessmentQuestion, Ethnicity, Gender, IdentifierType, Supplier].each(&:destroy_all)
     else
       puts 'you can only run this in the development or test environments'
     end


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [x] Updates fake_data.rake to use correct documentable on move creation. Document#move_id is now an ignored_column

### Why?

- We use this rake task for local testing/development