### PR TITLE
Use move date/date_from to determine correct supplier for move

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ bundle exec rake reference_data:create_regions
 bundle exec rake reference_data:create_suppliers
 bundle exec rake reference_data:create_supplier_locations
 bundle exec rake reference_data:create_prison_transfer_reasons
-bundle exec rake reference_data:link_suppliers
 ```
 
 Alternatively, **all** of the reference data can be created at once by running the combined rake task:

--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -70,7 +70,6 @@ module Api
 
     def creator
       @creator ||= Allocations::Creator.new(
-        doorkeeper_application_owner: doorkeeper_application_owner,
         allocation_params: allocation_params,
         complex_case_params: complex_case_params,
       )

--- a/app/controllers/api/v1/moves_actions.rb
+++ b/app/controllers/api/v1/moves_actions.rb
@@ -12,6 +12,7 @@ module Api::V1
 
     def create_and_render
       move = Move.new(new_move_attributes)
+      move.determine_supplier
       move.profile.documents = profile_documents
 
       authorize!(:create, move)
@@ -83,7 +84,6 @@ module Api::V1
           to_location: Location.find_by(id: new_move_params.dig(:relationships, :to_location, :data, :id)),
           court_hearings: CourtHearing.where(id: (new_move_params.dig(:relationships, :court_hearings, :data) || []).map { |court_hearing| court_hearing[:id] }),
           prison_transfer_reason: PrisonTransferReason.find_by(id: new_move_params.dig(:relationships, :prison_transfer_reason, :data, :id)),
-          supplier: SupplierChooser.new(doorkeeper_application_owner, from_location).call,
         )
       end
     end

--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -13,6 +13,7 @@ module Api::V2
 
     def create_and_render
       move = Move.new(move_attributes)
+      move.determine_supplier
       authorize!(:create, move)
       move.save!
 
@@ -23,6 +24,7 @@ module Api::V2
 
     def update_and_render
       move.assign_attributes(common_move_attributes)
+      move.determine_supplier
       action_name = move.status_changed? ? 'update_status' : 'update'
       move.save!
       move.allocation&.refresh_status_and_moves_count!
@@ -64,7 +66,6 @@ module Api::V2
 
     def move_attributes
       common_move_attributes.tap do |attributes|
-        attributes[:supplier] = SupplierChooser.new(doorkeeper_application_owner, from_location).call unless from_location_attributes.nil?
         attributes[:from_location] = from_location unless from_location_attributes.nil?
         attributes[:to_location] = to_location unless to_location_attributes.nil?
         attributes[:version] = 2

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -46,7 +46,8 @@ class Location < ApplicationRecord
 
   NOMIS_TYPES_WITH_DOCUMENTS = %w[STC SCH].freeze
 
-  has_and_belongs_to_many :suppliers
+  has_many :supplier_locations
+  has_many :suppliers, through: :supplier_locations
   has_and_belongs_to_many :regions
   # Deleting locations isn't really a thing in practice - so dependent: :destroy is a pragmatic choice
   has_many :moves_from, class_name: 'Move', foreign_key: :from_location_id, inverse_of: :from_location, dependent: :destroy
@@ -56,7 +57,6 @@ class Location < ApplicationRecord
   validates :title, presence: true
   validates :location_type, presence: true, inclusion: { in: location_types }
 
-  scope :supplier, ->(supplier_id) { joins(:suppliers).where(locations_suppliers: { supplier_id: supplier_id }) }
   scope :ordered_by_title, ->(direction) { order('locations.title' => direction) }
   scope :search_by_title, ->(search) { select(:id).where('title ILIKE :search', search: "%#{search}%") }
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -174,7 +174,7 @@ class Move < VersionedModel
   def determine_supplier
     # Supplier choice is based on from_location and effective date. As the from location cannot change after the
     # move is created we only need to look for date changes - if no change then skip the supplier update for speed.
-    return supplier unless date_changed? || date_from_changed?
+    return supplier unless new_record? || date_changed? || date_from_changed?
 
     effective_date = date.presence || date_from
     self.supplier = SupplierChooser.new(effective_date, from_location).call

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -171,6 +171,15 @@ class Move < VersionedModel
     feed_attributes
   end
 
+  def determine_supplier
+    # Supplier choice is based on from_location and effective date. As the from location cannot change after the
+    # move is created we only need to look for date changes - if no change then skip the supplier update for speed.
+    return supplier unless date_changed? || date_from_changed?
+
+    effective_date = date.presence || date_from
+    self.supplier = SupplierChooser.new(effective_date, from_location).call
+  end
+
 private
 
   def date_to_after_date_from

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Supplier < ApplicationRecord
-  has_and_belongs_to_many :locations
+  has_many :supplier_locations
+  has_many :locations, through: :supplier_locations
   has_many :subscriptions, dependent: :destroy
   has_many :moves, dependent: :restrict_with_exception
 

--- a/app/models/supplier_location.rb
+++ b/app/models/supplier_location.rb
@@ -6,6 +6,11 @@ class SupplierLocation < ApplicationRecord
 
   validate :effective_to_after_effective_from
 
+  scope :location, ->(location_id) { where(location_id: location_id) }
+  scope :effective_from, ->(date) { where(effective_from: nil).or(where('effective_from <= ?', date)) }
+  scope :effective_to, ->(date) { where(effective_to: nil).or(where('effective_to >= ?', date)) }
+  scope :effective_on, ->(date) { effective_from(date).effective_to(date) }
+
   def self.link_locations(effective_from: nil, effective_to: nil, supplier:, locations:)
     locations.each do |location|
       create!(effective_from: effective_from, effective_to: effective_to, supplier: supplier, location: location)

--- a/app/services/allocations/creator.rb
+++ b/app/services/allocations/creator.rb
@@ -2,10 +2,9 @@
 
 module Allocations
   class Creator
-    attr_accessor :doorkeeper_application_owner, :allocation_params, :complex_case_params, :allocation
+    attr_accessor :allocation_params, :complex_case_params, :allocation
 
-    def initialize(doorkeeper_application_owner:, allocation_params:, complex_case_params:)
-      self.doorkeeper_application_owner = doorkeeper_application_owner
+    def initialize(allocation_params:, complex_case_params:)
       self.allocation_params = allocation_params
       self.complex_case_params = complex_case_params
     end
@@ -28,7 +27,7 @@ module Allocations
     end
 
     def moves
-      supplier = SupplierChooser.new(doorkeeper_application_owner, allocation.from_location).call
+      supplier = SupplierChooser.new(allocation.date, allocation.from_location).call
 
       Array.new(allocation.moves_count) do
         Move.new(

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -16,6 +16,7 @@ module EventLog
         when Event::APPROVE
           move.status = Move::MOVE_STATUS_REQUESTED
           move.date = event.date
+          move.determine_supplier
           Allocations::CreateInNomis.call(move) if event.create_in_nomis?
         when Event::CANCEL
           move.status = Move::MOVE_STATUS_CANCELLED

--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -24,7 +24,8 @@ module Locations
     def apply_supplier_filters(scope)
       return scope unless filter_params.key?(:supplier_id)
 
-      scope.joins(:locations_suppliers).where(suppliers: { id: filter_params[:supplier_id] })
+      scope = scope.where(suppliers: { id: filter_params[:supplier_id] })
+      scope.merge(SupplierLocation.effective_on(Time.zone.today))
     end
   end
 end

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -4,7 +4,7 @@ module Moves
   class Finder
     attr_reader :filter_params, :ability
 
-    MOVE_INCLUDES = [:supplier, :court_hearings, :prison_transfer_reason, :original_move, profile: [documents: { file_attachment: :blob }, person_escort_record: [:framework, :framework_responses, framework_flags: :framework_question]], person: %i[gender ethnicity profiles], from_location: %i[locations_suppliers suppliers], to_location: %i[locations_suppliers suppliers], allocation: %i[to_location from_location]].freeze
+    MOVE_INCLUDES = [:supplier, :court_hearings, :prison_transfer_reason, :original_move, profile: [documents: { file_attachment: :blob }, person_escort_record: [:framework, :framework_responses, framework_flags: :framework_question]], person: %i[gender ethnicity profiles], from_location: %i[supplier_locations suppliers], to_location: %i[supplier_locations suppliers], allocation: %i[to_location from_location]].freeze
 
     def initialize(filter_params, ability, order_params)
       @filter_params = filter_params

--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -11,6 +11,7 @@ module Moves
 
     def call
       move.assign_attributes(attributes)
+      move.determine_supplier
       # NB: rather than update directly, we need to detect whether the move status has changed before saving the record
       self.status_changed = move.status_changed?
 

--- a/app/services/supplier_chooser.rb
+++ b/app/services/supplier_chooser.rb
@@ -9,6 +9,7 @@ class SupplierChooser
   def call
     return unless effective_date.present? && location.present?
 
+    # NB: business rules _should_ preclude multiple suppliers for visibility
     supplier_location = SupplierLocation.location(location.id).effective_on(effective_date).first
     supplier_location&.supplier
   end

--- a/app/services/supplier_chooser.rb
+++ b/app/services/supplier_chooser.rb
@@ -1,14 +1,15 @@
 class SupplierChooser
-  def initialize(doorkeeper_application_owner, from_location)
-    @doorkeeper_application_owner = doorkeeper_application_owner
-    @from_location = from_location
+  attr_accessor :effective_date, :location
+
+  def initialize(effective_date, location)
+    self.effective_date = effective_date
+    self.location = location
   end
 
   def call
-    return @doorkeeper_application_owner if @doorkeeper_application_owner
+    return unless effective_date.present? && location.present?
 
-    # TODO: Replace with the frontend supplied supplier
-    #       There can only ever be one supplier per location, currently
-    @from_location.suppliers.first
+    supplier_location = SupplierLocation.location(location.id).effective_on(effective_date).first
+    supplier_location&.supplier
   end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Location do
-  it { is_expected.to have_and_belong_to_many(:suppliers) }
+  it { is_expected.to have_many(:supplier_locations) }
+  it { is_expected.to have_many(:suppliers).through(:supplier_locations) }
   it { is_expected.to have_many(:moves_from) }
   it { is_expected.to have_many(:moves_to) }
 
@@ -44,33 +45,6 @@ RSpec.describe Location do
 
     it { expect(location.detained?).to be true }
     it { expect(location.not_detained?).to be false }
-  end
-
-  describe '#supplier' do
-    let(:supplier_one) { create(:supplier) }
-    let(:supplier_two) { create(:supplier) }
-    let!(:location_one) { create(:location, suppliers: [supplier_one]) }
-    let!(:location_two) { create(:location, suppliers: [supplier_two]) }
-
-    context 'when querying with first supplier' do
-      it 'finds the right location' do
-        expect(described_class.supplier(supplier_one.id)).to include(location_one)
-      end
-
-      it 'finds the right number of locations' do
-        expect(described_class.supplier(supplier_one.id).count).to eq(1)
-      end
-    end
-
-    context 'when querying with second supplier' do
-      it 'finds the right location' do
-        expect(described_class.supplier(supplier_two.id)).to include(location_two)
-      end
-
-      it 'finds the right number of locations' do
-        expect(described_class.supplier(supplier_two.id).count).to eq(1)
-      end
-    end
   end
 
   describe '#for_feed' do

--- a/spec/models/supplier_location_spec.rb
+++ b/spec/models/supplier_location_spec.rb
@@ -43,4 +43,58 @@ RSpec.describe SupplierLocation do
       )
     end
   end
+
+  describe '.effective_on' do
+    subject(:effective_on) { described_class.effective_on(date) }
+
+    let(:location) { create(:location) }
+    let(:supplier) { create(:supplier) }
+    let(:date) { Date.today }
+
+    context 'with a nil date parameter' do
+      let!(:supplier_location1) { create(:supplier_location, supplier: supplier, location: location) }
+      let!(:supplier_location2) { create(:supplier_location, supplier: supplier, location: location, effective_from: Date.today, effective_to: Date.today) }
+      let(:date) { nil }
+
+      it 'returns matching supplier locations' do
+        expect(effective_on).to contain_exactly(supplier_location1)
+      end
+    end
+
+    context 'without an effective from or to date' do
+      let!(:supplier_location) { create(:supplier_location, supplier: supplier, location: location) }
+
+      it 'returns matching supplier locations' do
+        expect(effective_on).to contain_exactly(supplier_location)
+      end
+    end
+
+    context 'with only an effective from date' do
+      let!(:supplier_location1) { create(:supplier_location, supplier: supplier, location: location, effective_from: date) }
+      let!(:supplier_location2) { create(:supplier_location, supplier: supplier, location: location, effective_from: date.tomorrow) }
+
+      it 'returns matching supplier locations' do
+        expect(effective_on).to contain_exactly(supplier_location1)
+      end
+    end
+
+    context 'with only an effective to date' do
+      let!(:supplier_location1) { create(:supplier_location, supplier: supplier, location: location, effective_to: date) }
+      let!(:supplier_location2) { create(:supplier_location, supplier: supplier, location: location, effective_to: date.yesterday) }
+
+      it 'returns matching supplier locations' do
+        expect(effective_on).to contain_exactly(supplier_location1)
+      end
+    end
+
+    context 'with effective from and to date' do
+      let!(:supplier_location1) { create(:supplier_location, supplier: supplier, location: location, effective_from: date, effective_to: date) }
+      let!(:supplier_location2) { create(:supplier_location, supplier: supplier, location: location, effective_to: date.yesterday) }
+      let!(:supplier_location3) { create(:supplier_location, supplier: supplier, location: location, effective_from: date.tomorrow) }
+
+      it 'returns matching supplier locations' do
+        expect(effective_on).to contain_exactly(supplier_location1)
+      end
+    end
+  end
 end

--- a/spec/models/supplier_location_spec.rb
+++ b/spec/models/supplier_location_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe SupplierLocation do
       let!(:supplier_location2) { create(:supplier_location, supplier: supplier, location: location, effective_from: Date.today, effective_to: Date.today) }
       let(:date) { nil }
 
-      it 'returns matching supplier locations' do
+      it 'returns matching supplier locations, excluding matches that have an effective date' do
         expect(effective_on).to contain_exactly(supplier_location1)
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe SupplierLocation do
     context 'without an effective from or to date' do
       let!(:supplier_location) { create(:supplier_location, supplier: supplier, location: location) }
 
-      it 'returns matching supplier locations' do
+      it 'returns matching supplier locations, ignoring effective dates completely' do
         expect(effective_on).to contain_exactly(supplier_location)
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe SupplierLocation do
       let!(:supplier_location1) { create(:supplier_location, supplier: supplier, location: location, effective_from: date) }
       let!(:supplier_location2) { create(:supplier_location, supplier: supplier, location: location, effective_from: date.tomorrow) }
 
-      it 'returns matching supplier locations' do
+      it 'returns matching supplier locations, excluding ineffective future matches' do
         expect(effective_on).to contain_exactly(supplier_location1)
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe SupplierLocation do
       let!(:supplier_location1) { create(:supplier_location, supplier: supplier, location: location, effective_to: date) }
       let!(:supplier_location2) { create(:supplier_location, supplier: supplier, location: location, effective_to: date.yesterday) }
 
-      it 'returns matching supplier locations' do
+      it 'returns matching supplier locations, excluding ineffective expired matches' do
         expect(effective_on).to contain_exactly(supplier_location1)
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe SupplierLocation do
       let!(:supplier_location2) { create(:supplier_location, supplier: supplier, location: location, effective_to: date.yesterday) }
       let!(:supplier_location3) { create(:supplier_location, supplier: supplier, location: location, effective_from: date.tomorrow) }
 
-      it 'returns matching supplier locations' do
+      it 'returns matching supplier locations, excluding ineffective future and expired matches' do
         expect(effective_on).to contain_exactly(supplier_location1)
       end
     end

--- a/spec/models/supplier_spec.rb
+++ b/spec/models/supplier_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe Supplier, type: :model do
   subject(:supplier) { create(:supplier, name: 'Test Supplier 123') }
 
-  it { is_expected.to have_and_belong_to_many(:locations) }
+  it { is_expected.to have_many(:supplier_locations) }
+  it { is_expected.to have_many(:locations).through(:supplier_locations) }
   it { is_expected.to have_many(:subscriptions) }
   it { is_expected.to have_many(:moves) }
 

--- a/spec/requests/api/move_events_controller_approve_spec.rb
+++ b/spec/requests/api/move_events_controller_approve_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Api::MoveEventsController do
         expect(move.reload.date).to eql(approved_date)
       end
 
+      it 'updates the move supplier' do
+        expect(move.reload.supplier).to eq(supplier)
+      end
+
       it 'creates a prison transfer event in Nomis' do
         expect(Allocations::CreateInNomis).to have_received(:call).with(move)
       end

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Api::MovesController do
 
       it 'sets the from_location supplier as the supplier on the move' do
         post_moves
-        expect(move.supplier).to eq(move.from_location.suppliers.first)
+        expect(move.supplier).to eq(supplier)
       end
 
       context 'with a real access token' do
@@ -67,10 +67,6 @@ RSpec.describe Api::MovesController do
 
         it 'audits the supplier' do
           expect(move.versions.map(&:whodunnit)).to eq([supplier.id])
-        end
-
-        it 'sets the application owner as the supplier on the move' do
-          expect(move.supplier).to eq(supplier)
         end
       end
 

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -65,23 +65,17 @@ RSpec.describe Api::MovesController do
     it 'sets the from_location supplier as the supplier on the move' do
       do_post
 
-      expect(move.supplier).to eq(move.from_location.suppliers.first)
+      expect(move.supplier).to eq(another_supplier)
     end
 
     context 'with a real access token' do
-      let(:application) { create(:application, owner: supplier) }
+      let(:application) { create(:application, owner: another_supplier) }
       let(:access_token) { create(:access_token, application: application).token }
 
       it 'audits the supplier' do
         do_post
 
-        expect(move.versions.map(&:whodunnit)).to eq([supplier.id])
-      end
-
-      it 'sets the application owner as the supplier on the move' do
-        do_post
-
-        expect(move.supplier).to eq(application.owner)
+        expect(move.versions.map(&:whodunnit)).to eq([another_supplier.id])
       end
     end
 

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::MovesController do
     let(:supplier) { create(:supplier) }
     let!(:from_location) { create :location, :police, suppliers: [supplier] }
     let(:profile) { create(:profile, documents: before_documents) }
-    let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile }
+    let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile, date_from: 2.days.ago }
     let(:move_id) { move.id }
     let(:date_from) { Date.yesterday }
     let(:date_to) { Date.tomorrow }
@@ -86,6 +86,10 @@ RSpec.describe Api::MovesController do
 
         it 'updates the status of a move' do
           expect(result.status).to eq 'requested'
+        end
+
+        it 'updates the supplier' do
+          expect(result.supplier).to eq supplier
         end
 
         it 'does not update the move type' do

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::MovesController do
   end
 
   describe 'PATCH /moves' do
-    let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile }
+    let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile, date_from: 2.days.ago }
 
     let(:from_location) { create :location, :police, suppliers: [supplier] }
     let(:move_id) { move.id }
@@ -59,6 +59,7 @@ RSpec.describe Api::MovesController do
         'move_agreed' => true,
         'move_agreed_by' => 'Fred Bloggs',
         'status' => 'requested',
+        'supplier_id' => supplier.id,
       }
     end
 

--- a/spec/services/allocations/creator_spec.rb
+++ b/spec/services/allocations/creator_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Allocations::Creator do
 
   let(:creator) do
     described_class.new(
-      doorkeeper_application_owner: 'foo',
       allocation_params: allocation_params,
       complex_case_params: complex_case_params,
     )
@@ -121,7 +120,7 @@ RSpec.describe Allocations::Creator do
 
     it 'calls the SupplierChooser service with the correct args' do
       call_creator
-      expect(SupplierChooser).to have_received(:new).with('foo', from_location)
+      expect(SupplierChooser).to have_received(:new).with(date, from_location)
     end
 
     it 'sets the allocation moves supplier' do

--- a/spec/services/locations/finder_spec.rb
+++ b/spec/services/locations/finder_spec.rb
@@ -6,18 +6,23 @@ RSpec.describe Locations::Finder do
   subject(:location_finder) { described_class.new(filter_params) }
 
   let(:supplier) { create(:supplier) }
-  let(:location) { create(:location) }
+  let(:location1) { create(:location) }
+  let(:location2) { create(:location) }
+  let(:other_location) { create(:location) }
 
   describe 'filtering' do
     context 'with a supplier' do
       let(:filter_params) { { supplier_id: supplier.id } }
 
       before do
-        location.suppliers << supplier
+        create(:location) # Not linked to supplier
+        create(:supplier_location, supplier: supplier, location: other_location, effective_to: Date.yesterday) # Not effective today
+        create(:supplier_location, supplier: supplier, location: location1) # Linked and effective
+        create(:supplier_location, supplier: supplier, location: location2) # Linked and effective
       end
 
-      it 'returns locations matching the supplier' do
-        expect(location_finder.call.pluck(:id)).to eql [location.id]
+      it 'returns currently effective locations linked to the supplier' do
+        expect(location_finder.call.pluck(:id)).to contain_exactly(location1.id, location2.id)
       end
     end
   end

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Moves::Updater do
   subject(:updater) { described_class.new(move, move_params) }
 
   let(:before_documents) { create_list(:document, 2) }
-  let!(:from_location) { create(:location, :police) }
-  let!(:move) { create(:move, :proposed, :prison_recall, from_location: from_location, profile: profile) }
+  let(:supplier) { create(:supplier) }
+  let!(:from_location) { create(:location, :police, suppliers: [supplier]) }
+  let!(:move) { create(:move, :proposed, :prison_recall, from_location: from_location, profile: profile, date_from: 2.days.ago) }
   let(:profile) { create(:profile, documents: before_documents) }
   let(:date_from) { Date.yesterday }
   let(:date_to) { Date.tomorrow }
@@ -40,6 +41,7 @@ RSpec.describe Moves::Updater do
         move_agreed_by: 'Fred Bloggs',
         date_from: date_from,
         date_to: date_to,
+        supplier: supplier,
       )
     end
 

--- a/spec/services/supplier_chooser_spec.rb
+++ b/spec/services/supplier_chooser_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SupplierChooser do
   context 'without an effective from or to date' do
     let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location) }
 
-    it 'returns matching supplier' do
+    it 'returns matching supplier, ignoring effective dates completely' do
       expect(service.call).to eq(supplier1)
     end
   end
@@ -18,7 +18,7 @@ RSpec.describe SupplierChooser do
     let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date) }
     let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_from: date.tomorrow) }
 
-    it 'returns matching supplier' do
+    it 'returns matching supplier, excluding ineffective future matches' do
       expect(service.call).to eq(supplier1)
     end
   end
@@ -27,7 +27,7 @@ RSpec.describe SupplierChooser do
     let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_to: date) }
     let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_to: date.yesterday) }
 
-    it 'returns matching supplier' do
+    it 'returns matching supplier, excluding ineffective expired matches' do
       expect(service.call).to eq(supplier1)
     end
   end
@@ -37,7 +37,7 @@ RSpec.describe SupplierChooser do
     let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_to: date.yesterday) }
     let!(:supplier_location3) { create(:supplier_location, supplier: supplier2, location: location, effective_from: date.tomorrow) }
 
-    it 'returns matching supplier' do
+    it 'returns matching supplier, excluding ineffective future and expired matches' do
       expect(service.call).to eq(supplier1)
     end
   end

--- a/spec/services/supplier_chooser_spec.rb
+++ b/spec/services/supplier_chooser_spec.rb
@@ -1,23 +1,82 @@
 RSpec.describe SupplierChooser do
-  subject(:service) { described_class.new(doorkeeper_application_owner, from_location) }
+  subject(:service) { described_class.new(date, location) }
 
-  let(:from_location) { instance_double('Location', suppliers: [supplier_one, supplier_two]) }
-  let(:supplier_one) { instance_double('Supplier') }
-  let(:supplier_two) { instance_double('Supplier') }
+  let(:supplier1) { create(:supplier) }
+  let(:supplier2) { create(:supplier) }
+  let(:location) { create(:location) }
+  let(:date) { Date.today }
 
-  context 'when doorkeeper_application_owner is nil' do
-    let(:doorkeeper_application_owner) { nil }
+  context 'without an effective from or to date' do
+    let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location) }
 
-    it 'returns the first supplier from move.from_location.suppliers' do
-      expect(service.call).to eq(supplier_one)
+    it 'returns matching supplier' do
+      expect(service.call).to eq(supplier1)
     end
   end
 
-  context 'when doorkeeper_application_owner is present' do
-    let(:doorkeeper_application_owner) { instance_double('Supplier') }
+  context 'with only an effective from date' do
+    let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date) }
+    let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_from: date.tomorrow) }
 
-    it 'returns the doorkeeper_application_owner' do
-      expect(service.call).to eq(doorkeeper_application_owner)
+    it 'returns matching supplier' do
+      expect(service.call).to eq(supplier1)
+    end
+  end
+
+  context 'with only an effective to date' do
+    let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_to: date) }
+    let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_to: date.yesterday) }
+
+    it 'returns matching supplier' do
+      expect(service.call).to eq(supplier1)
+    end
+  end
+
+  context 'with an effective from and to date' do
+    let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date, effective_to: date) }
+    let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_to: date.yesterday) }
+    let!(:supplier_location3) { create(:supplier_location, supplier: supplier2, location: location, effective_from: date.tomorrow) }
+
+    it 'returns matching supplier' do
+      expect(service.call).to eq(supplier1)
+    end
+  end
+
+  context 'with no supplier locations' do
+    it 'returns nil' do
+      expect(service.call).to be_nil
+    end
+  end
+
+  context 'with no matching location' do
+    let!(:supplier_location) { create(:supplier_location, supplier: supplier1) }
+
+    it 'returns nil' do
+      expect(service.call).to be_nil
+    end
+  end
+
+  context 'with no matching effective date' do
+    let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date.tomorrow, effective_to: date.tomorrow) }
+
+    it 'returns nil' do
+      expect(service.call).to be_nil
+    end
+  end
+
+  context 'with nil date parameter' do
+    let(:date) { nil }
+
+    it 'returns nil' do
+      expect(service.call).to be_nil
+    end
+  end
+
+  context 'with nil location parameter' do
+    let(:location) { nil }
+
+    it 'returns nil' do
+      expect(service.call).to be_nil
     end
   end
 end


### PR DESCRIPTION
### Jira link

P4-2041 P4-2062

### What?

- [x] Update SupplierChooser service to consider move date/date_from to determine correct supplier
- [x] Ensure that SupplierChooser is invoked whenever the move date or date_from is changed to ensure that the supplier choice remains correct.
- [x] Replace existing HABTM relationship between Supplier and Locations with SupplierLocation join
- [x] Remove legacy rake task `reference_data:link_suppliers` and associated helper methods
- [x] Update Locations reference data service to provide locations linked to supplier for current date (i.e. these change before/after go live date)
- [x] Remove redundant `supplier` method on Location model - this used to be used prior to introduction of SupplierChooser service.
- [x] Updated specs that were demonstrating supplier assignment based solely on API token - this behaviour is now removed in favour of using move date.

### Why?

- New SupplierLocation model supports effective dates for supplier contracts. We need to ensure that moves are assigned the correct supplier based on the move date - the location mapping changes either side of the go live date.
- Whenever the move date changes we need to determine the supplier location again as it may potentially have changed. If the date doesn't change then we can skip the update and avoid an extra database query.
- The legacy table `locations_suppliers` was used only for the HABTM relationship and is now ignored (will be removed in a future PR). The legacy rake task to populate that is hence no longer needed.

### Have you? (optional)

- [x] Updated README

### Deployment risks (optional)

- This affects a few API's but should not be a breaking change providing the SupplierLocation data is correctly populated before deploying this PR. A previous PR introduced a new rake task `create_supplier_locations` which needs to be run first on each environment before deploying this work, otherwise moves will potentially have a `nil` supplier assigned which means suppliers cannot see their moves.