### PR TITLE
Rewrite Runner using generic events

### DIFF
--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -37,6 +37,7 @@ class Journey < ApplicationRecord
   belongs_to :to_location, class_name: 'Location'
 
   has_many :events, as: :eventable, dependent: :destroy # NB: polymorphic association
+  has_many :generic_events, as: :eventable, dependent: :destroy # NB: polymorphic association
 
   enum states: {
     proposed: 'proposed',

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -85,6 +85,8 @@ class Move < VersionedModel
   has_many :court_hearings, dependent: :restrict_with_exception
   has_many :move_events, as: :eventable, dependent: :destroy # NB: polymorphic association
 
+  has_many :generic_events, as: :eventable, dependent: :destroy # NB: polymorphic association
+
   validates :from_location, presence: true
   validates :to_location, presence: true, unless: -> { prison_recall? || video_remand? }
   validates :move_type, inclusion: { in: move_types }

--- a/app/services/event_log/journey_executor.rb
+++ b/app/services/event_log/journey_executor.rb
@@ -16,4 +16,3 @@ module EventLog
     end
   end
 end
-

--- a/app/services/event_log/journey_executor.rb
+++ b/app/services/event_log/journey_executor.rb
@@ -1,0 +1,19 @@
+module EventLog
+  class JourneyExecutor
+    attr_reader :journey
+
+    def initialize(journey)
+      @journey = journey
+    end
+
+    def call
+      # iterate over all events in the log and apply changes to the journey
+      journey.generic_events.applied_order.each(&:trigger)
+
+      if journey.changed? && journey.valid?
+        journey.save!
+      end
+    end
+  end
+end
+

--- a/app/services/event_log/move_executor.rb
+++ b/app/services/event_log/move_executor.rb
@@ -23,11 +23,5 @@ module EventLog
         false
       end
     end
-
-  private
-
-    def events
-      move.move_events.default_order
-    end
   end
 end

--- a/app/services/event_log/move_executor.rb
+++ b/app/services/event_log/move_executor.rb
@@ -10,15 +10,13 @@ module EventLog
     def call
       # iterate over all events in the log and apply changes to the move
 
-      # move.move_events.applied_order.each do |event|
-      move.generic_events.applied_order.each do |event|
-        event.trigger
-      end
+      move.generic_events.applied_order.each(&:trigger)
 
       # save the move if it has changed, and notify webhooks and emails
       if move.changed?
         action_name = move.status_changed? ? 'update_status' : 'update'
         move.save! # save before notifying
+
         Notifier.prepare_notifications(topic: move, action_name: action_name)
         true
       else

--- a/app/services/event_log/move_runner.rb
+++ b/app/services/event_log/move_runner.rb
@@ -44,7 +44,9 @@ module EventLog
       # save the move if it has changed, and notify webhooks and emails
       if move.changed?
         action_name = move.status_changed? ? 'update_status' : 'update'
+
         move.save! # save before notifying
+
         Notifier.prepare_notifications(topic: move, action_name: action_name)
         true
       else

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -98,7 +98,7 @@ FactoryBot.define do
           { event_params: {
             attributes: {
               cancellation_reason: 'supplier_declined_to_move',
-              cancellation_reason_comment: 'computer says no',
+              cancellation_reason_comment: 'It was a mistake',
             },
           } }
         end
@@ -145,7 +145,7 @@ FactoryBot.define do
           { event_params: {
             attributes: {
               rejection_reason: 'no_transport_available',
-              cancellation_reason_comment: 'computer says no',
+              cancellation_reason_comment: 'It was a mistake',
             },
           } }
         end
@@ -157,7 +157,7 @@ FactoryBot.define do
           { event_params: {
             attributes: {
               rejection_reason: 'no_transport_available',
-              cancellation_reason_comment: 'computer says no',
+              cancellation_reason_comment: 'It was a mistake',
               rebook: true,
             },
           } }

--- a/spec/services/event_log/journey_executor_spec.rb
+++ b/spec/services/event_log/journey_executor_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventLog::JourneyExecutor do
+  subject(:journey_executor) { described_class.new(journey) }
+
+  let(:journey) { create(:journey, initial_state) }
+
+  shared_examples 'it does not change the state' do
+    it 'does not update the journey state' do
+      expect { journey_executor.call }.not_to change(journey, :state).from(initial_state.to_s)
+    end
+  end
+
+  shared_examples 'it changes the state to' do |new_state|
+    it 'updates the journey state' do
+      expect { journey_executor.call }.to change(journey, :state).from(initial_state.to_s).to(new_state.to_s)
+    end
+  end
+
+  describe 'proposed -> start + complete -> completed' do
+    let(:initial_state) { :proposed }
+
+    before do
+      create(:event_journey_start, eventable: journey, occurred_at: 1.minute.ago)
+      create(:event_journey_complete, eventable: journey, occurred_at: 1.minute.from_now)
+    end
+
+    it_behaves_like 'it changes the state to', :completed
+  end
+
+  describe 'completed -> uncomplete + cancel -> cancelled' do
+    let(:initial_state) { :completed }
+
+    before do
+      create(:event_journey_uncomplete, eventable: journey, occurred_at: 1.minute.ago)
+      create(:event_journey_cancel, eventable: journey, occurred_at: 1.minute.from_now)
+    end
+
+    it_behaves_like 'it changes the state to', :cancelled
+  end
+
+  describe 'proposed -> complete + cancel -> proposed' do
+    let(:initial_state) { :proposed }
+
+    before do
+      create(:event_journey_complete, eventable: journey, occurred_at: 1.minute.ago)
+      create(:event_journey_cancel, eventable: journey, occurred_at: 1.minute.from_now)
+    end
+
+    it_behaves_like 'it does not change the state' # NB: these are not valid events given the initial state so the state should not be updated
+  end
+
+  describe 'in_progress -> lodging + lockout -> in_progress' do
+    let(:initial_state) { :in_progress }
+
+    before do
+      create(:event_journey_lodging, eventable: journey, occurred_at: 1.minute.ago)
+      create(:event_journey_lockout, eventable: journey, occurred_at: 1.minute.from_now)
+    end
+
+    it_behaves_like 'it does not change the state'
+  end
+end

--- a/spec/services/event_log/move_executor_spec.rb
+++ b/spec/services/event_log/move_executor_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventLog::MoveExecutor do
+  subject(:move_executor) { described_class.new(move) }
+
+  # let!(:move) { create(:move, :requested, to_location: original_location) }
+  # let(:original_location) { create(:location) }
+
+  before do
+    # create :supplier_location, supplier: move.supplier, location: move.from_location
+
+    allow(Notifier).to receive(:prepare_notifications)
+  end
+
+  shared_examples_for 'it calls the Notifier with an update_status action_name' do
+    before { move_executor.call }
+
+    it 'calls the Notifier with update_status' do
+      expect(Notifier).to have_received(:prepare_notifications).with(topic: move, action_name: 'update_status')
+    end
+  end
+
+  shared_examples_for 'it calls the Notifier with an update action_name' do
+    before { move_executor.call }
+
+    it 'calls the Notifier with update' do
+      expect(Notifier).to have_received(:prepare_notifications).with(topic: move, action_name: 'update')
+    end
+  end
+
+  shared_examples_for 'it does not call the Notifier' do
+    before do
+      move_executor.call
+    rescue ActiveRecord::RecordInvalid
+      nil
+    end
+
+    it 'calls the Notifier with update' do
+      expect(Notifier).not_to have_received(:prepare_notifications)
+    end
+  end
+
+  context 'when event_name=start' do
+    context 'when the move is booked' do
+      let(:move) { create(:move, :booked) }
+
+      let!(:event) { create(:event_move_start, eventable: move) }
+
+      it 'updates the move status to in_transit' do
+        expect { move_executor.call }.to change(move, :status).from('booked').to('in_transit')
+      end
+
+      it_behaves_like 'it calls the Notifier with an update_status action_name'
+    end
+
+    context 'when the move is already in_transit' do
+      let!(:move) { create(:move, :in_transit) }
+
+      it_behaves_like 'it does not call the Notifier'
+
+      it 'does not change the move status' do
+        expect { move_executor.call }.not_to change(move, :status).from('in_transit')
+      end
+    end
+  end
+
+  context 'when event_name=redirect' do
+    let!(:move) { create(:move, :requested, to_location: original_location) }
+    let(:original_location) { create(:location) }
+
+    let!(:event1) { create(:event_move_redirect, eventable: move, occurred_at: event1_timestamp, details: event1_details) }
+    let(:event1_details) do
+      {
+        move_type: 'court_appearance',
+        to_location_id: event1_location.id,
+      }
+    end
+    let(:event1_location) { create(:location, :court, title: 'Event1-Location') }
+
+    let!(:event2) { create(:event_move_redirect, eventable: move, occurred_at: event2_timestamp, details: event2_details) }
+    let(:event2_details) do
+      {
+        move_type: 'court_appearance',
+        to_location_id: event2_location.id,
+      }
+    end
+
+    let(:event2_location) { create(:location, :court, title: 'Event2-Location') }
+
+    context 'when events are received in a chronological order' do
+      let(:event1_timestamp) { '2020-05-22 09:00:00' }  # chronologically first event created first
+      let(:event2_timestamp) { '2020-05-22 10:00:00' }  # chronologically second event created second
+
+      it 'updates the move to event2 redirect location' do
+        expect { move_executor.call }.to change(move, :to_location).from(original_location).to(event2_location)
+      end
+
+      it_behaves_like 'it calls the Notifier with an update action_name'
+    end
+
+    context 'when events are not received in a chronological order' do
+      let(:event1_timestamp) { '2020-05-22 10:00:00' } # chronologically second event created first
+      let(:event2_timestamp) { '2020-05-22 09:00:00' } # chronologically first event created second
+
+      it 'updates the move to event1 redirect location' do
+        expect { move_executor.call }.to change(move, :to_location).from(original_location).to(event1_location)
+      end
+
+      it_behaves_like 'it calls the Notifier with an update action_name'
+    end
+  end
+
+  context 'when event_name=cancel' do
+    let(:move) { create(:move, :requested) }
+    let!(:event) { create(:event_move_cancel, eventable: move) }
+
+    before do
+      allow(Allocations::RemoveFromNomis).to receive(:call)
+    end
+
+    context 'when the move is requested' do
+      it 'updates the move status to cancelled' do
+        expect { move_executor.call }.to change(move, :status).from('requested').to('cancelled')
+      end
+
+      it 'updates the move cancellation_reason' do
+        expect { move_executor.call }.to change(move, :cancellation_reason).from(nil).to(event.details['cancellation_reason'])
+      end
+
+      it 'updates the move cancellation_reason_comment' do
+        expect { move_executor.call }.to change(move, :cancellation_reason_comment).from(nil).to(event.details['cancellation_reason_comment'])
+      end
+
+      it 'removes prison transfer event from Nomis' do
+        move_executor.call
+        expect(Allocations::RemoveFromNomis).to have_received(:call).with(move)
+      end
+
+      it_behaves_like 'it calls the Notifier with an update_status action_name'
+    end
+
+    context 'when the move is already cancelled' do
+      let!(:move) { create(:move, :cancelled, cancellation_reason: 'made_in_error', cancellation_reason_comment: 'It was a mistake') }
+
+      it_behaves_like 'it does not call the Notifier'
+
+      it 'does not change the move status' do
+        expect { move_executor.call }.not_to change(move, :status).from('cancelled')
+      end
+    end
+  end
+
+  context 'when event_name=approve' do
+    let!(:event) { create(:event_move_approve, eventable: move) }
+
+    before do
+      allow(Allocations::CreateInNomis).to receive(:call)
+    end
+
+    context 'when the move is proposed' do
+      let!(:move) { create(:move, :proposed, date: Date.today) }
+
+      it 'updates the move status to requested' do
+        expect { move_executor.call }.to change(move, :status).from('proposed').to('requested')
+      end
+
+      it 'updates the move date' do
+        expect { move_executor.call }.to change(move, :date).from(Date.today).to(Date.tomorrow)
+      end
+
+      it 'does not create a prison transfer event in Nomis' do
+        move_executor.call
+        expect(Allocations::CreateInNomis).not_to have_received(:call).with(move)
+      end
+
+      it_behaves_like 'it calls the Notifier with an update_status action_name'
+    end
+  end
+end

--- a/spec/services/event_log/move_runner_spec.rb
+++ b/spec/services/event_log/move_runner_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe EventLog::MoveRunner do
       end
 
       it 'updates the move cancellation_reason_comment' do
-        expect { runner.call }.to change(move, :cancellation_reason_comment).from(nil).to('computer says no')
+        expect { runner.call }.to change(move, :cancellation_reason_comment).from(nil).to('It was a mistake')
       end
 
       it 'removes prison transfer event from Nomis' do
@@ -117,7 +117,7 @@ RSpec.describe EventLog::MoveRunner do
     end
 
     context 'when the move is already cancelled' do
-      let!(:move) { create(:move, :cancelled, cancellation_reason: 'supplier_declined_to_move', cancellation_reason_comment: 'computer says no') }
+      let!(:move) { create(:move, :cancelled, cancellation_reason: 'supplier_declined_to_move', cancellation_reason_comment: 'It was a mistake') }
 
       it_behaves_like 'it does not call the Notifier'
 
@@ -238,7 +238,7 @@ RSpec.describe EventLog::MoveRunner do
       end
 
       it 'updates the move cancellation_reason_comment' do
-        expect { runner.call }.to change(move, :cancellation_reason_comment).from(nil).to('computer says no')
+        expect { runner.call }.to change(move, :cancellation_reason_comment).from(nil).to('It was a mistake')
       end
 
       it_behaves_like 'it calls the Notifier with an update_status action_name'
@@ -255,7 +255,7 @@ RSpec.describe EventLog::MoveRunner do
     end
 
     context 'when the move is already rejected' do
-      let!(:move) { create(:move, :cancelled, rejection_reason: 'no_transport_available', cancellation_reason: 'rejected', cancellation_reason_comment: 'computer says no') }
+      let!(:move) { create(:move, :cancelled, rejection_reason: 'no_transport_available', cancellation_reason: 'rejected', cancellation_reason_comment: 'It was a mistake') }
 
       it_behaves_like 'it does not call the Notifier'
 


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/P4-2163

## What?

Rewrite the journey and move runner classes to use the generic events that we’re now writing out in both v1/v2 apis.

## Why?

To enable us to remove the v1 event writing### Have you? (optional)
