### PR TITLE
Clean up potential ambiguity on Moves::Finder

### DIFF
--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -68,8 +68,8 @@ module Moves
     end
 
     def apply_date_range_filters(scope)
-      scope = scope.where('date >= ?', filter_params[:date_from]) if filter_params.key?(:date_from)
-      scope = scope.where('date <= ?', filter_params[:date_to]) if filter_params.key?(:date_to)
+      scope = scope.where('moves.date >= ?', filter_params[:date_from]) if filter_params.key?(:date_from)
+      scope = scope.where('moves.date <= ?', filter_params[:date_to]) if filter_params.key?(:date_to)
       # created_at is a date/time, so inclusive filtering has to be subtly different
       scope = scope.where('moves.created_at >= ?', filter_params[:created_at_from]) if filter_params.key?(:created_at_from)
       scope = scope.where('moves.created_at < ?', Date.parse(filter_params[:created_at_to]) + 1) if filter_params.key?(:created_at_to)


### PR DESCRIPTION
### Jira link

P4-2085

### What?

- [x] Tightened up scope ambiguity in `Moves::Finder` service

### Why?

- We have `date` column on both `Move` and `Allocation` and in certain circumstances it's possible for the query to be constructed with both tables joined and a where condition specifying only `date` - this throws a Postgres error as it's unsure which table this refers to.
- See Jira ticket for further explanation and reproduction steps.