### PR TITLE
P4 2109 ensure supplier created moves owned by supplier

### DIFF
--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -72,6 +72,7 @@ module Api
       @creator ||= Allocations::Creator.new(
         allocation_params: allocation_params,
         complex_case_params: complex_case_params,
+        doorkeeper_application_owner: doorkeeper_application_owner
       )
     end
 

--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -72,7 +72,7 @@ module Api
       @creator ||= Allocations::Creator.new(
         allocation_params: allocation_params,
         complex_case_params: complex_case_params,
-        doorkeeper_application_owner: doorkeeper_application_owner
+        doorkeeper_application_owner: doorkeeper_application_owner,
       )
     end
 

--- a/app/controllers/api/v1/moves_actions.rb
+++ b/app/controllers/api/v1/moves_actions.rb
@@ -12,7 +12,7 @@ module Api::V1
 
     def create_and_render
       move = Move.new(new_move_attributes)
-      move.determine_supplier
+      move.determine_supplier(doorkeeper_application_owner)
       move.profile.documents = profile_documents
 
       authorize!(:create, move)
@@ -114,7 +114,7 @@ module Api::V1
     end
 
     def updater
-      @updater ||= Moves::Updater.new(move, update_move_params)
+      @updater ||= Moves::Updater.new(move, update_move_params, doorkeeper_application_owner)
     end
 
     def included_relationships

--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -13,18 +13,16 @@ module Api::V2
 
     def create_and_render
       move = Move.new(move_attributes)
-      move.determine_supplier
-      authorize!(:create, move)
-      move.save!
-
+      move.determine_supplier(doorkeeper_application_owner)
+      move.save! # NB: the move should be saved and notified even if the current user is no longer authorised to view it
       Notifier.prepare_notifications(topic: move, action_name: 'create')
-
+      authorize!(:create, move)
       render_move(move, :created)
     end
 
     def update_and_render
       move.assign_attributes(common_move_attributes)
-      move.determine_supplier
+      move.determine_supplier(doorkeeper_application_owner)
       action_name = move.status_changed? ? 'update_status' : 'update'
       move.save!
       move.allocation&.refresh_status_and_moves_count!

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -30,6 +30,10 @@ class Event < ApplicationRecord
     @supplier_id ||= details[:supplier_id]
   end
 
+  def supplier
+    Supplier.find_by(id: supplier_id) # NB: not a conventional table field, could be nil
+  end
+
   def event_params
     @event_params ||= details[:event_params]
   end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -171,13 +171,17 @@ class Move < VersionedModel
     feed_attributes
   end
 
-  def determine_supplier
+  def determine_supplier(doorkeeper_application_owner)
     # Supplier choice is based on from_location and effective date. As the from location cannot change after the
     # move is created we only need to look for date changes - if no change then skip the supplier update for speed.
-    return supplier unless new_record? || date_changed? || date_from_changed?
+    return supplier unless supplier.nil? || new_record? || date_changed? || date_from_changed?
 
-    effective_date = date.presence || date_from
-    self.supplier = SupplierChooser.new(effective_date, from_location).call
+    self.supplier = SupplierChooser.new(
+        effective_date: date.presence || date_from,
+        location: from_location,
+        new_record: new_record?,
+        existing_owner: supplier,
+        doorkeeper_application_owner: doorkeeper_application_owner).call
   end
 
 private

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -177,11 +177,12 @@ class Move < VersionedModel
     return supplier unless supplier.nil? || new_record? || date_changed? || date_from_changed?
 
     self.supplier = SupplierChooser.new(
-        effective_date: date.presence || date_from,
-        location: from_location,
-        new_record: new_record?,
-        existing_owner: supplier,
-        doorkeeper_application_owner: doorkeeper_application_owner).call
+      effective_date: date.presence || date_from,
+      location: from_location,
+      new_record: new_record?,
+      existing_owner: supplier,
+      doorkeeper_application_owner: doorkeeper_application_owner,
+    ).call
   end
 
 private

--- a/app/services/allocations/creator.rb
+++ b/app/services/allocations/creator.rb
@@ -29,10 +29,10 @@ module Allocations
 
     def moves
       supplier = SupplierChooser.new(
-          effective_date: allocation.date,
-          location: allocation.from_location,
-          new_record: true,
-          doorkeeper_application_owner: doorkeeper_application_owner
+        effective_date: allocation.date,
+        location: allocation.from_location,
+        new_record: true,
+        doorkeeper_application_owner: doorkeeper_application_owner,
       ).call
 
       Array.new(allocation.moves_count) do

--- a/app/services/allocations/creator.rb
+++ b/app/services/allocations/creator.rb
@@ -2,11 +2,12 @@
 
 module Allocations
   class Creator
-    attr_accessor :allocation_params, :complex_case_params, :allocation
+    attr_accessor :allocation_params, :complex_case_params, :allocation, :doorkeeper_application_owner
 
-    def initialize(allocation_params:, complex_case_params:)
+    def initialize(allocation_params:, complex_case_params:, doorkeeper_application_owner:)
       self.allocation_params = allocation_params
       self.complex_case_params = complex_case_params
+      self.doorkeeper_application_owner = doorkeeper_application_owner
     end
 
     def call
@@ -27,7 +28,12 @@ module Allocations
     end
 
     def moves
-      supplier = SupplierChooser.new(allocation.date, allocation.from_location).call
+      supplier = SupplierChooser.new(
+          effective_date: allocation.date,
+          location: allocation.from_location,
+          new_record: true,
+          doorkeeper_application_owner: doorkeeper_application_owner
+      ).call
 
       Array.new(allocation.moves_count) do
         Move.new(

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -16,7 +16,7 @@ module EventLog
         when Event::APPROVE
           move.status = Move::MOVE_STATUS_REQUESTED
           move.date = event.date
-          move.determine_supplier
+          move.determine_supplier(event.supplier)
           Allocations::CreateInNomis.call(move) if event.create_in_nomis?
         when Event::CANCEL
           move.status = Move::MOVE_STATUS_CANCELLED

--- a/app/services/moves/updater.rb
+++ b/app/services/moves/updater.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
+# NB: this is a V1 move updater
 module Moves
   class Updater
-    attr_accessor :move_params, :move, :status_changed
+    attr_accessor :move_params, :move, :status_changed, :doorkeeper_application_owner
 
-    def initialize(move, move_params)
+    def initialize(move, move_params, doorkeeper_application_owner)
       self.move = move
       self.move_params = move_params
+      self.doorkeeper_application_owner = doorkeeper_application_owner
     end
 
     def call
       move.assign_attributes(attributes)
-      move.determine_supplier
+      move.determine_supplier(doorkeeper_application_owner)
       # NB: rather than update directly, we need to detect whether the move status has changed before saving the record
       self.status_changed = move.status_changed?
 

--- a/app/services/supplier_chooser.rb
+++ b/app/services/supplier_chooser.rb
@@ -1,16 +1,85 @@
 class SupplierChooser
-  attr_accessor :effective_date, :location
+  attr_accessor :effective_date, :location, :new_record, :doorkeeper_application_owner, :existing_owner
 
-  def initialize(effective_date, location)
-    self.effective_date = effective_date
-    self.location = location
+  def initialize(effective_date:, location:, new_record:, doorkeeper_application_owner: nil, existing_owner: nil)
+    @effective_date = effective_date
+    @location = location
+    @new_record = new_record
+    @doorkeeper_application_owner = doorkeeper_application_owner
+    @existing_owner = existing_owner
   end
 
-  def call
-    return unless effective_date.present? && location.present?
+  # CREATING NEW RECORDS
+  # | Doorkeeper App Owner | Location+Date Owner | Resulting Owner |
+  # |----------------------|---------------------|-----------------|
+  # | nil                  | nil                 | nil             |
+  # | nil                  | Supplier1           | Supplier1       |
+  # | nil                  | Supplier2           | Supplier2       |
+  #
+  # | Supplier1            | nil                 | Supplier1       |
+  # | Supplier1            | Supplier1           | Supplier1       |
+  # | Supplier1            | Supplier2           | Supplier1       |
+  #
+  # | Supplier2            | nil                 | Supplier2       |
+  # | Supplier2            | Supplier1           | Supplier2       |
+  # | Supplier2            | Supplier2           | Supplier2       |
 
-    # NB: business rules _should_ preclude multiple suppliers for visibility
-    supplier_location = SupplierLocation.location(location.id).effective_on(effective_date).first
-    supplier_location&.supplier
+  # UPDATING EXISTING RECORDS
+  # | Location+Date Owner | Existing Owner | Doorkeeper App Owner | Resulting Owner |
+  # |---------------------|----------------|----------------------|-----------------|
+  # | nil                 | nil            | nil                  | nil             |
+  # | nil                 | nil            | Supplier1            | Supplier1       |
+  # | nil                 | nil            | Supplier2            | Supplier2       |
+  #
+  # | nil                 | Supplier1      | nil                  | Supplier1       |
+  # | nil                 | Supplier1      | Supplier1            | Supplier1       |
+  # | nil                 | Supplier1      | Supplier2            | Supplier1       |
+  #
+  # | nil                 | Supplier2      | nil                  | Supplier2       |
+  # | nil                 | Supplier2      | Supplier1            | Supplier2       |
+  # | nil                 | Supplier2      | Supplier2            | Supplier2       |
+  #
+  # | Supplier1           | nil            | nil                  | Supplier1       |
+  # | Supplier1           | nil            | Supplier1            | Supplier1       |
+  # | Supplier1           | nil            | Supplier2            | Supplier1       |
+  #
+  # | Supplier1           | Supplier1      | nil                  | Supplier1       |
+  # | Supplier1           | Supplier1      | Supplier1            | Supplier1       |
+  # | Supplier1           | Supplier1      | Supplier2            | Supplier1       |
+  #
+  # | Supplier1           | Supplier2      | nil                  | Supplier1       |
+  # | Supplier1           | Supplier2      | Supplier1            | Supplier1       |
+  # | Supplier1           | Supplier2      | Supplier2            | Supplier1       |
+  #
+  # | Supplier2           | nil            | nil                  | Supplier2       |
+  # | Supplier2           | nil            | Supplier1            | Supplier2       |
+  # | Supplier2           | nil            | Supplier2            | Supplier2       |
+  #
+  # | Supplier2           | Supplier1      | nil                  | Supplier2       |
+  # | Supplier2           | Supplier1      | Supplier1            | Supplier2       |
+  # | Supplier2           | Supplier1      | Supplier2            | Supplier2       |
+  #
+  # | Supplier2           | Supplier2      | nil                  | Supplier2       |
+  # | Supplier2           | Supplier2      | Supplier1            | Supplier2       |
+  # | Supplier2           | Supplier2      | Supplier2            | Supplier2       |
+
+  def call
+    if new_record
+      doorkeeper_application_owner || effective_supplier_for_location
+    else
+      effective_supplier_for_location || existing_owner || doorkeeper_application_owner
+    end
+  end
+
+private
+
+  def effective_supplier_for_location
+    # NB: business rules _should_ preclude multiple effective suppliers for a given location
+    return unless effective_date.present? && location.present?
+    SupplierLocation
+        .location(location.id)
+        .effective_on(effective_date)
+        .first
+        &.supplier
   end
 end

--- a/app/services/supplier_chooser.rb
+++ b/app/services/supplier_chooser.rb
@@ -76,6 +76,7 @@ private
   def effective_supplier_for_location
     # NB: business rules _should_ preclude multiple effective suppliers for a given location
     return unless effective_date.present? && location.present?
+
     SupplierLocation
         .location(location.id)
         .effective_on(effective_date)

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -584,11 +584,12 @@ RSpec.describe Move do
         it 'calls SupplierChooser service to update supplier' do
           determined_supplier
           expect(SupplierChooser).to have_received(:new).with(
-              effective_date: Date.tomorrow,
-              location: location,
-              new_record: false,
-              existing_owner: old_supplier,
-              doorkeeper_application_owner: old_supplier)
+            effective_date: Date.tomorrow,
+            location: location,
+            new_record: false,
+            existing_owner: old_supplier,
+            doorkeeper_application_owner: old_supplier,
+          )
         end
       end
 
@@ -604,11 +605,12 @@ RSpec.describe Move do
         it 'calls SupplierChooser service to update supplier' do
           determined_supplier
           expect(SupplierChooser).to have_received(:new).with(
-              effective_date: Date.tomorrow,
-              location: location,
-              new_record: false,
-              existing_owner: old_supplier,
-              doorkeeper_application_owner: old_supplier)
+            effective_date: Date.tomorrow,
+            location: location,
+            new_record: false,
+            existing_owner: old_supplier,
+            doorkeeper_application_owner: old_supplier,
+          )
         end
       end
     end
@@ -624,11 +626,12 @@ RSpec.describe Move do
         it 'calls SupplierChooser service' do
           determined_supplier
           expect(SupplierChooser).to have_received(:new).with(
-              effective_date: Date.today,
-              location: location,
-              new_record: true,
-              existing_owner: old_supplier,
-              doorkeeper_application_owner: old_supplier)
+            effective_date: Date.today,
+            location: location,
+            new_record: true,
+            existing_owner: old_supplier,
+            doorkeeper_application_owner: old_supplier,
+          )
         end
       end
 
@@ -644,11 +647,12 @@ RSpec.describe Move do
         it 'calls SupplierChooser service to update supplier' do
           determined_supplier
           expect(SupplierChooser).to have_received(:new).with(
-              effective_date: Date.tomorrow,
-              location: location,
-              new_record: true,
-              existing_owner: old_supplier,
-              doorkeeper_application_owner: old_supplier)
+            effective_date: Date.tomorrow,
+            location: location,
+            new_record: true,
+            existing_owner: old_supplier,
+            doorkeeper_application_owner: old_supplier,
+          )
         end
       end
 
@@ -664,11 +668,12 @@ RSpec.describe Move do
         it 'calls SupplierChooser service to update supplier' do
           determined_supplier
           expect(SupplierChooser).to have_received(:new).with(
-              effective_date: Date.tomorrow,
-              location: location,
-              new_record: true,
-              existing_owner: old_supplier,
-              doorkeeper_application_owner: old_supplier)
+            effective_date: Date.tomorrow,
+            location: location,
+            new_record: true,
+            existing_owner: old_supplier,
+            doorkeeper_application_owner: old_supplier,
+          )
         end
       end
     end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -544,58 +544,132 @@ RSpec.describe Move do
   end
 
   describe '#determine_supplier' do
-    subject(:determined_supplier) { move.determine_supplier }
+    subject(:determined_supplier) { move.determine_supplier(doorkeeper_application_owner) }
 
     let(:location) { create(:location, :police) }
     let(:old_supplier) { create(:supplier) }
     let(:new_supplier) { build(:supplier) }
     let(:date) { Date.today }
     let(:date_from) { Date.today }
-    let(:move) { create(:move, :cancelled, from_location: location, to_location: nil, supplier: old_supplier, date: date, date_from: date_from) }
+    let(:doorkeeper_application_owner) { old_supplier }
 
     before do
       supplier_chooser = instance_double('SupplierChooser', call: new_supplier)
       allow(SupplierChooser).to receive(:new).and_return(supplier_chooser)
     end
 
-    context 'when date and date_from have not changed' do
-      it 'returns existing supplier' do
-        expect(determined_supplier).to eq old_supplier
+    context 'with existing move' do
+      let(:move) { create(:move, :cancelled, from_location: location, to_location: nil, supplier: old_supplier, date: date, date_from: date_from) }
+
+      context 'when date and date_from have not changed' do
+        it 'returns existing supplier' do
+          expect(determined_supplier).to eq old_supplier
+        end
+
+        it 'does not call SupplierChooser service' do
+          determined_supplier
+          expect(SupplierChooser).not_to have_received(:new)
+        end
       end
 
-      it 'does not call SupplierChooser service' do
-        determined_supplier
-        expect(SupplierChooser).not_to have_received(:new)
+      context 'when date is present and has changed' do
+        let(:date_from) { nil }
+
+        before { move.date = Date.tomorrow }
+
+        it 'returns updated supplier' do
+          expect(determined_supplier).to eq new_supplier
+        end
+
+        it 'calls SupplierChooser service to update supplier' do
+          determined_supplier
+          expect(SupplierChooser).to have_received(:new).with(
+              effective_date: Date.tomorrow,
+              location: location,
+              new_record: false,
+              existing_owner: old_supplier,
+              doorkeeper_application_owner: old_supplier)
+        end
+      end
+
+      context 'when date_from is present and has changed' do
+        let(:date) { nil }
+
+        before { move.date_from = Date.tomorrow }
+
+        it 'returns updated supplier' do
+          expect(determined_supplier).to eq new_supplier
+        end
+
+        it 'calls SupplierChooser service to update supplier' do
+          determined_supplier
+          expect(SupplierChooser).to have_received(:new).with(
+              effective_date: Date.tomorrow,
+              location: location,
+              new_record: false,
+              existing_owner: old_supplier,
+              doorkeeper_application_owner: old_supplier)
+        end
       end
     end
 
-    context 'when date is present and has changed' do
-      let(:date_from) { nil }
+    context 'with new move' do
+      let(:move) { build(:move, :cancelled, from_location: location, to_location: nil, supplier: old_supplier, date: date, date_from: date_from) }
 
-      before { move.date = Date.tomorrow }
+      context 'when date and date_from have not changed' do
+        it 'returns new supplier' do
+          expect(determined_supplier).to eq new_supplier
+        end
 
-      it 'returns updated supplier' do
-        expect(determined_supplier).to eq new_supplier
+        it 'calls SupplierChooser service' do
+          determined_supplier
+          expect(SupplierChooser).to have_received(:new).with(
+              effective_date: Date.today,
+              location: location,
+              new_record: true,
+              existing_owner: old_supplier,
+              doorkeeper_application_owner: old_supplier)
+        end
       end
 
-      it 'calls SupplierChooser service to update supplier' do
-        determined_supplier
-        expect(SupplierChooser).to have_received(:new).with(Date.tomorrow, location)
+      context 'when date is present and has changed' do
+        let(:date_from) { nil }
+
+        before { move.date = Date.tomorrow }
+
+        it 'returns updated supplier' do
+          expect(determined_supplier).to eq new_supplier
+        end
+
+        it 'calls SupplierChooser service to update supplier' do
+          determined_supplier
+          expect(SupplierChooser).to have_received(:new).with(
+              effective_date: Date.tomorrow,
+              location: location,
+              new_record: true,
+              existing_owner: old_supplier,
+              doorkeeper_application_owner: old_supplier)
+        end
       end
-    end
 
-    context 'when date_from is present and has changed' do
-      let(:date) { nil }
+      context 'when date_from is present and has changed' do
+        let(:date) { nil }
 
-      before { move.date_from = Date.tomorrow }
+        before { move.date_from = Date.tomorrow }
 
-      it 'returns updated supplier' do
-        expect(determined_supplier).to eq new_supplier
-      end
+        it 'returns updated supplier' do
+          expect(determined_supplier).to eq new_supplier
+        end
 
-      it 'calls SupplierChooser service to update supplier' do
-        determined_supplier
-        expect(SupplierChooser).to have_received(:new).with(Date.tomorrow, location)
+        it 'calls SupplierChooser service to update supplier' do
+          determined_supplier
+          expect(SupplierChooser).to have_received(:new).with(
+              effective_date: Date.tomorrow,
+              location: location,
+              new_record: true,
+              existing_owner: old_supplier,
+              doorkeeper_application_owner: old_supplier)
+        end
       end
     end
   end

--- a/spec/services/allocations/creator_spec.rb
+++ b/spec/services/allocations/creator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Allocations::Creator do
     described_class.new(
       allocation_params: allocation_params,
       complex_case_params: complex_case_params,
-      doorkeeper_application_owner: doorkeeper_application_owner
+      doorkeeper_application_owner: doorkeeper_application_owner,
     )
   end
 
@@ -123,11 +123,11 @@ RSpec.describe Allocations::Creator do
     it 'calls the SupplierChooser service with the correct args' do
       call_creator
       expect(SupplierChooser).to have_received(:new).with(
-          effective_date: date,
-          location: from_location,
-          new_record: true,
-          doorkeeper_application_owner: doorkeeper_application_owner
-          )
+        effective_date: date,
+        location: from_location,
+        new_record: true,
+        doorkeeper_application_owner: doorkeeper_application_owner,
+      )
     end
 
     it 'sets the allocation moves supplier' do

--- a/spec/services/allocations/creator_spec.rb
+++ b/spec/services/allocations/creator_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Allocations::Creator do
     described_class.new(
       allocation_params: allocation_params,
       complex_case_params: complex_case_params,
+      doorkeeper_application_owner: doorkeeper_application_owner
     )
   end
 
@@ -63,6 +64,7 @@ RSpec.describe Allocations::Creator do
       },
     }
   end
+  let(:doorkeeper_application_owner) { nil }
 
   context 'with valid params' do
     it 'creates an allocation' do
@@ -120,7 +122,12 @@ RSpec.describe Allocations::Creator do
 
     it 'calls the SupplierChooser service with the correct args' do
       call_creator
-      expect(SupplierChooser).to have_received(:new).with(date, from_location)
+      expect(SupplierChooser).to have_received(:new).with(
+          effective_date: date,
+          location: from_location,
+          new_record: true,
+          doorkeeper_application_owner: doorkeeper_application_owner
+          )
     end
 
     it 'sets the allocation moves supplier' do

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Moves::Updater do
-  subject(:updater) { described_class.new(move, move_params) }
+  subject(:updater) { described_class.new(move, move_params, doorkeeper_application_owner) }
 
   let(:before_documents) { create_list(:document, 2) }
   let(:supplier) { create(:supplier) }
@@ -14,6 +14,7 @@ RSpec.describe Moves::Updater do
   let(:date_to) { Date.tomorrow }
   let(:status) { 'requested' }
   let(:cancellation_reason) { nil }
+  let(:doorkeeper_application_owner) { nil }
 
   let(:move_params) do
     {

--- a/spec/services/supplier_chooser_spec.rb
+++ b/spec/services/supplier_chooser_spec.rb
@@ -1,82 +1,151 @@
 RSpec.describe SupplierChooser do
-  subject(:service) { described_class.new(date, location) }
+  subject(:service) do
+    described_class.new(
+      effective_date: date,
+      location: location,
+      new_record: new_record,
+      doorkeeper_application_owner: doorkeeper_application_owner,
+      existing_owner: existing_owner
+      )
+    end
 
   let(:supplier1) { create(:supplier) }
   let(:supplier2) { create(:supplier) }
+  let(:supplier3) { create(:supplier) }
   let(:location) { create(:location) }
   let(:date) { Date.today }
+  let(:doorkeeper_application_owner) { nil }
+  let(:existing_owner) { nil }
 
-  context 'without an effective from or to date' do
-    let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location) }
+  context 'when new record' do
+    let(:new_record) { true }
 
-    it 'returns matching supplier, ignoring effective dates completely' do
-      expect(service.call).to eq(supplier1)
+    context 'with doorkeeper_application_owner' do
+      let(:doorkeeper_application_owner) { supplier2 }
+      let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location) }
+
+      it 'ignores the matching supplier location and returns the doorkeeper app owner' do
+        expect(service.call).to eq(doorkeeper_application_owner)
+      end
+    end
+
+    context 'without an effective from or to date' do
+      let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location) }
+
+      it 'returns matching supplier, ignoring effective dates completely' do
+        expect(service.call).to eq(supplier1)
+      end
+    end
+
+    context 'with only an effective from date' do
+      let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date) }
+      let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_from: date.tomorrow) }
+
+      it 'returns matching supplier, excluding ineffective future matches' do
+        expect(service.call).to eq(supplier1)
+      end
+    end
+
+    context 'with only an effective to date' do
+      let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_to: date) }
+      let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_to: date.yesterday) }
+
+      it 'returns matching supplier, excluding ineffective expired matches' do
+        expect(service.call).to eq(supplier1)
+      end
+    end
+
+    context 'with an effective from and to date' do
+      let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date, effective_to: date) }
+      let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_to: date.yesterday) }
+      let!(:supplier_location3) { create(:supplier_location, supplier: supplier2, location: location, effective_from: date.tomorrow) }
+
+      it 'returns matching supplier, excluding ineffective future and expired matches' do
+        expect(service.call).to eq(supplier1)
+      end
+    end
+
+    context 'with no supplier locations' do
+      it 'returns nil' do
+        expect(service.call).to be_nil
+      end
+    end
+
+    context 'with no matching location' do
+      let!(:supplier_location) { create(:supplier_location, supplier: supplier1) }
+
+      it 'returns nil' do
+        expect(service.call).to be_nil
+      end
+    end
+
+    context 'with no matching effective date' do
+      let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date.tomorrow, effective_to: date.tomorrow) }
+
+      it 'returns nil' do
+        expect(service.call).to be_nil
+      end
+    end
+
+    context 'with nil date parameter' do
+      let(:date) { nil }
+
+      it 'returns nil' do
+        expect(service.call).to be_nil
+      end
+    end
+
+    context 'with nil location parameter' do
+      let(:location) { nil }
+
+      it 'returns nil' do
+        expect(service.call).to be_nil
+      end
     end
   end
 
-  context 'with only an effective from date' do
-    let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date) }
-    let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_from: date.tomorrow) }
+  context 'when an existing record' do
+    let(:new_record) { false }
 
-    it 'returns matching supplier, excluding ineffective future matches' do
-      expect(service.call).to eq(supplier1)
+    context 'with doorkeeper_application_owner' do
+      let(:doorkeeper_application_owner) { supplier2 }
+      let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location) }
+
+      it 'ignores doorkeeper app owner and returns the matching supplier location' do
+        expect(service.call).to eq(supplier1)
+      end
     end
-  end
 
-  context 'with only an effective to date' do
-    let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_to: date) }
-    let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_to: date.yesterday) }
+    context 'with existing owner' do
+      let(:existing_owner) { supplier2 }
+      let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location) }
 
-    it 'returns matching supplier, excluding ineffective expired matches' do
-      expect(service.call).to eq(supplier1)
+      it 'ignores existing_owner and returns the matching supplier location' do
+        expect(service.call).to eq(supplier1)
+      end
     end
-  end
 
-  context 'with an effective from and to date' do
-    let!(:supplier_location1) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date, effective_to: date) }
-    let!(:supplier_location2) { create(:supplier_location, supplier: supplier2, location: location, effective_to: date.yesterday) }
-    let!(:supplier_location3) { create(:supplier_location, supplier: supplier2, location: location, effective_from: date.tomorrow) }
+    context 'without supplier_location owner' do
+      let(:existing_owner) { supplier2 }
+      let(:doorkeeper_application_owner) { supplier3 }
 
-    it 'returns matching supplier, excluding ineffective future and expired matches' do
-      expect(service.call).to eq(supplier1)
+      it 'returns the existing_owner and ignores the doorkeeper app owner' do
+        expect(service.call).to eq(supplier2)
+      end
     end
-  end
 
-  context 'with no supplier locations' do
-    it 'returns nil' do
-      expect(service.call).to be_nil
+    context 'without supplier_location or existing owner' do
+      let(:doorkeeper_application_owner) { supplier3 }
+
+      it 'returns the doorkeeper app owner' do
+        expect(service.call).to eq(supplier3)
+      end
     end
-  end
 
-  context 'with no matching location' do
-    let!(:supplier_location) { create(:supplier_location, supplier: supplier1) }
-
-    it 'returns nil' do
-      expect(service.call).to be_nil
-    end
-  end
-
-  context 'with no matching effective date' do
-    let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date.tomorrow, effective_to: date.tomorrow) }
-
-    it 'returns nil' do
-      expect(service.call).to be_nil
-    end
-  end
-
-  context 'with nil date parameter' do
-    let(:date) { nil }
-
-    it 'returns nil' do
-      expect(service.call).to be_nil
-    end
-  end
-
-  context 'with nil location parameter' do
-    let(:location) { nil }
-
-    it 'returns nil' do
-      expect(service.call).to be_nil
+    context 'without supplier_location or existing owner or doorkeeper app owner' do
+      it 'returns nil' do
+        expect(service.call).to be nil
+      end
     end
   end
 end

--- a/spec/services/supplier_chooser_spec.rb
+++ b/spec/services/supplier_chooser_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe SupplierChooser do
       location: location,
       new_record: new_record,
       doorkeeper_application_owner: doorkeeper_application_owner,
-      existing_owner: existing_owner
-      )
-    end
+      existing_owner: existing_owner,
+    )
+  end
 
   let(:supplier1) { create(:supplier) }
   let(:supplier2) { create(:supplier) }


### PR DESCRIPTION
### Jira link

P4-2109

### What?

I have added/removed/altered:

- [x] changed SupplierChooser logic to consider doorkeeper_app_owner, existing owner and whether its a new record or not
- [x] updated tests

### Why?

I am doing this because:

- suppliers must be able to create moves for any location: even one which they do not ordinarily service
- the previous logic would prevent suppliers creating e.g. court to prison moves

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- wide ranging and needs careful but urgent review

