### PR TITLE
Update .env.test to include new environment variables

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,5 @@
 # make sure rspec tests do not contact the real Nomis: they should use the wiremock server instead at http://localhost:8888
 NOMIS_SITE=http://localhost:8888
+NOMIS_PRISON_API_PATH_PREFIX='/api'
+NOMIS_SITE_FOR_API='http://localhost:8888'
+NOMIS_SITE_FOR_AUTH='http://localhost:8888/auth'

--- a/spec/support/mock_prison_api.rb
+++ b/spec/support/mock_prison_api.rb
@@ -4,8 +4,8 @@ RSpec.shared_context 'with mock prison-api' do
   # rubocop:disable RSpec/InstanceVariable
   before(:context) do
     # Make sure tests are using wiremocked Nomis, not real Nomis
-    unless ENV['NOMIS_SITE'] == 'http://localhost:8888'
-      raise "Expected NOMIS_SITE env var to point to wiremock server http://localhost:8888 (currently: #{ENV['NOMIS_SITE']})"
+    unless ENV['NOMIS_SITE_FOR_API'] == 'http://localhost:8888'
+      raise "Expected NOMIS_SITE_FOR_API env var to point to wiremock server http://localhost:8888 (currently: #{ENV['NOMIS_SITE_FOR_API']})"
     end
 
     # Start up an internal wiremock server unless EXTERNAL_WIREMOCK=true


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Updates .env.test values to match what wiremock expects and to stop calling nomis in ci

### Why?

I am doing this because:

- We use wiremock so we don't call nomis in test envs. We should match this behaviour like before.