### PR TITLE
[P4-2264] Remove GenericEvent:: prefix in type in feed view

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -1,7 +1,6 @@
 class GenericEvent < ApplicationRecord
   FEED_ATTRIBUTES = %w[
     id
-    type
     notes
     created_at
     updated_at
@@ -67,6 +66,7 @@ class GenericEvent < ApplicationRecord
 
   def for_feed
     feed = attributes.slice(*FEED_ATTRIBUTES)
+    feed.merge!('type' => type.sub('GenericEvent::', ''))
     feed.merge!(supplier&.for_feed) if supplier_id
     feed
   end

--- a/spec/models/generic_event/journey_lockout_spec.rb
+++ b/spec/models/generic_event/journey_lockout_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GenericEvent::JourneyLockout do
     let(:expected_json) do
       {
         'id' => generic_event.id,
-        'type' => 'GenericEvent::JourneyLockout',
+        'type' => 'JourneyLockout',
         'notes' => 'Flibble',
         'created_at' => be_a(Time),
         'updated_at' => be_a(Time),

--- a/spec/models/generic_event/journey_lodging_spec.rb
+++ b/spec/models/generic_event/journey_lodging_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GenericEvent::JourneyLodging do
     let(:expected_json) do
       {
         'id' => generic_event.id,
-        'type' => 'GenericEvent::JourneyLodging',
+        'type' => 'JourneyLodging',
         'notes' => 'Flibble',
         'created_at' => be_a(Time),
         'updated_at' => be_a(Time),

--- a/spec/models/generic_event/move_approve_spec.rb
+++ b/spec/models/generic_event/move_approve_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe GenericEvent::MoveApprove do
     let(:expected_json) do
       {
         'id' => generic_event.id,
-        'type' => 'GenericEvent::MoveApprove',
+        'type' => 'MoveApprove',
         'notes' => 'Flibble',
         'created_at' => be_a(Time),
         'updated_at' => be_a(Time),

--- a/spec/models/generic_event/move_cancel_spec.rb
+++ b/spec/models/generic_event/move_cancel_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe GenericEvent::MoveCancel do
       let(:expected_json) do
         {
           'id' => generic_event.id,
-          'type' => 'GenericEvent::MoveCancel',
+          'type' => 'MoveCancel',
           'notes' => 'Flibble',
           'created_at' => be_a(Time),
           'updated_at' => be_a(Time),
@@ -127,7 +127,7 @@ RSpec.describe GenericEvent::MoveCancel do
       let(:expected_json) do
         {
           'id' => generic_event.id,
-          'type' => 'GenericEvent::MoveCancel',
+          'type' => 'MoveCancel',
           'notes' => 'Flibble',
           'created_at' => be_a(Time),
           'updated_at' => be_a(Time),

--- a/spec/models/generic_event/move_lockout_spec.rb
+++ b/spec/models/generic_event/move_lockout_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe GenericEvent::MoveLockout do
     let(:expected_json) do
       {
         'id' => generic_event.id,
-        'type' => 'GenericEvent::MoveLockout',
+        'type' => 'MoveLockout',
         'notes' => 'Flibble',
         'created_at' => be_a(Time),
         'updated_at' => be_a(Time),

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe GenericEvent::MoveRedirect do
       let(:expected_json) do
         {
           'id' => generic_event.id,
-          'type' => 'GenericEvent::MoveRedirect',
+          'type' => 'MoveRedirect',
           'notes' => 'Flibble',
           'created_at' => be_a(Time),
           'updated_at' => be_a(Time),
@@ -95,7 +95,7 @@ RSpec.describe GenericEvent::MoveRedirect do
       let(:expected_json) do
         {
           'id' => generic_event.id,
-          'type' => 'GenericEvent::MoveRedirect',
+          'type' => 'MoveRedirect',
           'notes' => 'Flibble',
           'created_at' => be_a(Time),
           'updated_at' => be_a(Time),

--- a/spec/models/generic_event/move_reject_spec.rb
+++ b/spec/models/generic_event/move_reject_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe GenericEvent::MoveReject do
       let(:expected_json) do
         {
           'id' => generic_event.id,
-          'type' => 'GenericEvent::MoveReject',
+          'type' => 'MoveReject',
           'notes' => 'Flibble',
           'created_at' => be_a(Time),
           'updated_at' => be_a(Time),

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe GenericEvent, type: :model do
     it 'returns the expected attributes' do
       expected_attributes = {
         'id' => generic_event.id,
-        'type' => 'GenericEvent::MoveCancel',
+        'type' => 'MoveCancel',
         'notes' => 'Flibble',
         'created_at' => be_a(Time),
         'updated_at' => be_a(Time),


### PR DESCRIPTION
### Jira link

P4-2264

### What?

I have added/removed/altered:

- [x] Removes the prefix GenericEvent:: on type in the for_feed view for the hub
- [x] Updates corresponding tests

### Why?

I am doing this because:

- This is ugly and namespacing implementation detail that isn't relevant to the hub