### PR TITLE
Remove "Not for release" columns from CSV export

### DIFF
--- a/app/services/moves/exporter.rb
+++ b/app/services/moves/exporter.rb
@@ -56,8 +56,6 @@ module Moves
       'Sign or other language interpreter details',
       'Any other information',
       'Any other information details',
-      'Not for release',
-      'Not for release details',
       'Not to be released',
       'Not to be released details',
       'Requires special vehicle',
@@ -122,7 +120,6 @@ module Moves
         answer_details(answers, 'solicitor'), # Solicitor or other legal representation details
         answer_details(answers, 'interpreter'), # Sign or other language interpreter details
         answer_details(answers, 'other_court'), # Any other information details
-        answer_details(answers, 'not_for_release'), # Not for release details
         answer_details(answers, 'not_to_be_released'), # Not to be released details
         answer_details(answers, 'special_vehicle'), # Requires special vehicle details
         profile&.documents&.size || 0, # 'Uploaded documents',

--- a/spec/services/moves/exporter_spec.rb
+++ b/spec/services/moves/exporter_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Moves::Exporter do
   end
 
   it 'has correct number of header columns' do
-    expect(header.count).to eq(56)
+    expect(header.count).to eq(54)
   end
 
   it 'has correct number of body columns' do
-    expect(row.count).to eq(56)
+    expect(row.count).to eq(54)
   end
 
   it 'includes move details' do
@@ -65,7 +65,7 @@ RSpec.describe Moves::Exporter do
     expect(row).to include('false', '')
   end
 
-  %w[violent escape hold_separately self_harm concealed_items other_risks special_diet_or_allergy health_issue medication wheelchair pregnant other_health solicitor interpreter other_court not_for_release not_to_be_released special_vehicle].each do |alert_type|
+  %w[violent escape hold_separately self_harm concealed_items other_risks special_diet_or_allergy health_issue medication wheelchair pregnant other_health solicitor interpreter other_court not_to_be_released special_vehicle].each do |alert_type|
     it "includes TRUE flag and comments when #{alert_type} is present" do
       question.update(key: alert_type)
       move.profile.update(assessment_answers: [{ assessment_question_id: question.id, comments: 'Yikes!' }])


### PR DESCRIPTION
### Jira link

P4-2102

### What?

- [x] Remove "Not for release" columns from CSV export

### Why?

- Suppliers don't want this column as apparently it's redundant, and the information needed can be obtained from the "Not to be released" column instead.

### Deployment risks (optional)

- Resolves a production API issue