### PR TITLE
Allow personal care need types to be passed into the NOMIS client

### DIFF
--- a/app/lib/nomis_client/personal_care_needs.rb
+++ b/app/lib/nomis_client/personal_care_needs.rb
@@ -5,17 +5,17 @@ module NomisClient
     PERSONAL_CARE_TYPES = 'MATSTAT,PHY,DISAB'
 
     class << self
-      def get(nomis_offender_numbers)
-        get_response(nomis_offender_numbers: nomis_offender_numbers).map { |personal_care_needs|
+      def get(nomis_offender_numbers:, personal_care_types: PERSONAL_CARE_TYPES)
+        get_response(nomis_offender_numbers: nomis_offender_numbers, personal_care_types: personal_care_types).map { |personal_care_needs|
           personal_care_needs['personalCareNeeds'].map do |personal_care_need_attributes|
             attributes_for(personal_care_needs['offenderNo'], personal_care_need_attributes)
           end
         }.flatten
       end
 
-      def get_response(nomis_offender_numbers:)
+      def get_response(nomis_offender_numbers:, personal_care_types:)
         NomisClient::Base.post(
-          "/bookings/offenderNo/personal-care-needs?type=#{PERSONAL_CARE_TYPES}",
+          "/bookings/offenderNo/personal-care-needs?type=#{personal_care_types}",
           body: nomis_offender_numbers.to_json,
         ).parsed
       end

--- a/app/services/moves/import_people.rb
+++ b/app/services/moves/import_people.rb
@@ -18,7 +18,7 @@ module Moves
       people = NomisClient::People.get(prison_numbers).index_by { |p| p.fetch(:prison_number) }
       alerts = NomisClient::Alerts.get(prison_numbers).group_by { |p| p.fetch(:offender_no) }
       personal_care_needs = NomisClient::PersonalCareNeeds
-                            .get(prison_numbers)
+                            .get(nomis_offender_numbers: prison_numbers)
                             .group_by { |p| p.fetch(:offender_no) }
 
       new_person_count = 0

--- a/app/services/profiles/import_alerts_and_personal_care_needs.rb
+++ b/app/services/profiles/import_alerts_and_personal_care_needs.rb
@@ -15,7 +15,7 @@ module Profiles
   private
 
     def personal_care_needs
-      NomisClient::PersonalCareNeeds.get([@prison_number]).group_by { |p| p.fetch(:offender_no) }
+      NomisClient::PersonalCareNeeds.get(nomis_offender_numbers: [@prison_number]).group_by { |p| p.fetch(:offender_no) }
     end
 
     def alerts

--- a/spec/lib/nomis_client/personal_care_needs_spec.rb
+++ b/spec/lib/nomis_client/personal_care_needs_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe NomisClient::PersonalCareNeeds, with_nomis_client_authentication: true do
   describe '.get' do
     let(:nomis_offender_numbers) { [321, 123] }
-    let(:response) { described_class.get(nomis_offender_numbers) }
+    let(:response) { described_class.get(nomis_offender_numbers: nomis_offender_numbers) }
     let(:client_response) do
       [
         {


### PR DESCRIPTION
To allow flexibility around the NOMIS personal care needs query, allow types to be passed in, or default to already defined personal care need types. This will allow the PER to define its own personal care need types, which can be different to the PTR.