### PR TITLE
Different endpoint for returning moves in CSV format

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -8,6 +8,10 @@ module Api
       index_and_render
     end
 
+    def csv
+      send_file(Moves::Exporter.new(moves).call, type: 'text/csv', disposition: :inline)
+    end
+
     def show
       show_and_render
     end
@@ -18,6 +22,12 @@ module Api
 
     def update
       update_and_render
+    end
+
+  private
+
+    def moves
+      @moves ||= Moves::Finder.new(filter_params, current_ability, params[:sort] || {}).call
     end
 
     def validate_filter_params

--- a/app/controllers/api/v1/moves_actions.rb
+++ b/app/controllers/api/v1/moves_actions.rb
@@ -1,8 +1,6 @@
 module Api::V1
   module MovesActions
     def index_and_render
-      moves = Moves::Finder.new(filter_params, current_ability, params[:sort] || {}).call
-
       paginate moves,
                include: included_relationships - %w[court_hearings],
                fields: MoveSerializer::INCLUDED_FIELDS

--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -1,16 +1,10 @@
 module Api::V2
   module MovesActions
     def index_and_render
-      moves = Moves::Finder.new(filter_params, current_ability, params[:sort] || {}).call
-
-      if csv?
-        send_file(Moves::Exporter.new(moves).call, type: 'text/csv', disposition: :inline)
-      else
-        paginate moves,
-                 each_serializer: ::V2::MoveSerializer,
-                 include: included_relationships,
-                 fields: ::V2::MoveSerializer::INCLUDED_FIELDS
-      end
+      paginate moves,
+               each_serializer: ::V2::MoveSerializer,
+               include: included_relationships,
+               fields: ::V2::MoveSerializer::INCLUDED_FIELDS
     end
 
     def show_and_render

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -14,7 +14,6 @@ class ApiController < ApplicationController
   before_action :validate_include_params
 
   CONTENT_TYPE = 'application/vnd.api+json'
-  REGEXP_CSV = /(application|text)\/csv/i.freeze
   REGEXP_API_VERSION = %r{.*version=(?<version>\d+)}.freeze
 
   rescue_from ActionController::ParameterMissing, with: :render_bad_request_error
@@ -232,10 +231,6 @@ private
 
   def supported_relationships
     []
-  end
-
-  def csv?
-    request.headers['Accept']&.match?(REGEXP_CSV)
   end
 
   def api_version

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,9 @@ Rails.application.routes.draw do
       resources :profiles, only: %i[create update]
     end
     resources :moves, only: %i[index show create update] do
+      collection do
+        post 'csv'
+      end
       resources :journeys, only: %i[index show create update] do
         member do
           post 'cancel', controller: 'journey_events'

--- a/spec/requests/api/moves_controller_csv_spec.rb
+++ b/spec/requests/api/moves_controller_csv_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::MovesController do
+  subject(:post_moves_csv) { post '/api/moves/csv', params: params, headers: headers, as: :json }
+
+  let(:supplier) { create(:supplier) }
+  let(:access_token) { 'spoofed-token' }
+  let(:headers) do
+    {
+      'CONTENT_TYPE': ApiController::CONTENT_TYPE,
+      'Accept': 'text/csv',
+      'Authorization' => "Bearer #{access_token}",
+    }
+  end
+
+  let(:params) { {} }
+
+  describe 'POST /moves/csv' do
+    let!(:moves) { create_list :move, 2 }
+
+    it 'returns a success code' do
+      post_moves_csv
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns an inline file response' do
+      post_moves_csv
+      expect(response.headers['Content-Disposition']).to match('inline')
+    end
+
+    it 'sets the correct content type header' do
+      post_moves_csv
+      expect(response.headers['Content-Type']).to eq('text/csv')
+    end
+
+    describe 'filtering results' do
+      let(:from_location_id) { moves.first.from_location_id }
+      let(:filters) do
+        {
+          bar: 'bar',
+          from_location_id: from_location_id,
+          foo: 'foo',
+        }
+      end
+      let(:params) { { filter: filters } }
+
+      it 'delegates the query execution to Moves::Finder with the correct filters' do
+        ability = instance_double('Ability')
+        allow(Ability).to receive(:new).and_return(ability)
+
+        moves_finder = instance_double('Moves::Finder', call: Move.all)
+        allow(Moves::Finder).to receive(:new).and_return(moves_finder)
+
+        post_moves_csv
+
+        expect(Moves::Finder).to have_received(:new).with({ from_location_id: from_location_id }, ability, {})
+      end
+    end
+
+    it 'delegates the CSV generation to Moves::Exporter with the correct moves' do
+      moves_exporter = instance_double('Moves::Exporter', call: Tempfile.new)
+      allow(Moves::Exporter).to receive(:new).and_return(moves_exporter)
+
+      post_moves_csv
+
+      expect(Moves::Exporter).to have_received(:new).with(ActiveRecord::Relation)
+    end
+  end
+end

--- a/spec/requests/api/moves_controller_index_v2_spec.rb
+++ b/spec/requests/api/moves_controller_index_v2_spec.rb
@@ -202,34 +202,6 @@ RSpec.describe Api::MovesController do
         end
       end
     end
-
-    context 'with text/csv Accept header' do
-      let(:accept) { 'text/csv; version=2' }
-
-      it 'returns a success code' do
-        do_get
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'returns an inline file response' do
-        do_get
-        expect(response.headers['Content-Disposition']).to match('inline')
-      end
-
-      it 'sets the correct content type header' do
-        do_get
-        expect(response.headers['Content-Type']).to eq('text/csv')
-      end
-
-      it 'delegates the CSV generation to Moves::Exporter with the correct moves' do
-        moves_exporter = instance_double('Moves::Exporter', call: Tempfile.new)
-        allow(Moves::Exporter).to receive(:new).and_return(moves_exporter)
-
-        do_get
-
-        expect(Moves::Exporter).to have_received(:new).with(ActiveRecord::Relation)
-      end
-    end
   end
 
   def do_get

--- a/swagger/v2/accept_type_parameter.yaml
+++ b/swagger/v2/accept_type_parameter.yaml
@@ -5,8 +5,6 @@ Accept:
 
     We currently support `application/vnd.api+json` and `version` 1 and 2.
 
-    Additionally, the `GET /moves` endpoint only supports content type of `application/csv` or `text/csv`; this will return a CSV file rather than JSONAPI. When specifying a CSV content type pagination parameters are ignored and all relevant records are returned.
-
     You don't have to supply the media type. `version` _must_ be provided.
   in: header
   required: true


### PR DESCRIPTION
### Jira link

P4-2028

### What?

- [x] Moved the Moves CSV endpoint from `GET /moves` to `POST /moves/csv`
- [x] Refactored some moves controller/actions stuff to DRY this up across v1 and v2

### Why?

- The original endpoint chosen for this aligned with Rails idioms with a GET verb - primarily chosen as it's returning a list of moves. Whilst this works fine the use of GET imposes a limitation in the length of the passed URL query string - tested to be around 8k characters. This limit is set within the web hosting infrastructure so is not easy to get around.

- Some of the users have a large list of locations they can access, so building a request that specifies each of the required location id filters results in a 10k request - this was blowing up with a 413 error because of the request size. This could be better architected by performing location authorisation in the API rather than the front end (passing some user info to the API instead of locations), but that's a longer term goal and not something we can achieve now.

- To work around the immediate problem, this PR swaps to a POST request which doesn't have the same size limit, but does mean that the filter params must be passed in JSON format rather than as part of the query string. The new endpoint supports the same filter parameters as `GET /moves`. We can't use `POST /moves` for this as that is used to create a new move, so we have chosen `POST /moves/csv` as the new endpoint. This is intentionally undocumented as it's not intended for supplier use (only by the front end). All references to"csv" have been removed in the swagger documentation.

### Have you? (optional)

- [x] Updated API docs if necessary (to undocument the feature!)

### Deployment risks (optional)

- Not yet used in production