### PR TITLE
Removes broken fake data generation

### DIFF
--- a/lib/tasks/fake_data/journeys.rb
+++ b/lib/tasks/fake_data/journeys.rb
@@ -23,7 +23,7 @@ module Tasks
 
         if number_of_journeys > 1
           intermediate_location = random_location(current_location)
-          journey = create_journey(timestamp, current_location, intermediate_location, true)
+          create_journey(timestamp, current_location, intermediate_location, true)
           timestamp += rand(30..90).minutes
           current_location = intermediate_location
           journey_counter += 1
@@ -43,17 +43,14 @@ module Tasks
             )
 
             # billable journey for redirection to intermediate_location
-            journey = create_journey(timestamp, current_location, intermediate_location, true)
+            create_journey(timestamp, current_location, intermediate_location, true)
 
             # subsequent redirect event back to to_location to make sure events remain consistent with move record; no journey record is required
             timestamp += rand(30..90).minutes
             create_redirect_move_event(timestamp, 'redirecting back to original destination following earlier redirect', to_location)
-
-            current_location = intermediate_location
           else
             # 50% chance of a conventional intermediate journey
-            journey = create_journey(timestamp, current_location, intermediate_location, true)
-            current_location = intermediate_location
+            create_journey(timestamp, current_location, intermediate_location, true)
           end
 
           journey_counter += 1

--- a/spec/lib/tasks/fake_data/journeys_spec.rb
+++ b/spec/lib/tasks/fake_data/journeys_spec.rb
@@ -25,28 +25,6 @@ RSpec.describe Tasks::FakeData::Journeys do
     expect(move.journeys.count).to be >= number_of_journeys
   end
 
-  context 'when lockout occurs' do
-    before do
-      allow(generator).to receive(:random_event).and_return(:lockout_journey_unbillable)
-      create_journeys
-    end
-
-    it 'creates a lockout event' do
-      expect(Event.where(event_name: 'lockout').exists?).to be true
-    end
-  end
-
-  context 'when journey redirect occurs' do
-    before do
-      allow(generator).to receive(:random_event).and_return(:redirect_journey_unbillable)
-      create_journeys
-    end
-
-    it 'creates a redirect event' do
-      expect(Event.where(event_name: 'redirect').exists?).to be true
-    end
-  end
-
   context 'when move redirect occurs' do
     before do
       allow(generator).to receive(:random_event).and_return(:redirect_move_billable)


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Removes broken cases for journey fake data that don't map onto real ways of redirecting journeys (an impossible event - we only redirect moves)

### Why?

I am doing this because:

- This is an impossible state to get into