### PR TITLE
Add support for filtering moves by `location_id`

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -35,7 +35,7 @@ module Api
     end
 
     PERMITTED_FILTER_PARAMS = %i[
-      date_from date_to created_at_from created_at_to date_of_birth_from date_of_birth_to location_type status from_location_id to_location_id supplier_id move_type cancellation_reason rejection_reason has_relationship_to_allocation ready_for_transit
+      date_from date_to created_at_from created_at_to date_of_birth_from date_of_birth_to location_type status from_location_id to_location_id location_id supplier_id move_type cancellation_reason rejection_reason has_relationship_to_allocation ready_for_transit
     ].freeze
 
     def filter_params

--- a/spec/requests/api/moves_controller_filter_spec.rb
+++ b/spec/requests/api/moves_controller_filter_spec.rb
@@ -38,10 +38,28 @@ RSpec.describe Api::MovesController do
       it_behaves_like 'an api that filters moves correctly'
     end
 
+    describe 'by location_id' do
+      let(:filter_params) { { filter: { location_id: location.id } } }
+      let(:location) { create :location }
+      let(:expected_moves) { create_list(:move, 1, from_location: location) + create_list(:move, 1, to_location: location) }
+      let(:unexpected_moves) { create_list :move, 1 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
+
     describe 'by from_location_id' do
       let(:filter_params) { { filter: { from_location_id: location.id } } }
       let(:location) { create :location }
       let(:expected_moves) { create_list :move, 1, from_location: location }
+      let(:unexpected_moves) { create_list :move, 1 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
+
+    describe 'by to_location_id' do
+      let(:filter_params) { { filter: { to_location_id: location.id } } }
+      let(:location) { create :location }
+      let(:expected_moves) { create_list :move, 1, to_location: location }
       let(:unexpected_moves) { create_list :move, 1 }
 
       it_behaves_like 'an api that filters moves correctly'

--- a/spec/requests/api/moves_controller_filter_v2_spec.rb
+++ b/spec/requests/api/moves_controller_filter_v2_spec.rb
@@ -45,10 +45,28 @@ RSpec.describe Api::MovesController do
       it_behaves_like 'an api that filters moves correctly'
     end
 
+    describe 'by location_id' do
+      let(:filter_params) { { filter: { location_id: location.id } } }
+      let(:location) { create :location }
+      let(:expected_moves) { create_list(:move, 1, from_location: location) + create_list(:move, 1, to_location: location) }
+      let(:unexpected_moves) { create_list :move, 1 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
+
     describe 'by from_location_id' do
       let(:filter_params) { { filter: { from_location_id: location.id } } }
       let(:location) { create :location }
       let(:expected_moves) { create_list :move, 1, from_location: location }
+      let(:unexpected_moves) { create_list :move, 1 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
+
+    describe 'by to_location_id' do
+      let(:filter_params) { { filter: { to_location_id: location.id } } }
+      let(:location) { create :location }
+      let(:expected_moves) { create_list :move, 1, to_location: location }
       let(:unexpected_moves) { create_list :move, 1 }
 
       it_behaves_like 'an api that filters moves correctly'

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -25,6 +25,37 @@ RSpec.describe Moves::Finder do
       end
     end
 
+    describe 'by location_id' do
+      let!(:shared_location) { create :location }
+      let!(:move) { create :move, from_location: shared_location }
+      let!(:second_move) { create :move, to_location: shared_location }
+
+      context 'with matching location filter' do
+        let(:filter_params) { { location_id: shared_location.id } }
+
+        it 'returns moves matching from location or to location' do
+          expect(results).to contain_exactly(move, second_move)
+        end
+      end
+
+      context 'with two location filters' do
+        let!(:third_move) { create :move }
+        let(:filter_params) { { location_id: [shared_location.id, third_move.from_location_id] } }
+
+        it 'returns moves matching multiple locations' do
+          expect(results).to contain_exactly(move, second_move, third_move)
+        end
+      end
+
+      context 'with mis-matching location filter' do
+        let(:filter_params) { { location_id: Random.uuid } }
+
+        it 'returns empty results set' do
+          expect(results).to be_empty
+        end
+      end
+    end
+
     describe 'by from_location_id' do
       let!(:move) { create :move }
 
@@ -32,7 +63,7 @@ RSpec.describe Moves::Finder do
         let(:filter_params) { { from_location_id: [move.from_location_id] } }
 
         it 'returns moves matching from location' do
-          expect(results).to match_array [move]
+          expect(results).to contain_exactly(move)
         end
       end
 
@@ -41,12 +72,41 @@ RSpec.describe Moves::Finder do
         let(:filter_params) { { from_location_id: [move.from_location_id, second_move.from_location_id] } }
 
         it 'returns moves matching multiple locations' do
-          expect(results).to match_array [move, second_move]
+          expect(results).to contain_exactly(move, second_move)
         end
       end
 
       context 'with mis-matching location filter' do
         let(:filter_params) { { from_location_id: Random.uuid } }
+
+        it 'returns empty results set' do
+          expect(results).to be_empty
+        end
+      end
+    end
+
+    describe 'by to_location_id' do
+      let!(:move) { create :move }
+
+      context 'with matching location filter' do
+        let(:filter_params) { { to_location_id: [move.to_location_id] } }
+
+        it 'returns moves matching from location' do
+          expect(results).to contain_exactly(move)
+        end
+      end
+
+      context 'with two location filters' do
+        let!(:second_move) { create :from_prison_to_court }
+        let(:filter_params) { { to_location_id: [move.to_location_id, second_move.to_location_id] } }
+
+        it 'returns moves matching multiple locations' do
+          expect(results).to contain_exactly(move, second_move)
+        end
+      end
+
+      context 'with mis-matching location filter' do
+        let(:filter_params) { { to_location_id: Random.uuid } }
 
         it 'returns empty results set' do
           expect(results).to be_empty


### PR DESCRIPTION
### Jira link

P4-2206

### What?

- [x] Added support for filtering moves (via `GET /moves` endpoint) using `location_id`

### Why?

- This returns moves matching on **either** `from_location_id` **or** `to_location_id` - which allows the list of transfers in and out of a specific location to be returned in a single API call. This is to support initial work in the front end for PMU dashboard screens.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Extends existing API but is backwards compatible; behaviour is unchanged if new filter is not specified.