### PR TITLE
Use normal validation error when raising taken error

### DIFF
--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -43,8 +43,8 @@ class PersonEscortRecord < VersionedModel
     record = new(profile: profile, framework: framework)
     record.build_responses!
   rescue PG::UniqueViolation, ActiveRecord::RecordNotUnique
-    record.errors.add(:profile, 'has already been taken')
-    raise ActiveModel::ValidationError, record
+    record.errors.add(:profile, :taken)
+    raise ActiveRecord::RecordInvalid, record
   end
 
   def build_responses!

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -129,8 +129,10 @@ RSpec.describe Api::PersonEscortRecordsController do
         let(:errors_422) do
           [
             {
-              'title' => 'Invalid profile',
-              'detail' => 'Validation failed: Profile has already been taken',
+              'title' => 'Unprocessable entity',
+              'detail' => 'Profile has already been taken',
+              'source' => { 'pointer' => '/data/attributes/profile' },
+              'code' => 'taken',
             },
           ]
         end


### PR DESCRIPTION
We can throw a `ActiveRecord::RecordInvalid` when instantiating with record, as previously we couldn't in older rails, but its been changed: https://stackoverflow.com/questions/26024359/how-to-create-a-activerecordrecordinvalid-for-testing

This means the FE will not have to accommodate different types of errors