### PR TITLE
Add comment to explain enum usage for unstarted and fix test

### DIFF
--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -1,6 +1,8 @@
 class PersonEscortRecord < VersionedModel
   include StateMachineable
 
+  # "not_started" cannot be used as the name of the enum due to warnings in the model
+  # that it starts with a "not_".
   PERSON_ESCORT_RECORD_NOT_STARTED = 'not_started'.freeze
   PERSON_ESCORT_RECORD_IN_PROGRESS = 'in_progress'.freeze
   PERSON_ESCORT_RECORD_COMPLETED = 'completed'.freeze

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe FrameworkResponse do
 
       it 'clears flags on dependent responses if value changed' do
         parent_response = create(:string_response)
-        child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+        child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Yes', parent: parent_response.framework_question)
         child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, framework_flags: [create(:framework_flag)])
         parent_response.update_with_flags!('No')
 


### PR DESCRIPTION
* Due to enum value name restrictions around prepending `not_` unstarted is used as the main enum name, but the value `not_started` is surfaced through the API.

* Fix test to use values from the set options.

