### PR TITLE
Ensure that output buffer is flushed when generating CSV

### DIFF
--- a/app/services/moves/exporter.rb
+++ b/app/services/moves/exporter.rb
@@ -76,6 +76,7 @@ module Moves
         moves.find_each do |move|
           csv << attributes_row(move)
         end
+        file.flush
       end
     end
 


### PR DESCRIPTION
### Jira link

P4-2028

### What?

- [x] Ensure file buffer is flushed when generating moves CSV

### Why?

- It looks like the Tempfile wasn't flushing incomplete buffers, which meant for small number of moves nothing gets returned. This fixes it.