### PR TITLE
P4-2080 Support additional framework response types

### DIFF
--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -38,9 +38,9 @@ class FrameworkQuestion < VersionedModel
   def response_type
     case question_type
     when 'radio'
-      followup_comment ? 'object::details' : 'string'
+      followup_comment ? 'object::followup_comment' : 'string'
     when 'checkbox'
-      followup_comment ? 'collection::details' : 'array'
+      followup_comment ? 'collection::followup_comment' : 'array'
     when 'add_multiple_items'
       'collection::add_multiple_items'
     else

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -35,6 +35,19 @@ class FrameworkQuestion < VersionedModel
     response
   end
 
+  def response_type
+    case question_type
+    when 'radio'
+      followup_comment ? 'object::details' : 'string'
+    when 'checkbox'
+      followup_comment ? 'collection::details' : 'array'
+    when 'add_multiple_items'
+      'collection::add_multiple_items'
+    else
+      'string'
+    end
+  end
+
   def build_response(question, person_escort_record)
     klass =
       case question.question_type

--- a/app/serializers/framework_question_serializer.rb
+++ b/app/serializers/framework_question_serializer.rb
@@ -4,19 +4,6 @@ class FrameworkQuestionSerializer < ActiveModel::Serializer
   attributes :key, :section, :question_type, :options, :response_type
   has_many :dependents, key: :descendants
 
-  def response_type
-    case object.question_type
-    when 'radio'
-      object.followup_comment ? 'object' : 'string'
-    when 'checkbox'
-      object.followup_comment ? 'collection' : 'array'
-    when 'add_multiple_items'
-      'collection::add_multiple_items'
-    else
-      'string'
-    end
-  end
-
   SUPPORTED_RELATIONSHIPS = %w[
     framework
     descendants

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -7,16 +7,7 @@ class FrameworkResponseSerializer < ActiveModel::Serializer
   attributes :value, :value_type, :responded
 
   def value_type
-    case object.type
-    when 'FrameworkResponse::String'
-      'string'
-    when 'FrameworkResponse::Array'
-      'array'
-    when 'FrameworkResponse::Object'
-      'object'
-    when 'FrameworkResponse::Collection'
-      object.framework_question.question_type == 'add_multiple_items' ? 'collection::add_multiple_items' : 'collection'
-    end
+    object.framework_question.response_type
   end
 
   SUPPORTED_RELATIONSHIPS = %w[

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
   end
 
   factory :array_response, parent: :framework_response, class: 'FrameworkResponse::Array' do
-    association(:framework_question, options: ['Level 1', 'Level 2'])
+    association(:framework_question, :checkbox, options: ['Level 1', 'Level 2'])
     value { ['Level 1'] }
   end
 end

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe FrameworkQuestion do
       let(:framework_question) { create(:framework_question, followup_comment: true) }
 
       it 'returns response_type `object`' do
-        expect(framework_question.response_type).to eq('object::details')
+        expect(framework_question.response_type).to eq('object::followup_comment')
       end
     end
 
@@ -233,7 +233,7 @@ RSpec.describe FrameworkQuestion do
       let(:framework_question) { create(:framework_question, :checkbox, followup_comment: true) }
 
       it 'returns response_type `collection`' do
-        expect(framework_question.response_type).to eq('collection::details')
+        expect(framework_question.response_type).to eq('collection::followup_comment')
       end
     end
 

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -211,4 +211,54 @@ RSpec.describe FrameworkQuestion do
       expect(response).to be_a(FrameworkResponse::Collection)
     end
   end
+
+  describe '#response_type' do
+    context 'when question is of type radio with followup_comments' do
+      let(:framework_question) { create(:framework_question, followup_comment: true) }
+
+      it 'returns response_type `object`' do
+        expect(framework_question.response_type).to eq('object::details')
+      end
+    end
+
+    context 'when response is of type radio' do
+      let(:framework_question) { create(:framework_question) }
+
+      it 'returns response_type `string`' do
+        expect(framework_question.response_type).to eq('string')
+      end
+    end
+
+    context 'when question is of type checkbox with followup_comments' do
+      let(:framework_question) { create(:framework_question, :checkbox, followup_comment: true) }
+
+      it 'returns response_type `collection`' do
+        expect(framework_question.response_type).to eq('collection::details')
+      end
+    end
+
+    context 'when question is of type checkbox' do
+      let(:framework_question) { create(:framework_question, :checkbox) }
+
+      it 'returns response_type `array`' do
+        expect(framework_question.response_type).to eq('array')
+      end
+    end
+
+    context 'when question is of type `add_multiple_items`' do
+      let(:framework_question) { create(:framework_question, :add_multiple_items) }
+
+      it 'returns response_type `collection::add_multiple_items`' do
+        expect(framework_question.response_type).to eq('collection::add_multiple_items')
+      end
+    end
+
+    context 'when question is of type text' do
+      let(:framework_question) { create(:framework_question, :text) }
+
+      it 'returns response_type `string`' do
+        expect(framework_question.response_type).to eq('string')
+      end
+    end
+  end
 end

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Api::FrameworkResponsesController do
             "type": 'framework_responses',
             "attributes": {
               "value": value,
-              "value_type": 'object',
+              "value_type": 'object::details',
               "responded": true,
             },
           })
@@ -90,7 +90,7 @@ RSpec.describe Api::FrameworkResponsesController do
             "type": 'framework_responses',
             "attributes": {
               "value": value,
-              "value_type": 'collection',
+              "value_type": 'collection::details',
               "responded": true,
             },
           })
@@ -136,7 +136,7 @@ RSpec.describe Api::FrameworkResponsesController do
             "type": 'framework_responses',
             "attributes": {
               "value": [{ option: 'Level 1' }],
-              "value_type": 'collection',
+              "value_type": 'collection::details',
               "responded": true,
             },
           })
@@ -177,7 +177,7 @@ RSpec.describe Api::FrameworkResponsesController do
             "type": 'framework_responses',
             "attributes": {
               "value": { option: 'Yes' },
-              "value_type": 'object',
+              "value_type": 'object::details',
               "responded": true,
             },
           })

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Api::FrameworkResponsesController do
             "type": 'framework_responses',
             "attributes": {
               "value": value,
-              "value_type": 'object::details',
+              "value_type": 'object::followup_comment',
               "responded": true,
             },
           })
@@ -90,7 +90,7 @@ RSpec.describe Api::FrameworkResponsesController do
             "type": 'framework_responses',
             "attributes": {
               "value": value,
-              "value_type": 'collection::details',
+              "value_type": 'collection::followup_comment',
               "responded": true,
             },
           })
@@ -136,7 +136,7 @@ RSpec.describe Api::FrameworkResponsesController do
             "type": 'framework_responses',
             "attributes": {
               "value": [{ option: 'Level 1' }],
-              "value_type": 'collection::details',
+              "value_type": 'collection::followup_comment',
               "responded": true,
             },
           })
@@ -177,7 +177,7 @@ RSpec.describe Api::FrameworkResponsesController do
             "type": 'framework_responses',
             "attributes": {
               "value": { option: 'Yes' },
-              "value_type": 'object::details',
+              "value_type": 'object::followup_comment',
               "responded": true,
             },
           })

--- a/spec/serializers/framework_question_serializer_spec.rb
+++ b/spec/serializers/framework_question_serializer_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe FrameworkQuestionSerializer do
     expect(result[:data][:attributes][:options]).to eq(framework_question.options)
   end
 
+  it 'contains a `response_type` attribute' do
+    expect(result[:data][:attributes][:response_type]).to eq(framework_question.response_type)
+  end
+
   it 'contains a `framework` relationship' do
     expect(result[:data][:relationships][:framework][:data]).to eq(
       id: framework_question.framework.id,
@@ -46,56 +50,6 @@ RSpec.describe FrameworkQuestionSerializer do
       id: dependent_question.id,
       type: 'framework_questions',
     )
-  end
-
-  describe 'response_type' do
-    context 'when question is of type radio with followup_comments' do
-      let(:framework_question) { create(:framework_question, followup_comment: true) }
-
-      it 'returns response_type `object`' do
-        expect(result[:data][:attributes][:response_type]).to eq('object')
-      end
-    end
-
-    context 'when response is of type radio' do
-      let(:framework_question) { create(:framework_question) }
-
-      it 'returns response_type `string`' do
-        expect(result[:data][:attributes][:response_type]).to eq('string')
-      end
-    end
-
-    context 'when question is of type checkbox with followup_comments' do
-      let(:framework_question) { create(:framework_question, :checkbox, followup_comment: true) }
-
-      it 'returns response_type `collection`' do
-        expect(result[:data][:attributes][:response_type]).to eq('collection')
-      end
-    end
-
-    context 'when question is of type checkbox' do
-      let(:framework_question) { create(:framework_question, :checkbox) }
-
-      it 'returns response_type `array`' do
-        expect(result[:data][:attributes][:response_type]).to eq('array')
-      end
-    end
-
-    context 'when question is of type `add_multiple_items`' do
-      let(:framework_question) { create(:framework_question, :add_multiple_items) }
-
-      it 'returns response_type `collection::add_multiple_items`' do
-        expect(result[:data][:attributes][:response_type]).to eq('collection::add_multiple_items')
-      end
-    end
-
-    context 'when question is of type text' do
-      let(:framework_question) { create(:framework_question, :text) }
-
-      it 'returns response_type `string`' do
-        expect(result[:data][:attributes][:response_type]).to eq('string')
-      end
-    end
   end
 
   context 'with include options' do

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe FrameworkResponseSerializer do
     expect(result[:data][:attributes][:responded]).to eq(framework_response.responded)
   end
 
+  it 'contains a `value_type` attribute' do
+    expect(result[:data][:attributes][:value_type]).to eq(framework_response.framework_question.response_type)
+  end
+
   it 'contains a `person_escort_record` relationship' do
     expect(result[:data][:relationships][:person_escort_record][:data]).to eq(
       id: framework_response.person_escort_record.id,
@@ -51,48 +55,6 @@ RSpec.describe FrameworkResponseSerializer do
       id: flag.id,
       type: 'framework_flags',
     )
-  end
-
-  describe 'value_type' do
-    context 'when response is an object response' do
-      let(:framework_response) { create(:object_response) }
-
-      it 'returns value_type `object`' do
-        expect(result[:data][:attributes][:value_type]).to eq('object')
-      end
-    end
-
-    context 'when response is an string response' do
-      let(:framework_response) { create(:string_response) }
-
-      it 'returns value_type `string`' do
-        expect(result[:data][:attributes][:value_type]).to eq('string')
-      end
-    end
-
-    context 'when response is a collection response' do
-      let(:framework_response) { create(:collection_response) }
-
-      it 'returns value_type `collection`' do
-        expect(result[:data][:attributes][:value_type]).to eq('collection')
-      end
-    end
-
-    context 'when response is a collection response and question type is add multiple items' do
-      let(:framework_response) { create(:collection_response, :multiple_items) }
-
-      it 'returns value_type `collection`' do
-        expect(result[:data][:attributes][:value_type]).to eq('collection::add_multiple_items')
-      end
-    end
-
-    context 'when response is an array response' do
-      let(:framework_response) { create(:array_response) }
-
-      it 'returns value_type `array`' do
-        expect(result[:data][:attributes][:value_type]).to eq('array')
-      end
-    end
   end
 
   context 'with include options' do

--- a/swagger/v1/framework_question.yaml
+++ b/swagger/v1/framework_question.yaml
@@ -45,8 +45,8 @@ FrameworkQuestion:
           enum:
             - string
             - array
-            - object
-            - collection
+            - object::details
+            - collection::details
             - collection::add_multiple_items
           description: Indicates the type of response for the question
           readOnly: true

--- a/swagger/v1/framework_question.yaml
+++ b/swagger/v1/framework_question.yaml
@@ -45,8 +45,8 @@ FrameworkQuestion:
           enum:
             - string
             - array
-            - object::details
-            - collection::details
+            - object::followup_comment
+            - collection::followup_comment
             - collection::add_multiple_items
           description: Indicates the type of response for the question
           readOnly: true

--- a/swagger/v1/framework_response.yaml
+++ b/swagger/v1/framework_response.yaml
@@ -57,8 +57,8 @@ FrameworkResponse:
           enum:
             - string
             - array
-            - object::details
-            - collection::details
+            - object::followup_comment
+            - collection::followup_comment
             - collection::add_multiple_items
           description: Indicates the type of value for the answer provided
           readOnly: true

--- a/swagger/v1/framework_response.yaml
+++ b/swagger/v1/framework_response.yaml
@@ -57,8 +57,8 @@ FrameworkResponse:
           enum:
             - string
             - array
-            - object
-            - collection
+            - object::details
+            - collection::details
             - collection::add_multiple_items
           description: Indicates the type of value for the answer provided
           readOnly: true


### PR DESCRIPTION
### Jira link

[P4-2080](https://dsdmoj.atlassian.net/browse/P4-2080)

### What?

I have added/removed/altered:

- [x] Added new types for object and collection for framework responses
- [x] Moved the response type method to framework question and remove from serializers

### Why?

We currently support `collection::add_multiple_items` for a response that is a collection and of type multiple items. To
extend this pattern to other exact collections and objects, append `::followup_comment` to object and collection if it has followup comments. If another type of collection or object is added, we will add that type to those respectively. This will help the FE render the correct type of response.

This is a breaking change and has to be coordinated with the FE.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

