### PR TITLE
Quick fix for go live with Serco

### DIFF
--- a/app/services/supplier_chooser.rb
+++ b/app/services/supplier_chooser.rb
@@ -11,6 +11,12 @@ class SupplierChooser
 
     # NB: business rules _should_ preclude multiple suppliers for visibility
     supplier_location = SupplierLocation.location(location.id).effective_on(effective_date).first
-    supplier_location&.supplier
+
+    # FIXME: This is a very temporary solution to the issue of suppliers not being able to create
+    # moves for locations that have not been mapped in the supplier_locatations.yml files.
+    # Only one supplier (Serco) is going live initially so we can assume that any moves created that
+    # don't have a mapped supplier location are ones created by Serco. This can be replaced by a
+    # smarter solution in the very near future.
+    supplier_location&.supplier || Supplier.find_by(key: 'serco')
   end
 end

--- a/spec/services/supplier_chooser_spec.rb
+++ b/spec/services/supplier_chooser_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe SupplierChooser do
   subject(:service) { described_class.new(date, location) }
 
+  let!(:serco) { create(:supplier, key: 'serco') }
   let(:supplier1) { create(:supplier) }
   let(:supplier2) { create(:supplier) }
   let(:location) { create(:location) }
@@ -44,7 +45,12 @@ RSpec.describe SupplierChooser do
 
   context 'with no supplier locations' do
     it 'returns nil' do
+      pending 'temporarily returning Serco supplier instead'
       expect(service.call).to be_nil
+    end
+
+    it 'returns Serco' do
+      expect(service.call).to eq(serco)
     end
   end
 
@@ -52,7 +58,12 @@ RSpec.describe SupplierChooser do
     let!(:supplier_location) { create(:supplier_location, supplier: supplier1) }
 
     it 'returns nil' do
+      pending 'temporarily returning Serco supplier instead'
       expect(service.call).to be_nil
+    end
+
+    it 'returns Serco' do
+      expect(service.call).to eq(serco)
     end
   end
 
@@ -60,7 +71,12 @@ RSpec.describe SupplierChooser do
     let!(:supplier_location) { create(:supplier_location, supplier: supplier1, location: location, effective_from: date.tomorrow, effective_to: date.tomorrow) }
 
     it 'returns nil' do
+      pending 'temporarily returning Serco supplier instead'
       expect(service.call).to be_nil
+    end
+
+    it 'returns Serco' do
+      expect(service.call).to eq(serco)
     end
   end
 


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

- [x] Assume that if we can't find a supplier location mapping for a move then it was created via the API by Serco, so assign them as the move owner.

### Why?

- Moves created by suppliers include locations that are not mapped in the supplier_location.yml file. We need to come up with a nice solution for this, potentially reverting to the previous approach based on the doorkeeper_application_owner. As a short term fix we are going live with just one supplier, Serco, so can make the assumption that any moves created without an appropriate SupplierLocation mapping will have been created by Serco.

- This removes the immediate blocker to going live and gives us time to work on a longer term fix to support further suppliers, and is also a simple change to understand/review.