### PR TITLE
[P4-2161] Dual write events

### DIFF
--- a/app/controllers/concerns/journeys/eventable.rb
+++ b/app/controllers/concerns/journeys/eventable.rb
@@ -27,7 +27,9 @@ module Journeys
     end
 
     def create_generic_event(event)
-      # GenericEvent.from_event(event).save!
+      generic_event = GenericEvent.from_event(event)
+      generic_event.save!
+      event.update!(generic_event_id: generic_event.id)
     end
 
     def run_event_logs(journey)

--- a/app/controllers/concerns/moves/eventable.rb
+++ b/app/controllers/concerns/moves/eventable.rb
@@ -9,7 +9,8 @@ module Moves
 
     def process_event(moves, event_name, event_params)
       [moves].flatten.each do |move|
-        create_event(move, event_name, event_params)
+        event = create_event(move, event_name, event_params)
+        create_generic_event(event)
         run_event_logs(move)
       end
     end
@@ -23,6 +24,13 @@ module Moves
           supplier_id: supplier_id,
         },
       )
+    end
+
+    def create_generic_event(event)
+      generic_event = GenericEvent.from_event(event)
+      generic_event.save!
+      event.update!(generic_event_id: generic_event.id)
+      generic_event
     end
 
     def run_event_logs(move)

--- a/app/models/generic_event/move_approve.rb
+++ b/app/models/generic_event/move_approve.rb
@@ -39,7 +39,7 @@ class GenericEvent
       new(event.generic_event_attributes
               .merge(
                 details: {
-                  date: event.eventable.date,
+                  date: event.event_params&.dig(:attributes, :date),
                   create_in_nomis: event.event_params&.dig(:attributes, :create_in_nomis) || false,
                 },
               ))

--- a/spec/requests/api/journey_events_controller_cancel_spec.rb
+++ b/spec/requests/api/journey_events_controller_cancel_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey cancel event' do
-        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyCancel.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_complete_spec.rb
+++ b/spec/requests/api/journey_events_controller_complete_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey complete event' do
-        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyComplete.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_lockouts_spec.rb
+++ b/spec/requests/api/journey_events_controller_lockouts_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey lockout event' do
-        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyLockout.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_lodgings_spec.rb
+++ b/spec/requests/api/journey_events_controller_lodgings_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey lodging event' do
-        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyLodging.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_reject_spec.rb
+++ b/spec/requests/api/journey_events_controller_reject_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey reject event' do
-        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyReject.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_start_spec.rb
+++ b/spec/requests/api/journey_events_controller_start_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey reject event' do
-        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyStart.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_uncancel_spec.rb
+++ b/spec/requests/api/journey_events_controller_uncancel_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey uncancel event' do
-        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyUncancel.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_uncomplete_spec.rb
+++ b/spec/requests/api/journey_events_controller_uncomplete_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Api::JourneyEventsController do
       end
 
       it 'dual writes a journey uncomplete event' do
-        pending 'need to link generic events to the original event to enable debug/rollback behaviour'
         expect { do_post }.to change { GenericEvent::JourneyUncomplete.count }.by(1)
       end
     end

--- a/spec/requests/api/move_events_controller_accept_spec.rb
+++ b/spec/requests/api/move_events_controller_accept_spec.rb
@@ -3,16 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe Api::MoveEventsController do
+  subject(:do_post) do
+    post("/api/v1/moves/#{move_id}/accept", params: params, headers: headers, as: :json)
+  end
+
   describe 'POST /moves/:move_id/accept' do
     include_context 'with supplier with spoofed access token'
 
     let(:from_location) { create(:location, suppliers: [supplier]) }
     let(:move) { create(:move, :requested, from_location: from_location) }
     let(:move_id) { move.id }
-
-    before do
-      post("/api/v1/moves/#{move_id}/accept", params: params, headers: headers, as: :json)
-    end
 
     context 'with happy params' do
       let(:params) do
@@ -27,17 +27,30 @@ RSpec.describe Api::MoveEventsController do
         }
       end
 
-      it_behaves_like 'an endpoint that responds with success 204'
+      it_behaves_like 'an endpoint that responds with success 204' do
+        before do
+          do_post
+        end
+      end
 
       it 'changes the move to booked' do
+        do_post
         expect(move.reload).to be_booked
+      end
+
+      it 'dual writes a move accept event' do
+        expect { do_post }.to change { GenericEvent::MoveAccept.count }.by(1)
       end
     end
 
     context 'with unhappy params' do
       let(:params) { { foo: 'bar' } }
 
-      it_behaves_like 'an endpoint that responds with error 400'
+      it_behaves_like 'an endpoint that responds with error 400' do
+        before do
+          do_post
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/move_events_controller_approve_spec.rb
+++ b/spec/requests/api/move_events_controller_approve_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe Api::MoveEventsController do
         expect(Allocations::CreateInNomis).to have_received(:call).with(move)
       end
 
+      it 'creates a move approve event' do
+        expect(GenericEvent::MoveApprove.count).to eq(1)
+      end
+
       describe 'webhook and email notifications' do
         it 'calls the notifier' do
           expect(Notifier).to have_received(:prepare_notifications).with(topic: move, action_name: 'update_status')

--- a/spec/requests/api/move_events_controller_cancel_spec.rb
+++ b/spec/requests/api/move_events_controller_cancel_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe Api::MoveEventsController do
         expect(Allocations::RemoveFromNomis).to have_received(:call).with(move)
       end
 
+      it 'creates a move cancel event' do
+        expect(GenericEvent::MoveCancel.count).to eq(1)
+      end
+
       describe 'webhook and email notifications' do
         it 'calls the notifier when updating a person' do
           expect(Notifier).to have_received(:prepare_notifications).with(topic: move, action_name: 'update_status')

--- a/spec/requests/api/move_events_controller_complete_spec.rb
+++ b/spec/requests/api/move_events_controller_complete_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Api::MoveEventsController do
         expect(move.reload.status).to eql('completed')
       end
 
+      it 'creates a move complete event' do
+        expect(GenericEvent::MoveComplete.count).to eq(1)
+      end
+
       describe 'webhook and email notifications' do
         it 'calls the notifier when updating a person' do
           expect(Notifier).to have_received(:prepare_notifications).with(topic: move, action_name: 'update_status')

--- a/spec/requests/api/move_events_controller_lockout_spec.rb
+++ b/spec/requests/api/move_events_controller_lockout_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Api::MoveEventsController do
         expect(move.reload.status).to eql('requested')
       end
 
+      it 'creates a move lockout event' do
+        expect(GenericEvent::MoveLockout.count).to eq(1)
+      end
+
       describe 'webhook and email notifications' do
         it 'calls the notifier when updating a person' do
           expect(Notifier).not_to have_received(:prepare_notifications)

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe Api::MoveEventsController do
       it 'updates the move move_type' do
         expect { move.reload }.to change(move, :move_type).from('prison_transfer').to('court_appearance')
       end
+
+      it 'creates a move redirect event' do
+        expect(GenericEvent::MoveRedirect.count).to eq(1)
+      end
     end
 
     context 'with a video remand hearing' do

--- a/spec/requests/api/move_events_controller_reject_spec.rb
+++ b/spec/requests/api/move_events_controller_reject_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe Api::MoveEventsController do
         expect(rebooked_move.original_move).to eq(move)
       end
 
+      it 'creates a move reject event' do
+        expect(GenericEvent::MoveReject.count).to eq(1)
+      end
+
       describe 'webhook and email notifications' do
         it 'calls the notifier when updating a person' do
           expect(Notifier).to have_received(:prepare_notifications).with(topic: move, action_name: 'update_status')

--- a/spec/requests/api/move_events_controller_start_spec.rb
+++ b/spec/requests/api/move_events_controller_start_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Api::MoveEventsController do
       it 'changes the move to in_transit' do
         expect(move.reload).to be_in_transit
       end
+
+      it 'creates a move start event' do
+        expect(GenericEvent::MoveStart.count).to eq(1)
+      end
     end
 
     context 'with unhappy params' do


### PR DESCRIPTION
### Jira link

P4-2161

### What?

I have added/removed/altered:

- [x] Implement dual-write behaviour for both journey and move eventable modules

### Why?

I am doing this because:

- This is needed so that we can migrate to the new event model