### PR TITLE
[P4-2244] Updates event feed to use generic events

### DIFF
--- a/app/services/feeds/event.rb
+++ b/app/services/feeds/event.rb
@@ -8,7 +8,7 @@ module Feeds
     end
 
     def call
-      ::Event.includes(:eventable).updated_at_range(@updated_at_from, @updated_at_to).find_each do |event|
+      ::GenericEvent.includes(:eventable).updated_at_range(@updated_at_from, @updated_at_to).find_each do |event|
         @feed << event.for_feed.to_json
       end
 

--- a/spec/services/feeds/event_spec.rb
+++ b/spec/services/feeds/event_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Feeds::Event do
   let(:updated_at_to) { Time.zone.now.end_of_day - 1.day }
 
   describe '#call' do
-    let!(:on_start_event) { create(:event, updated_at: updated_at_from) }
-    let!(:on_end_event) { create(:event, updated_at: updated_at_to) }
+    let!(:on_start_event) { create(:event_move_cancel, updated_at: updated_at_from) }
+    let!(:on_end_event) { create(:event_journey_cancel, updated_at: updated_at_to) }
 
     let(:expected_json) do
       [on_start_event, on_end_event].sort_by(&:id).map { |event| JSON.parse(event.for_feed.to_json) }


### PR DESCRIPTION
### Jira link

P4-2244

### What?

I have added/removed/altered:

- [x] Updates events feed to use generic events

### Why?

I am doing this because:

- This will produce the agreed format for the hub.

