### PR TITLE
Add a new GET /moves filter for rejection reason

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -35,7 +35,7 @@ module Api
     end
 
     PERMITTED_FILTER_PARAMS = %i[
-      date_from date_to created_at_from created_at_to date_of_birth_from date_of_birth_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason has_relationship_to_allocation ready_for_transit
+      date_from date_to created_at_from created_at_to date_of_birth_from date_of_birth_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason rejection_reason has_relationship_to_allocation ready_for_transit
     ].freeze
 
     def filter_params

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -56,12 +56,13 @@ module Moves
       scope = apply_filter(scope, :status)
       scope = apply_filter(scope, :move_type)
       scope = apply_filter(scope, :cancellation_reason)
+      scope = apply_filter(scope, :rejection_reason)
       scope
     end
 
     def apply_filter(scope, param_name)
       if filter_params.key?(param_name)
-        scope.where(param_name => filter_params[param_name].split(','))
+        scope.where(param_name => filter_params[param_name]&.split(','))
       else
         scope
       end

--- a/app/services/moves/params_validator.rb
+++ b/app/services/moves/params_validator.rb
@@ -4,7 +4,7 @@ module Moves
   class ParamsValidator
     include ActiveModel::Validations
 
-    attr_reader :date_from, :date_to, :created_at_from, :created_at_to, :date_of_birth_from, :date_of_birth_to, :sort_by, :sort_direction, :move_type, :cancellation_reason
+    attr_reader :date_from, :date_to, :created_at_from, :created_at_to, :date_of_birth_from, :date_of_birth_to, :sort_by, :sort_direction, :move_type, :cancellation_reason, :rejection_reason
 
     validates_each :date_from, :date_to, :created_at_from, :created_at_to, :date_of_birth_from, :date_of_birth_to, allow_nil: true do |record, attr, value|
       Date.strptime(value, '%Y-%m-%d')
@@ -14,6 +14,7 @@ module Moves
 
     validates :move_type, inclusion: { in: Move.move_types }, allow_nil: true
     validates :cancellation_reason, inclusion: { in: Move::CANCELLATION_REASONS }, allow_nil: true
+    validates :rejection_reason, inclusion: { in: Move::REJECTION_REASONS }, allow_nil: true
     validates :sort_direction, inclusion: %w[asc desc], allow_nil: true
     validates :sort_by,
               inclusion: %w[name from_location to_location prison_transfer_reason created_at date_from date],
@@ -29,6 +30,7 @@ module Moves
       @date_of_birth_to = filter_params[:date_of_birth_to]
       @move_type = filter_params[:move_type]
       @cancellation_reason = filter_params[:cancellation_reason]
+      @rejection_reason = filter_params[:rejection_reason]
 
       @sort_by = sort_params[:by]
       @sort_direction = sort_params[:direction]

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -108,6 +108,20 @@ FactoryBot.define do
       cancellation_reason_comment { 'the move was cancelled because of some other reason' }
     end
 
+    trait :rejected_no_space do
+      status { 'cancelled' }
+      cancellation_reason { 'rejected' }
+      cancellation_reason_comment { 'no space available at the receiving prison' }
+      rejection_reason { 'no_space_at_receiving_prison' }
+    end
+
+    trait :rejected_no_transport do
+      status { 'cancelled' }
+      cancellation_reason { 'rejected' }
+      cancellation_reason_comment { 'no transportation available to move prisoner' }
+      rejection_reason { 'no_transport_available' }
+    end
+
     # Other traits
     trait :with_allocation do
       after(:create) do |move|

--- a/spec/requests/api/moves_controller_filter_spec.rb
+++ b/spec/requests/api/moves_controller_filter_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Api::MovesController do
 
     describe 'by supplier_id' do
       let(:filter_params) { { filter: { supplier_id: supplier.id } } }
-      let(:expected_moves) { create_list :move, 2, supplier: supplier }
-      let(:unexpected_moves) { create_list :move, 2, supplier: alternative_supplier }
+      let(:expected_moves) { create_list :move, 1, supplier: supplier }
+      let(:unexpected_moves) { create_list :move, 1, supplier: alternative_supplier }
 
       it_behaves_like 'an api that filters moves correctly'
     end
@@ -41,8 +41,8 @@ RSpec.describe Api::MovesController do
     describe 'by from_location_id' do
       let(:filter_params) { { filter: { from_location_id: location.id } } }
       let(:location) { create :location }
-      let(:expected_moves) { create_list :move, 3, from_location: location }
-      let(:unexpected_moves) { create_list :move, 3 }
+      let(:expected_moves) { create_list :move, 1, from_location: location }
+      let(:unexpected_moves) { create_list :move, 1 }
 
       it_behaves_like 'an api that filters moves correctly'
     end
@@ -52,9 +52,9 @@ RSpec.describe Api::MovesController do
       let(:middle_date) { Time.zone.parse('2019-12-26T12') }
       let(:last_date) { Time.zone.parse('2019-12-27') }
 
-      let(:first_moves) { create_list :move, 2, created_at: first_date }
-      let(:middle_moves) { create_list :move, 2, created_at: middle_date }
-      let(:last_moves) { create_list :move, 2, created_at: last_date }
+      let(:first_moves) { create_list :move, 1, created_at: first_date }
+      let(:middle_moves) { create_list :move, 1, created_at: middle_date }
+      let(:last_moves) { create_list :move, 1, created_at: last_date }
 
       context 'with a created_at_from' do
         let(:filter_params) { { filter: { created_at_from: middle_date.to_date.to_s } } }
@@ -107,9 +107,9 @@ RSpec.describe Api::MovesController do
 
     describe 'by move_type' do
       let(:filter_params) { { filter: { move_type: move_type } } }
-      let(:court_appearance_moves) { create_list :move, 3, :court_appearance }
-      let(:prison_recall_moves) { create_list :move, 3, :prison_recall }
-      let(:prison_transfer_moves) { create_list :move, 3, :prison_transfer }
+      let(:court_appearance_moves) { create_list :move, 1, :court_appearance }
+      let(:prison_recall_moves) { create_list :move, 1, :prison_recall }
+      let(:prison_transfer_moves) { create_list :move, 1, :prison_transfer }
 
       context 'when court_appearance' do
         let(:move_type) { 'court_appearance' }
@@ -184,10 +184,10 @@ RSpec.describe Api::MovesController do
 
     describe 'by cancellation_reason' do
       let(:filter_params) { { filter: { cancellation_reason: cancellation_reason } } }
-      let(:made_in_error_moves) { create_list :move, 3, :cancelled_made_in_error }
-      let(:supplier_declined_to_move_moves) { create_list :move, 3, :cancelled_supplier_declined_to_move }
-      let(:rejected_moves) { create_list :move, 3, :cancelled_rejected }
-      let(:other_moves) { create_list :move, 3, :cancelled_other }
+      let(:made_in_error_moves) { create_list :move, 1, :cancelled_made_in_error }
+      let(:supplier_declined_to_move_moves) { create_list :move, 1, :cancelled_supplier_declined_to_move }
+      let(:rejected_moves) { create_list :move, 1, :cancelled_rejected }
+      let(:other_moves) { create_list :move, 1, :cancelled_other }
 
       context 'when made_in_error' do
         let(:cancellation_reason) { 'made_in_error' }
@@ -217,6 +217,28 @@ RSpec.describe Api::MovesController do
         let(:cancellation_reason) { 'other' }
         let(:expected_moves) { other_moves }
         let(:unexpected_moves) { made_in_error_moves + supplier_declined_to_move_moves + rejected_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+    end
+
+    describe 'by rejection_reason' do
+      let(:filter_params) { { filter: { rejection_reason: rejection_reason } } }
+      let(:rejected_no_space_moves) { create_list :move, 1, :rejected_no_space }
+      let(:rejected_no_transport_moves) { create_list :move, 1, :rejected_no_transport }
+
+      context 'when no_space_at_receiving_prison' do
+        let(:rejection_reason) { 'no_space_at_receiving_prison' }
+        let(:expected_moves) { rejected_no_space_moves }
+        let(:unexpected_moves) { rejected_no_transport_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when no_transport_available' do
+        let(:rejection_reason) { 'no_transport_available' }
+        let(:expected_moves) { rejected_no_transport_moves }
+        let(:unexpected_moves) { rejected_no_space_moves }
 
         it_behaves_like 'an api that filters moves correctly'
       end

--- a/spec/requests/api/moves_controller_filter_v2_spec.rb
+++ b/spec/requests/api/moves_controller_filter_v2_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Api::MovesController do
 
     describe 'by supplier_id' do
       let(:filter_params) { { filter: { supplier_id: supplier.id } } }
-      let(:expected_moves) { create_list :move, 2, supplier: supplier }
-      let(:unexpected_moves) { create_list :move, 2, supplier: alternative_supplier }
+      let(:expected_moves) { create_list :move, 1, supplier: supplier }
+      let(:unexpected_moves) { create_list :move, 1, supplier: alternative_supplier }
 
       it_behaves_like 'an api that filters moves correctly'
     end
@@ -48,8 +48,8 @@ RSpec.describe Api::MovesController do
     describe 'by from_location_id' do
       let(:filter_params) { { filter: { from_location_id: location.id } } }
       let(:location) { create :location }
-      let(:expected_moves) { create_list :move, 3, from_location: location }
-      let(:unexpected_moves) { create_list :move, 3 }
+      let(:expected_moves) { create_list :move, 1, from_location: location }
+      let(:unexpected_moves) { create_list :move, 1 }
 
       it_behaves_like 'an api that filters moves correctly'
     end
@@ -59,9 +59,9 @@ RSpec.describe Api::MovesController do
       let(:middle_date) { Time.zone.parse('2019-12-26T12') }
       let(:last_date) { Time.zone.parse('2019-12-27') }
 
-      let(:first_moves) { create_list :move, 2, created_at: first_date }
-      let(:middle_moves) { create_list :move, 2, created_at: middle_date }
-      let(:last_moves) { create_list :move, 2, created_at: last_date }
+      let(:first_moves) { create_list :move, 1, created_at: first_date }
+      let(:middle_moves) { create_list :move, 1, created_at: middle_date }
+      let(:last_moves) { create_list :move, 1, created_at: last_date }
 
       context 'with a created_at_from' do
         let(:filter_params) { { filter: { created_at_from: middle_date.to_date.to_s } } }
@@ -114,9 +114,9 @@ RSpec.describe Api::MovesController do
 
     describe 'by move_type' do
       let(:filter_params) { { filter: { move_type: move_type } } }
-      let(:court_appearance_moves) { create_list :move, 3, :court_appearance }
-      let(:prison_recall_moves) { create_list :move, 3, :prison_recall }
-      let(:prison_transfer_moves) { create_list :move, 3, :prison_transfer }
+      let(:court_appearance_moves) { create_list :move, 1, :court_appearance }
+      let(:prison_recall_moves) { create_list :move, 1, :prison_recall }
+      let(:prison_transfer_moves) { create_list :move, 1, :prison_transfer }
 
       context 'when court_appearance' do
         let(:move_type) { 'court_appearance' }
@@ -191,10 +191,10 @@ RSpec.describe Api::MovesController do
 
     describe 'by cancellation_reason' do
       let(:filter_params) { { filter: { cancellation_reason: cancellation_reason } } }
-      let(:made_in_error_moves) { create_list :move, 3, :cancelled_made_in_error }
-      let(:supplier_declined_to_move_moves) { create_list :move, 3, :cancelled_supplier_declined_to_move }
-      let(:rejected_moves) { create_list :move, 3, :cancelled_rejected }
-      let(:other_moves) { create_list :move, 3, :cancelled_other }
+      let(:made_in_error_moves) { create_list :move, 1, :cancelled_made_in_error }
+      let(:supplier_declined_to_move_moves) { create_list :move, 1, :cancelled_supplier_declined_to_move }
+      let(:rejected_moves) { create_list :move, 1, :cancelled_rejected }
+      let(:other_moves) { create_list :move, 1, :cancelled_other }
 
       context 'when made_in_error' do
         let(:cancellation_reason) { 'made_in_error' }
@@ -224,6 +224,28 @@ RSpec.describe Api::MovesController do
         let(:cancellation_reason) { 'other' }
         let(:expected_moves) { other_moves }
         let(:unexpected_moves) { made_in_error_moves + supplier_declined_to_move_moves + rejected_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+    end
+
+    describe 'by rejection_reason' do
+      let(:filter_params) { { filter: { rejection_reason: rejection_reason } } }
+      let(:rejected_no_space_moves) { create_list :move, 1, :rejected_no_space }
+      let(:rejected_no_transport_moves) { create_list :move, 1, :rejected_no_transport }
+
+      context 'when no_space_at_receiving_prison' do
+        let(:rejection_reason) { 'no_space_at_receiving_prison' }
+        let(:expected_moves) { rejected_no_space_moves }
+        let(:unexpected_moves) { rejected_no_transport_moves }
+
+        it_behaves_like 'an api that filters moves correctly'
+      end
+
+      context 'when no_transport_available' do
+        let(:rejection_reason) { 'no_transport_available' }
+        let(:expected_moves) { rejected_no_transport_moves }
+        let(:unexpected_moves) { rejected_no_space_moves }
 
         it_behaves_like 'an api that filters moves correctly'
       end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -254,6 +254,22 @@ RSpec.describe Moves::Finder do
       let!(:cancelled_rejected_move) { create :move, :cancelled_rejected }
       let!(:cancelled_other_move) { create :move, :cancelled_other }
 
+      context 'with nil cancellation reason' do
+        let(:filter_params) { { cancellation_reason: nil } }
+
+        it 'returns only moves without a cancellation reason' do
+          expect(results).to be_empty
+        end
+      end
+
+      context 'with empty cancellation reason' do
+        let(:filter_params) { { cancellation_reason: '' } }
+
+        it 'returns only moves without a cancellation reason' do
+          expect(results).to be_empty
+        end
+      end
+
       context 'with matching cancellation_reason' do
         let(:filter_params) { { cancellation_reason: 'other' } }
 
@@ -272,6 +288,51 @@ RSpec.describe Moves::Finder do
 
       context 'with mis-matching cancellation_reason' do
         let(:filter_params) { { cancellation_reason: 'fruit bats' } }
+
+        it 'returns empty results set' do
+          expect(results).to be_empty
+        end
+      end
+    end
+
+    describe 'by rejection_reason' do
+      let!(:rejected_no_space) { create :move, :rejected_no_space }
+      let!(:rejected_no_transport) { create :move, :rejected_no_transport }
+
+      context 'with nil rejection reason' do
+        let(:filter_params) { { rejection_reason: nil } }
+
+        it 'returns only moves without a rejection reason' do
+          expect(results).to be_empty
+        end
+      end
+
+      context 'with empty rejection reason' do
+        let(:filter_params) { { rejection_reason: '' } }
+
+        it 'returns only moves without a rejection reason' do
+          expect(results).to be_empty
+        end
+      end
+
+      context 'with matching rejection' do
+        let(:filter_params) { { rejection_reason: 'no_space_at_receiving_prison' } }
+
+        it 'returns moves matching type' do
+          expect(results).to match_array [rejected_no_space]
+        end
+      end
+
+      context 'with multiple rejection' do
+        let(:filter_params) { { rejection_reason: 'no_space_at_receiving_prison,no_transport_available' } }
+
+        it 'returns moves matching status' do
+          expect(results).to match_array [rejected_no_space, rejected_no_transport]
+        end
+      end
+
+      context 'with mis-matching rejection' do
+        let(:filter_params) { { rejection_reason: 'arm stuck in a packet of cornflakes' } }
 
         it 'returns empty results set' do
           expect(results).to be_empty

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -623,6 +623,17 @@
                 - cancelled_by_pmu
                 - rejected
                 - other
+        - name: filter[rejection_reason]
+          in: query
+          explode: false
+          description: Filters results to only include moves with the given rejection_reasons
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - no_space_at_receiving_prison
+                - no_transport_available
         - name: filter[supplier_id]
           description: Filters results to only include moves for the given supplier UUIDs
           in: query

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -384,6 +384,17 @@
                 - cancelled_by_pmu
                 - rejected
                 - other
+        - name: filter[rejection_reason]
+          in: query
+          explode: false
+          description: Filters results to only include moves with the given rejection_reasons
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - no_space_at_receiving_prison
+                - no_transport_available
         - name: filter[supplier_id]
           description: Filters results to only include moves for the given supplier UUIDs
           in: query


### PR DESCRIPTION
### Jira link

P4-2059

### What?

- [x] Add support for a new filter on rejection reason to `Moves::Finder` service; this is exposed on v1 and v2 `GET /moves` endpoint.

### Why?

- This supports front end requirements to get a list of moves that are not rejected (By specifying a value of `nil` for the new filter). Follows existing patterns for other filters, also improved spec coverage slightly and refactored filter specs to avoid creating lots of unnecessary fixtures (now slightly faster).

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Extends production API, but is backwards compatible. New filter is optional.
