### PR TITLE
Adds supplier relationship to generic_event

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -36,6 +36,7 @@ class GenericEvent < ApplicationRecord
   ].freeze
 
   belongs_to :eventable, polymorphic: true, touch: true
+  belongs_to :supplier,  optional: true
 
   validates :eventable,      presence: true # What is the subject of the event
   validates :type,           presence: true # STI class of the event

--- a/db/migrate/20200923102115_add_supplier_to_generic_events.rb
+++ b/db/migrate/20200923102115_add_supplier_to_generic_events.rb
@@ -1,0 +1,7 @@
+class AddSupplierToGenericEvents < ActiveRecord::Migration[6.0]
+  def change
+    # Adds reference to supplier in generic event so that we can track the supplier via the existing
+    # and new event api through doorkeeper tokens
+    add_reference :generic_events, :supplier, type: :uuid, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_10_083822) do
+ActiveRecord::Schema.define(version: 2020_09_23_102115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -209,9 +209,11 @@ ActiveRecord::Schema.define(version: 2020_09_10_083822) do
     t.datetime "recorded_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "supplier_id"
     t.index ["eventable_id", "eventable_type"], name: "index_generic_events_on_eventable_id_and_eventable_type"
     t.index ["occurred_at"], name: "index_generic_events_on_occurred_at"
     t.index ["recorded_at"], name: "index_generic_events_on_recorded_at"
+    t.index ["supplier_id"], name: "index_generic_events_on_supplier_id"
   end
 
   create_table "identifier_types", id: :string, force: :cascade do |t|
@@ -517,6 +519,7 @@ ActiveRecord::Schema.define(version: 2020_09_10_083822) do
   add_foreign_key "framework_questions", "frameworks"
   add_foreign_key "framework_responses", "framework_questions"
   add_foreign_key "framework_responses", "person_escort_records"
+  add_foreign_key "generic_events", "suppliers"
   add_foreign_key "journeys", "locations", column: "from_location_id"
   add_foreign_key "journeys", "locations", column: "to_location_id"
   add_foreign_key "journeys", "moves"

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe GenericEvent, type: :model do
   subject(:generic_event) { build(:event_move_cancel) }
 
   it { is_expected.to belong_to(:eventable) }
+  it { is_expected.to belong_to(:supplier).optional }
   it { is_expected.to validate_presence_of(:eventable) }
   it { is_expected.to validate_presence_of(:type) }
   it { is_expected.to validate_presence_of(:occurred_at) }


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Adds supplier relationship to generic event

### Why?

I am doing this because:

- We want to make sure we're including the supplier that is currently present in the v1 apis on every generic event.