### PR TITLE
[P4-2098] Adds puma instrumentation

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,5 +36,12 @@ plugin :tmp_restart
 # run a new process instrumenter after work boot
 on_worker_boot do
   require 'prometheus_exporter/instrumentation'
+  require 'prometheus_exporter/client'
+
+  PrometheusExporter::Instrumentation::Puma.start
   PrometheusExporter::Instrumentation::Process.start(type: 'web')
+  PrometheusExporter::Instrumentation::ActiveRecord.start(
+    custom_labels: { type: 'puma_worker' },
+    config_labels: [:database, :host]
+  )
 end


### PR DESCRIPTION
### Jira link

P4-2098

### What?

I have added/removed/altered:

- [x] Adds prometheus exporter instrumentation for puma and active record

### Why?

I am doing this because:

- We're debugging slow requests and want to understand the puma queue backlog/active thread counts, etc.