### PR TITLE
Fix ecr cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,6 +411,14 @@ jobs:
             if [ "$COUNT" -lt 200 ]; then circleci step halt; exit 0;  fi
             echo "More than 200 images found. Proceeding with cleanup"
       - run:
+          name: Delete UNTAGGED images first
+          command: |
+            UNTAGGED_IMAGES=$( aws ecr list-images \
+              --repository-name book-a-secure-move/hmpps-book-secure-move-api \
+              --filter "tagStatus=UNTAGGED" --query 'imageIds[*]' --output json )
+            aws ecr batch-delete-image --repository-name book-a-secure-move/hmpps-book-secure-move-api \
+              --image-ids "$UNTAGGED_IMAGES" || true
+      - run:
           name: Build manifest
           command: |
             TO_DELETE=$(aws ecr describe-images \


### PR DESCRIPTION
### Jira link

n/a

### What?

I have added/removed/altered:

- [ ] Deletes all UNTAGGED images first while cleaning up ECR

### Why?

I am doing this because:
- If there are images without any tags, it will cause an issue later when we try to filter out images based on tags.
  If they don't have a tag, we don't want to keep it anyway. 


