### PR TITLE
P4-2067 Add NOMIS Mappings and Importer

### DIFF
--- a/app/models/framework_nomis_mapping.rb
+++ b/app/models/framework_nomis_mapping.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class FrameworkNomisMapping < VersionedModel
+  enum code_type: {
+    alert: 'alert',
+    personal_care_need: 'personal_care_need',
+    reasonable_adjustment: 'reasonable_adjustment',
+  }
+  validates :raw_nomis_mapping, presence: true
+  validates :code, presence: true
+  validates :code_type, presence: true, inclusion: { in: code_types }
+
+  has_and_belongs_to_many :framework_responses
+end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -17,6 +17,7 @@ class FrameworkResponse < VersionedModel
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
   has_and_belongs_to_many :framework_flags, autosave: true
   has_and_belongs_to_many :framework_nomis_mappings
+  has_many :framework_nomis_codes, through: :framework_question
 
   after_validation :set_responded_value, on: :update
 

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -16,6 +16,7 @@ class FrameworkResponse < VersionedModel
 
   belongs_to :parent, class_name: 'FrameworkResponse', optional: true
   has_and_belongs_to_many :framework_flags, autosave: true
+  has_and_belongs_to_many :framework_nomis_mappings
 
   after_validation :set_responded_value, on: :update
 

--- a/app/services/framework_nomis_mappings/alerts.rb
+++ b/app/services/framework_nomis_mappings/alerts.rb
@@ -1,0 +1,41 @@
+module FrameworkNomisMappings
+  class Alerts
+    attr_reader :prison_number
+
+    def initialize(prison_number:)
+      @prison_number = prison_number
+    end
+
+    def call
+      return [] unless prison_number
+
+      build_mappings.compact
+    end
+
+  private
+
+    def imported_alerts
+      @imported_alerts ||= NomisClient::Alerts.get([prison_number])
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, OAuth2::Error => e
+      Rails.logger.warn "Importing Framework alert mappings Error: #{e.message}"
+
+      []
+    end
+
+    def build_mappings
+      imported_alerts.map do |imported_alert|
+        next unless imported_alert[:active] == true && imported_alert[:expired] == false
+
+        FrameworkNomisMapping.new(
+          raw_nomis_mapping: imported_alert,
+          code_type: 'alert',
+          code: imported_alert[:alert_code],
+          code_description: imported_alert[:alert_code_description],
+          comments: imported_alert[:comment],
+          creation_date: imported_alert[:created_at],
+          expiry_date: imported_alert[:expires_at],
+        )
+      end
+    end
+  end
+end

--- a/app/services/framework_nomis_mappings/importer.rb
+++ b/app/services/framework_nomis_mappings/importer.rb
@@ -65,7 +65,7 @@ module FrameworkNomisMappings
 
           if mapping_nomis_codes.any?
             mapping_nomis_codes.each do |nomis_code|
-              hash[nomis_code.id] = mapping
+              hash[nomis_code.id] = hash[nomis_code.id].to_a + [mapping]
             end
           elsif mapping_nomis_fallback
             hash[mapping_nomis_fallback.id] = hash[mapping_nomis_fallback.id].to_a + [mapping]

--- a/app/services/framework_nomis_mappings/importer.rb
+++ b/app/services/framework_nomis_mappings/importer.rb
@@ -3,6 +3,7 @@
 module FrameworkNomisMappings
   class Importer
     attr_reader :person, :framework_responses, :framework_nomis_codes
+
     def initialize(person:, framework_responses:, framework_nomis_codes:)
       @person = person
       @framework_responses = framework_responses

--- a/app/services/framework_nomis_mappings/importer.rb
+++ b/app/services/framework_nomis_mappings/importer.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module FrameworkNomisMappings
+  class Importer
+    attr_reader :person, :framework_responses, :framework_nomis_codes
+    def initialize(person:, framework_responses:, framework_nomis_codes:)
+      @person = person
+      @framework_responses = framework_responses
+      @framework_nomis_codes = framework_nomis_codes
+    end
+
+    def call
+      return unless person && framework_responses.any? && framework_nomis_codes.any?
+
+      ActiveRecord::Base.transaction do
+        return unless persist_framework_nomis_mappings.any?
+
+        framework_responses.includes(:framework_nomis_mappings).each do |response|
+          nomis_code_ids = responses_to_codes[response.id]&.pluck(:nomis_code_id)
+          response.framework_nomis_mappings = nomis_code_ids_to_mappings.slice(*nomis_code_ids).values.flatten
+        end
+      end
+    end
+
+  private
+
+    def persist_framework_nomis_mappings
+      @persist_framework_nomis_mappings ||= begin
+        mappings = alert_mappings + personal_care_need_mappings + reasonable_adjust_mappings
+        # TODO: log any validation failures
+        import = FrameworkNomisMapping.import(mappings, all_or_none: true)
+
+        FrameworkNomisMapping.where(id: import.ids)
+      end
+    end
+
+    def alert_mappings
+      FrameworkNomisMappings::Alerts.new(prison_number: person.prison_number).call
+    end
+
+    def personal_care_need_mappings
+      FrameworkNomisMappings::PersonalCareNeeds.new(prison_number: person.prison_number).call
+    end
+
+    def reasonable_adjust_mappings
+      FrameworkNomisMappings::ReasonableAdjustments.new(
+        booking_id: person.latest_nomis_booking_id,
+        nomis_codes: grouped_framework_nomis_codes['reasonable_adjustment'],
+      ).call
+    end
+
+    def grouped_framework_nomis_codes
+      framework_nomis_codes.group_by(&:code_type)
+    end
+
+    def fallback_nomis_codes
+      @fallback_nomis_codes ||= framework_nomis_codes.select(&:fallback?)
+    end
+
+    def nomis_code_ids_to_mappings
+      @nomis_code_ids_to_mappings ||= begin
+        persist_framework_nomis_mappings.each_with_object({}) do |mapping, hash|
+          mapping_nomis_codes = framework_nomis_codes.select { |nomis_code| nomis_code.code == mapping.code && nomis_code.code_type == mapping.code_type }
+          mapping_nomis_fallback = fallback_nomis_codes.find { |fallback| fallback.code_type == mapping.code_type }
+
+          if mapping_nomis_codes.any?
+            mapping_nomis_codes.each do |nomis_code|
+              hash[nomis_code.id] = mapping
+            end
+          elsif mapping_nomis_fallback
+            hash[mapping_nomis_fallback.id] = hash[mapping_nomis_fallback.id].to_a + [mapping]
+          end
+        end
+      end
+    end
+
+    def responses_to_codes
+      @responses_to_codes ||= framework_responses.joins(:framework_nomis_codes).select('framework_responses.id as id, framework_nomis_codes.id as nomis_code_id').group_by(&:id)
+    end
+  end
+end

--- a/app/services/framework_nomis_mappings/personal_care_needs.rb
+++ b/app/services/framework_nomis_mappings/personal_care_needs.rb
@@ -1,0 +1,47 @@
+module FrameworkNomisMappings
+  class PersonalCareNeeds
+    PERSONAL_CARE_NEED_CODES = 'SC,MATSTAT,PHY,PSYCH,DISAB'.freeze
+    attr_reader :prison_number
+
+    def initialize(prison_number:)
+      @prison_number = prison_number
+    end
+
+    def call
+      return [] unless prison_number
+
+      build_mappings.compact
+    end
+
+  private
+
+    def imported_personal_care_needs
+      @imported_personal_care_needs ||= NomisClient::PersonalCareNeeds.get(nomis_offender_numbers: [prison_number], personal_care_types: PERSONAL_CARE_NEED_CODES)
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, OAuth2::Error => e
+      Rails.logger.warn "Importing Framework personal care needs mappings Error: #{e.message}"
+
+      []
+    end
+
+    def build_mappings
+      imported_personal_care_needs.map do |personal_care_need|
+        next unless valid_personal_care_need?(personal_care_need[:end_date], personal_care_need[:problem_status])
+
+        FrameworkNomisMapping.new(
+          raw_nomis_mapping: personal_care_need,
+          code_type: 'personal_care_need',
+          code: personal_care_need[:problem_code],
+          code_description: personal_care_need[:problem_description],
+          start_date: personal_care_need[:start_date],
+          end_date: personal_care_need[:end_date],
+        )
+      end
+    end
+
+    def valid_personal_care_need?(date, status)
+      end_date = Date.parse(date) if date.present?
+
+      status == 'ON' && (end_date.nil? || end_date >= Time.zone.today)
+    end
+  end
+end

--- a/app/services/framework_nomis_mappings/personal_care_needs.rb
+++ b/app/services/framework_nomis_mappings/personal_care_needs.rb
@@ -41,6 +41,8 @@ module FrameworkNomisMappings
     def valid_personal_care_need?(date, status)
       end_date = Date.parse(date) if date.present?
 
+      # Allow personal care needs that are 'ON' (ongoing) and end in the future if
+      # end date defined
       status == 'ON' && (end_date.nil? || end_date >= Time.zone.today)
     end
   end

--- a/app/services/framework_nomis_mappings/reasonable_adjustments.rb
+++ b/app/services/framework_nomis_mappings/reasonable_adjustments.rb
@@ -1,0 +1,48 @@
+module FrameworkNomisMappings
+  class ReasonableAdjustments
+    attr_reader :booking_id, :nomis_codes
+
+    def initialize(booking_id:, nomis_codes:)
+      @booking_id = booking_id
+      @nomis_codes = nomis_codes
+    end
+
+    def call
+      return [] unless booking_id && nomis_codes.any?
+
+      build_mappings.compact
+    end
+
+  private
+
+    def imported_reasonable_adjustments
+      @imported_reasonable_adjustments ||= NomisClient::ReasonableAdjustments.get(booking_id: booking_id, reasonable_adjustment_types: nomis_codes.pluck(:code).compact.join(','))
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, OAuth2::Error => e
+      Rails.logger.warn "Importing Framework reasonable adjustment mappings Error: #{e.message}"
+
+      []
+    end
+
+    def build_mappings
+      imported_reasonable_adjustments.map do |reasonable_adjustment|
+        next unless valid_reasonable_adjustment?(reasonable_adjustment[:end_date])
+
+        FrameworkNomisMapping.new(
+          raw_nomis_mapping: reasonable_adjustment,
+          code_type: 'reasonable_adjustment',
+          code: reasonable_adjustment[:treatment_code],
+          code_description: reasonable_adjustment[:treatment_description],
+          comments: reasonable_adjustment[:comment_text],
+          start_date: reasonable_adjustment[:start_date],
+          end_date: reasonable_adjustment[:end_date],
+        )
+      end
+    end
+
+    def valid_reasonable_adjustment?(date)
+      end_date = Date.parse(date) if date.present?
+
+      end_date.nil? || end_date >= Time.zone.today
+    end
+  end
+end

--- a/app/services/framework_nomis_mappings/reasonable_adjustments.rb
+++ b/app/services/framework_nomis_mappings/reasonable_adjustments.rb
@@ -8,7 +8,7 @@ module FrameworkNomisMappings
     end
 
     def call
-      return [] unless booking_id && nomis_codes.any?
+      return [] unless booking_id && nomis_codes.present?
 
       build_mappings.compact
     end
@@ -16,7 +16,7 @@ module FrameworkNomisMappings
   private
 
     def imported_reasonable_adjustments
-      @imported_reasonable_adjustments ||= NomisClient::ReasonableAdjustments.get(booking_id: booking_id, reasonable_adjustment_types: nomis_codes.pluck(:code).compact.join(','))
+      @imported_reasonable_adjustments ||= NomisClient::ReasonableAdjustments.get(booking_id: booking_id, reasonable_adjustment_types: nomis_codes.pluck(:code).compact.uniq.join(','))
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, OAuth2::Error => e
       Rails.logger.warn "Importing Framework reasonable adjustment mappings Error: #{e.message}"
 

--- a/db/migrate/20201001043209_create_framework_nomis_mappings.rb
+++ b/db/migrate/20201001043209_create_framework_nomis_mappings.rb
@@ -1,0 +1,17 @@
+class CreateFrameworkNomisMappings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :framework_nomis_mappings, id: :uuid do |t|
+      t.jsonb :raw_nomis_mapping, null: false
+      t.string :code, null: false
+      t.string :code_type, null: false
+      t.text :code_description
+      t.text :comments
+      t.date :start_date
+      t.date :end_date
+      t.date :creation_date
+      t.date :expiry_date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201001043655_create_framework_nomis_mappings_responses.rb
+++ b/db/migrate/20201001043655_create_framework_nomis_mappings_responses.rb
@@ -1,0 +1,11 @@
+class CreateFrameworkNomisMappingsResponses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :framework_nomis_mappings_responses, id: :uuid do |t|
+      t.uuid :framework_response_id
+      t.uuid :framework_nomis_mapping_id
+    end
+
+    add_index :framework_nomis_mappings_responses, :framework_response_id, name: 'index_framework_nomis_mappings_responses_on_response_id'
+    add_index :framework_nomis_mappings_responses, :framework_nomis_mapping_id, name: 'index_framework_nomis_mappings_responses_on_nomis_mapping_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_29_055929) do
+ActiveRecord::Schema.define(version: 2020_10_01_043655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -160,6 +160,27 @@ ActiveRecord::Schema.define(version: 2020_09_29_055929) do
     t.uuid "framework_nomis_code_id"
     t.index ["framework_nomis_code_id"], name: "index_framework_nomis_codes_questions_on_nomis_code_id"
     t.index ["framework_question_id"], name: "index_framework_nomis_codes_questions_on_question_id"
+  end
+
+  create_table "framework_nomis_mappings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "raw_nomis_mapping", null: false
+    t.string "code", null: false
+    t.string "code_type", null: false
+    t.text "code_description"
+    t.text "comments"
+    t.date "start_date"
+    t.date "end_date"
+    t.date "creation_date"
+    t.date "expiry_date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "framework_nomis_mappings_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "framework_response_id"
+    t.uuid "framework_nomis_mapping_id"
+    t.index ["framework_nomis_mapping_id"], name: "index_framework_nomis_mappings_responses_on_nomis_mapping_id"
+    t.index ["framework_response_id"], name: "index_framework_nomis_mappings_responses_on_response_id"
   end
 
   create_table "framework_questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/framework_nomis_code.rb
+++ b/spec/factories/framework_nomis_code.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :framework_nomis_code do
-    sequence(:code) { 'XAB' }
-    sequence(:code_type) { 'alert' }
+    code { 'XAB' }
+    code_type { 'alert' }
   end
 end

--- a/spec/factories/framework_nomis_mapping.rb
+++ b/spec/factories/framework_nomis_mapping.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :framework_nomis_mapping do
+    raw_nomis_mapping do
+      {
+        alert_id: 2,
+        alert_type: 'X',
+        alert_type_description: 'Security',
+        alert_code: 'XVL',
+        alert_code_description: 'Violent',
+        comment: 'SIR GP162/11 17/01/11 - threatening to take staff hostage',
+        created_at: '2013-03-29',
+        expires_at: '2018-06-08',
+        expired: true,
+        active: false,
+        offender_no: 'A9127EK',
+      }
+    end
+    code { 'XAB' }
+    code_type { 'alert' }
+    code_description { 'Violent' }
+    comments { 'SIR GP162/11 17/01/11 - threatening to take staff hostage' }
+    creation_date { '2013-03-29' }
+    expiry_date { '2018-06-08' }
+  end
+end

--- a/spec/models/framework_nomis_mapping_spec.rb
+++ b/spec/models/framework_nomis_mapping_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkNomisMapping do
+  subject { create(:framework_nomis_mapping) }
+
+  it { is_expected.to validate_presence_of(:raw_nomis_mapping) }
+  it { is_expected.to validate_presence_of(:code) }
+  it { is_expected.to validate_presence_of(:code_type) }
+  it { is_expected.to validate_inclusion_of(:code_type).in_array(%w[alert personal_care_need reasonable_adjustment]) }
+  it { is_expected.to have_and_belong_to_many(:framework_responses) }
+end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe FrameworkResponse do
 
   it { is_expected.to have_many(:dependents) }
   it { is_expected.to have_and_belong_to_many(:framework_flags) }
+  it { is_expected.to have_and_belong_to_many(:framework_nomis_mappings) }
   it { is_expected.to validate_presence_of(:type) }
 
   context 'with validations' do

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe FrameworkResponse do
   it { is_expected.to belong_to(:parent).optional }
 
   it { is_expected.to have_many(:dependents) }
+  it { is_expected.to have_many(:framework_nomis_codes).through(:framework_question) }
   it { is_expected.to have_and_belong_to_many(:framework_flags) }
   it { is_expected.to have_and_belong_to_many(:framework_nomis_mappings) }
   it { is_expected.to validate_presence_of(:type) }

--- a/spec/services/framework_nomis_mappings/alerts_spec.rb
+++ b/spec/services/framework_nomis_mappings/alerts_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkNomisMappings::Alerts do
+  it 'builds a framework NOMIS mapping for active alerts from NOMIS' do
+    allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings.first).to be_a(FrameworkNomisMapping)
+  end
+
+  it 'sets the correct attributes on framework NOMIS mappings' do
+    allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings.first).to have_attributes(
+      raw_nomis_mapping: nomis_alert,
+      code_type: 'alert',
+      code: 'XVL',
+      code_description: 'Violent',
+      comments: 'Some comment',
+      creation_date: Date.parse('2013-03-29'),
+      expiry_date: Date.parse('2100-06-08'),
+    )
+  end
+
+  it 'ignores alerts that have expired' do
+    allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert(expired: true)])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'ignores alerts that are not active' do
+    allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert(active: false)])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'returns an empty result if no prison number supplied' do
+    allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert])
+    mappings = described_class.new(prison_number: nil).call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'returns an empty result if importing NOMIS alerts fails' do
+    oauth2_response = instance_double('OAuth2::Response', body: '{}', parsed: {}, status: '', 'error=': '')
+    allow(NomisClient::Alerts).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'returns an empty result if no alerts found for prison number' do
+    allow(NomisClient::Alerts).to receive(:get).and_return([])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings).to be_empty
+  end
+
+  def nomis_alert(expired: false, active: true)
+    {
+      alert_id: 2,
+      alert_code: 'XVL',
+      alert_code_description: 'Violent',
+      comment: 'Some comment',
+      created_at: '2013-03-29',
+      expires_at: '2100-06-08',
+      expired: expired,
+      active: active,
+      offender_no: 'A9127EK',
+    }.with_indifferent_access
+  end
+end

--- a/spec/services/framework_nomis_mappings/importer_spec.rb
+++ b/spec/services/framework_nomis_mappings/importer_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkNomisMappings::Importer do
+  let(:nomis_alert) do
+    {
+      alert_id: 2,
+      alert_code: 'VI',
+      alert_code_description: 'Hold separately',
+      comment: 'Some comment',
+      created_at: '2013-03-29',
+      expires_at: '2100-06-08',
+      expired: false,
+      active: true,
+      offender_no: 'A9127EK',
+    }
+  end
+
+  let(:nomis_reasonable_adjustments) do
+    [
+      {
+        treatment_code: 'DA',
+        comment_text: 'Some comment',
+        start_date: '2014-03-29',
+        end_date: nil,
+        agency_id: 'LGI',
+        treatment_description: 'Some treatment description about DA',
+      },
+      {
+        treatment_code: 'BA',
+        comment_text: 'Some comment',
+        start_date: '2014-03-29',
+        end_date: nil,
+        agency_id: 'AGI',
+        treatment_description: 'Some treatment description about BA',
+      },
+    ]
+  end
+
+  let(:nomis_personal_care_needs) do
+    [
+      {
+        problem_code: 'VI',
+        problem_status: 'ON',
+        problem_description: 'Visually impaired',
+        start_date: '2015-03-29',
+        end_date: '2100-06-08',
+        offender_no: '321',
+      },
+      {
+        problem_code: 'PEEP',
+        problem_status: 'ON',
+        problem_description: 'Special vehicle',
+        start_date: '2015-03-29',
+        end_date: '2100-06-08',
+        offender_no: '321',
+      },
+    ]
+  end
+
+  let(:framework_response1) do
+    alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
+    question = create(:framework_question, framework_nomis_codes: [alert_code])
+    create(:string_response, framework_question: question)
+  end
+
+  let(:framework_response2) do
+    personal_care_need_code = create(:framework_nomis_code, code: 'VI', code_type: 'personal_care_need')
+    reasonable_adjustment_fallback = create(:framework_nomis_code, code: nil, code_type: 'reasonable_adjustment', fallback: true)
+    personal_care_need_fallback = create(:framework_nomis_code, code: nil, code_type: 'personal_care_need', fallback: true)
+    question = create(:framework_question, framework_nomis_codes: [personal_care_need_code, reasonable_adjustment_fallback, personal_care_need_fallback])
+    create(:string_response, framework_question: question)
+  end
+
+  let(:person) do
+    create(:person, :nomis_synced, latest_nomis_booking_id: 111_111)
+  end
+
+  before do
+    allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert])
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return(nomis_personal_care_needs)
+    allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return(nomis_reasonable_adjustments)
+  end
+
+  it 'persists alerts, reasonable adjustments and personal care needs NOMIS mappings' do
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+
+    expect { described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call }.to change(FrameworkNomisMapping, :count).by(5)
+  end
+
+  it 'associates NOMIS mappings correctly to framework responses' do
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+    described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call
+
+    expect(framework_response1.framework_nomis_mappings.pluck(:code)).to contain_exactly('VI')
+  end
+
+  it 'associates duplicate NOMIS mapping codes and types to framework responses' do
+    alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
+    question = create(:framework_question, framework_nomis_codes: [alert_code])
+    framework_response2 = create(:string_response, framework_question: question)
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+    described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call
+
+    expect(framework_response1.framework_nomis_mappings.pluck(:code, :code_type)).to contain_exactly(%w[VI alert])
+    expect(framework_response2.framework_nomis_mappings.pluck(:code, :code_type)).to contain_exactly(%w[VI alert])
+  end
+
+  it 'associates multiple NOMIS mappings to a fallback question response' do
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+    described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call
+
+    expect(framework_response2.framework_nomis_mappings.pluck(:code)).to contain_exactly('VI', 'DA', 'PEEP', 'BA')
+  end
+
+  it 'associates NOMIS mapping codes to responses scoped to NOMIS mapping type' do
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+    described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call
+
+    expect(framework_response1.framework_nomis_mappings.pluck(:code_type).uniq).to contain_exactly('alert')
+    expect(framework_response2.framework_nomis_mappings.pluck(:code_type).uniq).to contain_exactly('reasonable_adjustment', 'personal_care_need')
+  end
+
+  it 'does not associate NOMIS mappings mapped to a fallback if none exist' do
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id])
+    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+    described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call
+
+    expect(framework_response1.framework_nomis_mappings.pluck(:code)).to contain_exactly('VI')
+  end
+
+  it 'persists other NOMIS mappings if one import fails' do
+    oauth2_response = instance_double('OAuth2::Response', body: '{}', parsed: {}, status: '', 'error=': '')
+    allow(NomisClient::Alerts).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+
+    expect { described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call }.to change(FrameworkNomisMapping, :count).by(4)
+  end
+
+  it 'does nothing if no NOMIS mappings present for a person' do
+    allow(NomisClient::Alerts).to receive(:get).and_return([])
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([])
+    allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return([])
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+
+    expect { described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call }.not_to change(FrameworkNomisMapping, :count)
+  end
+
+  it 'does nothing is no person present' do
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+
+    expect { described_class.new(person: nil, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call }.not_to change(FrameworkNomisMapping, :count)
+  end
+
+  it 'does nothing if no framework responses present' do
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+
+    expect { described_class.new(person: person, framework_responses: [], framework_nomis_codes: framework_nomis_codes).call }.not_to change(FrameworkNomisMapping, :count)
+  end
+
+  it 'does nothing is no framework NOMIS codes present' do
+    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+
+    expect { described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: []).call }.not_to change(FrameworkNomisMapping, :count)
+  end
+end

--- a/spec/services/framework_nomis_mappings/importer_spec.rb
+++ b/spec/services/framework_nomis_mappings/importer_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe FrameworkNomisMappings::Importer do
     allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return(nomis_reasonable_adjustments)
   end
 
-  it 'persists alerts, reasonable adjustments and personal care needs NOMIS mappings' do
+  it 'persists all alerts, reasonable adjustments and personal care needs from NOMIS clients as NOMIS mappings' do
     framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
     framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
 
@@ -167,7 +167,7 @@ RSpec.describe FrameworkNomisMappings::Importer do
     expect { described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call }.not_to change(FrameworkNomisMapping, :count)
   end
 
-  it 'does nothing is no person present' do
+  it 'does nothing if no person present' do
     framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
     framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
 
@@ -181,7 +181,7 @@ RSpec.describe FrameworkNomisMappings::Importer do
     expect { described_class.new(person: person, framework_responses: [], framework_nomis_codes: framework_nomis_codes).call }.not_to change(FrameworkNomisMapping, :count)
   end
 
-  it 'does nothing is no framework NOMIS codes present' do
+  it 'does nothing if no framework NOMIS codes present' do
     framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
 
     expect { described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: []).call }.not_to change(FrameworkNomisMapping, :count)

--- a/spec/services/framework_nomis_mappings/personal_care_needs_spec.rb
+++ b/spec/services/framework_nomis_mappings/personal_care_needs_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe FrameworkNomisMappings::PersonalCareNeeds do
     expect(mappings).to be_empty
   end
 
-  it 'ignores personal care needs with status "I"' do
+  it 'ignores personal care needs with status "I" (recovered)' do
     allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([nomis_personal_care_need(problem_status: 'I')])
     mappings = described_class.new(prison_number: 'A9127EK').call
 
     expect(mappings).to be_empty
   end
 
-  it 'ignores personal care needs with status "EBS"' do
+  it 'ignores personal care needs with status "EBS" (Expired Body Scan Entry)' do
     allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([nomis_personal_care_need(problem_status: 'EBS')])
     mappings = described_class.new(prison_number: 'A9127EK').call
 

--- a/spec/services/framework_nomis_mappings/personal_care_needs_spec.rb
+++ b/spec/services/framework_nomis_mappings/personal_care_needs_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkNomisMappings::PersonalCareNeeds do
+  it 'builds a framework NOMIS mapping for active personal care needs from NOMIS' do
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([nomis_personal_care_need])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings.first).to be_a(FrameworkNomisMapping)
+  end
+
+  it 'sets the correct attributes on framework NOMIS mappings' do
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([nomis_personal_care_need])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings.first).to have_attributes(
+      raw_nomis_mapping: nomis_personal_care_need,
+      code_type: 'personal_care_need',
+      code: 'ACCU9',
+      code_description: 'Preg, acc under 9mths',
+      start_date: Date.parse('2010-06-21'),
+      end_date: Date.parse('2100-06-21'),
+    )
+  end
+
+  it 'imports personal care needs if end date is not set' do
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([nomis_personal_care_need])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings.count).to eq(1)
+  end
+
+  it 'ignores personal care needs that have ended' do
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([nomis_personal_care_need(end_date: '2010-06-21')])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'ignores personal care needs with status "I"' do
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([nomis_personal_care_need(problem_status: 'I')])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'ignores personal care needs with status "EBS"' do
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([nomis_personal_care_need(problem_status: 'EBS')])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'returns an empty result if no prison number supplied' do
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([nomis_personal_care_need])
+    mappings = described_class.new(prison_number: nil).call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'returns an empty result if importing NOMIS personal care needs fails' do
+    oauth2_response = instance_double('OAuth2::Response', body: '{}', parsed: {}, status: '', 'error=': '')
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'returns an empty result if no personal care needs found for prison number' do
+    allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([])
+    mappings = described_class.new(prison_number: 'A9127EK').call
+
+    expect(mappings).to be_empty
+  end
+
+  def nomis_personal_care_need(start_date: '2010-06-21', end_date: '2100-06-21', problem_status: 'ON')
+    {
+      problem_code: 'ACCU9',
+      problem_status: problem_status,
+      problem_description: 'Preg, acc under 9mths',
+      start_date: start_date,
+      end_date: end_date,
+      offender_no: '321',
+    }.with_indifferent_access
+  end
+end

--- a/spec/services/framework_nomis_mappings/reasonable_adjustments_spec.rb
+++ b/spec/services/framework_nomis_mappings/reasonable_adjustments_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkNomisMappings::ReasonableAdjustments do
+  let(:nomis_codes) do
+    [
+      create(:framework_nomis_code, code: 'A', code_type: 'reasonable_adjustment'),
+      create(:framework_nomis_code, code: 'C CB', code_type: 'reasonable_adjustment'),
+    ]
+  end
+
+  it 'builds a framework NOMIS mapping for active reasonable adjustments from NOMIS' do
+    allow(NomisClient::ReasonableAdjustments)
+      .to receive(:get)
+      .with(booking_id: 111_111, reasonable_adjustment_types: 'A,C CB')
+      .and_return([nomis_reasonable_adjustment])
+    mappings = described_class.new(booking_id: 111_111, nomis_codes: nomis_codes).call
+
+    expect(mappings.first).to be_a(FrameworkNomisMapping)
+  end
+
+  it 'sets the correct attributes on framework NOMIS mappings' do
+    allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return([nomis_reasonable_adjustment])
+    mappings = described_class.new(booking_id: 111_111, nomis_codes: nomis_codes).call
+
+    expect(mappings.first).to have_attributes(
+      raw_nomis_mapping: nomis_reasonable_adjustment,
+      code_type: 'reasonable_adjustment',
+      code: 'DA',
+      code_description: 'Some treatment description about DA',
+      comments: 'Some comment',
+      start_date: Date.parse('2010-06-21'),
+      end_date: Date.parse('2100-06-21'),
+    )
+  end
+
+  it 'imports reasonable adjustments if end date is not set' do
+    allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return([nomis_reasonable_adjustment])
+    mappings = described_class.new(booking_id: 111_111, nomis_codes: nomis_codes).call
+
+    expect(mappings.count).to eq(1)
+  end
+
+  it 'ignores reasonable adjustments that have ended' do
+    allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return([nomis_reasonable_adjustment(end_date: '2010-06-21')])
+    mappings = described_class.new(booking_id: 111_111, nomis_codes: nomis_codes).call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'returns an empty result if no booking id supplied' do
+    allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return([nomis_reasonable_adjustment])
+    mappings = described_class.new(booking_id: nil, nomis_codes: ['A', 'C CB']).call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'returns an empty result if no reasonable adjustment types supplied' do
+    allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return([nomis_reasonable_adjustment])
+    mappings = described_class.new(booking_id: 1_111_111, nomis_codes: []).call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'returns an empty result if importing NOMIS reasonable adjustments fails' do
+    oauth2_response = instance_double('OAuth2::Response', body: '{}', parsed: {}, status: '', 'error=': '')
+    allow(NomisClient::ReasonableAdjustments).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
+    mappings = described_class.new(booking_id: 111_111, nomis_codes: nomis_codes).call
+
+    expect(mappings).to be_empty
+  end
+
+  it 'returns an empty result if no reasonable adjustments found for booking id' do
+    allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return([])
+    mappings = described_class.new(booking_id: 111_111, nomis_codes: nomis_codes).call
+
+    expect(mappings).to be_empty
+  end
+
+  def nomis_reasonable_adjustment(start_date: '2010-06-21', end_date: '2100-06-21')
+    {
+      treatment_code: 'DA',
+      comment_text: 'Some comment',
+      start_date: start_date,
+      end_date: end_date,
+      agency_id: 'LGI',
+      treatment_description: 'Some treatment description about DA',
+    }.with_indifferent_access
+  end
+end


### PR DESCRIPTION
### Jira link

[P4-2067](https://dsdmoj.atlassian.net/browse/P4-2067)

### What?
- [x] Add Framework NOMIS mapping table and model
- [x] Add a mapping importer for each type of NOMIS mapping
- [x] Add NOMIS Mapping Importer

### Why?

NOMIS alerts, personal care needs as well as reasonable adjustments for a person will help users fill out the Person escort record more accurately. Each question in the PER is associated to the relevant mappings of NOMIS resource codes, or set as a fallback question if a person has NOMIS resources that are not associated to any question.

To allow users to view those associations, add an Importer which pulls in all the resources for a person, and maps them appropriately to the NOMIS response.

NOMIS codes are not unique to a question, so we need to make sure we associate mappings to each and every question a NOMIS code appears in. If this NOMIS code is not in out framework, we will group it under the fallback response with the correct type.

Failures of importing and validation/persisting of NOMIS mappings will be addressed in further tickets.
### Have you? (optional)

- Updated API docs if necessary: will happen in subsequent PRs

### Deployment risks (optional)

- The latest framework has not been added to production ENVs so we will not be using this importer yet

