### PR TITLE
Add new move cancellation reason

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -60,6 +60,7 @@ class Move < VersionedModel
   CANCELLATION_REASONS = [
     CANCELLATION_REASON_MADE_IN_ERROR = 'made_in_error',
     CANCELLATION_REASON_SUPPLIER_DECLINED_TO_MOVE = 'supplier_declined_to_move',
+    CANCELLATION_REASON_CANCELLED_BY_PMU = 'cancelled_by_pmu',
     CANCELLATION_REASON_REJECTED = 'rejected',
     CANCELLATION_REASON_OTHER = 'other',
   ].freeze

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Move do
           .in_array(%w[
             made_in_error
             supplier_declined_to_move
+            cancelled_by_pmu
             rejected
             other
           ])

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -620,6 +620,7 @@
               enum:
                 - made_in_error
                 - supplier_declined_to_move
+                - cancelled_by_pmu
                 - rejected
                 - other
         - name: filter[supplier_id]

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -381,6 +381,7 @@
               enum:
                 - made_in_error
                 - supplier_declined_to_move
+                - cancelled_by_pmu
                 - rejected
                 - other
         - name: filter[supplier_id]

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -98,6 +98,7 @@ Move:
             enum:
             - made_in_error
             - supplier_declined_to_move
+            - cancelled_by_pmu
             - rejected
             - other
           - type: 'null'

--- a/swagger/v1/move_cancellation_reason_attribute.yaml
+++ b/swagger/v1/move_cancellation_reason_attribute.yaml
@@ -4,6 +4,7 @@ MoveCancellationReason:
   enum:
   - made_in_error
   - supplier_declined_to_move
+  - cancelled_by_pmu
   - rejected
   - other
   description: The reason the move has been cancelled

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -103,6 +103,7 @@ Move:
               enum:
                 - made_in_error
                 - supplier_declined_to_move
+                - cancelled_by_pmu
                 - rejected
                 - other
             - type: "null"

--- a/swagger/v2/patch_move.yaml
+++ b/swagger/v2/patch_move.yaml
@@ -96,6 +96,7 @@ Move:
               enum:
                 - made_in_error
                 - supplier_declined_to_move
+                - cancelled_by_pmu
                 - rejected
                 - other
             - type: "null"


### PR DESCRIPTION
### Jira link

P4-2055

### What?

- [x] Add new move cancellation reason for "Cancelled by PMU"

### Why?

- We need to support this in the front end.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production (but is not a breaking change)

