### PR TITLE
Disable dual writing temporarily

### DIFF
--- a/app/controllers/concerns/journeys/eventable.rb
+++ b/app/controllers/concerns/journeys/eventable.rb
@@ -27,7 +27,7 @@ module Journeys
     end
 
     def create_generic_event(event)
-      GenericEvent.from_event(event).save!
+      # GenericEvent.from_event(event).save!
     end
 
     def run_event_logs(journey)

--- a/spec/requests/api/journey_events_controller_cancel_spec.rb
+++ b/spec/requests/api/journey_events_controller_cancel_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey cancel event' do
+        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyCancel.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_complete_spec.rb
+++ b/spec/requests/api/journey_events_controller_complete_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey complete event' do
+        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyComplete.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_lockouts_spec.rb
+++ b/spec/requests/api/journey_events_controller_lockouts_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey lockout event' do
+        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyLockout.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_lodgings_spec.rb
+++ b/spec/requests/api/journey_events_controller_lodgings_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey lodging event' do
+        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyLodging.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_reject_spec.rb
+++ b/spec/requests/api/journey_events_controller_reject_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey reject event' do
+        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyReject.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_start_spec.rb
+++ b/spec/requests/api/journey_events_controller_start_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey reject event' do
+        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyStart.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_uncancel_spec.rb
+++ b/spec/requests/api/journey_events_controller_uncancel_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey uncancel event' do
+        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyUncancel.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_uncomplete_spec.rb
+++ b/spec/requests/api/journey_events_controller_uncomplete_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey uncomplete event' do
+        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyUncomplete.count }.by(1)
       end
     end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I'm adding a reference from event -> generic_event in my rake task that enables use to avoid creating duplicate generic_events/means we can run the rake task over and over and get the same effect.

Dual writing events currently breaks this contract. In this PR I'm disabling the dual write functionality and will deploy/clear out generic events in all environments in a console. We then need to merge the rake task/migration which enables the reference and then switch on dual writing events.

I have added/removed/altered:

- [x] Disables dual writing events in journey eventable module.

### Why?

I am doing this because:

- We need to make sure we can safely rollback copied events/avoid duplicates via a reference. Currently written generic events are missing this reference and need removing.