### PR TITLE
Reduce N+1 queries for GET /allocations endpoint

### DIFF
--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -4,6 +4,8 @@ module Allocations
   class Finder
     attr_reader :filter_params, :search_params
 
+    ALLOCATION_INCLUDES = [:from_location, :to_location, moves: %i[profile]].freeze
+
     def initialize(filters: {}, ordering: {}, search: {})
       @search_params = search
       @filter_params = filters
@@ -17,7 +19,7 @@ module Allocations
     end
 
     def call
-      scope = apply_filters(Allocation)
+      scope = apply_filters(Allocation.includes(ALLOCATION_INCLUDES))
       scope = apply_search(scope)
       apply_ordering(scope)
     end


### PR DESCRIPTION
### Jira link

IM-7

### What?

- [x] Attempt to reduce N+1 queries for most common use case of `GET /allocations` endpoint

### Why?

- There are quite a lot of slow API requests in production, these are all including from_location, to_location, moves and move profiles which means lots of DB queries. The design of this needs to be improved (e.g. calculating allocation progress on the backend to avoid the need to send move and profile details), but as a short term fix this should help with reducing N+1 queries and hopefully improve the immediate issue.

### Deployment risks (optional)

- Should improve performance at least slightly, but needs to be tested on some reasonably realistic data volumes
