### PR TITLE
[P4-2162] Copy events rake task

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,6 +16,7 @@ class Event < ApplicationRecord
   ].freeze
 
   belongs_to :eventable, polymorphic: true, touch: true
+  belongs_to :generic_event
 
   validates :eventable, presence: true
   validates :event_name, presence: true, inclusion: { in: EVENT_NAMES }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,6 +23,8 @@ class Event < ApplicationRecord
   validates :details, presence: true
 
   scope :default_order, -> { order(client_timestamp: :asc) }
+  scope :copied, -> { where.not(generic_event_id: nil) }
+  scope :not_copied, -> { where(generic_event_id: nil) }
 
   serialize :details, HashWithIndifferentAccessSerializer
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,7 +16,6 @@ class Event < ApplicationRecord
   ].freeze
 
   belongs_to :eventable, polymorphic: true, touch: true
-  belongs_to :generic_event
 
   validates :eventable, presence: true
   validates :event_name, presence: true, inclusion: { in: EVENT_NAMES }

--- a/app/services/event_copier.rb
+++ b/app/services/event_copier.rb
@@ -1,0 +1,30 @@
+class EventCopier
+  def initialize
+    @results = {
+      failure_count: 0,
+      success_count: 0,
+      errors: [],
+    }
+  end
+
+  def call
+    Event.not_copied.find_each do |event|
+      generic_event = GenericEvent.from_event(event)
+
+      if generic_event.save
+        event.update(generic_event: generic_event)
+
+        @results[:success_count] += 1
+      else
+        @results[:errors] << {
+          'id' => event.id,
+          'errors' => event.errors.messages,
+        }
+
+        @results[:failure_count] += 1
+      end
+    end
+
+    @results
+  end
+end

--- a/app/services/event_copier.rb
+++ b/app/services/event_copier.rb
@@ -26,19 +26,21 @@ class EventCopier
 
           @results[:validation_failure_count] += 1
         end
+
+        next
+      end
+
+      if generic_event.save
+        event.update(generic_event_id: generic_event.id)
+
+        @results[:success_count] += 1
       else
-        if generic_event.save
-          event.update(generic_event_id: generic_event.id)
+        @results[:validation_errors] << {
+          'id' => event.id,
+          'errors' => generic_event.errors.messages,
+        }
 
-          @results[:success_count] += 1
-        else
-          @results[:validation_errors] << {
-            'id' => event.id,
-            'errors' => generic_event.errors.messages,
-          }
-
-          @results[:validation_failure_count] += 1
-        end
+        @results[:validation_failure_count] += 1
       end
     rescue NameError => e
       missing_event = e.message.split('::').last

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -5,18 +5,17 @@ namespace :events do
   task copy: :environment do
     dry_run = ENV.fetch('DRY_RUN', 'true') == 'true'
 
-    EventCopier.new.call
+    report = JSON.parse(EventCopier.new(dry_run: dry_run).call.to_json)
+
+    puts JSON.pretty_generate(report)
   end
 
   desc 'rollback copied events'
   task rollback: :environment do
-    dry_run = ENV.fetch('DRY_RUN', 'true') == 'true'
+    generic_event_ids = Event.copied.pluck(:generic_event_id)
 
-    GenericEvent.where(id: Event.copied.pluck(:generic_event_id)).delete_all
-  end
+    Event.copied.update_all(generic_event_id: nil)
 
-  desc 'report on copied events'
-  task report: :environment do
-    dry_run = ENV.fetch('DRY_RUN', 'true') == 'true'
+    GenericEvent.where(id: generic_event_ids).delete_all
   end
 end

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -16,6 +16,7 @@ namespace :events do
 
     Event.copied.update_all(generic_event_id: nil)
 
+    puts "Deleting #{generic_event_ids.count} generic_events..."
     GenericEvent.where(id: generic_event_ids).delete_all
   end
 end

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :events do
+  desc 'copy uncopied events to generic_event table'
+  task copy: :environment do
+    dry_run = ENV.fetch('DRY_RUN', 'true') == 'true'
+
+    EventCopier.new.call
+  end
+
+  desc 'rollback copied events'
+  task rollback: :environment do
+    dry_run = ENV.fetch('DRY_RUN', 'true') == 'true'
+
+    GenericEvent.where(id: Event.copied.pluck(:generic_event_id)).delete_all
+  end
+
+  desc 'report on copied events'
+  task report: :environment do
+    dry_run = ENV.fetch('DRY_RUN', 'true') == 'true'
+  end
+end

--- a/spec/services/event_copier_spec.rb
+++ b/spec/services/event_copier_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe EventCopier do
       end
     end
 
-    context 'when we are in a dry run' do
+    context 'when we are not in a dry run' do
       let(:dry_run) { false }
 
       it 'returns the correct report' do

--- a/spec/services/event_copier_spec.rb
+++ b/spec/services/event_copier_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 RSpec.describe EventCopier do
   subject(:service) { described_class.new(dry_run: dry_run) }
 
@@ -125,3 +126,4 @@ RSpec.describe EventCopier do
     end
   end
 end
+# rubocop:enable all

--- a/spec/services/event_copier_spec.rb
+++ b/spec/services/event_copier_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe EventCopier do
+  subject(:service) { described_class.new }
+
+  context 'when the STI matched by the eventable and event name exists' do
+    let!(:event) { create(:event, :cancel, eventable: journey, details: details) }
+    let(:journey) { create(:journey) }
+
+    context 'when the generic_event has invalid details' do
+      let(:details) do
+        {
+          event_params: {
+            attributes: {
+              cancellation_reason: 'invalid_reason',
+              cancellation_reason_comment: 'something of note',
+            },
+          },
+        }
+      end
+
+      it 'returns the correct report' do
+        expect(service.call).to eq(expected_report)
+      end
+
+      it 'does not create a GenericEvent' do
+        expect { service.call }.not_to change(GenericEvent, :count)
+      end
+    end
+
+    context 'when the generic_event has valid details' do
+      let(:details) do
+        {
+          event_params: {
+            attributes: {
+              cancellation_reason: 'made_in_error',
+              cancellation_reason_comment: 'something of note',
+            },
+          },
+        }
+      end
+
+      it 'returns the correct report' do
+        expected_report = {
+          failure_count: 0,
+          success_count: 1,
+          errors: [],
+        }
+
+        expect(service.call).to eq(expected_report)
+      end
+
+      it 'creates a GenericEvent' do
+        expect { service.call }.to change(GenericEvent, :count).by(1)
+      end
+    end
+  end
+
+  context 'when the STI matched by the eventable and event name does not exist' do
+    it 'skips the event'
+  end
+end

--- a/spec/services/event_copier_spec.rb
+++ b/spec/services/event_copier_spec.rb
@@ -1,42 +1,101 @@
 RSpec.describe EventCopier do
-  subject(:service) { described_class.new }
+  subject(:service) { described_class.new(dry_run: dry_run) }
 
-  context 'when the STI matched by the eventable and event name exists' do
-    let!(:event) { create(:event, :cancel, eventable: journey, details: details) }
-    let(:journey) { create(:journey) }
+  let!(:event) { create(:event, :cancel, eventable: move, details: details) }
+  let(:move) { create(:move) }
+  let(:dry_run) { false }
 
-    context 'when the generic_event has invalid details' do
-      let(:details) do
-        {
-          event_params: {
-            attributes: {
-              cancellation_reason: 'invalid_reason',
-              cancellation_reason_comment: 'something of note',
-            },
+  context 'when the generic_event has invalid details' do
+    let(:details) do
+      {
+        event_params: {
+          attributes: {
+            cancellation_reason: 'invalid_reason',
+            cancellation_reason_comment: 'something of note',
           },
-        }
-      end
+        },
+      }
+    end
+
+    context 'when we are in a dry run' do
+      let(:dry_run) { true }
 
       it 'returns the correct report' do
+        expected_report = {
+          failure_count: 1,
+          success_count: 0,
+          errors: [
+            {
+              'id' => event.id,
+              'errors' => {
+                cancellation_reason: ['is not included in the list'],
+              },
+            },
+          ],
+        }
+
+        expect(service.call).to eq(expected_report)
+      end
+    end
+
+    context 'when we are not in a dry run' do
+      let(:dry_run) { false }
+
+      it 'returns the correct report' do
+        expected_report = {
+          failure_count: 1,
+          success_count: 0,
+          errors: [
+            {
+              'id' => event.id,
+              'errors' => {
+                cancellation_reason: ['is not included in the list'],
+              },
+            },
+          ],
+        }
+
+        expect(service.call).to eq(expected_report)
+      end
+    end
+
+    it 'does not create a GenericEvent' do
+      expect { service.call }.not_to change(GenericEvent, :count)
+    end
+  end
+
+  context 'when the generic_event has valid details' do
+    let(:details) do
+      {
+        event_params: {
+          attributes: {
+            cancellation_reason: 'made_in_error',
+            cancellation_reason_comment: 'something of note',
+          },
+        },
+      }
+    end
+
+    context 'when we are in a dry run' do
+      let(:dry_run) { true }
+
+      it 'returns the correct report' do
+        expected_report = {
+          failure_count: 0,
+          success_count: 1,
+          errors: [],
+        }
+
         expect(service.call).to eq(expected_report)
       end
 
       it 'does not create a GenericEvent' do
-        expect { service.call }.not_to change(GenericEvent, :count)
+        expect { service.call }.not_to change(GenericEvent::MoveCancel, :count)
       end
     end
 
-    context 'when the generic_event has valid details' do
-      let(:details) do
-        {
-          event_params: {
-            attributes: {
-              cancellation_reason: 'made_in_error',
-              cancellation_reason_comment: 'something of note',
-            },
-          },
-        }
-      end
+    context 'when we are in a dry run' do
+      let(:dry_run) { false }
 
       it 'returns the correct report' do
         expected_report = {
@@ -49,12 +108,8 @@ RSpec.describe EventCopier do
       end
 
       it 'creates a GenericEvent' do
-        expect { service.call }.to change(GenericEvent, :count).by(1)
+        expect { service.call }.to change(GenericEvent::MoveCancel, :count).by(1)
       end
     end
-  end
-
-  context 'when the STI matched by the eventable and event name does not exist' do
-    it 'skips the event'
   end
 end

--- a/spec/services/event_copier_spec.rb
+++ b/spec/services/event_copier_spec.rb
@@ -22,9 +22,12 @@ RSpec.describe EventCopier do
 
       it 'returns the correct report' do
         expected_report = {
-          failure_count: 1,
+          validation_failure_count: 1,
           success_count: 0,
-          errors: [
+          dry_run: dry_run,
+          name_error_count: 0,
+          name_errors: Set.new,
+          validation_errors: [
             {
               'id' => event.id,
               'errors' => {
@@ -43,9 +46,12 @@ RSpec.describe EventCopier do
 
       it 'returns the correct report' do
         expected_report = {
-          failure_count: 1,
+          validation_failure_count: 1,
           success_count: 0,
-          errors: [
+          dry_run: dry_run,
+          name_errors: Set.new,
+          name_error_count: 0,
+          validation_errors: [
             {
               'id' => event.id,
               'errors' => {
@@ -81,9 +87,12 @@ RSpec.describe EventCopier do
 
       it 'returns the correct report' do
         expected_report = {
-          failure_count: 0,
+          validation_failure_count: 0,
           success_count: 1,
-          errors: [],
+          dry_run: dry_run,
+          name_errors: Set.new,
+          name_error_count: 0,
+          validation_errors: [],
         }
 
         expect(service.call).to eq(expected_report)
@@ -99,9 +108,12 @@ RSpec.describe EventCopier do
 
       it 'returns the correct report' do
         expected_report = {
-          failure_count: 0,
+          validation_failure_count: 0,
           success_count: 1,
-          errors: [],
+          dry_run: dry_run,
+          name_errors: Set.new,
+          name_error_count: 0,
+          validation_errors: [],
         }
 
         expect(service.call).to eq(expected_report)


### PR DESCRIPTION
### Jira link

P4-2162

### What?

I have added/removed/altered:

- [x] Adds rake task to copy events
- [x] Adds EventCopier service and tests

### Why?

I am doing this because:

- We need to copy all historical events as part of merging the two event tables