### PR TITLE
Disable Prometheus by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ ELASTIC_APM_ENABLED=false
 # This allow to disable the logging for AppInsights.
 # We do not need to log on AI since we use Kibana.
 APPINSIGHTS_LOGGING_ENABLED=false
+
+# Disable Prometheus metrics for local development
+PROMETHEUS_METRICS=false

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,13 +35,15 @@ plugin :tmp_restart
 
 preload_app!
 # run a new process instrumenter after work boot
-after_worker_boot do
-  require 'prometheus_exporter/instrumentation'
+if ENV['PROMETHEUS_METRICS'].in? ['on', 'true']
+  after_worker_boot do
+    require 'prometheus_exporter/instrumentation'
 
-  PrometheusExporter::Instrumentation::Puma.start
-  PrometheusExporter::Instrumentation::Process.start(type: 'web')
-  PrometheusExporter::Instrumentation::ActiveRecord.start(
-    custom_labels: { type: 'puma_worker' },
-    config_labels: %i[database host],
-  )
+    PrometheusExporter::Instrumentation::Puma.start
+    PrometheusExporter::Instrumentation::Process.start(type: 'web')
+    PrometheusExporter::Instrumentation::ActiveRecord.start(
+      custom_labels: { type: 'puma_worker' },
+      config_labels: %i[database host],
+    )
+  end
 end


### PR DESCRIPTION
To avoid `Prometheus Exporter, failed to send message Connection refused` in ENVs that don't have prometheus hooked up, make this optional according to ENV variable. This mirrors the setup in prometheus exporter initializer