### PR TITLE
[P4-2265] Adds supplier id to generic event attributes builder

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -66,6 +66,7 @@ class Event < ApplicationRecord
       eventable: eventable,
       details: {},
       created_by: 'unknown',
+      supplier_id: supplier_id,
     }
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe Event, type: :model do
   end
 
   describe '#generic_event_attributes' do
+    subject(:event) { build(:event, details: { supplier_id: '111' }) }
+
     it 'returns the correct attributes' do
       expected = {
         created_at: nil,
@@ -79,7 +81,7 @@ RSpec.describe Event, type: :model do
         details: {},
         eventable: be_a(Move),
         recorded_at: be_a(Time),
-        supplier_id: '1234',
+        supplier_id: '111',
         updated_at: nil,
       }
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -70,4 +70,20 @@ RSpec.describe Event, type: :model do
       expect(event.for_feed).to eq(expected_json)
     end
   end
+
+  describe '#generic_event_attributes' do
+    it 'returns the correct attributes' do
+      expected = {
+        created_at: nil,
+        created_by: 'unknown',
+        details: {},
+        eventable: be_a(Move),
+        recorded_at: be_a(Time),
+        supplier_id: '1234',
+        updated_at: nil,
+      }
+
+      expect(event.generic_event_attributes).to include_json(expected)
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

P4-2265

### What?

Generic events need to have their supplier id populated as part of the migration from Event -> GenericEvent. In the original conception of GenericEvent we weren't storing the supplier_id and were instead referencing the created_by field to determine the supplier as an enum. This was inconsistent with our approach in the rest of the code base.

- [x] Updates the common attribute builder for generic events with the supplier id

### Why?

I am doing this because:

- For consistency
- For reporting to the hub
- This enables us to copy/create new generic events with a supplier id