### PR TITLE
Making supplier_id not optional.

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -128,7 +128,7 @@ class Move < VersionedModel
   def rebook
     return rebooked if rebooked.present?
 
-    new_move = self.class.new(
+    Move.create!(
       original_move_id: id,
       from_location_id: from_location_id,
       to_location_id: to_location_id,
@@ -138,10 +138,8 @@ class Move < VersionedModel
       date: date && date + 7.days,
       date_from: date_from && date_from + 7.days,
       date_to: date_to && date_to + 7.days,
+      supplier: supplier
     )
-    new_move.determine_supplier
-    new_move.save!
-    new_move
   end
 
   def self.unfilled?

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -70,7 +70,7 @@ class Move < VersionedModel
     REJECTION_REASON_NO_TRANSPORT = 'no_transport_available',
   ].freeze
 
-  belongs_to :supplier, optional: true
+  belongs_to :supplier
   belongs_to :from_location, class_name: 'Location'
   belongs_to :to_location, class_name: 'Location', optional: true
   belongs_to :profile, optional: true, touch: true
@@ -126,7 +126,9 @@ class Move < VersionedModel
   end
 
   def rebook
-    rebooked || self.class.create(
+    return rebooked if rebooked.present?
+
+    new_booking = self.class.new(
       original_move_id: id,
       from_location_id: from_location_id,
       to_location_id: to_location_id,
@@ -134,9 +136,12 @@ class Move < VersionedModel
       profile_id: profile_id,
       status: MOVE_STATUS_PROPOSED,
       date: date && date + 7.days,
-      date_from: date_from && date_from + 7.days,
+      date_from: (date_from || date) + 7.days,
       date_to: date_to && date_to + 7.days,
     )
+    new_booking.determine_supplier
+    new_booking.save!
+    new_booking
   end
 
   def self.unfilled?

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -138,7 +138,7 @@ class Move < VersionedModel
       date: date && date + 7.days,
       date_from: date_from && date_from + 7.days,
       date_to: date_to && date_to + 7.days,
-      supplier: supplier
+      supplier: supplier,
     )
   end
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -128,7 +128,7 @@ class Move < VersionedModel
   def rebook
     return rebooked if rebooked.present?
 
-    new_booking = self.class.new(
+    new_move = self.class.new(
       original_move_id: id,
       from_location_id: from_location_id,
       to_location_id: to_location_id,
@@ -136,12 +136,12 @@ class Move < VersionedModel
       profile_id: profile_id,
       status: MOVE_STATUS_PROPOSED,
       date: date && date + 7.days,
-      date_from: (date_from || date) + 7.days,
+      date_from: date_from && date_from + 7.days,
       date_to: date_to && date_to + 7.days,
     )
-    new_booking.determine_supplier
-    new_booking.save!
-    new_booking
+    new_move.determine_supplier
+    new_move.save!
+    new_move
   end
 
   def self.unfilled?

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -12,9 +12,8 @@ FactoryBot.define do
     sequence(:created_at) { |n| Time.now - n.minutes }
     sequence(:date_from) { |n| Date.today - n.days }
 
-    trait :with_supplier do
-      association(:supplier)
-    end
+    association(:supplier)
+
     # Move types
     trait :court_appearance do
       # NB: Police / Prison / STC / SCH --> Court
@@ -169,6 +168,8 @@ FactoryBot.define do
     association(:profile)
     association(:from_location, :prison, factory: :location)
     association(:to_location, :court, factory: :location)
+    association(:supplier)
+
     date { Date.today }
     time_due { Time.now }
     status { 'requested' }

--- a/spec/jobs/prepare_move_notifications_job_spec.rb
+++ b/spec/jobs/prepare_move_notifications_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
   let(:subscription) { create :subscription }
   let(:supplier) { create :supplier, name: 'test', subscriptions: [subscription] }
   let(:location) { create :location, suppliers: [supplier] }
-  let(:move) { create :move, from_location: location }
+  let(:move) { create :move, from_location: location, supplier: supplier }
   let(:action_name) { 'create' }
   let(:send_webhooks) { true }
   let(:send_emails) { true }
@@ -17,6 +17,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
   before do
     create(:notification_type, :webhook)
     create(:notification_type, :email)
+
     allow(NotifyWebhookJob).to receive(:perform_later)
     allow(NotifyEmailJob).to receive(:perform_later)
   end
@@ -97,7 +98,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
   end
 
   context 'when creating a back-dated move' do
-    let(:move) { create :move, from_location: location, date: 2.days.ago }
+    let(:move) { create :move, from_location: location, date: 2.days.ago, supplier: supplier }
 
     it_behaves_like 'it creates a webhook notification record'
     it_behaves_like 'it does not create an email notification record'
@@ -106,7 +107,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
   end
 
   context 'when creating a move for today' do
-    let(:move) { create :move, from_location: location, date: Time.zone.today }
+    let(:move) { create :move, from_location: location, date: Time.zone.today, supplier: supplier }
 
     it_behaves_like 'it creates a webhook notification record'
     it_behaves_like 'it creates an email notification record'
@@ -115,7 +116,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
   end
 
   context 'when creating a forward-dated move' do
-    let(:move) { create :move, from_location: location, date: 2.days.from_now }
+    let(:move) { create :move, from_location: location, date: 2.days.from_now, supplier: supplier }
 
     it_behaves_like 'it creates a webhook notification record'
     it_behaves_like 'it creates an email notification record'

--- a/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PreparePersonEscortRecordNotificationsJob, type: :job do
   let(:supplier) { create :supplier, name: 'test', subscriptions: [subscription] }
   let(:location) { create :location, suppliers: [supplier] }
   let(:person_escort_record) { create(:person_escort_record) }
-  let!(:move) { create(:move, from_location: location, profile: person_escort_record.profile) }
+  let!(:move) { create(:move, from_location: location, profile: person_escort_record.profile, supplier: supplier) }
 
   before do
     create(:notification_type, :webhook)

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -446,9 +446,12 @@ RSpec.describe Move do
         expect(original_move.rebook.date_from).to eq(original_move.date_from + 7.days)
       end
 
-      it 'sets the move from_date to 7 days after date if from_date is NOT present' do
+      it 'raises an error is date_from is nil' do
         original_move.date_from = nil
-        expect(original_move.rebook.date_from).to eq(original_move.date + 7.days)
+
+        expect {
+          original_move.rebook.date_from
+        }.to raise_exception ActiveRecord::RecordInvalid
       end
 
       it 'sets the move to date to 7 days in the future if present' do

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -446,7 +446,7 @@ RSpec.describe Move do
         expect(original_move.rebook.date_from).to eq(original_move.date_from + 7.days)
       end
 
-      it 'raises an error is date_from is nil' do
+      it 'raises an error if date_from is nil' do
         original_move.date_from = nil
 
         expect {

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Move do
-  it { is_expected.to belong_to(:supplier).optional }
+  it { is_expected.to belong_to(:supplier) }
   it { is_expected.to belong_to(:from_location) }
   it { is_expected.to belong_to(:to_location).optional }
   it { is_expected.to belong_to(:profile).optional }
@@ -402,7 +402,11 @@ RSpec.describe Move do
   end
 
   describe '#rebook' do
-    let!(:original_move) { create(:move, :proposed, :with_allocation, :with_date_to) }
+    before do
+      create :supplier_location, supplier: original_move.supplier, location: original_move.from_location
+    end
+
+    let(:original_move) { create(:move, :proposed, :with_allocation, :with_date_to) }
 
     context 'when not yet rebooked' do
       it 'creates a new move' do
@@ -442,9 +446,9 @@ RSpec.describe Move do
         expect(original_move.rebook.date_from).to eq(original_move.date_from + 7.days)
       end
 
-      it 'sets the move date from to nil if not present' do
+      it 'sets the move from_date to 7 days after date if from_date is NOT present' do
         original_move.date_from = nil
-        expect(original_move.rebook.date_from).to be_nil
+        expect(original_move.rebook.date_from).to eq(original_move.date + 7.days)
       end
 
       it 'sets the move to date to 7 days in the future if present' do
@@ -508,7 +512,7 @@ RSpec.describe Move do
   end
 
   describe '#for_feed' do
-    subject(:move) { create(:move, :with_supplier) }
+    subject(:move) { create(:move) }
 
     let(:expected_json) do
       {

--- a/spec/requests/api/move_events_controller_approve_spec.rb
+++ b/spec/requests/api/move_events_controller_approve_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::MoveEventsController do
     let(:schema) { load_yaml_schema('post_move_events_responses.yaml') }
     let(:response_json) { JSON.parse(response.body) }
     let(:from_location) { create(:location, suppliers: [supplier]) }
-    let(:move) { create(:move, :proposed, from_location: from_location) }
+    let(:move) { create(:move, :proposed, from_location: from_location, supplier: supplier) }
     let(:approved_date) { move.date + 1.day }
     let(:move_id) { move.id }
     let(:approve_params) do

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe Api::MovesController do
           end
 
           context 'when the supplier has a webhook subscription', :skip_before do
-            let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
+            let!(:subscription) { create(:subscription, :no_email_address, supplier: move.supplier) }
             let!(:notification_type_webhook) { create(:notification_type, :webhook) }
             let(:notification) { subscription.notifications.last }
             let(:faraday_client) do
@@ -426,7 +426,7 @@ RSpec.describe Api::MovesController do
           end
 
           context 'when the supplier has an email subscription', :skip_before do
-            let!(:subscription) { create(:subscription, :no_callback_url, supplier: supplier) }
+            let!(:subscription) { create(:subscription, :no_callback_url, supplier: move.supplier) }
             let!(:notification_type_email) { create(:notification_type, :email) }
             let(:notification) { subscription.notifications.last }
             let(:notify_response) do
@@ -466,7 +466,7 @@ RSpec.describe Api::MovesController do
 
           context 'when the supplier has a webhook subscription', :skip_before do
             # NB: updates to existing moves should trigger a webhook notification
-            let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
+            let!(:subscription) { create(:subscription, :no_email_address, supplier: move.supplier) }
             let!(:notification_type_webhook) { create(:notification_type, :webhook) }
             let(:notification) { subscription.notifications.last }
             let(:faraday_client) do
@@ -505,7 +505,7 @@ RSpec.describe Api::MovesController do
 
           context 'when the supplier has an email subscription', :skip_before do
             # NB: updates to existing moves should trigger an email notification
-            let!(:subscription) { create(:subscription, :no_callback_url, supplier: supplier) }
+            let!(:subscription) { create(:subscription, :no_callback_url, supplier: move.supplier) }
             let!(:notification_type_email) { create(:notification_type, :email) }
             let(:notification) { subscription.notifications.last }
             let(:notify_response) do

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::MovesController do
     let(:supplier) { create(:supplier) }
     let!(:from_location) { create :location, :police, suppliers: [supplier] }
     let(:profile) { create(:profile, documents: before_documents) }
-    let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile }
+    let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile, supplier: supplier }
     let(:move_id) { move.id }
     let(:date_from) { Date.yesterday }
     let(:date_to) { Date.tomorrow }
@@ -61,6 +61,7 @@ RSpec.describe Api::MovesController do
             from_location: move.from_location,
             to_location: move.to_location,
             date: move.date,
+            supplier: supplier,
           )
           do_patch
         end
@@ -396,7 +397,7 @@ RSpec.describe Api::MovesController do
           end
 
           context 'when the supplier has a webhook subscription', :skip_before do
-            let!(:subscription) { create(:subscription, :no_email_address, supplier: move.supplier) }
+            let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
             let!(:notification_type_webhook) { create(:notification_type, :webhook) }
             let(:notification) { subscription.notifications.last }
             let(:faraday_client) do
@@ -426,7 +427,7 @@ RSpec.describe Api::MovesController do
           end
 
           context 'when the supplier has an email subscription', :skip_before do
-            let!(:subscription) { create(:subscription, :no_callback_url, supplier: move.supplier) }
+            let!(:subscription) { create(:subscription, :no_callback_url, supplier: supplier) }
             let!(:notification_type_email) { create(:notification_type, :email) }
             let(:notification) { subscription.notifications.last }
             let(:notify_response) do
@@ -462,11 +463,11 @@ RSpec.describe Api::MovesController do
         end
 
         context 'when updating an existing requested move without a change of move_status' do
-          let!(:move) { create :move, :requested, move_type: 'prison_recall', from_location: from_location }
+          let!(:move) { create :move, :requested, move_type: 'prison_recall', from_location: from_location, supplier: supplier}
 
           context 'when the supplier has a webhook subscription', :skip_before do
             # NB: updates to existing moves should trigger a webhook notification
-            let!(:subscription) { create(:subscription, :no_email_address, supplier: move.supplier) }
+            let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
             let!(:notification_type_webhook) { create(:notification_type, :webhook) }
             let(:notification) { subscription.notifications.last }
             let(:faraday_client) do
@@ -505,7 +506,7 @@ RSpec.describe Api::MovesController do
 
           context 'when the supplier has an email subscription', :skip_before do
             # NB: updates to existing moves should trigger an email notification
-            let!(:subscription) { create(:subscription, :no_callback_url, supplier: move.supplier) }
+            let!(:subscription) { create(:subscription, :no_callback_url, supplier: supplier) }
             let!(:notification_type_email) { create(:notification_type, :email) }
             let(:notification) { subscription.notifications.last }
             let(:notify_response) do
@@ -543,7 +544,7 @@ RSpec.describe Api::MovesController do
         end
 
         context 'when move is associated to an allocation' do
-          let!(:move) { create :move, :with_allocation, profile: profile }
+          let!(:move) { create :move, :with_allocation, profile: profile, supplier: supplier }
           let(:move_params) do
             {
               type: 'moves',

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -463,7 +463,7 @@ RSpec.describe Api::MovesController do
         end
 
         context 'when updating an existing requested move without a change of move_status' do
-          let!(:move) { create :move, :requested, move_type: 'prison_recall', from_location: from_location, supplier: supplier}
+          let!(:move) { create :move, :requested, move_type: 'prison_recall', from_location: from_location, supplier: supplier }
 
           context 'when the supplier has a webhook subscription', :skip_before do
             # NB: updates to existing moves should trigger a webhook notification

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::MovesController do
   end
 
   describe 'PATCH /moves' do
-# <<<<<<< HEAD
+    # <<<<<<< HEAD
     let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile, supplier: supplier }
 
     # let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile, date_from: 2.days.ago, supplier: supplier }

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -24,10 +24,7 @@ RSpec.describe Api::MovesController do
   end
 
   describe 'PATCH /moves' do
-    # <<<<<<< HEAD
     let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile, supplier: supplier }
-
-    # let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile, date_from: 2.days.ago, supplier: supplier }
 
     let(:from_location) { create :location, :police, suppliers: [supplier] }
     let(:move_id) { move.id }

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe Api::MovesController do
   end
 
   describe 'PATCH /moves' do
-    let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile }
+# <<<<<<< HEAD
+    let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile, supplier: supplier }
+
+    # let!(:move) { create :move, :proposed, :prison_recall, from_location: from_location, profile: profile, date_from: 2.days.ago, supplier: supplier }
 
     let(:from_location) { create :location, :police, suppliers: [supplier] }
     let(:move_id) { move.id }
@@ -340,7 +343,7 @@ RSpec.describe Api::MovesController do
     end
 
     context 'when updating an existing requested move without a change of move_status' do
-      let!(:move) { create :move, :requested, move_type: 'prison_recall', from_location: from_location }
+      let!(:move) { create :move, :requested, move_type: 'prison_recall', from_location: from_location, supplier: supplier }
 
       context 'when the supplier has a webhook subscription' do
         # NB: updates to existing moves should trigger a webhook notification

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Api::PersonEscortRecordsController do
       let!(:subscription) { create(:subscription, supplier: supplier) }
       let!(:notification_type_email) { create(:notification_type, :email) }
       let!(:notification_type_webhook) { create(:notification_type, :webhook) }
-      let!(:move) { create(:move, profile: person_escort_record.profile, from_location: from_location) }
+      let!(:move) { create(:move, profile: person_escort_record.profile, from_location: from_location, supplier: supplier) }
       let(:from_location) { create(:location, suppliers: [supplier]) }
       let(:faraday_client) do
         class_double(

--- a/spec/requests/api_stories/move_workflows/1_police_to_police/1_1_person_with_police_national_computer_spec.rb
+++ b/spec/requests/api_stories/move_workflows/1_police_to_police/1_1_person_with_police_national_computer_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe 'police-to-police transfer', type: :request, api_story: true do
     police2
 
     # Assign police1 location to Serco supplier
-    create :supplier_location, location: police1, supplier: serco_supplier, effective_from: Date.new(1900, 1, 1)
+    create :supplier_location, location: police1
 
     # These steps simulate the frontend creating a move request before the supplier processes it
 

--- a/spec/requests/api_stories/move_workflows/1_police_to_police/1_1_person_with_police_national_computer_spec.rb
+++ b/spec/requests/api_stories/move_workflows/1_police_to_police/1_1_person_with_police_national_computer_spec.rb
@@ -150,6 +150,9 @@ RSpec.describe 'police-to-police transfer', type: :request, api_story: true do
     police1
     police2
 
+    # Assign police1 location to Serco supplier
+    create :supplier_location, location: police1, supplier: serco_supplier, effective_from: Date.new(1900, 1, 1)
+
     # These steps simulate the frontend creating a move request before the supplier processes it
 
     # get person record(s)

--- a/spec/requests/api_stories/move_workflows/1_police_to_police/1_1_person_with_police_national_computer_spec.rb
+++ b/spec/requests/api_stories/move_workflows/1_police_to_police/1_1_person_with_police_national_computer_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe 'police-to-police transfer', type: :request, api_story: true do
     police2
 
     # Assign police1 location to Serco supplier
-    create :supplier_location, location: police1
+    create :supplier_location, location: police1, supplier: serco_supplier
 
     # These steps simulate the frontend creating a move request before the supplier processes it
 

--- a/spec/requests/api_stories/move_workflows/2_police_to_unspecified/2_1_person_with_police_national_computer_to_unspecified_prison_spec.rb
+++ b/spec/requests/api_stories/move_workflows/2_police_to_unspecified/2_1_person_with_police_national_computer_to_unspecified_prison_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe 'police to unknown prison recall', type: :request, api_story: tru
     prison
 
     # Assign the police location to the supplier
-    create :supplier_location, location: police, supplier: serco_supplier, effective_from: Date.new(1900, 1, 1)
+    create :supplier_location, location: police, supplier: serco_supplier
 
     # These steps simulate the frontend creating a move request before the supplier processes it
 

--- a/spec/requests/api_stories/move_workflows/2_police_to_unspecified/2_1_person_with_police_national_computer_to_unspecified_prison_spec.rb
+++ b/spec/requests/api_stories/move_workflows/2_police_to_unspecified/2_1_person_with_police_national_computer_to_unspecified_prison_spec.rb
@@ -168,6 +168,9 @@ RSpec.describe 'police to unknown prison recall', type: :request, api_story: tru
     police
     prison
 
+    # Assign the police location to the supplier
+    create :supplier_location, location: police, supplier: serco_supplier, effective_from: Date.new(1900, 1, 1)
+
     # These steps simulate the frontend creating a move request before the supplier processes it
 
     # get person record(s)

--- a/spec/requests/api_stories/move_workflows/5_court_to_prison/5_1_person_with_nomis_prison_number_spec.rb
+++ b/spec/requests/api_stories/move_workflows/5_court_to_prison/5_1_person_with_nomis_prison_number_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'court to prison move', type: :request, api_story: true do
     header 'Authorization', 'Bearer spoofed-token'
 
     # Assign location court to Serco supplier
-    create :supplier_location, location: court, supplier: serco_supplier, effective_from: Date.new(1900, 1, 1)
+    create :supplier_location, location: court, supplier: serco_supplier
   end
 
   # rubocop:disable RSpec/MultipleExpectations

--- a/spec/requests/api_stories/move_workflows/5_court_to_prison/5_1_person_with_nomis_prison_number_spec.rb
+++ b/spec/requests/api_stories/move_workflows/5_court_to_prison/5_1_person_with_nomis_prison_number_spec.rb
@@ -143,6 +143,9 @@ RSpec.describe 'court to prison move', type: :request, api_story: true do
     header 'Content-Type', 'application/vnd.api+json'
     header 'Accept', 'application/vnd.api+json; version=2'
     header 'Authorization', 'Bearer spoofed-token'
+
+    # Assign location court to Serco supplier
+    create :supplier_location, location: court, supplier: serco_supplier, effective_from: Date.new(1900, 1, 1)
   end
 
   # rubocop:disable RSpec/MultipleExpectations

--- a/spec/requests/api_stories/move_workflows/6_prison_to_prison_ipt/6_1_singleton_known_person_spec.rb
+++ b/spec/requests/api_stories/move_workflows/6_prison_to_prison_ipt/6_1_singleton_known_person_spec.rb
@@ -164,6 +164,9 @@ RSpec.describe 'singleton', type: :request, api_story: true do
     header 'Accept', 'application/vnd.api+json; version=2'
     header 'Authorization', 'Bearer spoofed-token'
 
+    # Assign prison1 location to Serco supplier
+    create :supplier_location, location: prison1, supplier: serco_supplier, effective_from: Date.new(1900, 1, 1)
+
     # These steps simulate the frontend creating a move request
 
     # get person record(s)

--- a/spec/requests/api_stories/move_workflows/6_prison_to_prison_ipt/6_1_singleton_known_person_spec.rb
+++ b/spec/requests/api_stories/move_workflows/6_prison_to_prison_ipt/6_1_singleton_known_person_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe 'singleton', type: :request, api_story: true do
     header 'Authorization', 'Bearer spoofed-token'
 
     # Assign prison1 location to Serco supplier
-    create :supplier_location, location: prison1, supplier: serco_supplier, effective_from: Date.new(1900, 1, 1)
+    create :supplier_location, location: prison1, supplier: serco_supplier
 
     # These steps simulate the frontend creating a move request
 

--- a/spec/services/event_log/move_runner_spec.rb
+++ b/spec/services/event_log/move_runner_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe EventLog::MoveRunner do
   let!(:move) { create(:move, :requested, to_location: original_location) }
   let(:original_location) { create(:location) }
 
-  before { allow(Notifier).to receive(:prepare_notifications) }
+  before do
+    create :supplier_location, supplier: move.supplier, location: move.from_location
+
+    allow(Notifier).to receive(:prepare_notifications)
+  end
 
   shared_examples_for 'it calls the Notifier with an update_status action_name' do
     before { runner.call }

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Moves::Finder do
 
     describe 'by supplier_id' do
       context 'with supplier filter' do
-        let(:move) { create :move, :with_supplier }
+        let(:move) { create :move }
         let(:filter_params) { { supplier_id: move.supplier_id } }
 
         it 'returns moves matching the supplier' do

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Moves::Updater do
   subject(:updater) { described_class.new(move, move_params) }
 
   let(:before_documents) { create_list(:document, 2) }
+  let(:supplier) { create(:supplier) }
   let!(:from_location) { create(:location, :police) }
-  let!(:move) { create(:move, :proposed, :prison_recall, from_location: from_location, profile: profile) }
+  let!(:move) { create(:move, :proposed, :prison_recall, from_location: from_location, profile: profile, supplier: supplier) }
   let(:profile) { create(:profile, documents: before_documents) }
   let(:date_from) { Date.yesterday }
   let(:date_to) { Date.tomorrow }
@@ -29,6 +30,8 @@ RSpec.describe Moves::Updater do
       },
     }
   end
+
+  before { create :supplier_location, supplier: move.supplier, location: move.from_location } # Used by SupplierChooser
 
   context 'with valid params' do
     it 'updates the correct attributes on an existing move' do

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -31,8 +31,6 @@ RSpec.describe Moves::Updater do
     }
   end
 
-  before { create :supplier_location, supplier: move.supplier, location: move.from_location } # Used by SupplierChooser
-
   context 'with valid params' do
     it 'updates the correct attributes on an existing move' do
       updater.call

--- a/spec/support/with_nomis_alerts_seed_data.rb
+++ b/spec/support/with_nomis_alerts_seed_data.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'with Nomis alerts reference data' do
+  let(:serco_supplier) { create :supplier, key: 'serco', name: 'Serco' }
+
   before do
     # Seed the database with nomis-sourced data for genders, ethnicities, alerts, identifiers, assessment questions
     Ethnicities::Importer.new(NomisClient::Ethnicities.get).call


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-2101

### What?
Make the relation **Move - Supplier** not optional.

### Why?
When a move is created or updated, a supplier should always be set.

