### PR TITLE
[P4-2164] Adds missing JourneyCreate and JourneyUpdate events

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -17,12 +17,14 @@ class GenericEvent < ApplicationRecord
   STI_CLASSES = %w[
     JourneyCancel
     JourneyComplete
+    JourneyCreate
     JourneyLockout
     JourneyLodging
     JourneyReject
     JourneyStart
     JourneyUncancel
     JourneyUncomplete
+    JourneyUpdate
     MoveAccept
     MoveApprove
     MoveCancel

--- a/app/models/generic_event/journey_create.rb
+++ b/app/models/generic_event/journey_create.rb
@@ -3,7 +3,7 @@ class GenericEvent
     include JourneyEventValidations
 
     def self.from_event(event)
-      new(event.generic_event_attributes)
+      new(event.generic_event_attributes.merge(details: event.details))
     end
   end
 end

--- a/app/models/generic_event/journey_create.rb
+++ b/app/models/generic_event/journey_create.rb
@@ -1,0 +1,9 @@
+class GenericEvent
+  class JourneyCreate < GenericEvent
+    include JourneyEventValidations
+
+    def self.from_event(event)
+      new(event.generic_event_attributes)
+    end
+  end
+end

--- a/app/models/generic_event/journey_update.rb
+++ b/app/models/generic_event/journey_update.rb
@@ -3,7 +3,7 @@ class GenericEvent
     include JourneyEventValidations
 
     def self.from_event(event)
-      new(event.generic_event_attributes)
+      new(event.generic_event_attributes.merge(details: event.details))
     end
   end
 end

--- a/app/models/generic_event/journey_update.rb
+++ b/app/models/generic_event/journey_update.rb
@@ -1,0 +1,9 @@
+class GenericEvent
+  class JourneyUpdate < GenericEvent
+    include JourneyEventValidations
+
+    def self.from_event(event)
+      new(event.generic_event_attributes)
+    end
+  end
+end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
   end
 
   factory :event_move_cancel, parent: :generic_event, class: 'GenericEvent::MoveCancel' do
+    eventable { association(:move) }
     details do
       {
         cancellation_reason: 'made_in_error',
@@ -76,6 +77,10 @@ FactoryBot.define do
     eventable { association(:journey) }
   end
 
+  factory :event_journey_create, parent: :generic_event, class: 'GenericEvent::JourneyCreate' do
+    eventable { association(:journey) }
+  end
+
   factory :event_journey_lockout, parent: :generic_event, class: 'GenericEvent::JourneyLockout' do
     eventable { association(:journey) }
     details do
@@ -107,6 +112,10 @@ FactoryBot.define do
   end
 
   factory :event_journey_uncomplete, parent: :generic_event, class: 'GenericEvent::JourneyUncomplete' do
+    eventable { association(:journey) }
+  end
+
+  factory :event_journey_update, parent: :generic_event, class: 'GenericEvent::JourneyUpdate' do
     eventable { association(:journey) }
   end
 end

--- a/spec/models/generic_event/journey_create_spec.rb
+++ b/spec/models/generic_event/journey_create_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe GenericEvent::JourneyCreate do
+  subject(:generic_event) { build(:event_journey_cancel) }
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
+
+  describe '.from_event' do
+    let(:journey) { create(:journey) }
+    let(:event) { create(:event, :create, eventable: journey) }
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => journey.id,
+        'eventable_type' => 'Journey',
+        'type' => 'GenericEvent::JourneyCreate',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {},
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+    end
+
+    it 'builds a valid generic_event' do
+      expect(described_class.from_event(event)).to be_valid
+    end
+  end
+end

--- a/spec/models/generic_event/journey_create_spec.rb
+++ b/spec/models/generic_event/journey_create_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe GenericEvent::JourneyCreate do
 
   describe '.from_event' do
     let(:journey) { create(:journey) }
-    let(:event) { create(:event, :create, eventable: journey) }
+    let(:event) { create(:event, :create, eventable: journey, details: details) }
+    let(:details) do
+      { event_params: { attributes: { notes: 'baz' } } }
+    end
 
     let(:expected_generic_event_attributes) do
       {
@@ -13,9 +16,9 @@ RSpec.describe GenericEvent::JourneyCreate do
         'eventable_id' => journey.id,
         'eventable_type' => 'Journey',
         'type' => 'GenericEvent::JourneyCreate',
-        'notes' => 'foo',
+        'notes' => 'baz',
         'created_by' => 'unknown',
-        'details' => {},
+        'details' => details,
         'occurred_at' => eq(event.client_timestamp),
         'recorded_at' => eq(event.client_timestamp),
         'created_at' => be_within(0.1.seconds).of(event.created_at),

--- a/spec/models/generic_event/journey_update_spec.rb
+++ b/spec/models/generic_event/journey_update_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe GenericEvent::JourneyUpdate do
+  subject(:generic_event) { build(:event_journey_update) }
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
+
+  describe '.from_event' do
+    let(:journey) { create(:journey) }
+    let(:event) { create(:event, :update, eventable: journey) }
+
+    let(:expected_generic_event_attributes) do
+      {
+        'id' => nil,
+        'eventable_id' => journey.id,
+        'eventable_type' => 'Journey',
+        'type' => 'GenericEvent::JourneyUpdate',
+        'notes' => 'foo',
+        'created_by' => 'unknown',
+        'details' => {},
+        'occurred_at' => eq(event.client_timestamp),
+        'recorded_at' => eq(event.client_timestamp),
+        'created_at' => be_within(0.1.seconds).of(event.created_at),
+        'updated_at' => be_within(0.1.seconds).of(event.updated_at),
+      }
+    end
+
+    it 'builds a generic_event with the correct attributes' do
+      expect(described_class.from_event(event).attributes).to include_json(expected_generic_event_attributes)
+    end
+
+    it 'builds a valid generic_event' do
+      expect(described_class.from_event(event)).to be_valid
+    end
+  end
+end

--- a/spec/models/generic_event/journey_update_spec.rb
+++ b/spec/models/generic_event/journey_update_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe GenericEvent::JourneyUpdate do
 
   describe '.from_event' do
     let(:journey) { create(:journey) }
-    let(:event) { create(:event, :update, eventable: journey) }
+    let(:event) { create(:event, :update, eventable: journey, details: details) }
+    let(:details) do
+      { event_params: { attributes: { notes: 'baz' } } }
+    end
 
     let(:expected_generic_event_attributes) do
       {
@@ -13,9 +16,9 @@ RSpec.describe GenericEvent::JourneyUpdate do
         'eventable_id' => journey.id,
         'eventable_type' => 'Journey',
         'type' => 'GenericEvent::JourneyUpdate',
-        'notes' => 'foo',
+        'notes' => 'baz',
         'created_by' => 'unknown',
-        'details' => {},
+        'details' => details,
         'occurred_at' => eq(event.client_timestamp),
         'recorded_at' => eq(event.client_timestamp),
         'created_at' => be_within(0.1.seconds).of(event.created_at),


### PR DESCRIPTION
### Jira link

P4-2164

### What?

I have added/removed/altered:

- [x] Added missing STI event classes `JourneyCreate` and `JourneyUpdate`

These events aren't documented, don't follow the standard process_event
behaviour and aren't affected by the event log.

We discovered these by auditing a migration outcome in production just
as we were going to make a breaking change.

These events are created via a controller callback for the update and
create actions: https://github.com/ministryofjustice/hmpps-book-secure-move-api/blob/5d1064f63a557f2b69eef16878ca8eb39e714e71/app/controllers/api/journeys_controller.rb#L10

### Why?

I am doing this because:

- Make sure that all events are copied by the event copier

