### PR TITLE
Add new endpoint for bulk update of PER framework responses

### DIFF
--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -101,6 +101,8 @@ class FrameworkResponse < VersionedModel
     SQL
   end
 
+  private_class_method :update_dependent_responses!, :descendants_tree, :recursive_tree
+
 private
 
   def set_responded_value

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -5,6 +5,9 @@ class FrameworkResponse < VersionedModel
 
   validates :type, presence: true
   validates :responded, inclusion: { in: [true, false] }
+  validates_each :value, on: :update do |record, _attr, value|
+    record.errors.add(:value, :blank) if requires_value?(value, record)
+  end
 
   belongs_to :framework_question
   belongs_to :person_escort_record
@@ -13,27 +16,17 @@ class FrameworkResponse < VersionedModel
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
   has_and_belongs_to_many :framework_flags, autosave: true
-  validates_each :value, on: :update do |record, _attr, value|
-    record.errors.add(:value, :blank) if requires_value?(value, record)
-  end
 
   after_validation :set_responded_value, on: :update
 
-  def self.requires_value?(value, record)
-    return false if value.present? || !record.framework_question.required
-
-    return true if record.parent.blank?
-
-    record.parent.option_selected?(record.framework_question.dependent_value)
-  end
-
   def update_with_flags!(value)
     ActiveRecord::Base.transaction do
-      old_value = self.value
       self.value = value
+      return unless value_text_changed? || value_json_changed?
 
-      update!(framework_flags: build_flags)
-      clear_dependent_values_and_flags!(old_value)
+      rebuild_flags
+      save!
+      self.class.clear_dependent_values_and_flags!([self])
 
       # lock the status update to avoid race condition on multiple response patches
       person_escort_record.with_lock do
@@ -50,31 +43,27 @@ class FrameworkResponse < VersionedModel
     end
   end
 
-private
-
-  def set_responded_value
-    self.responded = true
+  def rebuild_flags
+    self.framework_flags = framework_question.framework_flags.select { |flag| option_selected?(flag.question_value) }
   end
 
-  def build_flags
-    return [] unless framework_question.framework_flags.any?
+  def self.requires_value?(value, record)
+    return false if value.present? || !record.framework_question.required
 
-    framework_question.framework_flags.each_with_object([]) do |flag, arr|
-      if option_selected?(flag.question_value)
-        arr << flag
-      end
+    return true if record.parent.blank?
+
+    record.parent.option_selected?(record.framework_question.dependent_value)
+  end
+
+  def self.clear_dependent_values_and_flags!(responses_to_update)
+    all_dependent_ids = responses_to_update.map do |r|
+      r.dependents.includes(:framework_question, :parent).reject { |dependent| r.option_selected?(dependent.framework_question.dependent_value) }
     end
+
+    update_dependent_responses!(all_dependent_ids.flatten)
   end
 
-  def clear_dependent_values_and_flags!(old_value)
-    return unless old_value != value
-
-    dependent_ids = dependents.includes(:framework_question).reject { |dependent| option_selected?(dependent.framework_question.dependent_value) }
-
-    update_dependent_responses!(dependent_ids)
-  end
-
-  def update_dependent_responses!(dependent_ids)
+  def self.update_dependent_responses!(dependent_ids)
     return unless dependent_ids.any?
 
     descendants = descendants_tree(dependent_ids).includes(:framework_question, :framework_flags).map do |descendant|
@@ -87,15 +76,14 @@ private
       descendant
     end
 
-    FrameworkResponse.import(descendants, validate: false, recursive: true, all_or_none: true, on_duplicate_key_update: %i[value_json value_text responded])
+    import(descendants, validate: false, recursive: true, all_or_none: true, on_duplicate_key_update: %i[value_json value_text responded])
   end
 
-  def descendants_tree(ids)
-    FrameworkResponse
-      .where("framework_responses.id IN (#{recursive_tree})", ids)
+  def self.descendants_tree(ids)
+    where("framework_responses.id IN (#{recursive_tree})", ids)
   end
 
-  def recursive_tree
+  def self.recursive_tree
     # build full descendants tree
     <<-SQL
       WITH RECURSIVE tree AS (
@@ -112,5 +100,11 @@ private
 
       SELECT id FROM tree
     SQL
+  end
+
+private
+
+  def set_responded_value
+    self.responded = true
   end
 end

--- a/app/services/framework_responses/bulk_update_error.rb
+++ b/app/services/framework_responses/bulk_update_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FrameworkResponses
+  class BulkUpdateError < StandardError
+    attr_reader :errors
+
+    def initialize(errors)
+      super
+      @errors = errors
+    end
+  end
+end

--- a/app/services/framework_responses/bulk_updater.rb
+++ b/app/services/framework_responses/bulk_updater.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module FrameworkResponses
+  class BulkUpdater
+    attr_accessor :person_escort_record, :response_values_hash, :errors
+
+    def initialize(person_escort_record, response_values_hash)
+      self.person_escort_record = person_escort_record
+      self.response_values_hash = response_values_hash
+      self.errors = {}
+    end
+
+    def call
+      updated_responses = build_value_updates_list
+
+      raise BulkUpdateError.new(errors), 'Bulk update error' if errors.any?
+
+      # Ensure atomic behaviour as we don't want partial inconsistent updates
+      ActiveRecord::Base.transaction do
+        apply_bulk_response_changes(updated_responses)
+        apply_person_escort_record_changes
+      end
+    end
+
+  private
+
+    def build_value_updates_list
+      [].tap do |updated_responses|
+        validator = ActiveRecord::Import::Validator.new(FrameworkResponse)
+
+        FrameworkResponse.includes(framework_question: %i[framework_flags]).where(person_escort_record: person_escort_record).find(response_values_hash.keys).each do |response|
+          response.value = response_values_hash[response.id]
+          if validator.valid_model?(response)
+            updated_responses << response if response.changed?
+          else
+            errors[response.id] = response.errors.full_messages.first
+          end
+        rescue FrameworkResponse::ValueTypeError => e
+          errors[response.id] = "Value: #{e.message} is incorrect type"
+        end
+      end
+    end
+
+    def apply_bulk_response_changes(updated_responses)
+      # Bulk update all modified response values
+      FrameworkResponse.import(updated_responses, validate: false, on_duplicate_key_update: { conflict_target: [:id], columns: %i[value_text value_json responded] })
+
+      # Update associated flags for all modified response values
+      updated_flags = updated_responses.each(&:rebuild_flags)
+      FrameworkResponse.import(updated_flags, validate: false, recursive: true, all_or_none: true, on_duplicate_key_update: { conflict_target: [:id] })
+
+      # Clear dependent values for all modified response values
+      FrameworkResponse.clear_dependent_values_and_flags!(updated_responses)
+    end
+
+    def apply_person_escort_record_changes
+      # Update PER progress with revised responses
+      person_escort_record.update_status!
+    rescue FiniteMachine::InvalidStateError
+      raise ActiveRecord::ReadOnlyRecord, "Can't update framework_responses because person_escort_record is #{person_escort_record.status}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,11 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :person_escort_records, only: %i[create show update]
+    resources :person_escort_records, only: %i[create show update] do
+      member do
+        patch 'framework_responses', to: 'framework_responses#bulk_update'
+      end
+    end
     resources :framework_responses, only: %i[update]
 
     namespace :reference do

--- a/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Api::FrameworkResponsesController do
     let(:person_escort_record) { create(:person_escort_record, :in_progress) }
     let(:per_id) { person_escort_record.id }
 
-    let(:framework_response) { create(:string_response, person_escort_record: person_escort_record) }
-    let(:other_framework_response) { create(:string_response, person_escort_record: person_escort_record) }
+    let(:framework_response) { create(:string_response, person_escort_record: person_escort_record, value: 'No') }
+    let(:other_framework_response) { create(:string_response, person_escort_record: person_escort_record, value: 'Yes') }
     let(:framework_response_id) { framework_response.id }
     let(:other_framework_response_id) { other_framework_response.id }
 
@@ -132,55 +132,6 @@ RSpec.describe Api::FrameworkResponsesController do
         it 'updates response values' do
           expect(framework_response.reload.value).to eq(value.map(&:deep_stringify_keys))
           expect(other_framework_response.reload.value).to eq(other_value.map(&:deep_stringify_keys))
-        end
-      end
-
-      context 'when incorrect keys added to details collection responses' do
-        let(:framework_response) { create(:collection_response, :details, person_escort_record: person_escort_record) }
-        let(:other_framework_response) { create(:collection_response, :details, person_escort_record: person_escort_record) }
-        let(:value) { [{ option: 'Level 1', detailss: 'Some details' }] }
-        let(:other_value) { [{ option: 'Level 1', detailzz: 'Some details' }] }
-
-        it 'updates response values' do
-          expect(framework_response.reload.value).to eq([{ 'option' => 'Level 1', 'details' => nil }])
-          expect(other_framework_response.reload.value).to eq([{ 'option' => 'Level 1', 'details' => nil }])
-        end
-      end
-
-      context 'when incorrect keys added to multiple items collection responses' do
-        let(:framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
-        let(:other_framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
-        let(:framework_question) { framework_response.framework_question.dependents.first }
-        let(:other_framework_question) { other_framework_response.framework_question.dependents.first }
-
-        let(:value) do
-          [
-            { items: 1, responses: [{ value: ['Level 1'], framework_question_id: framework_question.id }] },
-            { item: 2, responses: [{ value: ['Level 2'], framework_question_id: framework_question.id }] },
-          ]
-        end
-        let(:other_value) do
-          [
-            { items: 1, responses: [{ value: ['Level 1'], framework_question_id: other_framework_question.id }] },
-            { item: 2, responses: [{ value: ['Level 2'], framework_question_id: other_framework_question.id }] },
-          ]
-        end
-
-        it 'updates response values' do
-          expect(framework_response.reload.value).to eq([{ 'item' => 2, 'responses' => [{ 'value' => ['Level 2'], 'framework_question_id' => framework_question.id }] }])
-          expect(other_framework_response.reload.value).to eq([{ 'item' => 2, 'responses' => [{ 'value' => ['Level 2'], 'framework_question_id' => other_framework_question.id }] }])
-        end
-      end
-
-      context 'when incorrect keys added to object responses' do
-        let(:framework_response) { create(:object_response, :details, person_escort_record: person_escort_record) }
-        let(:other_framework_response) { create(:object_response, :details, person_escort_record: person_escort_record) }
-        let(:value) { { option: 'Yes', detailss: 'Some details' } }
-        let(:other_value) { { option: 'No', detailzz: 'Some details' } }
-
-        it 'updates response values' do
-          expect(framework_response.reload.value).to eq({ 'option' => 'Yes', 'details' => nil })
-          expect(other_framework_response.reload.value).to eq({ 'option' => 'No', 'details' => nil })
         end
       end
     end

--- a/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::FrameworkResponsesController do
+  describe 'PATCH /person_escort_records/:per_id/framework_responses' do
+    include_context 'with supplier with spoofed access token'
+
+    subject(:bulk_update_framework_responses) do
+      patch "/api/person_escort_records/#{per_id}/framework_responses", params: bulk_per_params, headers: headers, as: :json
+    end
+
+    let(:schema) { load_yaml_schema('patch_framework_response_responses.yaml') }
+    let(:response_json) { JSON.parse(response.body) }
+    let(:person_escort_record) { create(:person_escort_record, :in_progress) }
+    let(:per_id) { person_escort_record.id }
+
+    let(:framework_response) { create(:string_response, person_escort_record: person_escort_record) }
+    let(:other_framework_response) { create(:string_response, person_escort_record: person_escort_record) }
+    let(:framework_response_id) { framework_response.id }
+    let(:other_framework_response_id) { other_framework_response.id }
+
+    let!(:flag) { create(:framework_flag, framework_question: framework_response.framework_question, question_value: 'Yes') }
+    let!(:other_flag) { create(:framework_flag, framework_question: other_framework_response.framework_question, question_value: 'No') }
+
+    let(:value) { 'Yes' }
+    let(:other_value) { 'No' }
+
+    let(:bulk_per_params) do
+      {
+        data: [
+          {
+            id: framework_response_id,
+            type: 'framework_responses',
+            attributes: {
+              value: value,
+            },
+          },
+          {
+            id: other_framework_response_id,
+            type: 'framework_responses',
+            attributes: {
+              value: other_value,
+            },
+          },
+        ],
+      }
+    end
+
+    context 'when successful' do
+      before { bulk_update_framework_responses }
+
+      it_behaves_like 'an endpoint that responds with success 204'
+
+      it 'updates PER status' do
+        expect(person_escort_record.reload.status).to eq('completed')
+      end
+
+      it 'attaches flags to the responses' do
+        expect(framework_response.framework_flags).to contain_exactly(flag)
+        expect(other_framework_response.framework_flags).to contain_exactly(other_flag)
+      end
+
+      context 'when responses are strings' do
+        it 'updates response values' do
+          expect(framework_response.reload.value).to eq(value)
+          expect(other_framework_response.reload.value).to eq(other_value)
+        end
+      end
+
+      context 'when responses are arrays' do
+        let(:framework_response) { create(:array_response, person_escort_record: person_escort_record) }
+        let(:other_framework_response) { create(:array_response, person_escort_record: person_escort_record) }
+        let(:value) { ['Level 1', 'Level 2'] }
+        let(:other_value) { ['Level 1'] }
+
+        it 'updates response values' do
+          expect(framework_response.reload.value).to eq(value)
+          expect(other_framework_response.reload.value).to eq(other_value)
+        end
+      end
+
+      context 'when responses are objects' do
+        let(:framework_response) { create(:object_response, :details, person_escort_record: person_escort_record) }
+        let(:other_framework_response) { create(:object_response, :details, person_escort_record: person_escort_record) }
+        let(:value) { { option: 'No', details: 'Some details' } }
+        let(:other_value) { { option: 'Yes', details: nil } }
+
+        it 'updates response values' do
+          expect(framework_response.reload.value).to eq(value.stringify_keys)
+          expect(other_framework_response.reload.value).to eq(other_value.stringify_keys)
+        end
+      end
+
+      context 'when responses are details collection' do
+        let(:framework_response) { create(:collection_response, :details, person_escort_record: person_escort_record) }
+        let(:other_framework_response) { create(:collection_response, :details, person_escort_record: person_escort_record) }
+        let(:value) { [{ option: 'Level 1', details: 'Some details' }, { option: 'Level 2', details: nil }] }
+        let(:other_value) { [{ option: 'Level 1', details: nil }, { option: 'Level 2', details: 'Some details' }] }
+
+        it 'updates response values' do
+          expect(framework_response.reload.value).to eq(value.map(&:stringify_keys))
+          expect(other_framework_response.reload.value).to eq(other_value.map(&:stringify_keys))
+        end
+      end
+
+      context 'when responses are multiple item collection' do
+        let(:framework_response) { create(:collection_response, :multiple_items, framework_question: question, value: nil, person_escort_record: person_escort_record) }
+        let(:other_framework_response) { create(:collection_response, :multiple_items, framework_question: question, value: nil, person_escort_record: person_escort_record) }
+        let(:question1) { create(:framework_question) }
+        let(:question2) { create(:framework_question, :checkbox) }
+        let(:question3) { create(:framework_question, :checkbox, followup_comment: true) }
+        let(:question4) { create(:framework_question, followup_comment: true) }
+        let(:question) { create(:framework_question, :add_multiple_items, dependents: [question1, question2, question3, question4]) }
+        let(:value) do
+          [
+            { item: 1, responses: [{ value: 'No', framework_question_id: question1.id }] },
+            { item: 2, responses: [{ value: ['Level 2'], framework_question_id: question2.id }] },
+            { item: 3, responses: [{ value: [{ option: 'Level 1', details: 'some detail' }], framework_question_id: question3.id }] },
+            { item: 4, responses: [{ value: { option: 'No', details: 'some detail' }, framework_question_id: question4.id }] },
+          ]
+        end
+        let(:other_value) do
+          [
+            { item: 1, responses: [{ value: 'Yes', framework_question_id: question1.id }] },
+            { item: 2, responses: [{ value: ['Level 2'], framework_question_id: question2.id }] },
+            { item: 3, responses: [{ value: [{ option: 'Level 1', details: nil }], framework_question_id: question3.id }] },
+            { item: 4, responses: [{ value: { option: 'Yes', details: nil }, framework_question_id: question4.id }] },
+          ]
+        end
+
+        it 'updates response values' do
+          expect(framework_response.reload.value).to eq(value.map(&:deep_stringify_keys))
+          expect(other_framework_response.reload.value).to eq(other_value.map(&:deep_stringify_keys))
+        end
+      end
+
+      context 'when incorrect keys added to details collection responses' do
+        let(:framework_response) { create(:collection_response, :details, person_escort_record: person_escort_record) }
+        let(:other_framework_response) { create(:collection_response, :details, person_escort_record: person_escort_record) }
+        let(:value) { [{ option: 'Level 1', detailss: 'Some details' }] }
+        let(:other_value) { [{ option: 'Level 1', detailzz: 'Some details' }] }
+
+        it 'updates response values' do
+          expect(framework_response.reload.value).to eq([{ 'option' => 'Level 1', 'details' => nil }])
+          expect(other_framework_response.reload.value).to eq([{ 'option' => 'Level 1', 'details' => nil }])
+        end
+      end
+
+      context 'when incorrect keys added to multiple items collection responses' do
+        let(:framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
+        let(:other_framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
+        let(:framework_question) { framework_response.framework_question.dependents.first }
+        let(:other_framework_question) { other_framework_response.framework_question.dependents.first }
+
+        let(:value) do
+          [
+            { items: 1, responses: [{ value: ['Level 1'], framework_question_id: framework_question.id }] },
+            { item: 2, responses: [{ value: ['Level 2'], framework_question_id: framework_question.id }] },
+          ]
+        end
+        let(:other_value) do
+          [
+            { items: 1, responses: [{ value: ['Level 1'], framework_question_id: other_framework_question.id }] },
+            { item: 2, responses: [{ value: ['Level 2'], framework_question_id: other_framework_question.id }] },
+          ]
+        end
+
+        it 'updates response values' do
+          expect(framework_response.reload.value).to eq([{ 'item' => 2, 'responses' => [{ 'value' => ['Level 2'], 'framework_question_id' => framework_question.id }] }])
+          expect(other_framework_response.reload.value).to eq([{ 'item' => 2, 'responses' => [{ 'value' => ['Level 2'], 'framework_question_id' => other_framework_question.id }] }])
+        end
+      end
+
+      context 'when incorrect keys added to object responses' do
+        let(:framework_response) { create(:object_response, :details, person_escort_record: person_escort_record) }
+        let(:other_framework_response) { create(:object_response, :details, person_escort_record: person_escort_record) }
+        let(:value) { { option: 'Yes', detailss: 'Some details' } }
+        let(:other_value) { { option: 'No', detailzz: 'Some details' } }
+
+        it 'updates response values' do
+          expect(framework_response.reload.value).to eq({ 'option' => 'Yes', 'details' => nil })
+          expect(other_framework_response.reload.value).to eq({ 'option' => 'No', 'details' => nil })
+        end
+      end
+    end
+
+    context 'when unsuccessful' do
+      before { bulk_update_framework_responses }
+
+      context 'with a bad request' do
+        let(:bulk_per_params) { nil }
+
+        it_behaves_like 'an endpoint that responds with error 400'
+      end
+
+      context 'when the person_escort_record_id is not found' do
+        let(:per_id) { 'foo-bar' }
+        let(:detail_404) { "Couldn't find PersonEscortRecord with 'id'=foo-bar" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+
+      context 'with invalid values' do
+        let(:value) { 'foo-bar' }
+        let(:other_value) { 'bar-baz' }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [
+              {
+                'id' => framework_response_id,
+                'title' => 'Invalid value',
+                'detail' => 'Value is not included in the list',
+              },
+              {
+                'id' => other_framework_response_id,
+                'title' => 'Invalid value',
+                'detail' => 'Value is not included in the list',
+              },
+            ]
+          end
+        end
+      end
+
+      context 'with incorrect value type' do
+        let(:value) { %w[foo-bar] }
+        let(:other_value) { %w[bar-baz] }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [
+              {
+                'id' => framework_response_id,
+                'title' => 'Invalid value',
+                'detail' => 'Value: ["foo-bar"] is incorrect type',
+                'source' => { pointer: '/data/attributes/value' },
+              },
+              {
+                'id' => other_framework_response_id,
+                'title' => 'Invalid value',
+                'detail' => 'Value: ["bar-baz"] is incorrect type',
+                'source' => { pointer: '/data/attributes/value' },
+              },
+            ]
+          end
+        end
+      end
+
+      context 'with a nested invalid value' do
+        let(:framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
+        let(:framework_question) { framework_response.framework_question.dependents.first }
+        let(:other_framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
+        let(:other_framework_question) { other_framework_response.framework_question.dependents.first }
+
+        let(:value) do
+          [
+            { item: 1, responses: [{ value: ['Level 1'], framework_question_id: framework_question.id }] },
+            { item: 2, responses: [{ value: ['Level 3'], framework_question_id: framework_question.id }] },
+            { item: 3, responses: [{ value: ['Level 2'], framework_question_id: framework_question.id }] },
+          ]
+        end
+        let(:other_value) do
+          [
+            { item: 1, responses: [{ value: ['Level 1'], framework_question_id: other_framework_question.id }] },
+            { item: 2, responses: [{ value: ['Level 3'], framework_question_id: other_framework_question.id }] },
+            { item: 3, responses: [{ value: ['Level 2'], framework_question_id: other_framework_question.id }] },
+          ]
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [
+              {
+                'id' => framework_response_id,
+                'title' => 'Invalid value',
+                'detail' => 'Items[1] responses[0] value Level 3 are not valid options',
+              },
+              {
+                'id' => other_framework_response_id,
+                'title' => 'Invalid value',
+                'detail' => 'Items[1] responses[0] value Level 3 are not valid options',
+              },
+            ]
+          end
+        end
+      end
+
+      context 'with a nested incorrect value type' do
+        let(:framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
+        let(:framework_question) { framework_response.framework_question.dependents.first }
+        let(:other_framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
+        let(:other_framework_question) { other_framework_response.framework_question.dependents.first }
+
+        let(:value) do
+          [
+            { item: 1, responses: [{ value: ['Level 1'], framework_question_id: framework_question.id }] },
+            { item: 2, responses: [{ value: 'Level 2', framework_question_id: framework_question.id }] },
+            { item: 3, responses: [{ value: ['Level 2'], framework_question_id: framework_question.id }] },
+          ]
+        end
+        let(:other_value) do
+          [
+            { item: 1, responses: [{ value: ['Level 1'], framework_question_id: other_framework_question.id }] },
+            { item: 2, responses: [{ value: 'Level 2', framework_question_id: other_framework_question.id }] },
+            { item: 3, responses: [{ value: ['Level 2'], framework_question_id: other_framework_question.id }] },
+          ]
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [
+              {
+                'id' => framework_response_id,
+                'title' => 'Invalid value',
+                'detail' => 'Value: Level 2 is incorrect type',
+                'source' => { pointer: '/data/attributes/value' },
+              },
+              {
+                'id' => other_framework_response_id,
+                'title' => 'Invalid value',
+                'detail' => 'Value: Level 2 is incorrect type',
+                'source' => { pointer: '/data/attributes/value' },
+              },
+            ]
+          end
+        end
+      end
+
+      context 'when person_escort_record confirmed' do
+        let(:person_escort_record) { create(:person_escort_record, :confirmed) }
+        let(:detail_403) { "Can't update framework_responses because person_escort_record is confirmed" }
+
+        it_behaves_like 'an endpoint that responds with error 403'
+      end
+
+      context 'when the framework_response_id is not found' do
+        let(:framework_response_id) { 'foo' }
+        let(:other_framework_response_id) { 'bar' }
+        let(:detail_404) { "Couldn't find FrameworkResponse with 'id'=[\"foo\", \"bar\"]" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+    end
+  end
+end

--- a/spec/services/framework_responses/bulk_updater_spec.rb
+++ b/spec/services/framework_responses/bulk_updater_spec.rb
@@ -1,0 +1,305 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkResponses::BulkUpdater do
+  it 'updates response value' do
+    per = create(:person_escort_record)
+    response = create(:string_response, person_escort_record: per, value: nil)
+    described_class.new(per, { response.id => 'Yes' }).call
+
+    expect(response.reload.value).to eq('Yes')
+  end
+
+  it 'does not attach flags if no flags attached to question' do
+    per = create(:person_escort_record)
+    create(:framework_flag)
+    response = create(:string_response, person_escort_record: per)
+    described_class.new(per, { response.id => 'Yes' }).call
+
+    expect(response.reload.framework_flags).to be_empty
+  end
+
+  it 'does not attach flags if answer supplied does not match flag' do
+    per = create(:person_escort_record)
+    flag = create(:framework_flag)
+    response = create(:string_response, value: nil, framework_question: flag.framework_question, person_escort_record: per)
+    described_class.new(per, { response.id => 'No' }).call
+
+    expect(response.reload.framework_flags).to be_empty
+  end
+
+  it 'attaches flags if answer supplied matches flag for string' do
+    per = create(:person_escort_record)
+    flag = create(:framework_flag)
+    response = create(:string_response, value: nil, framework_question: flag.framework_question, person_escort_record: per)
+    described_class.new(per, { response.id => 'Yes' }).call
+
+    expect(response.reload.framework_flags).to contain_exactly(flag)
+  end
+
+  it 'attaches flags if answer supplied matches flag for array' do
+    per = create(:person_escort_record)
+    response = create(:array_response, value: nil, person_escort_record: per)
+    flag = create(:framework_flag, question_value: 'Level 1', framework_question: response.framework_question)
+    described_class.new(per, { response.id => ['Level 1', 'Level 2'] }).call
+
+    expect(response.reload.framework_flags).to contain_exactly(flag)
+  end
+
+  it 'attaches flags if answer supplied matches flag for object' do
+    per = create(:person_escort_record)
+    response = create(:object_response, :details, value: nil, person_escort_record: per)
+    flag = create(:framework_flag, question_value: 'Yes', framework_question: response.framework_question)
+    described_class.new(per, { response.id => { option: 'Yes', details: 'something' } }).call
+
+    expect(response.reload.framework_flags).to contain_exactly(flag)
+  end
+
+  it 'attaches flags if answer supplied matches flag for collection' do
+    per = create(:person_escort_record)
+    response = create(:collection_response, :details, value: nil, person_escort_record: per)
+    flag = create(:framework_flag, question_value: 'Level 1', framework_question: response.framework_question)
+    described_class.new(per, { response.id => [{ option: 'Level 1', details: 'something' }] }).call
+
+    expect(response.reload.framework_flags).to contain_exactly(flag)
+  end
+
+  it 'attaches multiple flags if answer supplied matches flag' do
+    per = create(:person_escort_record)
+    framework_question = create(:framework_question)
+    flag1 = create(:framework_flag, framework_question: framework_question)
+    flag2 = create(:framework_flag, framework_question: framework_question)
+    response = create(:string_response, value: nil, framework_question: framework_question, person_escort_record: per)
+    described_class.new(per, { response.id => 'Yes' }).call
+
+    expect(response.reload.framework_flags).to contain_exactly(flag1, flag2)
+  end
+
+  it 'detaches flag if answer changed' do
+    per = create(:person_escort_record)
+    framework_question = create(:framework_question)
+    flag1 = create(:framework_flag, framework_question: framework_question)
+    flag2 = create(:framework_flag, framework_question: framework_question)
+    response = create(:string_response, framework_question: framework_question, framework_flags: [flag1, flag2], person_escort_record: per)
+    described_class.new(per, { response.id => 'No' }).call
+
+    expect(response.reload.framework_flags).to be_empty
+  end
+
+  it 'attaches another flag if answer changed' do
+    per = create(:person_escort_record)
+    framework_question = create(:framework_question)
+    flag1 = create(:framework_flag, framework_question: framework_question)
+    flag2 = create(:framework_flag, question_value: 'No', framework_question: framework_question)
+    response = create(:string_response, framework_question: framework_question, framework_flags: [flag1], person_escort_record: per)
+    described_class.new(per, { response.id => 'No' }).call
+
+    expect(response.reload.framework_flags).to contain_exactly(flag2)
+  end
+
+  context 'when dependent responses' do
+    it 'clears dependent responses if value changed' do
+      per = create(:person_escort_record)
+      parent_response = create(:string_response, person_escort_record: per)
+      child1_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
+      child2_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
+      child_response1 = create(:string_response, framework_question: child1_question, parent: parent_response, person_escort_record: per)
+      child_response2 = create(:string_response, framework_question: child2_question, parent: parent_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => 'No' }).call
+
+      [child_response1, child_response2].each do |response|
+        expect(response.reload.value).to be_nil
+      end
+    end
+
+    it 'does not clear value of current response' do
+      per = create(:person_escort_record)
+      parent_response = create(:string_response, person_escort_record: per)
+      child_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
+      create(:string_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => 'No' }).call
+
+      expect(parent_response.reload.value).to eq('No')
+    end
+
+    it 'clears dependent responses if value changed on array' do
+      per = create(:person_escort_record)
+      parent_response = create(:array_response, person_escort_record: per)
+      child_question = create(:framework_question, :checkbox, dependent_value: 'Level 1', parent: parent_response.framework_question)
+      child_response = create(:array_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => ['Level 2'] }).call
+
+      expect(child_response.reload.value).to be_empty
+    end
+
+    it 'clears dependent responses if value changed on object' do
+      per = create(:person_escort_record)
+      parent_response = create(:object_response, :details, person_escort_record: per)
+      child_question = create(:framework_question, followup_comment: true, dependent_value: 'Yes', parent: parent_response.framework_question)
+      child_response = create(:object_response, :details, framework_question: child_question, parent: parent_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => { option: 'No' } }).call
+
+      expect(child_response.reload.value).to be_empty
+    end
+
+    it 'clears dependent responses if value changed on collection' do
+      per = create(:person_escort_record)
+      parent_response = create(:collection_response, :details, person_escort_record: per)
+      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => [option: 'Level 2'] }).call
+
+      expect(child_response.reload.value).to be_empty
+    end
+
+    it 'does not clear dependent responses if value similar' do
+      per = create(:person_escort_record)
+      parent_response = create(:string_response, person_escort_record: per)
+      child_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
+      child_response = create(:string_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => 'Yes' }).call
+
+      expect(child_response.reload.value).to eq('Yes')
+    end
+
+    it 'does not clear dependent responses if value similar on array' do
+      per = create(:person_escort_record)
+      parent_response = create(:array_response, person_escort_record: per)
+      child_question = create(:framework_question, :checkbox, dependent_value: 'Level 1', parent: parent_response.framework_question)
+      child_response = create(:array_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => ['Level 1', 'Level 2'] }).call
+
+      expect(child_response.reload.value).to eq(['Level 1'])
+    end
+
+    it 'does not clear dependent responses if value similar on object' do
+      per = create(:person_escort_record)
+      parent_response = create(:object_response, :details, person_escort_record: per)
+      child_question = create(:framework_question, followup_comment: true, dependent_value: 'Yes', parent: parent_response.framework_question)
+      child_response = create(:object_response, :details, framework_question: child_question, parent: parent_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => { option: 'Yes' } }).call
+
+      expect(child_response.reload.value).to eq('option' => 'Yes', 'details' => 'some comment')
+    end
+
+    it 'does not clear dependent responses if value similar on collection' do
+      per = create(:person_escort_record)
+      parent_response = create(:collection_response, :details, person_escort_record: per)
+      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => [{ option: 'Level 1' }, { option: 'Level 2' }] }).call
+
+      expect(child_response.reload.value).to contain_exactly(
+        { 'option' => 'Level 1', 'details' => 'some comment' },
+        { 'option' => 'Level 2', 'details' => 'another comment' },
+      )
+    end
+
+    it 'clears all hierarchy of dependent responses' do
+      per = create(:person_escort_record)
+      parent_response = create(:string_response, person_escort_record: per)
+      child_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
+      grand_child_question1 = create(:framework_question, dependent_value: 'Yes', parent: child_question)
+      grand_child_question2 = create(:framework_question, dependent_value: 'No', parent: child_question)
+      child_response = create(:string_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
+      grand_child_response1 = create(:string_response, framework_question: grand_child_question1, parent: child_response, person_escort_record: per)
+      grand_child_response2 = create(:string_response, framework_question: grand_child_question2, parent: child_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => 'No' }).call
+
+      [grand_child_response1, grand_child_response2].each do |response|
+        expect(response.reload.value).to be_nil
+      end
+    end
+
+    it 'clears only relevant dependent responses according to dependent value' do
+      per = create(:person_escort_record)
+      parent_response = create(:array_response, person_escort_record: per)
+      child1_question = create(:framework_question, dependent_value: 'Level 1', parent: parent_response.framework_question)
+      child2_question = create(:framework_question, dependent_value: 'Level 2', parent: parent_response.framework_question)
+      create(:string_response, framework_question: child1_question, parent: parent_response, person_escort_record: per)
+      child_response = create(:string_response, framework_question: child2_question, parent: parent_response, person_escort_record: per)
+      described_class.new(per, { parent_response.id => ['Level 2'] }).call
+
+      expect(child_response.reload.value).to eq('Yes')
+    end
+
+    it 'does not clear dependent values if record invalid' do
+      per = create(:person_escort_record)
+      parent_response = create(:array_response, person_escort_record: per)
+      child_question = create(:framework_question, :checkbox, dependent_value: 'Level 1', parent: parent_response.framework_question)
+      child_response = create(:array_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
+
+      expect { described_class.new(per, { parent_response.id => 'Level 2' }).call }.to raise_error(FrameworkResponses::BulkUpdateError)
+      expect(child_response.reload.value).to eq(['Level 1'])
+    end
+
+    it 'clears flags on dependent responses if value changed' do
+      per = create(:person_escort_record)
+      parent_response = create(:collection_response, :details, person_escort_record: per)
+      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, framework_flags: [create(:framework_flag)], person_escort_record: per)
+      described_class.new(per, { parent_response.id => [option: 'Level 2'] }).call
+
+      expect(child_response.reload.framework_flags).to be_empty
+    end
+
+    it 'does not clear flags on dependent responses if value not changed' do
+      per = create(:person_escort_record)
+      parent_response = create(:collection_response, :details, person_escort_record: per)
+      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+      flag = create(:framework_flag)
+      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, framework_flags: [flag], person_escort_record: per)
+      described_class.new(per, { parent_response.id => [option: 'Level 1'] }).call
+
+      expect(child_response.reload.framework_flags).to contain_exactly(flag)
+    end
+
+    it 'sets responded to false on dependent responses if value changed' do
+      per = create(:person_escort_record)
+      parent_response = create(:collection_response, :details, person_escort_record: per)
+      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, responded: true, person_escort_record: per)
+      described_class.new(per, { parent_response.id => [option: 'Level 2'] }).call
+
+      expect(child_response.reload.responded).to be(false)
+    end
+
+    it 'does not set responded to false on dependent responses if value not changed' do
+      per = create(:person_escort_record)
+      parent_response = create(:collection_response, :details, person_escort_record: per)
+      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, responded: true, person_escort_record: per)
+      described_class.new(per, { parent_response.id => [option: 'Level 1'] }).call
+
+      expect(child_response.reload.responded).to be(true)
+    end
+  end
+
+  context 'with person_escort_record status' do
+    it 'does not change person escort record status answers provided invalid' do
+      per = create(:person_escort_record)
+      response = create(:string_response, value: nil, person_escort_record: per)
+
+      expect { described_class.new(per, { response.id => %w[Yes] }).call }.to raise_error(FrameworkResponses::BulkUpdateError)
+      expect(per.reload).to be_unstarted
+    end
+
+    it 'updates person escort record status if some answers provided' do
+      per = create(:person_escort_record)
+      response1 = create(:string_response, value: nil, person_escort_record: per)
+      create(:string_response, value: nil, person_escort_record: per)
+      described_class.new(per, { response1.id => 'Yes' }).call
+
+      expect(per.reload).to be_in_progress
+    end
+
+    it 'does not allow updating responses if person_escort_record status is confirmed' do
+      per = create(:person_escort_record, :confirmed, :with_responses)
+      response = per.framework_responses.first
+
+      expect { described_class.new(per, { response.id => 'No' }).call }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      expect(response.reload.value).to eq('Yes')
+    end
+  end
+end

--- a/spec/services/framework_responses/bulk_updater_spec.rb
+++ b/spec/services/framework_responses/bulk_updater_spec.rb
@@ -3,77 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe FrameworkResponses::BulkUpdater do
-  it 'updates response value' do
+  it 'marks values as responded' do
     per = create(:person_escort_record)
-    response = create(:string_response, person_escort_record: per, value: nil)
-    described_class.new(per, { response.id => 'Yes' }).call
+    response1 = create(:string_response, person_escort_record: per, value: nil)
+    response2 = create(:string_response, person_escort_record: per, value: nil)
+    described_class.new(per, { response1.id => 'Yes', response2.id => 'No' }).call
 
-    expect(response.reload.value).to eq('Yes')
+    expect(response1.reload).to be_responded
+    expect(response2.reload).to be_responded
   end
 
-  it 'does not attach flags if no flags attached to question' do
+  it 'updates response values' do
     per = create(:person_escort_record)
-    create(:framework_flag)
-    response = create(:string_response, person_escort_record: per)
-    described_class.new(per, { response.id => 'Yes' }).call
+    response1 = create(:string_response, person_escort_record: per, value: nil)
+    response2 = create(:string_response, person_escort_record: per, value: nil)
+    described_class.new(per, { response1.id => 'Yes', response2.id => 'No' }).call
 
-    expect(response.reload.framework_flags).to be_empty
-  end
-
-  it 'does not attach flags if answer supplied does not match flag' do
-    per = create(:person_escort_record)
-    flag = create(:framework_flag)
-    response = create(:string_response, value: nil, framework_question: flag.framework_question, person_escort_record: per)
-    described_class.new(per, { response.id => 'No' }).call
-
-    expect(response.reload.framework_flags).to be_empty
+    expect(response1.reload.value).to eq('Yes')
+    expect(response2.reload.value).to eq('No')
   end
 
   it 'attaches flags if answer supplied matches flag for string' do
     per = create(:person_escort_record)
-    flag = create(:framework_flag)
-    response = create(:string_response, value: nil, framework_question: flag.framework_question, person_escort_record: per)
-    described_class.new(per, { response.id => 'Yes' }).call
+    flag1 = create(:framework_flag)
+    flag2 = create(:framework_flag)
+    response1 = create(:string_response, value: nil, framework_question: flag1.framework_question, person_escort_record: per)
+    response2 = create(:string_response, value: nil, framework_question: flag2.framework_question, person_escort_record: per)
+    described_class.new(per, { response1.id => 'Yes', response2.id => 'No' }).call
 
-    expect(response.reload.framework_flags).to contain_exactly(flag)
-  end
-
-  it 'attaches flags if answer supplied matches flag for array' do
-    per = create(:person_escort_record)
-    response = create(:array_response, value: nil, person_escort_record: per)
-    flag = create(:framework_flag, question_value: 'Level 1', framework_question: response.framework_question)
-    described_class.new(per, { response.id => ['Level 1', 'Level 2'] }).call
-
-    expect(response.reload.framework_flags).to contain_exactly(flag)
-  end
-
-  it 'attaches flags if answer supplied matches flag for object' do
-    per = create(:person_escort_record)
-    response = create(:object_response, :details, value: nil, person_escort_record: per)
-    flag = create(:framework_flag, question_value: 'Yes', framework_question: response.framework_question)
-    described_class.new(per, { response.id => { option: 'Yes', details: 'something' } }).call
-
-    expect(response.reload.framework_flags).to contain_exactly(flag)
-  end
-
-  it 'attaches flags if answer supplied matches flag for collection' do
-    per = create(:person_escort_record)
-    response = create(:collection_response, :details, value: nil, person_escort_record: per)
-    flag = create(:framework_flag, question_value: 'Level 1', framework_question: response.framework_question)
-    described_class.new(per, { response.id => [{ option: 'Level 1', details: 'something' }] }).call
-
-    expect(response.reload.framework_flags).to contain_exactly(flag)
-  end
-
-  it 'attaches multiple flags if answer supplied matches flag' do
-    per = create(:person_escort_record)
-    framework_question = create(:framework_question)
-    flag1 = create(:framework_flag, framework_question: framework_question)
-    flag2 = create(:framework_flag, framework_question: framework_question)
-    response = create(:string_response, value: nil, framework_question: framework_question, person_escort_record: per)
-    described_class.new(per, { response.id => 'Yes' }).call
-
-    expect(response.reload.framework_flags).to contain_exactly(flag1, flag2)
+    expect(response1.reload.framework_flags).to contain_exactly(flag1)
+    expect(response2.reload.framework_flags).to be_empty
   end
 
   it 'detaches flag if answer changed' do
@@ -81,198 +40,49 @@ RSpec.describe FrameworkResponses::BulkUpdater do
     framework_question = create(:framework_question)
     flag1 = create(:framework_flag, framework_question: framework_question)
     flag2 = create(:framework_flag, framework_question: framework_question)
-    response = create(:string_response, framework_question: framework_question, framework_flags: [flag1, flag2], person_escort_record: per)
-    described_class.new(per, { response.id => 'No' }).call
+    response1 = create(:string_response, framework_question: framework_question, framework_flags: [flag1, flag2], person_escort_record: per)
+    response2 = create(:string_response, framework_question: framework_question, framework_flags: [flag1, flag2], person_escort_record: per)
+    described_class.new(per, { response1.id => 'No', response2.id => 'Yes' }).call
 
-    expect(response.reload.framework_flags).to be_empty
-  end
-
-  it 'attaches another flag if answer changed' do
-    per = create(:person_escort_record)
-    framework_question = create(:framework_question)
-    flag1 = create(:framework_flag, framework_question: framework_question)
-    flag2 = create(:framework_flag, question_value: 'No', framework_question: framework_question)
-    response = create(:string_response, framework_question: framework_question, framework_flags: [flag1], person_escort_record: per)
-    described_class.new(per, { response.id => 'No' }).call
-
-    expect(response.reload.framework_flags).to contain_exactly(flag2)
+    expect(response1.reload.framework_flags).to be_empty
+    expect(response2.reload.framework_flags).to contain_exactly(flag1, flag2)
   end
 
   context 'when dependent responses' do
     it 'clears dependent responses if value changed' do
       per = create(:person_escort_record)
-      parent_response = create(:string_response, person_escort_record: per)
-      child1_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
-      child2_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
-      child_response1 = create(:string_response, framework_question: child1_question, parent: parent_response, person_escort_record: per)
-      child_response2 = create(:string_response, framework_question: child2_question, parent: parent_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => 'No' }).call
+      parent1_response = create(:string_response, person_escort_record: per)
+      parent2_response = create(:string_response, person_escort_record: per)
+      child1_question = create(:framework_question, dependent_value: 'Yes', parent: parent1_response.framework_question)
+      child2_question = create(:framework_question, dependent_value: 'Yes', parent: parent2_response.framework_question)
+      child_response1 = create(:string_response, framework_question: child1_question, parent: parent1_response, person_escort_record: per)
+      child_response2 = create(:string_response, framework_question: child2_question, parent: parent2_response, person_escort_record: per)
+      described_class.new(per, { parent1_response.id => 'No', parent2_response.id => 'No' }).call
 
       [child_response1, child_response2].each do |response|
         expect(response.reload.value).to be_nil
       end
     end
+  end
 
-    it 'does not clear value of current response' do
+  context 'with validation error' do
+    it 'raises BulkUpdateErrors' do
       per = create(:person_escort_record)
-      parent_response = create(:string_response, person_escort_record: per)
-      child_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
-      create(:string_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => 'No' }).call
+      response1 = create(:string_response, person_escort_record: per, value: nil)
+      response2 = create(:string_response, person_escort_record: per, value: nil)
 
-      expect(parent_response.reload.value).to eq('No')
+      expect { described_class.new(per, { response1.id => 'Foo', response2.id => 'No' }).call }.to raise_error(FrameworkResponses::BulkUpdateError)
     end
 
-    it 'clears dependent responses if value changed on array' do
+    it 'does not update responses' do
       per = create(:person_escort_record)
-      parent_response = create(:array_response, person_escort_record: per)
-      child_question = create(:framework_question, :checkbox, dependent_value: 'Level 1', parent: parent_response.framework_question)
-      child_response = create(:array_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => ['Level 2'] }).call
+      response1 = create(:string_response, person_escort_record: per, value: nil)
+      response2 = create(:string_response, person_escort_record: per, value: nil)
+      described_class.new(per, { response1.id => 'Foo', response2.id => 'No' }).call
 
-      expect(child_response.reload.value).to be_empty
-    end
-
-    it 'clears dependent responses if value changed on object' do
-      per = create(:person_escort_record)
-      parent_response = create(:object_response, :details, person_escort_record: per)
-      child_question = create(:framework_question, followup_comment: true, dependent_value: 'Yes', parent: parent_response.framework_question)
-      child_response = create(:object_response, :details, framework_question: child_question, parent: parent_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => { option: 'No' } }).call
-
-      expect(child_response.reload.value).to be_empty
-    end
-
-    it 'clears dependent responses if value changed on collection' do
-      per = create(:person_escort_record)
-      parent_response = create(:collection_response, :details, person_escort_record: per)
-      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
-      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => [option: 'Level 2'] }).call
-
-      expect(child_response.reload.value).to be_empty
-    end
-
-    it 'does not clear dependent responses if value similar' do
-      per = create(:person_escort_record)
-      parent_response = create(:string_response, person_escort_record: per)
-      child_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
-      child_response = create(:string_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => 'Yes' }).call
-
-      expect(child_response.reload.value).to eq('Yes')
-    end
-
-    it 'does not clear dependent responses if value similar on array' do
-      per = create(:person_escort_record)
-      parent_response = create(:array_response, person_escort_record: per)
-      child_question = create(:framework_question, :checkbox, dependent_value: 'Level 1', parent: parent_response.framework_question)
-      child_response = create(:array_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => ['Level 1', 'Level 2'] }).call
-
-      expect(child_response.reload.value).to eq(['Level 1'])
-    end
-
-    it 'does not clear dependent responses if value similar on object' do
-      per = create(:person_escort_record)
-      parent_response = create(:object_response, :details, person_escort_record: per)
-      child_question = create(:framework_question, followup_comment: true, dependent_value: 'Yes', parent: parent_response.framework_question)
-      child_response = create(:object_response, :details, framework_question: child_question, parent: parent_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => { option: 'Yes' } }).call
-
-      expect(child_response.reload.value).to eq('option' => 'Yes', 'details' => 'some comment')
-    end
-
-    it 'does not clear dependent responses if value similar on collection' do
-      per = create(:person_escort_record)
-      parent_response = create(:collection_response, :details, person_escort_record: per)
-      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
-      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => [{ option: 'Level 1' }, { option: 'Level 2' }] }).call
-
-      expect(child_response.reload.value).to contain_exactly(
-        { 'option' => 'Level 1', 'details' => 'some comment' },
-        { 'option' => 'Level 2', 'details' => 'another comment' },
-      )
-    end
-
-    it 'clears all hierarchy of dependent responses' do
-      per = create(:person_escort_record)
-      parent_response = create(:string_response, person_escort_record: per)
-      child_question = create(:framework_question, dependent_value: 'Yes', parent: parent_response.framework_question)
-      grand_child_question1 = create(:framework_question, dependent_value: 'Yes', parent: child_question)
-      grand_child_question2 = create(:framework_question, dependent_value: 'No', parent: child_question)
-      child_response = create(:string_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
-      grand_child_response1 = create(:string_response, framework_question: grand_child_question1, parent: child_response, person_escort_record: per)
-      grand_child_response2 = create(:string_response, framework_question: grand_child_question2, parent: child_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => 'No' }).call
-
-      [grand_child_response1, grand_child_response2].each do |response|
-        expect(response.reload.value).to be_nil
-      end
-    end
-
-    it 'clears only relevant dependent responses according to dependent value' do
-      per = create(:person_escort_record)
-      parent_response = create(:array_response, person_escort_record: per)
-      child1_question = create(:framework_question, dependent_value: 'Level 1', parent: parent_response.framework_question)
-      child2_question = create(:framework_question, dependent_value: 'Level 2', parent: parent_response.framework_question)
-      create(:string_response, framework_question: child1_question, parent: parent_response, person_escort_record: per)
-      child_response = create(:string_response, framework_question: child2_question, parent: parent_response, person_escort_record: per)
-      described_class.new(per, { parent_response.id => ['Level 2'] }).call
-
-      expect(child_response.reload.value).to eq('Yes')
-    end
-
-    it 'does not clear dependent values if record invalid' do
-      per = create(:person_escort_record)
-      parent_response = create(:array_response, person_escort_record: per)
-      child_question = create(:framework_question, :checkbox, dependent_value: 'Level 1', parent: parent_response.framework_question)
-      child_response = create(:array_response, framework_question: child_question, parent: parent_response, person_escort_record: per)
-
-      expect { described_class.new(per, { parent_response.id => 'Level 2' }).call }.to raise_error(FrameworkResponses::BulkUpdateError)
-      expect(child_response.reload.value).to eq(['Level 1'])
-    end
-
-    it 'clears flags on dependent responses if value changed' do
-      per = create(:person_escort_record)
-      parent_response = create(:collection_response, :details, person_escort_record: per)
-      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
-      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, framework_flags: [create(:framework_flag)], person_escort_record: per)
-      described_class.new(per, { parent_response.id => [option: 'Level 2'] }).call
-
-      expect(child_response.reload.framework_flags).to be_empty
-    end
-
-    it 'does not clear flags on dependent responses if value not changed' do
-      per = create(:person_escort_record)
-      parent_response = create(:collection_response, :details, person_escort_record: per)
-      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
-      flag = create(:framework_flag)
-      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, framework_flags: [flag], person_escort_record: per)
-      described_class.new(per, { parent_response.id => [option: 'Level 1'] }).call
-
-      expect(child_response.reload.framework_flags).to contain_exactly(flag)
-    end
-
-    it 'sets responded to false on dependent responses if value changed' do
-      per = create(:person_escort_record)
-      parent_response = create(:collection_response, :details, person_escort_record: per)
-      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
-      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, responded: true, person_escort_record: per)
-      described_class.new(per, { parent_response.id => [option: 'Level 2'] }).call
-
-      expect(child_response.reload.responded).to be(false)
-    end
-
-    it 'does not set responded to false on dependent responses if value not changed' do
-      per = create(:person_escort_record)
-      parent_response = create(:collection_response, :details, person_escort_record: per)
-      child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
-      child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, responded: true, person_escort_record: per)
-      described_class.new(per, { parent_response.id => [option: 'Level 1'] }).call
-
-      expect(child_response.reload.responded).to be(true)
+    rescue FrameworkResponses::BulkUpdateError
+      expect(response1.reload.value).to be_nil
+      expect(response2.reload.value).to be_nil
     end
   end
 

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2768,7 +2768,9 @@
           required: true
           description: __Array__ of framework_response objects to be modified
           schema:
-            "$ref": "../v1/patch_framework_response.yaml#/PatchFrameworkResponse"
+            type: array
+            items:
+              "$ref": "../v1/patch_framework_response.yaml#/PatchFrameworkResponse"
       responses:
         "204":
           description: no content

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2751,6 +2751,58 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/patch_person_escort_record_responses.yaml#/422"
+  "/person_escort_records/{person_escort_record_id}/framework_responses":
+    patch:
+      summary: Bulk updates multiple framework response values for a person_escort_record
+      description:
+        "This method updates multiple framework response values for the specified person_escort_record"
+      tags:
+        - Framework Responses
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - "$ref": "../v1/person_escort_record_id_parameter.yaml#/PersonEscortRecordId"
+        - name: body
+          in: body
+          required: true
+          description: __Array__ of framework_response objects to be modified
+          schema:
+            "$ref": "../v1/patch_framework_response.yaml#/PatchFrameworkResponse"
+      responses:
+        "204":
+          description: no content
+          content:
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/400"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/401"
+        "404":
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/404"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/415"
+        "422":
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/422"
   "/reference/allocation_complex_cases":
     get:
       summary: Returns a list of allocation complex cases


### PR DESCRIPTION
### Jira link

P4-1799

### What?

- [x] Added a new endpoint to `PATCH /person_transfer_records/:id/framework_responses` that accepts an array of framework responses to update in bulk.
- [x] Added a new `FrameworkResponses::BulkUpdater` service to wrap the implementation details of the new endpoint
- [x] Refactored existing `FrameworkResponse` method to allow updates to multiple instances at once

### Why?

- Suppliers cannot use the existing endpoint to `PATCH /framework_responses/:id` as they will be using mobile devices with potentially patchy communication. It's more convenient and performant for them to submit the entire set of framework responses for a PER in a single request, rather than send ~60 individual requests for each response.

- JSONAPI typically only supports updating a singular resource, but there is a draft specification for a bulk update extension which this follows. Essentially this passes an array of resources rather than just one, but each resource has the usual structure (see request specs for details).

- Implementation makes extensive use of the `activerecord-import` gem; this is able to provide bulk data upserts in a single query which means that 60 framework response values can be updated in a single hit. The code is optimised to avoid updating responses where the value doesn't change, which gives a best to worst case response time (depending how many of the 60 framework responses were modified) in the range 180-900ms. This should be acceptable and avoids the need to introduce further complexity with asynchronous updating.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Introduces a new endpoint, so minimal risk as not yet used