### PR TITLE
[P4-1979] Adds move events

### DIFF
--- a/app/models/concerns/move_event_validations.rb
+++ b/app/models/concerns/move_event_validations.rb
@@ -1,0 +1,11 @@
+require 'active_support/concern'
+
+module MoveEventValidations
+  extend ActiveSupport::Concern
+
+  EVENTABLE_TYPES = %w[Move].freeze
+
+  included do
+    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+  end
+end

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -28,11 +28,11 @@ class GenericEvent < ApplicationRecord
 
   belongs_to :eventable, polymorphic: true, touch: true
 
-  validates :eventable,      presence: true
-  validates :type,           presence: true
-  validates :occurred_at,    presence: true
-  validates :recorded_at,    presence: true
-  validates :details,        presence: true
+  validates :eventable,      presence: true # What is the subject of the event
+  validates :type,           presence: true # STI class of the event
+  validates :occurred_at,    presence: true # When did a human think the event occurred
+  validates :recorded_at,    presence: true # When did supplier/frontend record the event
+  validates :details,        presence: true # Details that are specific to each event.
   validates :created_by,     presence: true, inclusion: { in: CREATED_BY_OPTIONS }
 
   # This scope is used to determine the apply order of events as they were determined to have occurred.

--- a/app/models/generic_event/move_accept.rb
+++ b/app/models/generic_event/move_accept.rb
@@ -1,0 +1,11 @@
+class GenericEvent
+  class MoveAccept < GenericEvent
+    EVENTABLE_TYPES = %w[Move].freeze
+
+    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+
+    def trigger
+      eventable.status = Move::MOVE_STATUS_BOOKED
+    end
+  end
+end

--- a/app/models/generic_event/move_approve.rb
+++ b/app/models/generic_event/move_approve.rb
@@ -1,8 +1,6 @@
 class GenericEvent
   class MoveApprove < GenericEvent
-    EVENTABLE_TYPES = %w[Move].freeze
-
-    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+    include MoveEventValidations
     validates :date, presence: true
 
     validates_each :date do |record, attr, value|

--- a/app/models/generic_event/move_approve.rb
+++ b/app/models/generic_event/move_approve.rb
@@ -10,7 +10,7 @@ class GenericEvent
     end
 
     def date
-      @date ||= details['date']
+      details['date']
     end
 
     def date=(date)

--- a/app/models/generic_event/move_approve.rb
+++ b/app/models/generic_event/move_approve.rb
@@ -1,0 +1,28 @@
+class GenericEvent
+  class MoveApprove < GenericEvent
+    EVENTABLE_TYPES = %w[Move].freeze
+
+    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+
+    def date
+      @date ||= details['date']
+    end
+
+    def date=(date)
+      details['date'] = date
+    end
+
+    def trigger
+      eventable.status = Move::MOVE_STATUS_REQUESTED
+
+      eventable.date = date
+      Allocations::CreateInNomis.call(eventable) if create_in_nomis?
+    end
+
+  private
+
+    def create_in_nomis?
+      details.fetch(:create_in_nomis, false)
+    end
+  end
+end

--- a/app/models/generic_event/move_cancel.rb
+++ b/app/models/generic_event/move_cancel.rb
@@ -2,10 +2,9 @@ class GenericEvent
   class MoveCancel < GenericEvent
     attr_writer :cancellation_reason
 
-    EVENTABLE_TYPES = %w[Move].freeze
+    include MoveEventValidations
 
     validates :cancellation_reason, inclusion: { in: Move::CANCELLATION_REASONS }
-    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
 
     def cancellation_reason
       @cancellation_reason ||= details['cancellation_reason']

--- a/app/models/generic_event/move_cancel.rb
+++ b/app/models/generic_event/move_cancel.rb
@@ -11,7 +11,7 @@ class GenericEvent
     end
 
     def cancellation_reason_comment
-      @cancellation_reason_comment ||= details.fetch('cancellation_reason_comment', '')
+      details.fetch('cancellation_reason_comment', '')
     end
 
     def trigger

--- a/app/models/generic_event/move_cancel.rb
+++ b/app/models/generic_event/move_cancel.rb
@@ -12,7 +12,7 @@ class GenericEvent
     end
 
     def cancellation_reason_comment
-      @cancellation_reason_comment ||= details['cancellation_reason_comment']
+      @cancellation_reason_comment ||= details.fetch('cancellation_reason_comment', '')
     end
 
     def trigger
@@ -21,6 +21,13 @@ class GenericEvent
       eventable.cancellation_reason_comment = cancellation_reason_comment
 
       Allocations::RemoveFromNomis.call(eventable)
+    end
+
+    def for_feed
+      super.tap do |common_feed_attributes|
+        # NB: Force cancellation_reason_comment to be present
+        common_feed_attributes['details']['cancellation_reason_comment'] = cancellation_reason_comment
+      end
     end
   end
 end

--- a/app/models/generic_event/move_complete.rb
+++ b/app/models/generic_event/move_complete.rb
@@ -1,8 +1,6 @@
 class GenericEvent
   class MoveComplete < GenericEvent
-    EVENTABLE_TYPES = %w[Move].freeze
-
-    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+    include MoveEventValidations
 
     def trigger
       eventable.status = Move::MOVE_STATUS_COMPLETED

--- a/app/models/generic_event/move_complete.rb
+++ b/app/models/generic_event/move_complete.rb
@@ -1,0 +1,11 @@
+class GenericEvent
+  class MoveComplete < GenericEvent
+    EVENTABLE_TYPES = %w[Move].freeze
+
+    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+
+    def trigger
+      eventable.status = Move::MOVE_STATUS_COMPLETED
+    end
+  end
+end

--- a/app/models/generic_event/move_lockout.rb
+++ b/app/models/generic_event/move_lockout.rb
@@ -1,6 +1,7 @@
 class GenericEvent
   class MoveLockout < GenericEvent
     include MoveEventValidations
+
     validates :from_location_id, presence: true
 
     def from_location_id=(id)
@@ -8,7 +9,7 @@ class GenericEvent
     end
 
     def from_location_id
-      @from_location_id ||= details['from_location_id']
+      details['from_location_id']
     end
 
     def from_location

--- a/app/models/generic_event/move_lockout.rb
+++ b/app/models/generic_event/move_lockout.rb
@@ -1,8 +1,6 @@
 class GenericEvent
   class MoveLockout < GenericEvent
-    EVENTABLE_TYPES = %w[Move].freeze
-
-    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+    include MoveEventValidations
     validates :from_location_id, presence: true
 
     def from_location_id=(id)

--- a/app/models/generic_event/move_lockout.rb
+++ b/app/models/generic_event/move_lockout.rb
@@ -1,0 +1,26 @@
+class GenericEvent
+  class MoveLockout < GenericEvent
+    EVENTABLE_TYPES = %w[Move].freeze
+
+    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+    validates :from_location_id, presence: true
+
+    def from_location_id=(id)
+      details['from_location_id'] = id
+    end
+
+    def from_location_id
+      @from_location_id ||= details['from_location_id']
+    end
+
+    def from_location
+      Location.find_by(id: from_location_id)
+    end
+
+    def for_feed
+      super.tap do |common_feed_attributes|
+        common_feed_attributes['details'] = from_location.for_feed(prefix: 'from')
+      end
+    end
+  end
+end

--- a/app/models/generic_event/move_redirect.rb
+++ b/app/models/generic_event/move_redirect.rb
@@ -1,0 +1,36 @@
+class GenericEvent
+  class MoveRedirect < GenericEvent
+    EVENTABLE_TYPES = %w[Move].freeze
+
+    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+    validates :to_location_id, presence: true
+
+    def to_location_id=(id)
+      details['to_location_id'] = id
+    end
+
+    def to_location_id
+      details['to_location_id']
+    end
+
+    def move_type
+      details['move_type']
+    end
+
+    def to_location
+      Location.find_by(id: to_location_id)
+    end
+
+    def trigger
+      eventable.to_location = to_location
+      eventable.move_type = move_type if move_type.present?
+    end
+
+    def for_feed
+      super.tap do |common_feed_attributes|
+        common_feed_attributes['details'] = to_location.for_feed(prefix: 'to')
+        common_feed_attributes['details']['move_type'] = move_type if move_type.present?
+      end
+    end
+  end
+end

--- a/app/models/generic_event/move_redirect.rb
+++ b/app/models/generic_event/move_redirect.rb
@@ -1,8 +1,6 @@
 class GenericEvent
   class MoveRedirect < GenericEvent
-    EVENTABLE_TYPES = %w[Move].freeze
-
-    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+    include MoveEventValidations
     validates :to_location_id, presence: true
 
     def to_location_id=(id)

--- a/app/models/generic_event/move_reject.rb
+++ b/app/models/generic_event/move_reject.rb
@@ -1,0 +1,38 @@
+class GenericEvent
+  class MoveReject < GenericEvent
+    EVENTABLE_TYPES = %w[Move].freeze
+
+    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+    validates :rejection_reason, inclusion: { in: Move::REJECTION_REASONS }
+
+    def rejection_reason
+      details['rejection_reason']
+    end
+
+    def rejection_reason=(reason)
+      details['rejection_reason'] = reason
+    end
+
+    def cancellation_reason_comment
+      details['cancellation_reason_comment']
+    end
+
+    def rebook?
+      details.fetch('rebook', false)
+    end
+
+    def trigger
+      eventable.status = Move::MOVE_STATUS_CANCELLED
+      eventable.rejection_reason = rejection_reason
+      eventable.cancellation_reason = Move::CANCELLATION_REASON_REJECTED
+      eventable.cancellation_reason_comment = cancellation_reason_comment
+      eventable.rebook if rebook?
+    end
+
+    def for_feed
+      super.tap do |common_feed_attributes|
+        common_feed_attributes['details']['rebook'] = rebook?
+      end
+    end
+  end
+end

--- a/app/models/generic_event/move_reject.rb
+++ b/app/models/generic_event/move_reject.rb
@@ -1,8 +1,7 @@
 class GenericEvent
   class MoveReject < GenericEvent
-    EVENTABLE_TYPES = %w[Move].freeze
+    include MoveEventValidations
 
-    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
     validates :rejection_reason, inclusion: { in: Move::REJECTION_REASONS }
 
     def rejection_reason

--- a/app/models/generic_event/move_start.rb
+++ b/app/models/generic_event/move_start.rb
@@ -1,8 +1,6 @@
 class GenericEvent
   class MoveStart < GenericEvent
-    EVENTABLE_TYPES = %w[Move].freeze
-
-    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+    include MoveEventValidations
 
     def trigger
       eventable.status = Move::MOVE_STATUS_IN_TRANSIT

--- a/app/models/generic_event/move_start.rb
+++ b/app/models/generic_event/move_start.rb
@@ -1,0 +1,11 @@
+class GenericEvent
+  class MoveStart < GenericEvent
+    EVENTABLE_TYPES = %w[Move].freeze
+
+    validates :eventable_type, inclusion: { in: EVENTABLE_TYPES }
+
+    def trigger
+      eventable.status = Move::MOVE_STATUS_IN_TRANSIT
+    end
+  end
+end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -47,6 +47,7 @@ FactoryBot.define do
     eventable { association(:move) }
     details do
       {
+        move_type: 'court_appearance',
         to_location_id: create(:location).id,
       }
     end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
     eventable { association(:move) }
     details do
       {
-        rejection_reason: 'made_in_error',
+        rejection_reason: 'no_space_at_receiving_prison',
         cancellation_reason_comment: 'It was a mistake',
         rebook: false,
       }

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -7,6 +7,20 @@ FactoryBot.define do
     created_by { GenericEvent::CREATED_BY_OPTIONS.sample }
   end
 
+  factory :event_move_accept, parent: :generic_event, class: 'GenericEvent::MoveAccept' do
+    eventable { association(:move) }
+  end
+
+  factory :event_move_approve, parent: :generic_event, class: 'GenericEvent::MoveApprove' do
+    eventable { association(:move) }
+    details do
+      {
+        date: '2020-06-16',
+        create_in_nomis: true,
+      }
+    end
+  end
+
   factory :event_move_cancel, parent: :generic_event, class: 'GenericEvent::MoveCancel' do
     details do
       {
@@ -14,6 +28,43 @@ FactoryBot.define do
         cancellation_reason_comment: 'It was a mistake',
       }
     end
+  end
+
+  factory :event_move_complete, parent: :generic_event, class: 'GenericEvent::MoveComplete' do
+    eventable { association(:move) }
+  end
+
+  factory :event_move_lockout, parent: :generic_event, class: 'GenericEvent::MoveLockout' do
+    eventable { association(:move) }
+    details do
+      {
+        from_location_id: create(:location).id,
+      }
+    end
+  end
+
+  factory :event_move_redirect, parent: :generic_event, class: 'GenericEvent::MoveRedirect' do
+    eventable { association(:move) }
+    details do
+      {
+        to_location_id: create(:location).id,
+      }
+    end
+  end
+
+  factory :event_move_reject, parent: :generic_event, class: 'GenericEvent::MoveReject' do
+    eventable { association(:move) }
+    details do
+      {
+        rejection_reason: 'made_in_error',
+        cancellation_reason_comment: 'It was a mistake',
+        rebook: false,
+      }
+    end
+  end
+
+  factory :event_move_start, parent: :generic_event, class: 'GenericEvent::MoveStart' do
+    eventable { association(:move) }
   end
 
   factory :event_journey_cancel, parent: :generic_event, class: 'GenericEvent::JourneyCancel' do

--- a/spec/models/generic_event/move_accept_spec.rb
+++ b/spec/models/generic_event/move_accept_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe GenericEvent::MoveAccept do
+  subject(:generic_event) { build(:event_move_accept) }
+
+  it_behaves_like 'a move event' do
+    subject(:generic_event) { build(:event_move_accept) }
+  end
+
+  describe '#trigger' do
+    it 'does not persist changes to the eventable' do
+      generic_event.trigger
+      expect(generic_event.eventable).not_to be_persisted
+    end
+
+    it 'sets the eventable `status` to booked' do
+      expect { generic_event.trigger }.to change { generic_event.eventable.status }.from('requested').to('booked')
+    end
+  end
+end

--- a/spec/models/generic_event/move_accept_spec.rb
+++ b/spec/models/generic_event/move_accept_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe GenericEvent::MoveAccept do
   subject(:generic_event) { build(:event_move_accept) }
 
-  it_behaves_like 'a move event' do
-    subject(:generic_event) { build(:event_move_accept) }
-  end
+  it_behaves_like 'a move event'
 
   describe '#trigger' do
     it 'does not persist changes to the eventable' do

--- a/spec/models/generic_event/move_approve_spec.rb
+++ b/spec/models/generic_event/move_approve_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GenericEvent::MoveApprove do
 
   let(:eventable) { build(:move, :proposed) }
   let(:create_in_nomis) { true }
-  let(:date) { '2019-01-01'}
+  let(:date) { '2019-01-01' }
 
   it { is_expected.to validate_presence_of(:date)}
 
@@ -20,9 +20,7 @@ RSpec.describe GenericEvent::MoveApprove do
     it { is_expected.to be_invalid }
   end
 
-  it_behaves_like 'a move event' do
-    subject(:generic_event) { build(:event_move_approve) }
-  end
+  it_behaves_like 'a move event'
 
   describe '#trigger' do
     before do

--- a/spec/models/generic_event/move_approve_spec.rb
+++ b/spec/models/generic_event/move_approve_spec.rb
@@ -1,18 +1,50 @@
 RSpec.describe GenericEvent::MoveApprove do
-  subject(:generic_event) { build(:event_move_accept) }
+  subject(:generic_event) { build(:event_move_approve, eventable: eventable) }
+
+  let(:eventable) { build(:move, :proposed) }
 
   it_behaves_like 'a move event' do
-    subject(:generic_event) { build(:event_move_accept) }
+    subject(:generic_event) { build(:event_move_approve) }
   end
 
   describe '#trigger' do
     it 'does not persist changes to the eventable' do
       generic_event.trigger
+
       expect(generic_event.eventable).not_to be_persisted
     end
 
-    it 'sets the eventable `status` to booked' do
-      expect { generic_event.trigger }.to change { generic_event.eventable.status }.from('requested').to('booked')
+    rub
+    it 'sets the eventable `status` to requested' do
+      expect { generic_event.trigger }.to change { generic_event.eventable.status }.from('proposed').to('requested')
+    end
+
+    it 'sets the correct date' do
+      expect { generic_event.trigger }.to change { generic_event.eventable.date }.from(eventable.date).to(Date.parse(generic_event.date))
+    end
+
+    context 'when the PMU wants the move to be created in Nomis' do
+      before do
+        allow(Allocations::CreateInNomis).to receive(:call)
+      end
+
+      it 'calls the create in Nomis service' do
+        generic_event.details[:create_in_nomis] = true
+
+        generic_event.trigger
+
+        expect(Allocations::CreateInNomis).to have_received(:call).with(eventable)
+      end
+
+      context 'when the PMU does NOT want the move to be created in Nomis' do
+        it 'does NOT call the create in Nomis service' do
+          generic_event.details[:create_in_nomis] = false
+
+          generic_event.trigger
+
+          expect(Allocations::CreateInNomis).not_to have_received(:call)
+        end
+      end
     end
   end
 end

--- a/spec/models/generic_event/move_approve_spec.rb
+++ b/spec/models/generic_event/move_approve_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe GenericEvent::MoveApprove do
+  subject(:generic_event) { build(:event_move_accept) }
+
+  it_behaves_like 'a move event' do
+    subject(:generic_event) { build(:event_move_accept) }
+  end
+
+  describe '#trigger' do
+    it 'does not persist changes to the eventable' do
+      generic_event.trigger
+      expect(generic_event.eventable).not_to be_persisted
+    end
+
+    it 'sets the eventable `status` to booked' do
+      expect { generic_event.trigger }.to change { generic_event.eventable.status }.from('requested').to('booked')
+    end
+  end
+end

--- a/spec/models/generic_event/move_approve_spec.rb
+++ b/spec/models/generic_event/move_approve_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe GenericEvent::MoveApprove do
   let(:create_in_nomis) { true }
   let(:date) { '2019-01-01' }
 
-  it { is_expected.to validate_presence_of(:date)}
+  it { is_expected.to validate_presence_of(:date) }
 
   context 'when the date format is not an iso8601 date' do
-    let(:date) { '2019/01/01'}
+    let(:date) { '2019/01/01' }
 
     it { is_expected.to be_invalid }
   end

--- a/spec/models/generic_event/move_cancel_spec.rb
+++ b/spec/models/generic_event/move_cancel_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe GenericEvent::MoveCancel do
   subject(:generic_event) { build(:event_move_cancel) }
 
-  it_behaves_like 'a move event' do
-    subject(:generic_event) { build(:event_move_cancel) }
-  end
+  it_behaves_like 'a move event'
 
   it 'validates cancellation_reason' do
     expect(generic_event).to validate_inclusion_of(:cancellation_reason).in_array(Move::CANCELLATION_REASONS)

--- a/spec/models/generic_event/move_cancel_spec.rb
+++ b/spec/models/generic_event/move_cancel_spec.rb
@@ -49,4 +49,66 @@ RSpec.describe GenericEvent::MoveCancel do
       expect(Allocations::RemoveFromNomis).to have_received(:call).with(generic_event.eventable)
     end
   end
+
+  describe '#for_feed' do
+    subject(:generic_event) { create(:event_move_cancel, details: details) }
+
+    context 'when the cancellation_reason_comment is present' do
+      let(:details) do
+        {
+          cancellation_reason: 'made_in_error',
+          cancellation_reason_comment: 'It was a mistake',
+        }
+      end
+
+      let(:expected_json) do
+        {
+          'id' => generic_event.id,
+          'type' => 'GenericEvent::MoveCancel',
+          'notes' => 'Flibble',
+          'created_at' => be_a(Time),
+          'updated_at' => be_a(Time),
+          'occurred_at' => be_a(Time),
+          'recorded_at' => be_a(Time),
+          'eventable_id' => generic_event.eventable_id,
+          'eventable_type' => 'Move',
+          'details' => generic_event.details,
+        }
+      end
+
+      it 'generates a feed document' do
+        expect(generic_event.for_feed).to include_json(expected_json)
+      end
+    end
+
+    context 'when the cancellation_reason_comment is not present' do
+      let(:details) do
+        {
+          cancellation_reason: 'made_in_error',
+        }
+      end
+
+      let(:expected_json) do
+        {
+          'id' => generic_event.id,
+          'type' => 'GenericEvent::MoveCancel',
+          'notes' => 'Flibble',
+          'created_at' => be_a(Time),
+          'updated_at' => be_a(Time),
+          'occurred_at' => be_a(Time),
+          'recorded_at' => be_a(Time),
+          'eventable_id' => generic_event.eventable_id,
+          'eventable_type' => 'Move',
+          'details' => {
+            'cancellation_reason' => 'made_in_error',
+            'cancellation_reason_comment' => '',
+          },
+        }
+      end
+
+      it 'generates a feed document' do
+        expect(generic_event.for_feed).to include_json(expected_json)
+      end
+    end
+  end
 end

--- a/spec/models/generic_event/move_complete_spec.rb
+++ b/spec/models/generic_event/move_complete_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe GenericEvent::MoveComplete do
+  subject(:generic_event) { build(:event_move_complete) }
+
+  it_behaves_like 'a move event' do
+    subject(:generic_event) { build(:event_move_complete) }
+  end
+
+  describe '#trigger' do
+    it 'does not persist changes to the eventable' do
+      generic_event.trigger
+      expect(generic_event.eventable).not_to be_persisted
+    end
+
+    it 'sets the eventable `status` to booked' do
+      expect { generic_event.trigger }.to change { generic_event.eventable.status }.from('requested').to('completed')
+    end
+  end
+end

--- a/spec/models/generic_event/move_complete_spec.rb
+++ b/spec/models/generic_event/move_complete_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe GenericEvent::MoveComplete do
   subject(:generic_event) { build(:event_move_complete) }
 
-  it_behaves_like 'a move event' do
-    subject(:generic_event) { build(:event_move_complete) }
-  end
+  it_behaves_like 'a move event'
 
   describe '#trigger' do
     it 'does not persist changes to the eventable' do

--- a/spec/models/generic_event/move_lockout_spec.rb
+++ b/spec/models/generic_event/move_lockout_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe GenericEvent::MoveLockout do
+  subject(:generic_event) { build(:event_move_lockout) }
+
+  it_behaves_like 'a move event' do
+    subject(:generic_event) { build(:event_move_complete) }
+  end
+
+  it { is_expected.to validate_presence_of(:from_location_id) }
+
+  describe '#from_location' do
+    it 'returns a `Location` if from_location_id is in the details' do
+      location = create(:location)
+      generic_event.details['from_location_id'] = location.id
+      expect(generic_event.from_location).to eq(location)
+    end
+
+    it 'returns nil if from_location_id is nil in the details' do
+      generic_event.details['from_location_id'] = nil
+      expect(generic_event.from_location).to be_nil
+    end
+  end
+
+  describe '#for_feed' do
+    subject(:generic_event) { create(:event_move_lockout, details: { from_location_id: from_location.id }) }
+
+    let(:from_location) { create(:location) }
+
+    let(:expected_json) do
+      {
+        'id' => generic_event.id,
+        'type' => 'GenericEvent::MoveLockout',
+        'notes' => 'Flibble',
+        'created_at' => be_a(Time),
+        'updated_at' => be_a(Time),
+        'occurred_at' => be_a(Time),
+        'recorded_at' => be_a(Time),
+        'eventable_id' => generic_event.eventable_id,
+        'eventable_type' => 'Move',
+        'details' => {
+          'from_location_type' => from_location.location_type,
+          'from_location' => from_location.nomis_agency_id,
+        },
+      }
+    end
+
+    it 'generates a feed document' do
+      expect(generic_event.for_feed).to include_json(expected_json)
+    end
+  end
+end

--- a/spec/models/generic_event/move_lockout_spec.rb
+++ b/spec/models/generic_event/move_lockout_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe GenericEvent::MoveLockout do
   subject(:generic_event) { build(:event_move_lockout) }
 
-  it_behaves_like 'a move event' do
-    subject(:generic_event) { build(:event_move_complete) }
-  end
+  it_behaves_like 'a move event'
 
   it { is_expected.to validate_presence_of(:from_location_id) }
 

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe GenericEvent::MoveRedirect do
 
     let(:details) { { move_type: 'court_appearance' } }
 
-    let(:to_location) { create(:location)}
-    let(:eventable) { build(:move, move_type: 'prison_transfer')}
+    let(:to_location) { create(:location) }
+    let(:eventable) { build(:move, move_type: 'prison_transfer') }
 
     it 'does not persist changes to the eventable' do
       generic_event.trigger

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -1,0 +1,120 @@
+RSpec.describe GenericEvent::MoveRedirect do
+  subject(:generic_event) { build(:event_move_redirect) }
+
+  it_behaves_like 'a move event' do
+    subject(:generic_event) { build(:event_move_redirect) }
+  end
+
+  it { is_expected.to validate_presence_of(:to_location_id) }
+
+  describe '#to_location' do
+    it 'returns a `Location` if to_location_id is in the details' do
+      location = create(:location)
+      generic_event.details['to_location_id'] = location.id
+      expect(generic_event.to_location).to eq(location)
+    end
+
+    it 'returns nil if to_location_id is nil in the details' do
+      generic_event.details['to_location_id'] = nil
+      expect(generic_event.to_location).to be_nil
+    end
+  end
+
+  describe '#trigger' do
+    subject(:generic_event) { build(:event_move_redirect, details: details, eventable: eventable) }
+
+    let(:details) { { move_type: 'court_appearance' } }
+
+    let(:to_location) { create(:location)}
+    let(:eventable) { build(:move, move_type: 'prison_transfer')}
+
+    it 'does not persist changes to the eventable' do
+      generic_event.trigger
+
+      expect(generic_event.eventable).not_to be_persisted
+    end
+
+    it 'sets the eventable `to_location` to the to_location' do
+      expect { generic_event.trigger }.to change { generic_event.eventable.to_location }.to(generic_event.to_location)
+    end
+
+    context 'when a move_type is included in the details' do
+      let(:details) do
+        {
+          move_type: 'court_appearance',
+          to_location_id: to_location.id,
+        }
+      end
+
+      it 'sets the eventable `move_type' do
+        expect { generic_event.trigger }.to change { generic_event.eventable.move_type }.from('prison_transfer').to('court_appearance')
+      end
+    end
+  end
+
+  describe '#for_feed' do
+    subject(:generic_event) { create(:event_move_redirect, details: details) }
+
+    let(:to_location) { create(:location) }
+
+    context 'when the move_type is present' do
+      let(:details) do
+        {
+          to_location_id: to_location.id,
+          move_type: 'court_appearance',
+        }
+      end
+      let(:expected_json) do
+        {
+          'id' => generic_event.id,
+          'type' => 'GenericEvent::MoveRedirect',
+          'notes' => 'Flibble',
+          'created_at' => be_a(Time),
+          'updated_at' => be_a(Time),
+          'occurred_at' => be_a(Time),
+          'recorded_at' => be_a(Time),
+          'eventable_id' => generic_event.eventable_id,
+          'eventable_type' => 'Move',
+          'details' => {
+            'to_location_type' => to_location.location_type,
+            'to_location' => to_location.nomis_agency_id,
+            'move_type' => 'court_appearance',
+          },
+        }
+      end
+
+      it 'generates a feed document' do
+        expect(generic_event.for_feed).to include_json(expected_json)
+      end
+    end
+
+    context 'when the move_type is absent' do
+      let(:details) do
+        {
+          to_location_id: to_location.id,
+        }
+      end
+      let(:expected_json) do
+        {
+          'id' => generic_event.id,
+          'type' => 'GenericEvent::MoveRedirect',
+          'notes' => 'Flibble',
+          'created_at' => be_a(Time),
+          'updated_at' => be_a(Time),
+          'occurred_at' => be_a(Time),
+          'recorded_at' => be_a(Time),
+          'eventable_id' => generic_event.eventable_id,
+          'eventable_type' => 'Move',
+          'details' => {
+            'to_location_type' => to_location.location_type,
+            'to_location' => to_location.nomis_agency_id,
+          },
+        }
+      end
+
+      it 'generates a feed document' do
+        expect(generic_event.for_feed).to include_json(expected_json)
+      end
+    end
+  end
+end

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe GenericEvent::MoveRedirect do
   subject(:generic_event) { build(:event_move_redirect) }
 
-  it_behaves_like 'a move event' do
-    subject(:generic_event) { build(:event_move_redirect) }
-  end
+  it_behaves_like 'a move event'
 
   it { is_expected.to validate_presence_of(:to_location_id) }
 

--- a/spec/models/generic_event/move_reject_spec.rb
+++ b/spec/models/generic_event/move_reject_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe GenericEvent::MoveReject do
   subject(:generic_event) { build(:event_move_reject) }
 
-  it_behaves_like 'a move event' do
-    subject(:generic_event) { build(:event_move_reject) }
-  end
+  it_behaves_like 'a move event'
 
   it { is_expected.to validate_inclusion_of(:rejection_reason).in_array(Move::REJECTION_REASONS) }
 

--- a/spec/models/generic_event/move_reject_spec.rb
+++ b/spec/models/generic_event/move_reject_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GenericEvent::MoveReject do
         rebook: rebook,
       }
     end
-    let(:eventable) { build(:move)}
+    let(:eventable) { build(:move) }
     let(:rebook) { false }
 
     it 'does not persist changes to the eventable' do

--- a/spec/models/generic_event/move_reject_spec.rb
+++ b/spec/models/generic_event/move_reject_spec.rb
@@ -1,0 +1,96 @@
+RSpec.describe GenericEvent::MoveReject do
+  subject(:generic_event) { build(:event_move_reject) }
+
+  it_behaves_like 'a move event' do
+    subject(:generic_event) { build(:event_move_reject) }
+  end
+
+  it { is_expected.to validate_inclusion_of(:rejection_reason).in_array(Move::REJECTION_REASONS) }
+
+  describe '#trigger' do
+    subject(:generic_event) { build(:event_move_reject, details: details, eventable: eventable) }
+
+    before do
+      allow(eventable).to receive(:rebook)
+    end
+
+    let(:details) do
+      {
+        rejection_reason: 'no_space_at_receiving_prison',
+        cancellation_reason_comment: 'Wibble',
+        rebook: rebook,
+      }
+    end
+    let(:eventable) { build(:move)}
+    let(:rebook) { false }
+
+    it 'does not persist changes to the eventable' do
+      generic_event.trigger
+
+      expect(generic_event.eventable).not_to be_persisted
+    end
+
+    it 'sets the eventable `status` to cancelled' do
+      expect { generic_event.trigger }.to change(eventable, :status).from('requested').to('cancelled')
+    end
+
+    it 'sets the eventable `rejection_reason` to no_space_at_receiving_prison' do
+      expect { generic_event.trigger }.to change(eventable, :rejection_reason).from(nil).to('no_space_at_receiving_prison')
+    end
+
+    it 'sets the eventable `cancellation_reason` to rejected' do
+      expect { generic_event.trigger }.to change(eventable, :cancellation_reason).from(nil).to('rejected')
+    end
+
+    it 'sets the eventable `cancellation_reason_comment`' do
+      expect { generic_event.trigger }.to change(eventable, :cancellation_reason_comment).from(nil).to('Wibble')
+    end
+
+    context 'when the user wants to rebook the move' do
+      let(:rebook) { true }
+
+      it 'rebooks the move' do
+        generic_event.trigger
+        expect(eventable).to have_received(:rebook)
+      end
+    end
+
+    context 'when the user does not want to rebook the move' do
+      let(:rebook) { false }
+
+      it 'does not rebook the move' do
+        generic_event.trigger
+        expect(eventable).not_to have_received(:rebook)
+      end
+    end
+  end
+
+  describe '#for_feed' do
+    subject(:generic_event) { create(:event_move_reject) }
+
+    context 'when the move_type is present' do
+      let(:expected_json) do
+        {
+          'id' => generic_event.id,
+          'type' => 'GenericEvent::MoveReject',
+          'notes' => 'Flibble',
+          'created_at' => be_a(Time),
+          'updated_at' => be_a(Time),
+          'occurred_at' => be_a(Time),
+          'recorded_at' => be_a(Time),
+          'eventable_id' => generic_event.eventable_id,
+          'eventable_type' => 'Move',
+          'details' => {
+            'rejection_reason' => 'no_space_at_receiving_prison',
+            'cancellation_reason_comment' => 'It was a mistake',
+            'rebook' => false,
+          },
+        }
+      end
+
+      it 'generates a feed document' do
+        expect(generic_event.for_feed).to include_json(expected_json)
+      end
+    end
+  end
+end

--- a/spec/models/generic_event/move_start_spec.rb
+++ b/spec/models/generic_event/move_start_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe GenericEvent::MoveStart do
+  subject(:generic_event) { build(:event_move_start) }
+
+  it_behaves_like 'a move event' do
+    subject(:generic_event) { build(:event_move_start) }
+  end
+
+  describe '#trigger' do
+    it 'does not persist changes to the eventable' do
+      generic_event.trigger
+      expect(generic_event.eventable).not_to be_persisted
+    end
+
+    it 'sets the eventable `status` to in_transit' do
+      expect { generic_event.trigger }.to change { generic_event.eventable.status }.from('requested').to('in_transit')
+    end
+  end
+end

--- a/spec/models/generic_event/move_start_spec.rb
+++ b/spec/models/generic_event/move_start_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe GenericEvent::MoveStart do
   subject(:generic_event) { build(:event_move_start) }
 
-  it_behaves_like 'a move event' do
-    subject(:generic_event) { build(:event_move_start) }
-  end
+  it_behaves_like 'a move event'
 
   describe '#trigger' do
     it 'does not persist changes to the eventable' do


### PR DESCRIPTION
### Jira link

P4-1979

### What?

I have added/removed/altered:

- [x] Added MoveAccept and specs
- [x] Added MoveApprove and specs
- [x] Added MoveCancel and specs
- [x] Added MoveComplete and specs
- [x] Added MoveLockout and specs
- [x] Added MoveRedirect and specs
- [x] Added MoveReject and specs
- [x] Added MoveStart and specs

### Why?

I am doing this because:

- We need these as part of the generic and existing event apis