### PR TITLE
P4-2067 Allow passing in a Move to create a Person Escort Record

### DIFF
--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -4,10 +4,11 @@ module Api
   class PersonEscortRecordsController < ApiController
     after_action :send_notification, only: :update
 
+    # TODO: Remove profile id and transition to Move id, for now accept both
     NEW_PERMITTED_PER_PARAMS = [
       :type,
       attributes: [:version],
-      relationships: [profile: {}],
+      relationships: [profile: {}, move: {}],
     ].freeze
 
     UPDATE_PERMITTED_PER_PARAMS = [
@@ -16,9 +17,11 @@ module Api
     ].freeze
 
     def create
+      # TODO: Remove profile id and transition to Move id, for now accept both
       person_escort_record = PersonEscortRecord.save_with_responses!(
         version: new_person_escort_record_params.dig(:attributes, :version),
         profile_id: new_person_escort_record_params.dig(:relationships, :profile, :data, :id),
+        move_id: new_person_escort_record_params.dig(:relationships, :move, :data, :id),
       )
 
       render_person_escort_record(person_escort_record, :created)

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -75,6 +75,7 @@ class Move < VersionedModel
   belongs_to :to_location, class_name: 'Location', optional: true
   belongs_to :profile, optional: true, touch: true
   has_one :person, through: :profile
+  has_one :person_escort_record
 
   belongs_to :prison_transfer_reason, optional: true
   belongs_to :allocation, inverse_of: :moves, optional: true

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -37,11 +37,19 @@ class PersonEscortRecord < VersionedModel
            :confirmed?,
            to: :state_machine
 
-  def self.save_with_responses!(profile_id:, version: nil)
-    profile = Profile.find(profile_id)
+  def self.save_with_responses!(profile_id: nil, version: nil, move_id: nil)
+    # TODO: Remove profile id and transition to Move id, for now accept both
+    if move_id.present?
+      move = Move.find(move_id)
+      profile = move.profile
+    else
+      move = nil
+      profile = Profile.find(profile_id)
+    end
+
     framework = Framework.find_by!(version: version)
 
-    record = new(profile: profile, framework: framework)
+    record = new(profile: profile, move: move, framework: framework)
     record.build_responses!
   rescue PG::UniqueViolation, ActiveRecord::RecordNotUnique
     record.errors.add(:profile, :taken)

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -25,6 +25,7 @@ class PersonEscortRecord < VersionedModel
   has_many :framework_questions, through: :framework
   has_many :framework_flags, through: :framework_responses
   belongs_to :profile
+  belongs_to :move, optional: true
 
   has_state_machine PersonEscortRecordStateMachine, on: :status
 

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -1,5 +1,6 @@
 class PersonEscortRecordSerializer < ActiveModel::Serializer
   belongs_to :profile, record_type: :profile
+  belongs_to :move, record_type: :move
   belongs_to :framework, record_type: :framework
   has_many :framework_responses, serializer: FrameworkResponseSerializer, key: :responses
   has_many :framework_flags, key: :flags
@@ -31,6 +32,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   end
 
   SUPPORTED_RELATIONSHIPS = %w[
+    move
     framework
     profile.person
     responses.question

--- a/db/migrate/20200929055929_add_move_to_person_escort_record.rb
+++ b/db/migrate/20200929055929_add_move_to_person_escort_record.rb
@@ -1,0 +1,5 @@
+class AddMoveToPersonEscortRecord < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :person_escort_records, :move, type: :uuid, index: true, foreign_key: true, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_23_123415) do
+ActiveRecord::Schema.define(version: 2020_09_29_055929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -440,7 +440,9 @@ ActiveRecord::Schema.define(version: 2020_09_23_123415) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "confirmed_at"
+    t.uuid "move_id"
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
+    t.index ["move_id"], name: "index_person_escort_records_on_move_id"
     t.index ["profile_id"], name: "index_person_escort_records_on_profile_id", unique: true
   end
 
@@ -551,6 +553,7 @@ ActiveRecord::Schema.define(version: 2020_09_23_123415) do
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "person_escort_records", "frameworks"
+  add_foreign_key "person_escort_records", "moves"
   add_foreign_key "person_escort_records", "profiles"
   add_foreign_key "profiles", "people", name: "profiles_person_id"
   add_foreign_key "subscriptions", "suppliers"

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Move do
   it { is_expected.to have_many(:notifications) }
   it { is_expected.to have_many(:journeys) }
   it { is_expected.to have_many(:move_events) }
+  it { is_expected.to have_one(:person_escort_record) }
 
   it { is_expected.to validate_presence_of(:from_location) }
   it { is_expected.to validate_presence_of(:date) }

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe PersonEscortRecord do
   it { is_expected.to have_many(:framework_flags).through(:framework_responses) }
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:profile) }
+  it { is_expected.to belong_to(:move).optional }
 
   it 'validates uniqueness of profile' do
     person_escort_record = build(:person_escort_record)

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Api::PersonEscortRecordsController do
     let(:response_json) { JSON.parse(response.body) }
     let(:profile) { create(:profile) }
     let(:profile_id) { profile.id }
+    let(:move) { create(:move, profile: profile) }
+    let(:move_id) { move.id }
     let(:framework) { create(:framework, framework_questions: [build(:framework_question, section: 'risk-information')]) }
     let(:framework_version) { framework.version }
 
@@ -59,6 +61,88 @@ RSpec.describe Api::PersonEscortRecordsController do
               "data": {
                 "id": profile_id,
                 "type": 'profiles',
+              },
+            },
+            "move": {
+              "data": {},
+            },
+            "framework": {
+              "data": {
+                "id": framework.id,
+                "type": 'frameworks',
+              },
+            },
+            "responses": {
+              "data": [
+                {
+                  "id": FrameworkResponse.last.id,
+                  "type": 'framework_responses',
+                },
+              ],
+            },
+            "flags": {
+              "data": [],
+            },
+          },
+        }
+      end
+
+      it_behaves_like 'an endpoint that responds with success 201'
+
+      it 'returns the correct data' do
+        expect(response_json).to include_json(data: data)
+      end
+    end
+
+    # TODO: Remove profile id and transition to Move id, for now accept both
+    context 'when successful with move' do
+      let(:person_escort_record_params) do
+        {
+          data: {
+            "type": 'person_escort_records',
+            "attributes": {
+              "version": framework_version,
+            },
+            "relationships": {
+              "move": {
+                "data": {
+                  "id": move_id,
+                  "type": 'moves',
+                },
+              },
+            },
+          },
+        }
+      end
+      let(:schema) { load_yaml_schema('post_person_escort_record_responses.yaml') }
+      let(:data) do
+        {
+          "id": PersonEscortRecord.last.id,
+          "type": 'person_escort_records',
+          "attributes": {
+            "version": framework_version,
+            "status": 'not_started',
+            "confirmed_at": nil,
+          },
+          "meta": {
+            'section_progress' => [
+              {
+                "key": 'risk-information',
+                "status": 'not_started',
+              },
+            ],
+          },
+          "relationships": {
+            "profile": {
+              "data": {
+                "id": profile_id,
+                "type": 'profiles',
+              },
+            },
+            "move": {
+              "data": {
+                "id": move_id,
+                "type": 'moves',
               },
             },
             "framework": {

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe PersonEscortRecordSerializer do
   subject(:serializer) { described_class.new(person_escort_record) }
 
-  let(:person_escort_record) { create(:person_escort_record) }
+  let(:move) { create(:move) }
+  let(:person_escort_record) { create(:person_escort_record, move: move, profile: move.profile) }
   let(:result) { ActiveModelSerializers::Adapter.create(serializer, include: includes).serializable_hash }
   let(:includes) { {} }
 
@@ -33,6 +34,13 @@ RSpec.describe PersonEscortRecordSerializer do
     expect(result[:data][:relationships][:profile][:data]).to eq(
       id: person_escort_record.profile.id,
       type: 'profiles',
+    )
+  end
+
+  it 'contains a `move` relationship' do
+    expect(result[:data][:relationships][:move][:data]).to eq(
+      id: person_escort_record.move.id,
+      type: 'moves',
     )
   end
 

--- a/spec/services/frameworks/question_spec.rb
+++ b/spec/services/frameworks/question_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Frameworks::Question do
       expect(question.required).to eq(true)
     end
 
-    it 'sets a question as not requried if no validation available' do
+    it 'sets a question as not required if no validation available' do
       filepath = Rails.root.join(fixture_path, 'medical-professional-referral.yml')
       question = FrameworkQuestion.new(section: 'health', key: 'medical-professional-referral')
       described_class.new(filepath: filepath, questions: { 'medical-professional-referral' => question }).call

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -76,6 +76,9 @@ PersonEscortRecord:
         profile:
           $ref: profile_reference.yaml#/ProfileReference
           description: The profile of the person being moved
+        move:
+          $ref: move_reference.yaml#/MoveReference
+          description: The move of the person being moved
         framework:
           $ref: framework_reference.yaml#/FrameworkReference
           description: The framework associated with this person_escort_record


### PR DESCRIPTION
### Jira link

[P4-2067](https://dsdmoj.atlassian.net/browse/P4-22067)

### What?

- [x] Added new relationship on Person escort record to Move
- [x] Allow Move optionally to be passed in on Person escort record creation
- [x] Surface Move relationship on the Person Escort Record endpoint

### Why?

To allow the Person escort record access to a location's type, to determine if a location is a Police or Prison location for importing NOMIS resources, we need access to the Move associated to the PER. We cannot do that through the Profile, as a Profile can belong to multiple Moves. Instead we need to pass in the Move to create the Person Escort Record, and associate the Move's profile instead.

Since transitioning to passing in a Move to create a PER is a breaking change, support both Profile and Move until the FE completes the transition to only use Move. For now the Move relationship is optional.

### Have you? (optional)

- [x] I will update API docs when we officially support only Move relationship creation when creating the PER

### Deployment risks (optional)

- Changes an api that is used in production

