### PR TITLE
[P4-2068] Separate auth and prison api urls and update prefix

### DIFF
--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -25,7 +25,7 @@ module NomisClient
       REFRESH_TOKEN_TIMEFRAME_IN_SECONDS = 5
 
       def token_request(method, path, params)
-        token.send(method, "#{ENV['NOMIS_API_PATH_PREFIX']}#{path}", params)
+        token.send(method, "#{ENV['NOMIS_PRISON_API_PATH_PREFIX']}#{path}", params)
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
         Rails.logger.warn "Nomis Connection Error: #{e.message}"
         raise e

--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -41,9 +41,9 @@ module NomisClient
         @client ||= OAuth2::Client.new(
           ENV['NOMIS_CLIENT_ID'],
           ENV['NOMIS_CLIENT_SECRET'],
-          site: ENV['NOMIS_SITE'],
+          site: ENV['NOMIS_SITE_FOR_API'],
           auth_scheme: ENV['NOMIS_AUTH_SCHEME'],
-          token_url: "#{ENV['NOMIS_AUTH_PATH_PREFIX']}/oauth/token",
+          token_url: "#{ENV['NOMIS_SITE_FOR_AUTH']}/oauth/token",
           raise_errors: true,
           connection_opts: { request: { timeout: NOMIS_TIMEOUT, open_timeout: NOMIS_TIMEOUT } },
         )

--- a/spec/lib/nomis_client/activities_spec.rb
+++ b/spec/lib/nomis_client/activities_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe NomisClient::Activities, with_nomis_client_authentication: true d
       activities_get
 
       expect(token).to have_received(:get).with(
-        "/elite2api/api/bookings/1495077/activities?fromDate=#{start_date.iso8601}&toDate=#{end_date.iso8601}",
+        "/api/bookings/1495077/activities?fromDate=#{start_date.iso8601}&toDate=#{end_date.iso8601}",
         headers: { 'Page-Limit' => '1000' },
       )
     end

--- a/spec/lib/nomis_client/allocations_spec.rb
+++ b/spec/lib/nomis_client/allocations_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
 
       expect(token)
         .to have_received(:post)
-        .with('/elite2api/api/bookings/1111/prison-to-prison', body: '{}', headers: { Accept: 'application/json', 'Content-Type': 'application/json' })
+        .with('/api/bookings/1111/prison-to-prison', body: '{}', headers: { Accept: 'application/json', 'Content-Type': 'application/json' })
     end
 
     context 'when Nomis returns an error' do
@@ -65,7 +65,7 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
 
       expect(token)
         .to have_received(:put)
-        .with('/elite2api/api/bookings/1111/prison-to-prison/2222/cancel', body: '{}', headers: { Accept: 'application/json', 'Content-Type': 'application/json' })
+        .with('/api/bookings/1111/prison-to-prison/2222/cancel', body: '{}', headers: { Accept: 'application/json', 'Content-Type': 'application/json' })
     end
 
     context 'when Nomis returns an error' do

--- a/spec/lib/nomis_client/court_cases_spec.rb
+++ b/spec/lib/nomis_client/court_cases_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe NomisClient::CourtCases, with_nomis_client_authentication: true d
     it 'calls the nomis client with the correct booking id' do
       described_class.get(booking_id, filter_params)
 
-      expect(token).to have_received(:get).with('/elite2api/api/bookings/1495077/court-cases', {})
+      expect(token).to have_received(:get).with('/api/bookings/1495077/court-cases', {})
     end
 
     context 'when no filter_params are passed' do
       it 'returns active court cases' do
         described_class.get(booking_id)
 
-        expect(token).to have_received(:get).with("/elite2api/api/bookings/#{booking_id}/court-cases?activeOnly=true", {})
+        expect(token).to have_received(:get).with("/api/bookings/#{booking_id}/court-cases?activeOnly=true", {})
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe NomisClient::CourtCases, with_nomis_client_authentication: true d
       it 'returns active court cases' do
         described_class.get(booking_id, filter_params)
 
-        expect(token).to have_received(:get).with("/elite2api/api/bookings/#{booking_id}/court-cases?activeOnly=true", {})
+        expect(token).to have_received(:get).with("/api/bookings/#{booking_id}/court-cases?activeOnly=true", {})
       end
     end
   end

--- a/spec/lib/nomis_client/court_hearings_spec.rb
+++ b/spec/lib/nomis_client/court_hearings_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe NomisClient::CourtHearings, with_nomis_client_authentication: tru
       court_hearings_get
 
       expect(token).to have_received(:get).with(
-        "/elite2api/api/bookings/1495077/court-hearings?fromDate=#{start_date.iso8601}&toDate=#{end_date.iso8601}",
+        "/api/bookings/1495077/court-hearings?fromDate=#{start_date.iso8601}&toDate=#{end_date.iso8601}",
         headers: { 'Page-Limit' => '1000' },
       )
     end
@@ -41,7 +41,7 @@ RSpec.describe NomisClient::CourtHearings, with_nomis_client_authentication: tru
 
       expect(token)
         .to have_received(:post)
-        .with('/elite2api/api/bookings/1111/court-cases/2222/prison-to-court-hearings', body: '{}', headers: { Accept: 'application/json', 'Content-Type': 'application/json' })
+        .with('/api/bookings/1111/court-cases/2222/prison-to-court-hearings', body: '{}', headers: { Accept: 'application/json', 'Content-Type': 'application/json' })
     end
 
     context 'when Nomis returns an error' do

--- a/spec/wiremock/prison-api/mappings/elite2api_api_bookings_offenderno_alerts-88bf8e3c-ca15-4af2-98f6-022dcb9f72f2.json
+++ b/spec/wiremock/prison-api/mappings/elite2api_api_bookings_offenderno_alerts-88bf8e3c-ca15-4af2-98f6-022dcb9f72f2.json
@@ -2,7 +2,7 @@
   "id" : "88bf8e3c-ca15-4af2-98f6-022dcb9f72f2",
   "name" : "elite2api_api_bookings_offenderno_alerts",
   "request" : {
-    "url" : "/elite2api/api/bookings/offenderNo/alerts",
+    "url" : "/api/bookings/offenderNo/alerts",
     "method" : "POST",
     "bodyPatterns" : [ {
       "equalToJson" : "[\"G8133UA\"]",

--- a/spec/wiremock/prison-api/mappings/elite2api_api_bookings_offenderno_personal-care-needs-dcb2c2b0-5b51-412f-86a0-c8034c5f9206.json
+++ b/spec/wiremock/prison-api/mappings/elite2api_api_bookings_offenderno_personal-care-needs-dcb2c2b0-5b51-412f-86a0-c8034c5f9206.json
@@ -2,7 +2,7 @@
   "id" : "dcb2c2b0-5b51-412f-86a0-c8034c5f9206",
   "name" : "elite2api_api_bookings_offenderno_personal-care-needs",
   "request" : {
-    "url" : "/elite2api/api/bookings/offenderNo/personal-care-needs?type=MATSTAT%2CPHY%2CDISAB",
+    "url" : "/api/bookings/offenderNo/personal-care-needs?type=MATSTAT%2CPHY%2CDISAB",
     "method" : "POST",
     "bodyPatterns" : [ {
       "equalToJson" : "[\"G8133UA\"]",

--- a/spec/wiremock/prison-api/mappings/elite2api_api_prisoners-0fe4f90b-2609-4749-a7eb-02fbdb68509e.json
+++ b/spec/wiremock/prison-api/mappings/elite2api_api_prisoners-0fe4f90b-2609-4749-a7eb-02fbdb68509e.json
@@ -2,7 +2,7 @@
   "id" : "0fe4f90b-2609-4749-a7eb-02fbdb68509e",
   "name" : "elite2api_api_prisoners",
   "request" : {
-    "url" : "/elite2api/api/prisoners",
+    "url" : "/api/prisoners",
     "method" : "POST",
     "bodyPatterns" : [ {
       "equalToJson" : "{\"offenderNos\":[\"G8133UA\"]}",

--- a/spec/wiremock/prison-api/mappings/elite2api_api_reference-domains_domains_alert-2a9c3aa2-2e54-4d26-9268-e23aefa1d3cd.json
+++ b/spec/wiremock/prison-api/mappings/elite2api_api_reference-domains_domains_alert-2a9c3aa2-2e54-4d26-9268-e23aefa1d3cd.json
@@ -2,7 +2,7 @@
   "id" : "2a9c3aa2-2e54-4d26-9268-e23aefa1d3cd",
   "name" : "elite2api_api_reference-domains_domains_alert",
   "request" : {
-    "url" : "/elite2api/api/reference-domains/domains/ALERT",
+    "url" : "/api/reference-domains/domains/ALERT",
     "method" : "GET"
   },
   "response" : {

--- a/spec/wiremock/prison-api/mappings/elite2api_api_reference-domains_domains_alert_code-a79bc685-519f-4cda-8cd0-0e2b4f1ec15e.json
+++ b/spec/wiremock/prison-api/mappings/elite2api_api_reference-domains_domains_alert_code-a79bc685-519f-4cda-8cd0-0e2b4f1ec15e.json
@@ -2,7 +2,7 @@
   "id" : "a79bc685-519f-4cda-8cd0-0e2b4f1ec15e",
   "name" : "elite2api_api_reference-domains_domains_alert_code",
   "request" : {
-    "url" : "/elite2api/api/reference-domains/domains/ALERT_CODE",
+    "url" : "/api/reference-domains/domains/ALERT_CODE",
     "method" : "GET"
   },
   "response" : {

--- a/spec/wiremock/prison-api/mappings/elite2api_api_reference-domains_domains_ethnicity-a5e4e845-fbe7-4e85-acd9-3b54b7664c61.json
+++ b/spec/wiremock/prison-api/mappings/elite2api_api_reference-domains_domains_ethnicity-a5e4e845-fbe7-4e85-acd9-3b54b7664c61.json
@@ -2,7 +2,7 @@
   "id" : "a5e4e845-fbe7-4e85-acd9-3b54b7664c61",
   "name" : "elite2api_api_reference-domains_domains_ethnicity",
   "request" : {
-    "url" : "/elite2api/api/reference-domains/domains/ETHNICITY",
+    "url" : "/api/reference-domains/domains/ETHNICITY",
     "method" : "GET"
   },
   "response" : {

--- a/spec/wiremock/prison-api/mappings/elite2api_api_reference-domains_domains_sex-3c1ad947-cef0-4a62-bde1-3910a5c6e41e.json
+++ b/spec/wiremock/prison-api/mappings/elite2api_api_reference-domains_domains_sex-3c1ad947-cef0-4a62-bde1-3910a5c6e41e.json
@@ -2,7 +2,7 @@
   "id" : "3c1ad947-cef0-4a62-bde1-3910a5c6e41e",
   "name" : "elite2api_api_reference-domains_domains_sex",
   "request" : {
-    "url" : "/elite2api/api/reference-domains/domains/SEX",
+    "url" : "/api/reference-domains/domains/SEX",
     "method" : "GET"
   },
   "response" : {


### PR DESCRIPTION
### Jira link

P4-2068

### What?

I have added/removed/altered:

- [x] Updates prison api client implementation to use a separate token url and prefix
- [x] Updates specs to reflect change of prefix

### Why?

I am doing this because:

- The prison api is now separate from the auth api