### PR TITLE
[P4-2164] Removes dual writing of v1 and v2 events

### DIFF
--- a/app/controllers/api/generic_events_controller.rb
+++ b/app/controllers/api/generic_events_controller.rb
@@ -41,7 +41,7 @@ module Api
     end
 
     def event_relationships
-      @event_relationships ||= params.require(:data)[:relationships]
+      @event_relationships ||= params.require(:data)[:relationships].to_unsafe_hash
     end
 
     def eventable_params

--- a/app/services/generic_events/event_specific_relationships_mapper.rb
+++ b/app/services/generic_events/event_specific_relationships_mapper.rb
@@ -1,7 +1,7 @@
 module GenericEvents
   class EventSpecificRelationshipsMapper
     def initialize(event_relationships)
-      @event_relationships = event_relationships.to_unsafe_hash.except('eventable')
+      @event_relationships = event_relationships.to_h.except('eventable')
     end
 
     def call

--- a/spec/requests/api/journey_events_controller_cancel_spec.rb
+++ b/spec/requests/api/journey_events_controller_cancel_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::JourneyEventsController do
         expect(journey.reload).to be_cancelled
       end
 
-      it 'dual writes a journey cancel event' do
+      it 'writes a journey cancel event' do
         expect { do_post }.to change { GenericEvent::JourneyCancel.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_complete_spec.rb
+++ b/spec/requests/api/journey_events_controller_complete_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::JourneyEventsController do
         expect(journey.reload).to be_completed
       end
 
-      it 'dual writes a journey complete event' do
+      it 'writes a journey complete event' do
         expect { do_post }.to change { GenericEvent::JourneyComplete.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_lockouts_spec.rb
+++ b/spec/requests/api/journey_events_controller_lockouts_spec.rb
@@ -38,12 +38,7 @@ RSpec.describe Api::JourneyEventsController do
         end
       end
 
-      it 'logs a lockout event record' do
-        do_post
-        expect(journey.events.last.event_name).to eql('lockout')
-      end
-
-      it 'dual writes a journey lockout event' do
+      it 'writes a journey lockout event' do
         expect { do_post }.to change { GenericEvent::JourneyLockout.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_lodgings_spec.rb
+++ b/spec/requests/api/journey_events_controller_lodgings_spec.rb
@@ -38,12 +38,7 @@ RSpec.describe Api::JourneyEventsController do
         end
       end
 
-      it 'logs a lodging event record' do
-        do_post
-        expect(journey.events.last.event_name).to eql('lodging')
-      end
-
-      it 'dual writes a journey lodging event' do
+      it 'writes a journey lodging event' do
         expect { do_post }.to change { GenericEvent::JourneyLodging.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_reject_spec.rb
+++ b/spec/requests/api/journey_events_controller_reject_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::JourneyEventsController do
         expect(journey.reload).to be_rejected
       end
 
-      it 'dual writes a journey reject event' do
+      it 'writes a journey reject event' do
         expect { do_post }.to change { GenericEvent::JourneyReject.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_start_spec.rb
+++ b/spec/requests/api/journey_events_controller_start_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::JourneyEventsController do
         expect(journey.reload).to be_in_progress
       end
 
-      it 'dual writes a journey reject event' do
+      it 'writes a journey reject event' do
         expect { do_post }.to change { GenericEvent::JourneyStart.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_uncancel_spec.rb
+++ b/spec/requests/api/journey_events_controller_uncancel_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::JourneyEventsController do
         expect(journey.reload).to be_in_progress
       end
 
-      it 'dual writes a journey uncancel event' do
+      it 'writes a journey uncancel event' do
         expect { do_post }.to change { GenericEvent::JourneyUncancel.count }.by(1)
       end
     end

--- a/spec/requests/api/journey_events_controller_uncomplete_spec.rb
+++ b/spec/requests/api/journey_events_controller_uncomplete_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::JourneyEventsController do
         expect(journey.reload).to be_in_progress
       end
 
-      it 'dual writes a journey uncomplete event' do
+      it 'writes a journey uncomplete event' do
         expect { do_post }.to change { GenericEvent::JourneyUncomplete.count }.by(1)
       end
     end

--- a/spec/requests/api/move_events_controller_accept_spec.rb
+++ b/spec/requests/api/move_events_controller_accept_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Api::MoveEventsController do
         expect(move.reload).to be_booked
       end
 
-      it 'dual writes a move accept event' do
+      it 'writes a move accept event' do
         expect { do_post }.to change { GenericEvent::MoveAccept.count }.by(1)
       end
     end

--- a/spec/services/generic_events/event_specific_relationships_mapper_spec.rb
+++ b/spec/services/generic_events/event_specific_relationships_mapper_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe GenericEvents::EventSpecificRelationshipsMapper do
-  subject(:mapper) { described_class.new(ActionController::Parameters.new(event_relationships)) }
+  subject(:mapper) { described_class.new(HashWithIndifferentAccess.new(event_relationships)) }
 
   context 'when only the eventable is passed' do
     let(:event_relationships) do


### PR DESCRIPTION
### Jira link

P4-2164

### What?

I have added/removed/altered:

- [x] Removes dual writing of events

### Why?

I am doing this because:

- The old event model is no longer referenced so this is no longer necessary.