### PR TITLE
Add missing swagger docs for extra location types

### DIFF
--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2955,6 +2955,15 @@
               - court
               - police
               - prison
+              - secure_training_centre
+              - secure_childrens_home
+              - approved_premises
+              - probation_office
+              - community_rehabilitation_company
+              - foreign_national_prison
+              - voluntary_hostel
+              - high_security_hospital
+              - immigration_detention_centre
         - name: filter[nomis_agency_id]
           in: query
           description: Filters results by NOMIS agency ID


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

- [x] Add missing swagger docs for extra location types

### Why?

- These are defined in the schema for `Location` but missing from the example location types in the ref data endpoint.

### Have you? (optional)

- [x] Updated API docs if necessary