### PR TITLE
fix api_story tags

### DIFF
--- a/spec/requests/api_stories/move_workflows/1_police_to_police/1_1_person_with_police_national_computer_spec.rb
+++ b/spec/requests/api_stories/move_workflows/1_police_to_police/1_1_person_with_police_national_computer_spec.rb
@@ -6,7 +6,7 @@ require 'rack/test'
 # https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki/API-Walkthroughs
 
 # rubocop:disable Rails/HttpPositionalArguments
-RSpec.describe 'police-to-police transfer', type: :request do
+RSpec.describe 'police-to-police transfer', type: :request, api_story: true do
   include Rack::Test::Methods
   include_context 'with mock prison-api'
   include_context 'with Nomis alerts reference data'

--- a/spec/requests/api_stories/move_workflows/2_police_to_unspecified/2_1_person_with_police_national_computer_to_unspecified_prison_spec.rb
+++ b/spec/requests/api_stories/move_workflows/2_police_to_unspecified/2_1_person_with_police_national_computer_to_unspecified_prison_spec.rb
@@ -6,7 +6,7 @@ require 'rack/test'
 # https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki/API-Walkthroughs
 
 # rubocop:disable Rails/HttpPositionalArguments
-RSpec.describe 'police to unknown prison recall', type: :request do
+RSpec.describe 'police to unknown prison recall', type: :request, api_story: true do
   include Rack::Test::Methods
   include_context 'with mock prison-api'
   include_context 'with Nomis alerts reference data'

--- a/spec/requests/api_stories/move_workflows/5_court_to_prison/5_1_person_with_nomis_prison_number_spec.rb
+++ b/spec/requests/api_stories/move_workflows/5_court_to_prison/5_1_person_with_nomis_prison_number_spec.rb
@@ -6,7 +6,7 @@ require 'rack/test'
 # https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki/API-Walkthroughs
 
 # rubocop:disable Rails/HttpPositionalArguments
-RSpec.describe 'court to prison move', type: :request do
+RSpec.describe 'court to prison move', type: :request, api_story: true do
   include Rack::Test::Methods
   include_context 'with mock prison-api'
   include_context 'with Nomis alerts reference data'

--- a/spec/requests/api_stories/move_workflows/6_prison_to_prison_ipt/6_1_singleton_known_person_spec.rb
+++ b/spec/requests/api_stories/move_workflows/6_prison_to_prison_ipt/6_1_singleton_known_person_spec.rb
@@ -6,7 +6,7 @@ require 'rack/test'
 # https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki/API-Walkthroughs
 
 # rubocop:disable Rails/HttpPositionalArguments
-RSpec.describe 'singleton', type: :request do
+RSpec.describe 'singleton', type: :request, api_story: true do
   include Rack::Test::Methods
   include_context 'with mock prison-api'
   include_context 'with Nomis alerts reference data'


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] makes sure api story rspecs are tagged api_story


### Why?

I am doing this because:

- so they can be excluded with `rspec --tag ~@api_story`

