### PR TITLE
P4-2061 Fix type validation in Framework Responses

### DIFF
--- a/app/controllers/api/framework_responses_controller.rb
+++ b/app/controllers/api/framework_responses_controller.rb
@@ -13,6 +13,8 @@ module Api
       ],
     ].freeze
 
+    rescue_from FrameworkResponse::ValueTypeError, with: :render_value_type_error
+
     def update
       framework_response.update_with_flags!(update_framework_response_attributes)
 
@@ -35,6 +37,17 @@ module Api
 
     def framework_response
       @framework_response ||= FrameworkResponse.find(params[:id])
+    end
+
+    def render_value_type_error(exception)
+      render(
+        json: { errors: [{
+          title: 'Invalid Value type',
+          detail: "Value: #{exception.message} is incorrect type",
+          source: { pointer: '/data/attributes/value' },
+        }] },
+        status: :unprocessable_entity,
+      )
     end
   end
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -42,6 +42,13 @@ class FrameworkResponse < VersionedModel
     raise ActiveRecord::ReadOnlyRecord, "Can't update framework_responses because person_escort_record is #{person_escort_record.status}"
   end
 
+  def value=(raw_value)
+    unless raw_value.blank? || value_type_valid?(raw_value)
+      errors.add(:value, 'is incorrect type')
+      raise ActiveModel::ValidationError, self
+    end
+  end
+
 private
 
   def set_responded_value

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FrameworkResponse < VersionedModel
+  ValueTypeError = Class.new(StandardError)
+
   validates :type, presence: true
   validates :responded, inclusion: { in: [true, false] }
 
@@ -44,8 +46,7 @@ class FrameworkResponse < VersionedModel
 
   def value=(raw_value)
     unless raw_value.blank? || value_type_valid?(raw_value)
-      errors.add(:value, 'is incorrect type')
-      raise ActiveModel::ValidationError, self
+      raise FrameworkResponse::ValueTypeError, raw_value
     end
   end
 

--- a/app/models/framework_response/array.rb
+++ b/app/models/framework_response/array.rb
@@ -1,6 +1,5 @@
 class FrameworkResponse
   class Array < FrameworkResponse
-    validate :validate_array_type
     validates :value_text, absence: true
     validate :validate_value_inclusion, on: :update
 
@@ -9,6 +8,8 @@ class FrameworkResponse
     end
 
     def value=(raw_value)
+      super
+
       self.value_json = raw_value.presence || []
     end
 
@@ -26,10 +27,8 @@ class FrameworkResponse
       end
     end
 
-    def validate_array_type
-      unless value.is_a?(::Array)
-        errors.add(:value, 'is incorrect type')
-      end
+    def value_type_valid?(raw_value)
+      raw_value.is_a?(::Array)
     end
   end
 end

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -5,7 +5,7 @@ class FrameworkResponse
     validate :validate_multiple_items_collection, on: :update, if: -> { multiple_items? }
 
     def value
-      value_json.delete_if(&:empty?)
+      value_json&.delete_if(&:empty?)
       value_json.presence || []
     end
 

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -1,20 +1,21 @@
 class FrameworkResponse
   class Collection < FrameworkResponse
-    validate :validate_collection_type
     validates :value_text, absence: true
     validate :validate_details_collection, on: :update, if: -> { response_details }
     validate :validate_multiple_items_collection, on: :update, if: -> { multiple_items? }
 
     def value
-      value_json.delete_if(&:empty?) if collection_type_valid?(value_json)
+      value_json.delete_if(&:empty?)
       value_json.presence || []
     end
 
     def value=(raw_value)
+      super
+
       self.value_json =
-        if response_details && collection_type_valid?(raw_value)
+        if response_details
           details_collection(raw_value).to_a
-        elsif multiple_items? && collection_type_valid?(raw_value)
+        elsif multiple_items?
           multiple_items_collection(raw_value).to_a
         else
           raw_value.presence || []
@@ -69,14 +70,8 @@ class FrameworkResponse
       framework_question.question_type == 'add_multiple_items'
     end
 
-    def validate_collection_type
-      unless collection_type_valid?(value)
-        errors.add(:value, 'is incorrect type')
-      end
-    end
-
-    def collection_type_valid?(collection)
-      collection.is_a?(::Array) && collection.all?(::Hash)
+    def value_type_valid?(raw_value)
+      raw_value.is_a?(::Array) && raw_value.all?(::Hash)
     end
   end
 end

--- a/app/models/framework_response/multiple_item_object.rb
+++ b/app/models/framework_response/multiple_item_object.rb
@@ -58,8 +58,7 @@ class FrameworkResponse
 
     def validate_responses_type
       unless responses.blank? || responses_type_valid?
-        errors.add(:responses, 'is incorrect type')
-        raise ActiveModel::ValidationError, self
+        raise FrameworkResponse::ValueTypeError, responses
       end
     end
 

--- a/app/models/framework_response/multiple_item_object.rb
+++ b/app/models/framework_response/multiple_item_object.rb
@@ -8,7 +8,6 @@ class FrameworkResponse
 
     validates :item, presence: true, numericality: { only_integer: true }
     validates :responses, presence: true
-    validate :validate_responses_type
     validate :multiple_response_objects
     validate :required_questions
 
@@ -20,6 +19,8 @@ class FrameworkResponse
       attributes.deep_symbolize_keys! if attributes.respond_to?(:deep_symbolize_keys!)
       @item = attributes[:item]
       @responses = attributes[:responses] || []
+
+      validate_responses_type
     end
 
     def as_json(_options = {})
@@ -34,7 +35,7 @@ class FrameworkResponse
   private
 
     def multiple_response_objects
-      return unless responses_type_valid? && response_objects.any? { |object| object.invalid?(:update) }
+      return unless response_objects.any? { |object| object.invalid?(:update) }
 
       response_objects.each_with_index do |object, index|
         object.errors.each do |key, value|
@@ -56,8 +57,9 @@ class FrameworkResponse
     end
 
     def validate_responses_type
-      unless responses_type_valid?
+      unless responses.blank? || responses_type_valid?
         errors.add(:responses, 'is incorrect type')
+        raise ActiveModel::ValidationError, self
       end
     end
 
@@ -66,8 +68,6 @@ class FrameworkResponse
     end
 
     def required_questions
-      return unless responses_type_valid?
-
       question_ids = responses.map { |response| response[:framework_question_id] }
       questions.each do |question|
         next unless question.required

--- a/app/models/framework_response/object.rb
+++ b/app/models/framework_response/object.rb
@@ -1,6 +1,5 @@
 class FrameworkResponse
   class Object < FrameworkResponse
-    validate :validate_object_type
     validates :value_text, absence: true
     validate :validate_details_object, on: :update, if: -> { response_details }
 
@@ -9,6 +8,8 @@ class FrameworkResponse
     end
 
     def value=(raw_value)
+      super
+
       self.value_json =
         if response_details
           details_object(attributes: raw_value)
@@ -24,8 +25,6 @@ class FrameworkResponse
   private
 
     def details_object(attributes:)
-      return attributes unless attributes.is_a?(::Hash)
-
       DetailsObject.new(
         attributes: attributes,
         question_options: framework_question.options,
@@ -46,10 +45,8 @@ class FrameworkResponse
       end
     end
 
-    def validate_object_type
-      unless value.is_a?(::Hash)
-        errors.add(:value, 'is incorrect type')
-      end
+    def value_type_valid?(raw_value)
+      raw_value.is_a?(::Hash)
     end
   end
 end

--- a/app/models/framework_response/string.rb
+++ b/app/models/framework_response/string.rb
@@ -8,6 +8,8 @@ class FrameworkResponse
     end
 
     def value=(raw_value)
+      super
+
       self.value_text = raw_value
     end
 
@@ -20,6 +22,10 @@ class FrameworkResponse
     end
 
   private
+
+    def value_type_valid?(raw_value)
+      raw_value.is_a?(::String)
+    end
 
     def question_options_and_value_present?
       question_options.any? && value.present?

--- a/spec/models/framework_response/array_spec.rb
+++ b/spec/models/framework_response/array_spec.rb
@@ -26,15 +26,14 @@ RSpec.describe FrameworkResponse::Array do
     it 'validates correct type is passed in on creation' do
       question = create(:framework_question, :checkbox)
 
-      expect { build(:array_response, framework_question: question, value: { 'option' => 'Level 4' }) }.to raise_error(ActiveModel::ValidationError, /Value is incorrect type/)
+      expect { build(:array_response, framework_question: question, value: { 'option' => 'Level 4' }) }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     it 'validates correct type is passed in on update' do
       question = create(:framework_question, :checkbox)
       response = create(:array_response, framework_question: question)
 
-      expect { response.update(value: { 'option' => 'Level 4' }) }.to raise_error(ActiveModel::ValidationError)
-      expect(response.errors.messages[:value]).to contain_exactly('is incorrect type')
+      expect { response.update(value: { 'option' => 'Level 4' }) }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     context 'when question required' do

--- a/spec/models/framework_response/array_spec.rb
+++ b/spec/models/framework_response/array_spec.rb
@@ -23,13 +23,18 @@ RSpec.describe FrameworkResponse::Array do
       expect(response).to be_valid
     end
 
-    it 'validates correct type is passed in' do
+    it 'validates correct type is passed in on creation' do
+      question = create(:framework_question, :checkbox)
+
+      expect { build(:array_response, framework_question: question, value: { 'option' => 'Level 4' }) }.to raise_error(ActiveModel::ValidationError, /Value is incorrect type/)
+    end
+
+    it 'validates correct type is passed in on update' do
       question = create(:framework_question, :checkbox)
       response = create(:array_response, framework_question: question)
-      response.update(value: { 'option' => 'Level 4' })
 
-      expect(response).not_to be_valid
-      expect(response.errors.messages[:value]).to eq(['is incorrect type'])
+      expect { response.update(value: { 'option' => 'Level 4' }) }.to raise_error(ActiveModel::ValidationError)
+      expect(response.errors.messages[:value]).to contain_exactly('is incorrect type')
     end
 
     context 'when question required' do

--- a/spec/models/framework_response/collection_spec.rb
+++ b/spec/models/framework_response/collection_spec.rb
@@ -11,12 +11,11 @@ RSpec.describe FrameworkResponse::Collection do
     it 'validates correct type is passed in' do
       response = create(:collection_response, :details)
 
-      expect { response.update(value: { 'option' => 'Level 4' }) }.to raise_error(ActiveModel::ValidationError)
-      expect(response.errors.messages[:value]).to contain_exactly('is incorrect type')
+      expect { response.update(value: { 'option' => 'Level 4' }) }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     it 'validates correct type nested in array is passed in' do
-      expect { build(:collection_response, :details, value: ['option', 'Level 4']) }.to raise_error(ActiveModel::ValidationError, /Value is incorrect type/)
+      expect { build(:collection_response, :details, value: ['option', 'Level 4']) }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     it 'validates details collection' do

--- a/spec/models/framework_response/collection_spec.rb
+++ b/spec/models/framework_response/collection_spec.rb
@@ -10,17 +10,13 @@ RSpec.describe FrameworkResponse::Collection do
 
     it 'validates correct type is passed in' do
       response = create(:collection_response, :details)
-      response.update(value: { 'option' => 'Level 4' })
 
-      expect(response).not_to be_valid
-      expect(response.errors.messages[:value]).to eq(['is incorrect type'])
+      expect { response.update(value: { 'option' => 'Level 4' }) }.to raise_error(ActiveModel::ValidationError)
+      expect(response.errors.messages[:value]).to contain_exactly('is incorrect type')
     end
 
     it 'validates correct type nested in array is passed in' do
-      response = build(:collection_response, :details, value: ['option', 'Level 4'])
-
-      expect(response).not_to be_valid
-      expect(response.errors.messages[:value]).to eq(['is incorrect type'])
+      expect { build(:collection_response, :details, value: ['option', 'Level 4']) }.to raise_error(ActiveModel::ValidationError, /Value is incorrect type/)
     end
 
     it 'validates details collection' do

--- a/spec/models/framework_response/multiple_item_object_spec.rb
+++ b/spec/models/framework_response/multiple_item_object_spec.rb
@@ -65,10 +65,8 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
     it 'validates type of responses key' do
       questions = [create(:framework_question)]
       attributes = { item: 1, responses: { value: 'Yes', framework_question_id: questions.first.id } }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
 
-      expect(object).not_to be_valid
-      expect(object.errors.messages[:responses]).to eq(['is incorrect type'])
+      expect { described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record) }.to raise_error(ActiveModel::ValidationError, /is incorrect type/)
     end
 
     it 'validates responses include value key if multiple responses supplied and question required' do

--- a/spec/models/framework_response/multiple_item_object_spec.rb
+++ b/spec/models/framework_response/multiple_item_object_spec.rb
@@ -138,8 +138,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
       object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
 
-      expect(object).not_to be_valid
-      expect(object.errors.messages[:"responses[0].value"]).to eq(['is incorrect type'])
+      expect { object.valid? }.to raise_error(ActiveModel::ValidationError, /is incorrect type/)
     end
 
     it 'does not validate the response if value for response is valid' do

--- a/spec/models/framework_response/multiple_item_object_spec.rb
+++ b/spec/models/framework_response/multiple_item_object_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       questions = [create(:framework_question)]
       attributes = { item: 1, responses: { value: 'Yes', framework_question_id: questions.first.id } }
 
-      expect { described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record) }.to raise_error(ActiveModel::ValidationError, /is incorrect type/)
+      expect { described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record) }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     it 'validates responses include value key if multiple responses supplied and question required' do
@@ -136,7 +136,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
       object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
 
-      expect { object.valid? }.to raise_error(ActiveModel::ValidationError, /is incorrect type/)
+      expect { object.valid? }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     it 'does not validate the response if value for response is valid' do

--- a/spec/models/framework_response/multiple_items_collection_spec.rb
+++ b/spec/models/framework_response/multiple_items_collection_spec.rb
@@ -10,14 +10,24 @@ RSpec.describe FrameworkResponse::MultipleItemsCollection, type: :model do
       question1 = create(:framework_question, :checkbox)
       question2 = create(:framework_question)
       questions = [question1, question2]
-      response1 = { value: 'Level 1', framework_question_id: question1.id }
+      response1 = { value: ['Level 3'], framework_question_id: question1.id }
       response2 = { value: 'Yes', framework_question_id: question2.id }
       collection = [{ item: 1, responses: [response2] }, { item: 2, responses: [response1, response2] }]
 
       collection = described_class.new(collection: collection, person_escort_record: person_escort_record, questions: questions)
 
       expect(collection).not_to be_valid
-      expect(collection.errors.messages[:"items[1].responses[0].value"]).to eq(['is incorrect type'])
+      expect(collection.errors.messages[:"items[1].responses[0].value"]).to eq(['Level 3 are not valid options'])
+    end
+
+    it 'validates the object type passed' do
+      question = create(:framework_question, :checkbox)
+      response = { value: 'Level 3', framework_question_id: question.id }
+      collection = [{ item: 1, responses: [response] }]
+
+      collection = described_class.new(collection: collection, person_escort_record: person_escort_record, questions: [question])
+
+      expect { collection.valid? }.to raise_error(ActiveModel::ValidationError, /is incorrect type/)
     end
   end
 

--- a/spec/models/framework_response/multiple_items_collection_spec.rb
+++ b/spec/models/framework_response/multiple_items_collection_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FrameworkResponse::MultipleItemsCollection, type: :model do
 
       collection = described_class.new(collection: collection, person_escort_record: person_escort_record, questions: [question])
 
-      expect { collection.valid? }.to raise_error(ActiveModel::ValidationError, /is incorrect type/)
+      expect { collection.valid? }.to raise_error(FrameworkResponse::ValueTypeError)
     end
   end
 

--- a/spec/models/framework_response/object_spec.rb
+++ b/spec/models/framework_response/object_spec.rb
@@ -9,14 +9,13 @@ RSpec.describe FrameworkResponse::Object do
     it { is_expected.to validate_absence_of(:value_text) }
 
     it 'validates correct type is passed in on creation' do
-      expect { build(:object_response, :details, value: ['Level 4']) }.to raise_error(ActiveModel::ValidationError, /Value is incorrect type/)
+      expect { build(:object_response, :details, value: ['Level 4']) }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     it 'validates correct type is passed in on update' do
       response = create(:object_response, :details)
 
-      expect { response.update(value: ['Level 4']) }.to raise_error(ActiveModel::ValidationError)
-      expect(response.errors.messages[:value]).to contain_exactly('is incorrect type')
+      expect { response.update(value: ['Level 4']) }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     it 'validates details object' do

--- a/spec/models/framework_response/object_spec.rb
+++ b/spec/models/framework_response/object_spec.rb
@@ -8,12 +8,15 @@ RSpec.describe FrameworkResponse::Object do
   context 'with validations' do
     it { is_expected.to validate_absence_of(:value_text) }
 
-    it 'validates correct type is passed in' do
-      response = create(:object_response, :details)
-      response.update(value: ['Level 4'])
+    it 'validates correct type is passed in on creation' do
+      expect { build(:object_response, :details, value: ['Level 4']) }.to raise_error(ActiveModel::ValidationError, /Value is incorrect type/)
+    end
 
-      expect(response).not_to be_valid
-      expect(response.errors.messages[:value]).to eq(['is incorrect type'])
+    it 'validates correct type is passed in on update' do
+      response = create(:object_response, :details)
+
+      expect { response.update(value: ['Level 4']) }.to raise_error(ActiveModel::ValidationError)
+      expect(response.errors.messages[:value]).to contain_exactly('is incorrect type')
     end
 
     it 'validates details object' do

--- a/spec/models/framework_response/string_spec.rb
+++ b/spec/models/framework_response/string_spec.rb
@@ -29,14 +29,13 @@ RSpec.describe FrameworkResponse::String do
     end
 
     it 'validates correct type is passed in on creation' do
-      expect { build(:string_response, value: { 'option' => 'some option' }) }.to raise_error(ActiveModel::ValidationError, /Value is incorrect type/)
+      expect { build(:string_response, value: { 'option' => 'some option' }) }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     it 'validates correct type is passed in on update' do
       response = create(:string_response)
 
-      expect { response.update(value: { 'option' => 'some option' }) }.to raise_error(ActiveModel::ValidationError)
-      expect(response.errors.messages[:value]).to contain_exactly('is incorrect type')
+      expect { response.update(value: { 'option' => 'some option' }) }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     context 'when question required' do

--- a/spec/models/framework_response/string_spec.rb
+++ b/spec/models/framework_response/string_spec.rb
@@ -28,11 +28,15 @@ RSpec.describe FrameworkResponse::String do
       expect(response).to be_valid
     end
 
-    it 'validates type as not included in options since it is converted to a string' do
-      response = build(:string_response, value: { 'option' => 'some option' })
+    it 'validates correct type is passed in on creation' do
+      expect { build(:string_response, value: { 'option' => 'some option' }) }.to raise_error(ActiveModel::ValidationError, /Value is incorrect type/)
+    end
 
-      expect(response).not_to be_valid
-      expect(response.errors.messages[:value]).to eq(['is not included in the list'])
+    it 'validates correct type is passed in on update' do
+      response = create(:string_response)
+
+      expect { response.update(value: { 'option' => 'some option' }) }.to raise_error(ActiveModel::ValidationError)
+      expect(response.errors.messages[:value]).to contain_exactly('is incorrect type')
     end
 
     context 'when question required' do

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe FrameworkResponse do
         child_question = create(:framework_question, :checkbox, dependent_value: 'Level 1', parent: parent_response.framework_question)
         child_response = create(:array_response, framework_question: child_question, parent: parent_response)
 
-        expect { parent_response.update_with_flags!('Level 2') }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { parent_response.update_with_flags!('Level 2') }.to raise_error(ActiveModel::ValidationError)
         expect(child_response.reload.value).to eq(['Level 1'])
       end
 
@@ -405,10 +405,10 @@ RSpec.describe FrameworkResponse do
     end
 
     context 'with person_escort_record status' do
-      it 'does not change person escort record status if no answers provided invalid' do
+      it 'does not change person escort record status answers provided invalid' do
         response = create(:string_response, value: nil)
 
-        expect { response.update_with_flags!(%w[Yes]) }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { response.update_with_flags!(%w[Yes]) }.to raise_error(ActiveModel::ValidationError)
         expect(response.person_escort_record).to be_unstarted
       end
 

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe FrameworkResponse do
         child_question = create(:framework_question, :checkbox, dependent_value: 'Level 1', parent: parent_response.framework_question)
         child_response = create(:array_response, framework_question: child_question, parent: parent_response)
 
-        expect { parent_response.update_with_flags!('Level 2') }.to raise_error(ActiveModel::ValidationError)
+        expect { parent_response.update_with_flags!('Level 2') }.to raise_error(FrameworkResponse::ValueTypeError)
         expect(child_response.reload.value).to eq(['Level 1'])
       end
 
@@ -408,7 +408,7 @@ RSpec.describe FrameworkResponse do
       it 'does not change person escort record status answers provided invalid' do
         response = create(:string_response, value: nil)
 
-        expect { response.update_with_flags!(%w[Yes]) }.to raise_error(ActiveModel::ValidationError)
+        expect { response.update_with_flags!(%w[Yes]) }.to raise_error(FrameworkResponse::ValueTypeError)
         expect(response.person_escort_record).to be_unstarted
       end
 

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Api::FrameworkResponsesController do
       end
 
       context 'when response is a multiple item collection' do
-        let(:framework_response) { create(:collection_response, :multiple_items, framework_question: question) }
+        let(:framework_response) { create(:collection_response, :multiple_items, framework_question: question, value: nil) }
         let(:question1) { create(:framework_question) }
         let(:question2) { create(:framework_question, :checkbox) }
         let(:question3) { create(:framework_question, :checkbox, followup_comment: true) }

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -222,6 +222,22 @@ RSpec.describe Api::FrameworkResponsesController do
         end
       end
 
+      context 'with incorrect value type' do
+        let(:value) { %w[foo-bar] }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [
+              {
+                'title' => 'Invalid Value type',
+                'detail' => 'Value: ["foo-bar"] is incorrect type',
+                'source' => { pointer: '/data/attributes/value' },
+              },
+            ]
+          end
+        end
+      end
+
       context 'with a nested invalid value' do
         let(:framework_response) { create(:collection_response, :multiple_items) }
         let(:framework_question) { framework_response.framework_question.dependents.first }
@@ -238,6 +254,31 @@ RSpec.describe Api::FrameworkResponsesController do
           let(:errors_422) do
             [{ 'title' => 'Unprocessable entity',
                'detail' => 'Items[1].responses[0].value level 3 are not valid options' }]
+          end
+        end
+      end
+
+      context 'with a nested incorrect value type' do
+        let(:framework_response) { create(:collection_response, :multiple_items) }
+        let(:framework_question) { framework_response.framework_question.dependents.first }
+
+        let(:value) do
+          [
+            { item: 1, responses: [{ value: ['Level 1'], framework_question_id: framework_question.id }] },
+            { item: 2, responses: [{ value: 'Level 2', framework_question_id: framework_question.id }] },
+            { item: 3, responses: [{ value: ['Level 2'], framework_question_id: framework_question.id }] },
+          ]
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [
+              {
+                'title' => 'Invalid Value type',
+                'detail' => 'Value: Level 2 is incorrect type',
+                'source' => { pointer: '/data/attributes/value' },
+              },
+            ]
           end
         end
       end


### PR DESCRIPTION
### Jira link

[P4-2061](https://dsdmoj.atlassian.net/browse/P4-2061)

### What?

I have added/removed/altered:

- [x] Moved type validation to run before setting the value in framework responses
- [x] Moved type validation in multiple item objects for framework responses to initializer

### Why?

Check the response type on setting the value in the base response class to avoid having to check errors in validations
later on, which has caused us to duplicate type validation across multiple points when creating/updating records to avoid random errors.

Now we first call super on value setting which checks the type, and fails if it is invalid.
The same is done in the multiple item object, where now the validation error is in the initialisation to avoid duplicating checking the type everywhere.

### Deployment risks (optional)

- Changes an api that is used in production

Can be tested on https://booksecuremove-br-master.herokuapp.com/