### PR TITLE
[P4-2265] Adds supplier to generic_event feed

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -3,7 +3,6 @@ class GenericEvent < ApplicationRecord
   FEED_ATTRIBUTES = %w[
     id
     type
-    actioned_by
     notes
     created_at
     updated_at
@@ -55,7 +54,9 @@ class GenericEvent < ApplicationRecord
   def trigger; end
 
   def for_feed
-    attributes.slice(*FEED_ATTRIBUTES)
+    feed = attributes.slice(*FEED_ATTRIBUTES)
+    feed.merge!(supplier&.for_feed) if supplier_id
+    feed
   end
 
   def self.from_event(event)

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe GenericEvent, type: :model do
   end
 
   describe '#for_feed' do
-    subject(:generic_event) { create(:event_move_cancel) }
+    subject(:generic_event) { create(:event_move_cancel, supplier: create(:supplier, key: 'serco')) }
 
     it 'returns the expected attributes' do
       expected_attributes = {
@@ -61,6 +61,7 @@ RSpec.describe GenericEvent, type: :model do
         'eventable_id' => generic_event.eventable_id,
         'eventable_type' => 'Move',
         'details' => { 'cancellation_reason' => 'made_in_error', 'cancellation_reason_comment' => 'It was a mistake' },
+        'supplier' => 'serco',
       }
 
       expect(generic_event.for_feed).to include_json(expected_attributes)


### PR DESCRIPTION
### Jira link

P4-2265

### What?

I have added/removed/altered:

- [x] Update event feed to include supplier

### Why?

I am doing this because:

- We need the supplier in the generic event feed for when we backfill the generic events for the JPC.