### PR TITLE
[P4-2161] Dual write journey events

### DIFF
--- a/app/controllers/concerns/journeys/eventable.rb
+++ b/app/controllers/concerns/journeys/eventable.rb
@@ -9,7 +9,8 @@ module Journeys
 
     def process_event(journeys, event_name, event_params)
       [journeys].flatten.each do |journey|
-        create_event(journey, event_name, event_params)
+        event = create_event(journey, event_name, event_params)
+        create_generic_event(event)
         run_event_logs(journey)
       end
     end
@@ -24,6 +25,8 @@ module Journeys
         },
       )
     end
+
+    def create_generic_event(event); end
 
     def run_event_logs(journey)
       EventLog::JourneyRunner.new(journey).call

--- a/app/controllers/concerns/journeys/eventable.rb
+++ b/app/controllers/concerns/journeys/eventable.rb
@@ -26,7 +26,9 @@ module Journeys
       )
     end
 
-    def create_generic_event(event); end
+    def create_generic_event(event)
+      GenericEvent.from_event(event).save!
+    end
 
     def run_event_logs(journey)
       EventLog::JourneyRunner.new(journey).call

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -53,4 +53,17 @@ class Event < ApplicationRecord
   def for_feed
     attributes.as_json
   end
+
+  def generic_event_attributes
+    {
+      occurred_at: client_timestamp,
+      recorded_at: client_timestamp,
+      created_at: created_at,
+      updated_at: updated_at,
+      notes: notes || '',
+      eventable: eventable,
+      details: {},
+      created_by: 'unknown',
+    }
+  end
 end

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -51,6 +51,6 @@ class GenericEvent < ApplicationRecord
   def self.from_event(event)
     type = "GenericEvent::#{event.eventable_type}#{event.event_name.capitalize}"
 
-    type.constantize.from_event(event).save
+    type.constantize.from_event(event)
   end
 end

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -1,6 +1,5 @@
 class GenericEvent < ApplicationRecord
   CREATED_BY_OPTIONS = %w[serco geoamey unknown].freeze
-
   FEED_ATTRIBUTES = %w[
     id
     type
@@ -47,5 +46,11 @@ class GenericEvent < ApplicationRecord
 
   def for_feed
     attributes.slice(*FEED_ATTRIBUTES)
+  end
+
+  def self.from_event(event)
+    type = "GenericEvent::#{event.eventable_type}#{event.event_name.capitalize}"
+
+    type.constantize.from_event(event).save
   end
 end

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -31,8 +31,9 @@ class GenericEvent < ApplicationRecord
   validates :type,           presence: true # STI class of the event
   validates :occurred_at,    presence: true # When did a human think the event occurred
   validates :recorded_at,    presence: true # When did supplier/frontend record the event
-  validates :details,        presence: true # Details that are specific to each event.
   validates :created_by,     presence: true, inclusion: { in: CREATED_BY_OPTIONS }
+
+  validates :details # Details that are specific to each event.
 
   # This scope is used to determine the apply order of events as they were determined to have occurred.
   # The order is important as far as the eventable state machine sequencing, the correctness

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -33,8 +33,6 @@ class GenericEvent < ApplicationRecord
   validates :recorded_at,    presence: true # When did supplier/frontend record the event
   validates :created_by,     presence: true, inclusion: { in: CREATED_BY_OPTIONS }
 
-  validates :details # Details that are specific to each event.
-
   # This scope is used to determine the apply order of events as they were determined to have occurred.
   # The order is important as far as the eventable state machine sequencing, the correctness
   # of any attributes of the eventable and for reporting purposes.

--- a/app/models/generic_event/journey_cancel.rb
+++ b/app/models/generic_event/journey_cancel.rb
@@ -7,13 +7,7 @@ class GenericEvent
     end
 
     def self.from_event(event)
-      new(
-        occurred_at: event.client_timestamp,
-        recorded_at: event.client_timestamp,
-        created_at: event.created_at,
-        updated_at: event.updated_at,
-        notes: event.notes,
-      )
+      new(event.generic_event_attributes)
     end
   end
 end

--- a/app/models/generic_event/journey_cancel.rb
+++ b/app/models/generic_event/journey_cancel.rb
@@ -5,5 +5,15 @@ class GenericEvent
     def trigger
       eventable.cancel
     end
+
+    def self.from_event(event)
+      new(
+        occurred_at: event.client_timestamp,
+        recorded_at: event.client_timestamp,
+        created_at: event.created_at,
+        updated_at: event.updated_at,
+        notes: event.notes,
+      )
+    end
   end
 end

--- a/app/models/generic_event/journey_complete.rb
+++ b/app/models/generic_event/journey_complete.rb
@@ -5,5 +5,9 @@ class GenericEvent
     def trigger
       eventable.complete
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes)
+    end
   end
 end

--- a/app/models/generic_event/journey_lockout.rb
+++ b/app/models/generic_event/journey_lockout.rb
@@ -21,5 +21,15 @@ class GenericEvent
         common_feed_attributes['details'] = from_location.for_feed(prefix: 'from')
       end
     end
+
+    def self.from_event(event)
+      generic_event_attributes = event.generic_event_attributes.merge(
+        details: {
+          from_location_id: event.event_params&.dig(:relationships, :from_location, :data, :id),
+        },
+      )
+
+      new(generic_event_attributes)
+    end
   end
 end

--- a/app/models/generic_event/journey_lodging.rb
+++ b/app/models/generic_event/journey_lodging.rb
@@ -4,10 +4,6 @@ class GenericEvent
 
     validates :to_location_id, presence: true
 
-    eventable
-    event_name
-    runner, trigger
-
     def to_location_id=(id)
       details['to_location_id'] = id
     end
@@ -24,6 +20,16 @@ class GenericEvent
       super.tap do |common_feed_attributes|
         common_feed_attributes['details'] = to_location.for_feed(prefix: 'to')
       end
+    end
+
+    def self.from_event(event)
+      generic_event_attributes = event.generic_event_attributes.merge(
+        details: {
+          to_location_id: event.event_params&.dig(:relationships, :to_location, :data, :id),
+        },
+      )
+
+      new(generic_event_attributes)
     end
   end
 end

--- a/app/models/generic_event/journey_lodging.rb
+++ b/app/models/generic_event/journey_lodging.rb
@@ -4,6 +4,10 @@ class GenericEvent
 
     validates :to_location_id, presence: true
 
+    eventable
+    event_name
+    runner, trigger
+
     def to_location_id=(id)
       details['to_location_id'] = id
     end

--- a/app/models/generic_event/journey_reject.rb
+++ b/app/models/generic_event/journey_reject.rb
@@ -5,5 +5,9 @@ class GenericEvent
     def trigger
       eventable.reject
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes)
+    end
   end
 end

--- a/app/models/generic_event/journey_start.rb
+++ b/app/models/generic_event/journey_start.rb
@@ -5,5 +5,9 @@ class GenericEvent
     def trigger
       eventable.start
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes)
+    end
   end
 end

--- a/app/models/generic_event/journey_uncancel.rb
+++ b/app/models/generic_event/journey_uncancel.rb
@@ -5,5 +5,9 @@ class GenericEvent
     def trigger
       eventable.uncancel
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes)
+    end
   end
 end

--- a/app/models/generic_event/journey_uncomplete.rb
+++ b/app/models/generic_event/journey_uncomplete.rb
@@ -5,5 +5,9 @@ class GenericEvent
     def trigger
       eventable.uncomplete
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes)
+    end
   end
 end

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -8,38 +8,7 @@ module EventLog
 
     # Process events in order of client_timestamp
     def call
-      # iterate over all events in the log and apply changes to the move
-      events.each do |event| # NB: do not use events.find_each as it will break the ordering
-        case event.event_name
-        when Event::ACCEPT
-          move.status = Move::MOVE_STATUS_BOOKED
-        when Event::APPROVE
-          move.status = Move::MOVE_STATUS_REQUESTED
-          move.date = event.date
-          Allocations::CreateInNomis.call(move) if event.create_in_nomis?
-        when Event::CANCEL
-          move.status = Move::MOVE_STATUS_CANCELLED
-          move.cancellation_reason = event.cancellation_reason
-          move.cancellation_reason_comment = event.cancellation_reason_comment
-          Allocations::RemoveFromNomis.call(move)
-        when Event::COMPLETE
-          move.status = Move::MOVE_STATUS_COMPLETED
-        when Event::LOCKOUT
-          # no action to perform when a move is locked out, this event is purely for auditing
-        when Event::REDIRECT
-          move.to_location = event.to_location
-          move.move_type = event.move_type if event.move_type.present?
-        when Event::REJECT
-          move.status = Move::MOVE_STATUS_CANCELLED
-          move.rejection_reason = event.rejection_reason
-          move.cancellation_reason = Move::CANCELLATION_REASON_REJECTED
-          move.cancellation_reason_comment = event.cancellation_reason_comment
-          move.rebook if event.rebook?
-        when Event::START
-          move.status = Move::MOVE_STATUS_IN_TRANSIT
-          # TODO: handle other move events here
-        end
-      end
+      events.map(&:trigger)
 
       # save the move if it has changed, and notify webhooks and emails
       if move.changed?
@@ -55,7 +24,7 @@ module EventLog
   private
 
     def events
-      move.move_events.default_order
+      move.generic_events.applied_order
     end
   end
 end

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -8,7 +8,38 @@ module EventLog
 
     # Process events in order of client_timestamp
     def call
-      events.map(&:trigger)
+      # iterate over all events in the log and apply changes to the move
+      events.each do |event| # NB: do not use events.find_each as it will break the ordering
+        case event.event_name
+        when Event::ACCEPT
+          move.status = Move::MOVE_STATUS_BOOKED
+        when Event::APPROVE
+          move.status = Move::MOVE_STATUS_REQUESTED
+          move.date = event.date
+          Allocations::CreateInNomis.call(move) if event.create_in_nomis?
+        when Event::CANCEL
+          move.status = Move::MOVE_STATUS_CANCELLED
+          move.cancellation_reason = event.cancellation_reason
+          move.cancellation_reason_comment = event.cancellation_reason_comment
+          Allocations::RemoveFromNomis.call(move)
+        when Event::COMPLETE
+          move.status = Move::MOVE_STATUS_COMPLETED
+        when Event::LOCKOUT
+          # no action to perform when a move is locked out, this event is purely for auditing
+        when Event::REDIRECT
+          move.to_location = event.to_location
+          move.move_type = event.move_type if event.move_type.present?
+        when Event::REJECT
+          move.status = Move::MOVE_STATUS_CANCELLED
+          move.rejection_reason = event.rejection_reason
+          move.cancellation_reason = Move::CANCELLATION_REASON_REJECTED
+          move.cancellation_reason_comment = event.cancellation_reason_comment
+          move.rebook if event.rebook?
+        when Event::START
+          move.status = Move::MOVE_STATUS_IN_TRANSIT
+          # TODO: handle other move events here
+        end
+      end
 
       # save the move if it has changed, and notify webhooks and emails
       if move.changed?
@@ -24,7 +55,7 @@ module EventLog
   private
 
     def events
-      move.generic_events.applied_order
+      move.move_events.default_order
     end
   end
 end

--- a/spec/models/generic_event/journey_cancel_spec.rb
+++ b/spec/models/generic_event/journey_cancel_spec.rb
@@ -4,4 +4,33 @@ RSpec.describe GenericEvent::JourneyCancel do
   it_behaves_like 'a journey event', :cancel do
     subject(:generic_event) { build(:event_journey_cancel) }
   end
+
+  describe '.from_event' do
+    let(:journey) { create(:journey) }
+    let(:event) { create(:event, :cancel, eventable: journey) }
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => journey.id,
+        'eventable_type' => 'Journey',
+        'type' => 'GenericEvent::JourneyCancel',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {},
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+    end
+
+    it 'builds a valid generic_event' do
+      expect(described_class.from_event(event)).to be_valid
+    end
+  end
 end

--- a/spec/models/generic_event/journey_complete_spec.rb
+++ b/spec/models/generic_event/journey_complete_spec.rb
@@ -4,4 +4,33 @@ RSpec.describe GenericEvent::JourneyComplete do
   it_behaves_like 'a journey event', :complete do
     subject(:generic_event) { build(:event_journey_complete) }
   end
+
+  describe '.from_event' do
+    let(:journey) { create(:journey) }
+    let(:event) { create(:event, :complete, eventable: journey) }
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => journey.id,
+        'eventable_type' => 'Journey',
+        'type' => 'GenericEvent::JourneyComplete',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {},
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+    end
+
+    it 'builds a valid generic_event' do
+      expect(described_class.from_event(event)).to be_valid
+    end
+  end
 end

--- a/spec/models/generic_event/journey_lockout_spec.rb
+++ b/spec/models/generic_event/journey_lockout_spec.rb
@@ -44,4 +44,62 @@ RSpec.describe GenericEvent::JourneyLockout do
       expect(generic_event.for_feed).to include_json(expected_json)
     end
   end
+
+  describe '.from_event' do
+    let(:journey) { create(:journey) }
+
+    context 'when the event has locations' do
+      let(:event) { create(:event, :cancel, :locations, eventable: journey) }
+      let(:expected_generic_event_attributes) do
+        {
+          'id' => nil,
+          'eventable_id' => journey.id,
+          'eventable_type' => 'Journey',
+          'type' => 'GenericEvent::JourneyLockout',
+          'notes' => 'foo',
+          'created_by' => 'unknown',
+          'details' => { 'from_location_id' => match(uuid_regex) },
+          'occurred_at' => eq(event.client_timestamp),
+          'recorded_at' => eq(event.client_timestamp),
+          'created_at' => be_within(0.1.seconds).of(event.created_at),
+          'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+        }
+      end
+
+      it 'builds a generic_event with the correct attributes' do
+        expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+      end
+
+      it 'builds a valid generic_event' do
+        expect(described_class.from_event(event)).to be_valid
+      end
+    end
+
+    context 'when the event does not have locations' do
+      let(:event) { create(:event, :cancel, eventable: journey) }
+      let(:expected_generic_event_attributes) do
+        {
+          'id' => nil,
+          'eventable_id' => journey.id,
+          'eventable_type' => 'Journey',
+          'type' => 'GenericEvent::JourneyLockout',
+          'notes' => 'foo',
+          'created_by' => 'unknown',
+          'details' => { 'from_location_id' => nil },
+          'occurred_at' => eq(event.client_timestamp),
+          'recorded_at' => eq(event.client_timestamp),
+          'created_at' => be_within(0.1.seconds).of(event.created_at),
+          'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+        }
+      end
+
+      it 'builds a generic_event with the correct attributes' do
+        expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+      end
+
+      it 'builds an invalid generic_event' do
+        expect(described_class.from_event(event)).not_to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/generic_event/journey_lodging_spec.rb
+++ b/spec/models/generic_event/journey_lodging_spec.rb
@@ -44,4 +44,62 @@ RSpec.describe GenericEvent::JourneyLodging do
       expect(generic_event.for_feed).to include_json(expected_json)
     end
   end
+
+  describe '.from_event' do
+    let(:journey) { create(:journey) }
+
+    context 'when the event has locations' do
+      let(:event) { create(:event, :cancel, :locations, eventable: journey) }
+      let(:expected_generic_event_attributes) do
+        {
+          'id' => nil,
+          'eventable_id' => journey.id,
+          'eventable_type' => 'Journey',
+          'type' => 'GenericEvent::JourneyLodging',
+          'notes' => 'foo',
+          'created_by' => 'unknown',
+          'details' => { 'to_location_id' => match(uuid_regex) },
+          'occurred_at' => eq(event.client_timestamp),
+          'recorded_at' => eq(event.client_timestamp),
+          'created_at' => be_within(0.1.seconds).of(event.created_at),
+          'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+        }
+      end
+
+      it 'builds a generic_event with the correct attributes' do
+        expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+      end
+
+      it 'builds a valid generic_event' do
+        expect(described_class.from_event(event)).to be_valid
+      end
+    end
+
+    context 'when the event does not have locations' do
+      let(:event) { create(:event, :cancel, eventable: journey) }
+      let(:expected_generic_event_attributes) do
+        {
+          'id' => nil,
+          'eventable_id' => journey.id,
+          'eventable_type' => 'Journey',
+          'type' => 'GenericEvent::JourneyLodging',
+          'notes' => 'foo',
+          'created_by' => 'unknown',
+          'details' => { 'to_location_id' => nil },
+          'occurred_at' => eq(event.client_timestamp),
+          'recorded_at' => eq(event.client_timestamp),
+          'created_at' => be_within(0.1.seconds).of(event.created_at),
+          'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+        }
+      end
+
+      it 'builds a generic_event with the correct attributes' do
+        expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+      end
+
+      it 'builds an invalid generic_event' do
+        expect(described_class.from_event(event)).not_to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/generic_event/journey_reject_spec.rb
+++ b/spec/models/generic_event/journey_reject_spec.rb
@@ -4,4 +4,33 @@ RSpec.describe GenericEvent::JourneyReject do
   it_behaves_like 'a journey event', :reject do
     subject(:generic_event) { build(:event_journey_reject) }
   end
+
+  describe '.from_event' do
+    let(:journey) { create(:journey) }
+    let(:event) { create(:event, :reject, eventable: journey) }
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => journey.id,
+        'eventable_type' => 'Journey',
+        'type' => 'GenericEvent::JourneyReject',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {},
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+    end
+
+    it 'builds a valid generic_event' do
+      expect(described_class.from_event(event)).to be_valid
+    end
+  end
 end

--- a/spec/models/generic_event/journey_start_spec.rb
+++ b/spec/models/generic_event/journey_start_spec.rb
@@ -4,4 +4,33 @@ RSpec.describe GenericEvent::JourneyStart do
   it_behaves_like 'a journey event', :start do
     subject(:generic_event) { build(:event_journey_start) }
   end
+
+  describe '.from_event' do
+    let(:journey) { create(:journey) }
+    let(:event) { create(:event, :start, eventable: journey) }
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => journey.id,
+        'eventable_type' => 'Journey',
+        'type' => 'GenericEvent::JourneyStart',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {},
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+    end
+
+    it 'builds a valid generic_event' do
+      expect(described_class.from_event(event)).to be_valid
+    end
+  end
 end

--- a/spec/models/generic_event/journey_uncancel_spec.rb
+++ b/spec/models/generic_event/journey_uncancel_spec.rb
@@ -4,4 +4,33 @@ RSpec.describe GenericEvent::JourneyUncancel do
   it_behaves_like 'a journey event', :uncancel do
     subject(:generic_event) { build(:event_journey_uncancel) }
   end
+
+  describe '.from_event' do
+    let(:journey) { create(:journey) }
+    let(:event) { create(:event, :uncancel, eventable: journey) }
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => journey.id,
+        'eventable_type' => 'Journey',
+        'type' => 'GenericEvent::JourneyUncancel',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {},
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+    end
+
+    it 'builds a valid generic_event' do
+      expect(described_class.from_event(event)).to be_valid
+    end
+  end
 end

--- a/spec/models/generic_event/journey_uncomplete_spec.rb
+++ b/spec/models/generic_event/journey_uncomplete_spec.rb
@@ -4,4 +4,33 @@ RSpec.describe GenericEvent::JourneyUncomplete do
   it_behaves_like 'a journey event', :uncomplete do
     subject(:generic_event) { build(:event_journey_uncomplete) }
   end
+
+  describe '.from_event' do
+    let(:journey) { create(:journey) }
+    let(:event) { create(:event, :uncomplete, eventable: journey) }
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => journey.id,
+        'eventable_type' => 'Journey',
+        'type' => 'GenericEvent::JourneyUncomplete',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {},
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+    end
+
+    it 'builds a valid generic_event' do
+      expect(described_class.from_event(event)).to be_valid
+    end
+  end
 end

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -57,19 +57,11 @@ RSpec.describe GenericEvent, type: :model do
   end
 
   describe '.from_event' do
-    context 'when the eventable is a Journey' do
-      context 'when the event_name is `cancel`' do
-        let(:event) { create(:event, :cancel, eventable: eventable) }
-        let(:eventable) { create(:journey)}
+    let(:event) { create(:event, :cancel, eventable: eventable) }
+    let(:eventable) { create(:journey) }
 
-        it 'calls JourneyCancel.from_event' do
-          allow(GenericEvent::JourneyCancel).to receive(:from_event)
-
-          described_class.from_event(event)
-
-          expect(GenericEvent::JourneyCancel).to receive(:from_event).with(event)
-        end
-      end
+    it 'returns an initialized JournalCancel event' do
+      expect(described_class.from_event(event)).to be_a(GenericEvent::JourneyCancel)
     end
   end
 end

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe GenericEvent, type: :model do
   it { is_expected.to validate_presence_of(:type) }
   it { is_expected.to validate_presence_of(:occurred_at) }
   it { is_expected.to validate_presence_of(:recorded_at) }
-  it { is_expected.to validate_presence_of(:details) }
   it { is_expected.to validate_presence_of(:created_by) }
 
   it { expect(generic_event).to validate_inclusion_of(:created_by).in_array(%w[serco geoamey unknown]) }

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -55,4 +55,21 @@ RSpec.describe GenericEvent, type: :model do
       expect(generic_event.for_feed).to include_json(expected_attributes)
     end
   end
+
+  describe '.from_event' do
+    context 'when the eventable is a Journey' do
+      context 'when the event_name is `cancel`' do
+        let(:event) { create(:event, :cancel, eventable: eventable) }
+        let(:eventable) { create(:journey)}
+
+        it 'calls JourneyCancel.from_event' do
+          allow(GenericEvent::JourneyCancel).to receive(:from_event)
+
+          described_class.from_event(event)
+
+          expect(GenericEvent::JourneyCancel).to receive(:from_event).with(event)
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/journey_events_controller_cancel_spec.rb
+++ b/spec/requests/api/journey_events_controller_cancel_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/cancel' do
+    subject(:do_post) do
+      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/cancel", params: params, headers: headers, as: :json)
+    end
+
     include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
@@ -12,10 +16,6 @@ RSpec.describe Api::JourneyEventsController do
     let(:journey) { create(:journey, initial_journey_state, move: move, supplier: supplier) }
     let(:journey_id) { journey.id }
     let(:initial_journey_state) { :in_progress }
-
-    before do
-      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/cancel", params: params, headers: headers, as: :json)
-    end
 
     context 'with happy params' do
       let(:params) do
@@ -30,17 +30,30 @@ RSpec.describe Api::JourneyEventsController do
         }
       end
 
-      it_behaves_like 'an endpoint that responds with success 204'
+      it_behaves_like 'an endpoint that responds with success 204' do
+        before do
+          do_post
+        end
+      end
 
       it 'cancels the journey' do
+        do_post
         expect(journey.reload).to be_cancelled
+      end
+
+      it 'dual writes a journey cancel event' do
+        expect { do_post }.to change { GenericEvent::JourneyCancel.count }.by(1)
       end
     end
 
     context 'with unhappy params' do
       let(:params) { { foo: 'bar' } }
 
-      it_behaves_like 'an endpoint that responds with error 400'
+      it_behaves_like 'an endpoint that responds with error 400' do
+        before do
+          do_post
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/journey_events_controller_complete_spec.rb
+++ b/spec/requests/api/journey_events_controller_complete_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/complete' do
+    subject(:do_post) do
+      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/complete", params: params, headers: headers, as: :json)
+    end
+
     include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
@@ -12,10 +16,6 @@ RSpec.describe Api::JourneyEventsController do
     let(:journey) { create(:journey, initial_journey_state, move: move, supplier: supplier) }
     let(:journey_id) { journey.id }
     let(:initial_journey_state) { :in_progress }
-
-    before do
-      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/complete", params: params, headers: headers, as: :json)
-    end
 
     context 'with happy params' do
       let(:params) do
@@ -30,17 +30,30 @@ RSpec.describe Api::JourneyEventsController do
         }
       end
 
-      it_behaves_like 'an endpoint that responds with success 204'
+      it_behaves_like 'an endpoint that responds with success 204' do
+        before do
+          do_post
+        end
+      end
 
       it 'completes the journey' do
+        do_post
         expect(journey.reload).to be_completed
+      end
+
+      it 'dual writes a journey complete event' do
+        expect { do_post }.to change { GenericEvent::JourneyComplete.count }.by(1)
       end
     end
 
     context 'with unhappy params' do
       let(:params) { { foo: 'bar' } }
 
-      it_behaves_like 'an endpoint that responds with error 400'
+      it_behaves_like 'an endpoint that responds with error 400' do
+        before do
+          do_post
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/journey_events_controller_lockouts_spec.rb
+++ b/spec/requests/api/journey_events_controller_lockouts_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/lockouts' do
+    subject(:do_post) do
+      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/lockouts", params: params, headers: headers, as: :json)
+    end
+
     include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
@@ -13,10 +17,6 @@ RSpec.describe Api::JourneyEventsController do
     let(:journey_id) { journey.id }
     let(:initial_journey_state) { :in_progress }
     let(:location) { create(:location) }
-
-    before do
-      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/lockouts", params: params, headers: headers, as: :json)
-    end
 
     context 'with happy params' do
       let(:params) do
@@ -32,17 +32,30 @@ RSpec.describe Api::JourneyEventsController do
         }
       end
 
-      it_behaves_like 'an endpoint that responds with success 204'
+      it_behaves_like 'an endpoint that responds with success 204' do
+        before do
+          do_post
+        end
+      end
 
       it 'logs a lockout event record' do
+        do_post
         expect(journey.events.last.event_name).to eql('lockout')
+      end
+
+      it 'dual writes a journey lockout event' do
+        expect { do_post }.to change { GenericEvent::JourneyLockout.count }.by(1)
       end
     end
 
     context 'with unhappy params' do
       let(:params) { { foo: 'bar' } }
 
-      it_behaves_like 'an endpoint that responds with error 400'
+      it_behaves_like 'an endpoint that responds with error 400' do
+        before do
+          do_post
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/journey_events_controller_reject_spec.rb
+++ b/spec/requests/api/journey_events_controller_reject_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/reject' do
+    subject(:do_post) do
+      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/reject", params: params, headers: headers, as: :json)
+    end
+
     include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
@@ -12,10 +16,6 @@ RSpec.describe Api::JourneyEventsController do
     let(:journey) { create(:journey, initial_journey_state, move: move, supplier: supplier) }
     let(:journey_id) { journey.id }
     let(:initial_journey_state) { :proposed }
-
-    before do
-      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/reject", params: params, headers: headers, as: :json)
-    end
 
     context 'with happy params' do
       let(:params) do
@@ -30,17 +30,30 @@ RSpec.describe Api::JourneyEventsController do
         }
       end
 
-      it_behaves_like 'an endpoint that responds with success 204'
+      it_behaves_like 'an endpoint that responds with success 204' do
+        before do
+          do_post
+        end
+      end
 
       it 'rejects the journey' do
+        do_post
         expect(journey.reload).to be_rejected
+      end
+
+      it 'dual writes a journey reject event' do
+        expect { do_post }.to change { GenericEvent::JourneyReject.count }.by(1)
       end
     end
 
     context 'with unhappy params' do
       let(:params) { { foo: 'bar' } }
 
-      it_behaves_like 'an endpoint that responds with error 400'
+      it_behaves_like 'an endpoint that responds with error 400' do
+        before do
+          do_post
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/journey_events_controller_start_spec.rb
+++ b/spec/requests/api/journey_events_controller_start_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/start' do
+    subject(:do_post) do
+      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/start", params: params, headers: headers, as: :json)
+    end
+
     include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
@@ -12,10 +16,6 @@ RSpec.describe Api::JourneyEventsController do
     let(:journey) { create(:journey, initial_journey_state, move: move, supplier: supplier) }
     let(:journey_id) { journey.id }
     let(:initial_journey_state) { :proposed }
-
-    before do
-      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/start", params: params, headers: headers, as: :json)
-    end
 
     context 'with happy params' do
       let(:params) do
@@ -30,17 +30,30 @@ RSpec.describe Api::JourneyEventsController do
         }
       end
 
-      it_behaves_like 'an endpoint that responds with success 204'
+      it_behaves_like 'an endpoint that responds with success 204' do
+        before do
+          do_post
+        end
+      end
 
       it 'starts the journey' do
+        do_post
         expect(journey.reload).to be_in_progress
+      end
+
+      it 'dual writes a journey reject event' do
+        expect { do_post }.to change { GenericEvent::JourneyStart.count }.by(1)
       end
     end
 
     context 'with unhappy params' do
       let(:params) { { foo: 'bar' } }
 
-      it_behaves_like 'an endpoint that responds with error 400'
+      it_behaves_like 'an endpoint that responds with error 400' do
+        before do
+          do_post
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/journey_events_controller_uncancel_spec.rb
+++ b/spec/requests/api/journey_events_controller_uncancel_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/uncancel' do
+    subject(:do_post) do
+      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/uncancel", params: params, headers: headers, as: :json)
+    end
+
     include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
@@ -12,10 +16,6 @@ RSpec.describe Api::JourneyEventsController do
     let(:journey) { create(:journey, initial_journey_state, move: move, supplier: supplier) }
     let(:journey_id) { journey.id }
     let(:initial_journey_state) { :cancelled }
-
-    before do
-      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/uncancel", params: params, headers: headers, as: :json)
-    end
 
     context 'with happy params' do
       let(:params) do
@@ -30,17 +30,30 @@ RSpec.describe Api::JourneyEventsController do
         }
       end
 
-      it_behaves_like 'an endpoint that responds with success 204'
+      it_behaves_like 'an endpoint that responds with success 204' do
+        before do
+          do_post
+        end
+      end
 
       it 'uncancels the journey' do
+        do_post
         expect(journey.reload).to be_in_progress
+      end
+
+      it 'dual writes a journey uncancel event' do
+        expect { do_post }.to change { GenericEvent::JourneyUncancel.count }.by(1)
       end
     end
 
     context 'with unhappy params' do
       let(:params) { { foo: 'bar' } }
 
-      it_behaves_like 'an endpoint that responds with error 400'
+      it_behaves_like 'an endpoint that responds with error 400' do
+        before do
+          do_post
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/journey_events_controller_uncomplete_spec.rb
+++ b/spec/requests/api/journey_events_controller_uncomplete_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Api::JourneyEventsController do
   describe 'POST /moves/:move_id/journeys/:journey_id/uncomplete' do
+    subject(:do_post) do
+      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/uncomplete", params: params, headers: headers, as: :json)
+    end
+
     include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
@@ -12,10 +16,6 @@ RSpec.describe Api::JourneyEventsController do
     let(:journey) { create(:journey, initial_journey_state, move: move, supplier: supplier) }
     let(:journey_id) { journey.id }
     let(:initial_journey_state) { :completed }
-
-    before do
-      post("/api/v1/moves/#{move_id}/journeys/#{journey_id}/uncomplete", params: params, headers: headers, as: :json)
-    end
 
     context 'with happy params' do
       let(:params) do
@@ -30,17 +30,30 @@ RSpec.describe Api::JourneyEventsController do
         }
       end
 
-      it_behaves_like 'an endpoint that responds with success 204'
+      it_behaves_like 'an endpoint that responds with success 204' do
+        before do
+          do_post
+        end
+      end
 
       it 'uncompletes the journey' do
+        do_post
         expect(journey.reload).to be_in_progress
+      end
+
+      it 'dual writes a journey uncomplete event' do
+        expect { do_post }.to change { GenericEvent::JourneyUncomplete.count }.by(1)
       end
     end
 
     context 'with unhappy params' do
       let(:params) { { foo: 'bar' } }
 
-      it_behaves_like 'an endpoint that responds with error 400'
+      it_behaves_like 'an endpoint that responds with error 400' do
+        before do
+          do_post
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,8 @@ RSpec.configure do |config|
     # clear cache between each test
     Rails.cache.clear
   end
+
+  def uuid_regex
+    /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/
+  end
 end


### PR DESCRIPTION
### Jira link

P4-2161

### What?

I have added/removed/altered:

- [x] Adds event builder for journey_cancel.rb
- [x] Adds event builder for journey_complete.rb
- [x] Adds event builder for journey_lockout.rb
- [x] Adds event builder for journey_lodging.rb
- [x] Adds event builder for journey_reject.rb
- [x] Adds event builder for journey_start.rb
- [x] Adds event builder for journey_uncancel.rb
- [x] Adds event builder for journey_uncomplete.rb
- [x] Dual write journey events in JourneyEventable

### Why?

We're dual writing so we can safely migrate from event v1 -> generic_event v2.