### PR TITLE
Update notifications rake task to avoid assuming ownership of moves

### DIFF
--- a/lib/tasks/notifications.rake
+++ b/lib/tasks/notifications.rake
@@ -17,16 +17,13 @@ namespace :notifications do
       .where('date >= ?', from_date)
       .where(status: statuses)
 
-    # moves assumed to belong to the supplier (based on from_location)
-    moves_assumed = Move
+    # moves that don't belong to any supplier
+    moves_unassigned = Move
       .where(supplier_id: nil)
-      .where(from_location: Location.supplier(supplier))
-      .where('date >= ?', from_date)
-      .where(status: statuses)
 
     puts "For moves dated from #{from_date} with statuses of #{statuses}"
     puts "\tthere are #{moves_assigned.count} assigned moves for #{supplier.name}"
-    puts "\tthere are #{moves_assumed.count} assumed moves for #{supplier.name}"
+    puts "\tthere are #{moves_unassigned.count} moves not assigned to any supplier"
 
     puts "Sending webhooks: #{send_webhooks}"
     puts "Sending emails: #{send_emails}"
@@ -42,10 +39,6 @@ namespace :notifications do
       PrepareMoveNotificationsJob.perform_now(topic_id: move.id, action_name: 'update', send_webhooks: send_webhooks, send_emails: send_emails, only_supplier_id: supplier.id)
     end
 
-    puts 'Processing assumed moves...'
-    moves_assumed.find_each do |move|
-      PrepareMoveNotificationsJob.perform_now(topic_id: move.id, action_name: 'update', send_webhooks: send_webhooks, send_emails: send_emails, only_supplier_id: supplier.id)
-    end
     puts 'All done.'
   end
 end


### PR DESCRIPTION
### Jira link

P4-2038

### What?

- [x] Avoid use of removed `Location.supplier` scope in notification rake task

### Why?

- We can't determine move owner solely by location any more - this instead needs to consider the effective date (implemented in SupplierChooser service). However it's also a little beyond the scope of this rake task to be updating the supplier - we have another rake task to do that, so I've updated this to just report if there any moves found without a supplier assigned, but otherwise ignore those when sending out notifications.