### PR TITLE
P4 2161 dual write events

### DIFF
--- a/app/models/generic_event/move_accept.rb
+++ b/app/models/generic_event/move_accept.rb
@@ -7,5 +7,9 @@ class GenericEvent
     def trigger
       eventable.status = Move::MOVE_STATUS_BOOKED
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes)
+    end
   end
 end

--- a/app/models/generic_event/move_approve.rb
+++ b/app/models/generic_event/move_approve.rb
@@ -40,7 +40,7 @@ class GenericEvent
               .merge(
                 details: {
                   date: event.eventable.date,
-                  create_in_nomis: event.details.fetch(:create_in_nomis, false),
+                  create_in_nomis: event.event_params&.dig(:attributes, :create_in_nomis) || false,
                 },
               ))
     end

--- a/app/models/generic_event/move_approve.rb
+++ b/app/models/generic_event/move_approve.rb
@@ -34,5 +34,15 @@ class GenericEvent
         common_feed_attributes['details']['create_in_nomis'] = create_in_nomis?
       end
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes
+              .merge(
+                details: {
+                  date: event.eventable.date,
+                  create_in_nomis: event.details.fetch(:create_in_nomis, false),
+                },
+              ))
+    end
   end
 end

--- a/app/models/generic_event/move_cancel.rb
+++ b/app/models/generic_event/move_cancel.rb
@@ -28,5 +28,15 @@ class GenericEvent
         common_feed_attributes['details']['cancellation_reason_comment'] = cancellation_reason_comment
       end
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes
+                .merge(
+                  details: {
+                    cancellation_reason: event.event_params&.dig(:attributes, :cancellation_reason),
+                    cancellation_reason_comment: event.event_params&.dig(:attributes, :cancellation_reason_comment),
+                  },
+                ))
+    end
   end
 end

--- a/app/models/generic_event/move_complete.rb
+++ b/app/models/generic_event/move_complete.rb
@@ -5,5 +5,9 @@ class GenericEvent
     def trigger
       eventable.status = Move::MOVE_STATUS_COMPLETED
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes)
+    end
   end
 end

--- a/app/models/generic_event/move_lockout.rb
+++ b/app/models/generic_event/move_lockout.rb
@@ -21,5 +21,13 @@ class GenericEvent
         common_feed_attributes['details'] = from_location.for_feed(prefix: 'from')
       end
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes.merge(
+            details: {
+              from_location_id: event.event_params&.dig(:relationships, :from_location, :data, :id),
+            },
+          ))
+    end
   end
 end

--- a/app/models/generic_event/move_redirect.rb
+++ b/app/models/generic_event/move_redirect.rb
@@ -30,5 +30,14 @@ class GenericEvent
         common_feed_attributes['details']['move_type'] = move_type if move_type.present?
       end
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes.merge(
+            details: {
+              to_location_id: event.event_params&.dig(:relationships, :to_location, :data, :id),
+              move_type: event.event_params&.dig(:attributes, :move_type),
+            },
+          ))
+    end
   end
 end

--- a/app/models/generic_event/move_reject.rb
+++ b/app/models/generic_event/move_reject.rb
@@ -40,6 +40,7 @@ class GenericEvent
                 details: {
                   rejection_reason: event.event_params&.dig(:attributes, :rejection_reason),
                   cancellation_reason_comment: event.event_params&.dig(:attributes, :cancellation_reason_comment),
+                  rebook: event.event_params&.dig(:attributes, :rebook) || false,
                 },
               ))
     end

--- a/app/models/generic_event/move_reject.rb
+++ b/app/models/generic_event/move_reject.rb
@@ -33,5 +33,15 @@ class GenericEvent
         common_feed_attributes['details']['rebook'] = rebook?
       end
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes
+              .merge(
+                details: {
+                  rejection_reason: event.event_params&.dig(:attributes, :rejection_reason),
+                  cancellation_reason_comment: event.event_params&.dig(:attributes, :cancellation_reason_comment),
+                },
+              ))
+    end
   end
 end

--- a/app/models/generic_event/move_start.rb
+++ b/app/models/generic_event/move_start.rb
@@ -5,5 +5,9 @@ class GenericEvent
     def trigger
       eventable.status = Move::MOVE_STATUS_IN_TRANSIT
     end
+
+    def self.from_event(event)
+      new(event.generic_event_attributes)
+    end
   end
 end

--- a/spec/models/generic_event/move_accept_spec.rb
+++ b/spec/models/generic_event/move_accept_spec.rb
@@ -13,4 +13,39 @@ RSpec.describe GenericEvent::MoveAccept do
       expect { generic_event.trigger }.to change { generic_event.eventable.status }.from('requested').to('booked')
     end
   end
+
+  describe '.from_event' do
+    let(:move) { create(:move) }
+    let(:event) do
+      create(:event, :accept, :locations, eventable: move,
+                                          details: {
+                                            event_params: {
+                                              attributes: {
+                                                notes: 'notes',
+                                              },
+                                            },
+                                          })
+    end
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => move.id,
+        'eventable_type' => 'Move',
+        'type' => 'GenericEvent::MoveAccept',
+        'notes' => 'notes',
+        'created_by' => 'unknown',
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(
+        described_class.from_event(event).attributes,
+      ).to include_json(expected_generic_event_attributes)
+    end
+  end
 end

--- a/spec/models/generic_event/move_approve_spec.rb
+++ b/spec/models/generic_event/move_approve_spec.rb
@@ -95,9 +95,8 @@ RSpec.describe GenericEvent::MoveApprove do
                                            details: {
                                              event_params: {
                                                attributes: {
-                                                 rejection_reason: 'no_space_at_receiving_prison',
-                                                 cancellation_reason_comment: 'a comment',
-                                                 rebook: 'false',
+                                                 date: move.date,
+                                                 create_in_nomis: true,
                                                  notes: 'foo',
                                                },
                                              },
@@ -113,8 +112,8 @@ RSpec.describe GenericEvent::MoveApprove do
         'notes' => 'foo',
         'created_by' => 'unknown',
         'details' => {
-          date: '2020-01-30',
-          create_in_nomis: false,
+          'date' => '2020-01-30',
+          'create_in_nomis' => true,
         },
         'occurred_at' => eq(event.client_timestamp),
         'recorded_at' => eq(event.client_timestamp),
@@ -122,8 +121,6 @@ RSpec.describe GenericEvent::MoveApprove do
         'updated_at' => be_within(0.1.seconds).of(event.updated_at),
       }
     end
-
-    let(:date) { Date.new(2020, 1, 30) }
 
     it 'builds a generic_event with the correct attributes' do
       expect(

--- a/spec/models/generic_event/move_approve_spec.rb
+++ b/spec/models/generic_event/move_approve_spec.rb
@@ -87,4 +87,48 @@ RSpec.describe GenericEvent::MoveApprove do
       expect(generic_event.for_feed).to include_json(expected_json)
     end
   end
+
+  describe '.from_event' do
+    let(:move) { create(:move, date: Date.new(2020, 1, 30)) }
+    let(:event) do
+      create(:event, :approve, :locations, eventable: move,
+                                           details: {
+                                             event_params: {
+                                               attributes: {
+                                                 rejection_reason: 'no_space_at_receiving_prison',
+                                                 cancellation_reason_comment: 'a comment',
+                                                 rebook: 'false',
+                                                 notes: 'foo',
+                                               },
+                                             },
+                                           })
+    end
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => move.id,
+        'eventable_type' => 'Move',
+        'type' => 'GenericEvent::MoveApprove',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {
+          date: '2020-01-30',
+          create_in_nomis: false,
+        },
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    let(:date) { Date.new(2020, 1, 30) }
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(
+        described_class.from_event(event).attributes,
+      ).to include_json(expected_generic_event_attributes)
+    end
+  end
 end

--- a/spec/models/generic_event/move_cancel_spec.rb
+++ b/spec/models/generic_event/move_cancel_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe GenericEvent::MoveCancel do
         'type' => 'GenericEvent::MoveCancel',
         'notes' => 'foo',
         'created_by' => 'unknown',
-        'details' => { cancellation_reason: 'aaa', cancellation_reason_comment: 'bbb' },
+        'details' => { 'cancellation_reason' => 'aaa', 'cancellation_reason_comment' => 'bbb' },
         'occurred_at' => eq(event.client_timestamp),
         'recorded_at' => eq(event.client_timestamp),
         'created_at' => be_within(0.1.seconds).of(event.created_at),

--- a/spec/models/generic_event/move_cancel_spec.rb
+++ b/spec/models/generic_event/move_cancel_spec.rb
@@ -48,6 +48,44 @@ RSpec.describe GenericEvent::MoveCancel do
     end
   end
 
+  describe '.from_event' do
+    let(:move) { create(:move) }
+    let(:event) do
+      create(:event, :cancel, :locations, eventable: move,
+                                          details: {
+                                            event_params: {
+                                              attributes: {
+                                                cancellation_reason: 'aaa',
+                                                cancellation_reason_comment: 'bbb',
+                                                notes: 'foo',
+                                              },
+                                            },
+                                          })
+    end
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => move.id,
+        'eventable_type' => 'Move',
+        'type' => 'GenericEvent::MoveCancel',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => { cancellation_reason: 'aaa', cancellation_reason_comment: 'bbb' },
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(
+        described_class.from_event(event).attributes,
+      ).to include_json(expected_generic_event_attributes)
+    end
+  end
+
   describe '#for_feed' do
     subject(:generic_event) { create(:event_move_cancel, details: details) }
 

--- a/spec/models/generic_event/move_complete_spec.rb
+++ b/spec/models/generic_event/move_complete_spec.rb
@@ -13,4 +13,40 @@ RSpec.describe GenericEvent::MoveComplete do
       expect { generic_event.trigger }.to change { generic_event.eventable.status }.from('requested').to('completed')
     end
   end
+
+  describe '.from_event' do
+    let(:move) { create(:move) }
+    let(:event) do
+      create(:event, :complete, :locations, eventable: move,
+                                            details: {
+                                              event_params: {
+                                                attributes: {
+                                                  notes: 'foo',
+                                                },
+                                              },
+                                            })
+    end
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => move.id,
+        'eventable_type' => 'Move',
+        'type' => 'GenericEvent::MoveComplete',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {},
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(
+        described_class.from_event(event).attributes,
+      ).to include_json(expected_generic_event_attributes)
+    end
+  end
 end

--- a/spec/models/generic_event/move_lockout_spec.rb
+++ b/spec/models/generic_event/move_lockout_spec.rb
@@ -45,4 +45,46 @@ RSpec.describe GenericEvent::MoveLockout do
       expect(generic_event.for_feed).to include_json(expected_json)
     end
   end
+
+  describe '.from_event' do
+    let(:move) { create(:move) }
+
+    let(:event) do
+      create(:event, :lockout, eventable: move,
+                               details: {
+                                 event_params: {
+                                   attributes: {
+                                     notes: 'notes',
+                                   },
+                                   relationships: {
+                                     from_location: { data: { id: move.from_location.id } },
+                                   },
+                                 },
+                               })
+    end
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => move.id,
+        'eventable_type' => 'Move',
+        'type' => 'GenericEvent::MoveLockout',
+        'notes' => 'notes',
+        'details' => {
+          'from_location_id' => move.from_location.id,
+        },
+        'created_by' => 'unknown',
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(
+        described_class.from_event(event).attributes,
+      ).to include_json(expected_generic_event_attributes)
+    end
+  end
 end

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -114,5 +114,49 @@ RSpec.describe GenericEvent::MoveRedirect do
         expect(generic_event.for_feed).to include_json(expected_json)
       end
     end
+
+    describe '.from_event' do
+      let(:move) { create(:move) }
+      let(:new_location) { create(:location) }
+      let(:event) do
+        create(:event, :redirect, :locations, eventable: move,
+                                              details: {
+                                                event_params: {
+                                                  attributes: {
+                                                    notes: 'foo',
+                                                    move_type: 'prison_transfer',
+                                                  },
+                                                  relationships: {
+                                                    to_location: { data: { id: move.from_location.id } },
+                                                  },
+                                                },
+                                              })
+      end
+
+      let(:expected_generic_event_attributes) do
+        {
+          'id' => nil,
+          'eventable_id' => move.id,
+          'eventable_type' => 'Move',
+          'type' => 'GenericEvent::MoveRedirect',
+          'notes' => 'foo',
+          'created_by' => 'unknown',
+          'details' => {
+            'to_location_id' => move.from_location.id,
+            'move_type' => 'prison_transfer',
+          },
+          'occurred_at' => eq(event.client_timestamp),
+          'recorded_at' => eq(event.client_timestamp),
+          'created_at' => be_within(0.1.seconds).of(event.created_at),
+          'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+        }
+      end
+
+      it 'builds a generic_event with the correct attributes' do
+        expect(
+          described_class.from_event(event).attributes,
+        ).to include_json(expected_generic_event_attributes)
+      end
+    end
   end
 end

--- a/spec/models/generic_event/move_reject_spec.rb
+++ b/spec/models/generic_event/move_reject_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe GenericEvent::MoveReject do
                                               attributes: {
                                                 rejection_reason: 'no_space_at_receiving_prison',
                                                 cancellation_reason_comment: 'a comment',
-                                                rebook: 'false',
+                                                rebook: false,
                                                 notes: 'foo',
                                               },
                                             },
@@ -119,6 +119,7 @@ RSpec.describe GenericEvent::MoveReject do
         'details' => {
           'rejection_reason' => 'no_space_at_receiving_prison',
           'cancellation_reason_comment' => 'a comment',
+          'rebook' => false,
         },
         'occurred_at' => eq(event.client_timestamp),
         'recorded_at' => eq(event.client_timestamp),

--- a/spec/models/generic_event/move_reject_spec.rb
+++ b/spec/models/generic_event/move_reject_spec.rb
@@ -91,4 +91,46 @@ RSpec.describe GenericEvent::MoveReject do
       end
     end
   end
+
+  describe '.from_event' do
+    let(:move) { create(:move) }
+    let(:event) do
+      create(:event, :reject, :locations, eventable: move,
+                                          details: {
+                                            event_params: {
+                                              attributes: {
+                                                rejection_reason: 'no_space_at_receiving_prison',
+                                                cancellation_reason_comment: 'a comment',
+                                                rebook: 'false',
+                                                notes: 'foo',
+                                              },
+                                            },
+                                          })
+    end
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => move.id,
+        'eventable_type' => 'Move',
+        'type' => 'GenericEvent::MoveReject',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {
+          'rejection_reason' => 'no_space_at_receiving_prison',
+          'cancellation_reason_comment' => 'a comment',
+        },
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(
+        described_class.from_event(event).attributes,
+      ).to include_json(expected_generic_event_attributes)
+    end
+  end
 end

--- a/spec/models/generic_event/move_start_spec.rb
+++ b/spec/models/generic_event/move_start_spec.rb
@@ -13,4 +13,41 @@ RSpec.describe GenericEvent::MoveStart do
       expect { generic_event.trigger }.to change { generic_event.eventable.status }.from('requested').to('in_transit')
     end
   end
+
+  describe '.from_event' do
+    let(:move) { create(:move) }
+
+    let(:event) do
+      create(:event, :start, :locations, eventable: move,
+                                         details: {
+                                           event_params: {
+                                             attributes: {
+                                               notes: 'foo',
+                                             },
+                                           },
+                                         })
+    end
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => move.id,
+        'eventable_type' => 'Move',
+        'type' => 'GenericEvent::MoveStart',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {},
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(
+        described_class.from_event(event).attributes,
+      ).to include_json(expected_generic_event_attributes)
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-2161

### What?
Adds move events builder: 

- [x] accept
- [x] approve
- [x] cancel
- [x] complete
- [x] lockouts
- [x] redirects
- [x] reject
- [x] start


### Why?

We need to avoid mutual dependencies during the migration to using generic_events table in the v1 endpoints to avoid issues with maintaining two tables in future.

