### PR TITLE
Minor tweaks to CSV export format

### DIFF
--- a/app/services/moves/exporter.rb
+++ b/app/services/moves/exporter.rb
@@ -97,12 +97,12 @@ module Moves
         move.to_location&.title, # To location name
         move.to_location&.nomis_agency_id, # To location code
         move.additional_information, # Additional information
-        move.date&.strftime('%d/%m/%Y'), # Date of travel
+        move.date&.strftime('%Y-%m-%d'), # Date of travel
         person&.police_national_computer, # PNC number
         person&.prison_number, # Prison number
         person&.last_name, # Last name
         person&.first_names, # First name(s)
-        person&.date_of_birth&.strftime('%d/%m/%Y'), # Date of birth
+        person&.date_of_birth&.strftime('%Y-%m-%d'), # Date of birth
         person&.gender&.title, # Gender
         person&.ethnicity&.title, # Ethnicity
         person&.ethnicity&.key, # Ethnicity code
@@ -124,7 +124,7 @@ module Moves
         answer_details(answers, 'not_for_release'), # Not for release details
         answer_details(answers, 'not_to_be_released'), # Not to be released details
         answer_details(answers, 'special_vehicle'), # Requires special vehicle details
-        profile&.documents&.size, # 'Uploaded documents',
+        profile&.documents&.size || 0, # 'Uploaded documents',
       ].flatten # Expand answer_details column pairs into individual columns
     end
 
@@ -136,7 +136,7 @@ module Moves
       end
 
       # Return the flag and comments together so we only need a single pass through the assessment answers for each key
-      [comments.present?.to_s.upcase, comments&.join("\n\n")]
+      [comments.present?.to_s, comments&.join("\n\n")]
     end
   end
 end

--- a/spec/services/moves/exporter_spec.rb
+++ b/spec/services/moves/exporter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Moves::Exporter do
   end
 
   it 'includes move timestamps and date' do
-    expect(row).to include(move.created_at.iso8601, move.updated_at.iso8601, move.date.strftime('%d/%m/%Y'))
+    expect(row).to include(move.created_at.iso8601, move.updated_at.iso8601, move.date.strftime('%Y-%m-%d'))
   end
 
   it 'includes from location details' do
@@ -50,7 +50,7 @@ RSpec.describe Moves::Exporter do
   end
 
   it 'includes person date of birth' do
-    expect(row).to include(person.date_of_birth&.strftime('%d/%m/%Y'))
+    expect(row).to include(person.date_of_birth&.strftime('%Y-%m-%d'))
   end
 
   it 'includes person gender' do
@@ -62,14 +62,14 @@ RSpec.describe Moves::Exporter do
   end
 
   it 'includes FALSE flag and empty comments when no alerts are present' do
-    expect(row).to include('FALSE', '')
+    expect(row).to include('false', '')
   end
 
   %w[violent escape hold_separately self_harm concealed_items other_risks special_diet_or_allergy health_issue medication wheelchair pregnant other_health solicitor interpreter other_court not_for_release not_to_be_released special_vehicle].each do |alert_type|
     it "includes TRUE flag and comments when #{alert_type} is present" do
       question.update(key: alert_type)
       move.profile.update(assessment_answers: [{ assessment_question_id: question.id, comments: 'Yikes!' }])
-      expect(row).to include('TRUE', 'Yikes!')
+      expect(row).to include('true', 'Yikes!')
     end
   end
 
@@ -88,5 +88,10 @@ RSpec.describe Moves::Exporter do
   it 'includes move profile documents count' do
     create(:document, documentable: move.profile)
     expect(row.last).to eq '1'
+  end
+
+  it 'includes 0 documents count if no profile' do
+    move.person = nil
+    expect(row.last).to eq '0'
   end
 end


### PR DESCRIPTION
### Jira link

P4-2028

### What?

- [x] Tweaked CSV output for `GET /moves` endpoint:
  - Changed TRUE/FALSE flags to lower case true/false
  - Ensure that 0 is returned for document count when there's not a profile
  - Change date format to `YYYY-MM-DD`

### Why?

- This better matches the original Javascript version - although the quote style still isn't an exact match, but most apps (e.g. Excel, Numbers) will be able to open the file. I did play with setting `force_quotes` option on the CSV generator but that quotes things that definitely shouldn't be quoted (e.g. date and boolean values) so I think it's better without that.

### Deployment risks (optional)

- Changes the API, but is a closer match to the original javascript file (and is not yet used in production)
