### PR TITLE
P4-2198 Fix unique profile when creating the PER error

### DIFF
--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -42,6 +42,9 @@ class PersonEscortRecord < VersionedModel
 
     record = new(profile: profile, framework: framework)
     record.build_responses!
+  rescue PG::UniqueViolation
+    record.errors.add(:profile, 'has already been taken')
+    raise ActiveModel::ValidationError, record
   end
 
   def build_responses!

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -105,6 +105,47 @@ RSpec.describe Api::PersonEscortRecordsController do
         it_behaves_like 'an endpoint that responds with error 404'
       end
 
+      context 'when a person escort record already exists on a profile' do
+        let(:errors_422) do
+          [
+            {
+              'title' => 'Unprocessable entity',
+              'detail' => 'Profile has already been taken',
+              'source' => { 'pointer' => '/data/attributes/profile' },
+              'code' => 'taken',
+            },
+          ]
+        end
+
+        before do
+          post '/api/v1/person_escort_records', params: person_escort_record_params, headers: headers, as: :json
+          post '/api/v1/person_escort_records', params: person_escort_record_params, headers: headers, as: :json
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422'
+      end
+
+      context 'when a person escort record already exists on a profile and unique index error thrown' do
+        let(:errors_422) do
+          [
+            {
+              'title' => 'Invalid profile',
+              'detail' => 'Validation failed: Profile has already been taken',
+            },
+          ]
+        end
+
+        before do
+          person_escort_record = PersonEscortRecord.new
+          allow(PersonEscortRecord).to receive(:new).and_return(person_escort_record)
+          allow(person_escort_record).to receive(:build_responses!).and_raise(PG::UniqueViolation, 'duplicate key value violates unique constraint')
+
+          post '/api/v1/person_escort_records', params: person_escort_record_params, headers: headers, as: :json
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422'
+      end
+
       context 'with a reference to a missing framework' do
         let(:framework_version) { '0.2.1' }
         let(:detail_404) { "Couldn't find Framework" }


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2198

When a user is double clicking create the PER button, they are seeing a 500 error as opposed to be gracefully redirected to the already created PER. Ideally the API should be catching this uniqueness validation error, and returning a 422 with the relevant message, however due to the way our app is setup in production, where we have multiple instances attempting the same thing,  this isn't being caught as a validation error on uniqueness, and is falling back to the database level of
errors, and raises an exception.

I found that this article explains it pretty well: https://thoughtbot.com/blog/the-perils-of-uniqueness-validations

We have to manually catch this error if it happens. I've added tests for both instances, so now we can handle the uniqueness validation as well as the DB error itself.