### PR TITLE
Add new tasks to backfill generic event starting from a certain date

### DIFF
--- a/app/lib/cloud_data_feed.rb
+++ b/app/lib/cloud_data_feed.rb
@@ -4,14 +4,18 @@ class CloudDataFeed
     @bucket = @s3.bucket(bucket_name)
   end
 
-  def write(content, obj_name)
-    report_date = Time.zone.today.strftime('%Y/%m/%d')
-    file_date = Time.zone.today.strftime('%Y-%m-%d')
+  def write(content, obj_name, report_date = Time.zone.today)
+    folder_name = report_date.strftime('%Y/%m/%d')
+    filename = report_date.strftime('%Y-%m-%d')
 
-    full_name = "#{report_date}/#{file_date}-#{obj_name}"
-    obj = @bucket.object(full_name)
+    full_name = "#{folder_name}/#{filename}-#{obj_name}"
+    obj = bucket.object(full_name)
     obj.put(body: content)
 
     full_name
   end
+
+private
+
+  attr_reader :bucket
 end

--- a/lib/tasks/feeds/event.rake
+++ b/lib/tasks/feeds/event.rake
@@ -5,4 +5,24 @@ namespace :feeds do
 
     CloudDataFeed.new.write(feed, 'events.jsonl')
   end
+
+  desc 'Exports the JSON starting from a certain date (inclusive)'
+  task events_from_date: :environment do
+    start_date_param = ENV.fetch('START_DATE', nil)
+
+    unless start_date_param
+      puts 'Please specify the START_DATE ENV variable.'
+      puts 'for example: START_DATE="2020-08-29"'
+      return
+    end
+
+    start_date = Date.parse(start_date_param)
+
+    (start_date..Time.zone.today).each do |day|
+      puts "Processing day #{day}"
+      feed = Feeds::Event.new(day.beginning_of_day, day.end_of_day).call
+
+      CloudDataFeed.new.write(feed, 'events.jsonl', day)
+    end
+  end
 end

--- a/spec/lib/cloud_data_feed_spec.rb
+++ b/spec/lib/cloud_data_feed_spec.rb
@@ -12,8 +12,19 @@ RSpec.describe CloudDataFeed do
 
   it 'writes a file on S3 and return the full_name' do
     full_name = described_class.new('bucket_name')
-                               .write('some content', 'report.json')
+                    .write('some content', 'report.json')
 
     expect(full_name).to eq('2020/01/30/2020-01-30-report.json')
+  end
+
+  context 'when a report date is specified' do
+    let(:report_date) { Date.new(2020, 1, 15) }
+
+    it 'creates a file and names it base on the report date ' do
+      full_name = described_class.new('bucket_name')
+                                 .write('some content', 'report.json', report_date)
+
+      expect(full_name).to eq('2020/01/15/2020-01-15-report.json')
+    end
   end
 end


### PR DESCRIPTION
### Jira link

P4-2263

What

Write a script to backfill all generic events from updated_at from last 3 days of August to now.

Why

We need this for the JPC
