### PR TITLE
P4-2166 fix Brecon Custody Suite mapping

### DIFF
--- a/lib/tasks/data/supplier_locations_go_live.yml
+++ b/lib/tasks/data/supplier_locations_go_live.yml
@@ -30,6 +30,7 @@ suppliers:
     - DP1
     - DP2
     - DP3
+    - DP4
     - DP5
     - DP6
     - DP7
@@ -199,7 +200,6 @@ suppliers:
     - DC4
     - DC5
     - DC6
-    - DP4
     - DST1
     - DST2
     - DST3


### PR DESCRIPTION
### Jira link

P4-2166

### What?

I have added/removed/altered:

- [x] Moved Brecon Custody Suite from Serco back to Geoamey

### Why?

I am doing this because:

- it was incorrectly mapped to Serco

### Deployment risks (optional)

- Already manually fixed on Production last week

