### PR TITLE
P4-2067 Import NOMIS mappings when creating the PER

### DIFF
--- a/app/serializers/framework_nomis_mapping_serializer.rb
+++ b/app/serializers/framework_nomis_mapping_serializer.rb
@@ -1,10 +1,5 @@
 class FrameworkNomisMappingSerializer < ActiveModel::Serializer
   type 'framework_nomis_mappings'
-  has_many :framework_responses, key: :responses
 
   attributes :code, :code_type, :code_description, :comments, :start_date, :end_date, :creation_date, :expiry_date
-
-  SUPPORTED_RELATIONSHIPS = %w[
-    responses
-  ].freeze
 end

--- a/app/serializers/framework_nomis_mapping_serializer.rb
+++ b/app/serializers/framework_nomis_mapping_serializer.rb
@@ -1,0 +1,10 @@
+class FrameworkNomisMappingSerializer < ActiveModel::Serializer
+  type 'framework_nomis_mappings'
+  has_many :framework_responses, key: :responses
+
+  attributes :code, :code_type, :code_description, :comments, :start_date, :end_date, :creation_date, :expiry_date
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    responses
+  ].freeze
+end

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -3,6 +3,7 @@ class FrameworkResponseSerializer < ActiveModel::Serializer
   belongs_to :person_escort_record
   belongs_to :framework_question, key: :question
   has_many :framework_flags, key: :flags
+  has_many :framework_nomis_mappings, key: :nomis_mappings
 
   attributes :value, :value_type, :responded
 
@@ -12,6 +13,7 @@ class FrameworkResponseSerializer < ActiveModel::Serializer
 
   SUPPORTED_RELATIONSHIPS = %w[
     person_escort_record
+    nomis_mappings
     question.descendants
     flags
   ].freeze

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -40,6 +40,7 @@ class MoveSerializer < ActiveModel::Serializer
     profile.person_escort_record.flags
     profile.person_escort_record.framework
     profile.person_escort_record.responses
+    profile.person_escort_record.responses.nomis_mappings
     profile.person_escort_record.responses.question
     profile.person_escort_record.responses.question.descendants.**
     from_location

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -5,7 +5,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   has_many :framework_responses, serializer: FrameworkResponseSerializer, key: :responses
   has_many :framework_flags, key: :flags
 
-  attributes :version, :status, :confirmed_at
+  attributes :version, :status, :confirmed_at, :created_at
 
   meta do
     { section_progress: object.section_progress }
@@ -20,7 +20,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
   end
 
   def framework_responses
-    object.framework_responses.includes(:framework_flags, framework_question: [:framework, dependents: :dependents])
+    object.framework_responses.includes(:framework_flags, :framework_nomis_mappings, framework_question: [:framework, dependents: :dependents])
   end
 
   def status
@@ -36,6 +36,7 @@ class PersonEscortRecordSerializer < ActiveModel::Serializer
     framework
     profile.person
     responses.question
+    responses.nomis_mappings
     responses.question.descendants.**
     flags
   ].freeze

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -37,6 +37,7 @@ module V2
       profile.person_escort_record.flags
       profile.person_escort_record.framework
       profile.person_escort_record.responses
+      profile.person_escort_record.responses.nomis_mappings
       profile.person_escort_record.responses.question
       profile.person_escort_record.responses.question.descendants.**
       from_location

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -5,6 +5,20 @@ require 'rails_helper'
 RSpec.describe PersonEscortRecord do
   subject { create(:person_escort_record) }
 
+  let(:nomis_alert) do
+    {
+      alert_id: 2,
+      alert_code: 'VI',
+      alert_code_description: 'Hold separately',
+      comment: 'Some comment',
+      created_at: '2013-03-29',
+      expires_at: '2100-06-08',
+      expired: false,
+      active: true,
+      offender_no: 'A9127EK',
+    }
+  end
+
   it { is_expected.to validate_presence_of(:status) }
   it { is_expected.to validate_inclusion_of(:status).in_array(%w[unstarted in_progress completed confirmed]) }
   it { is_expected.to have_many(:framework_responses) }
@@ -108,6 +122,17 @@ RSpec.describe PersonEscortRecord do
       expect(person_escort_record.framework_responses.count).to eq(2)
     end
 
+    it 'creates NOMIS mappings for framework responses' do
+      move = create(:move)
+      framework = create(:framework)
+      alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
+      create(:framework_question, framework: framework, framework_nomis_codes: [alert_code])
+      allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert])
+      person_escort_record = described_class.save_with_responses!(move_id: move.id, version: framework.version)
+
+      expect(person_escort_record.framework_responses.first.framework_nomis_mappings.count).to eq(1)
+    end
+
     it 'sets correct response for framework questions' do
       profile = create(:profile)
       framework = create(:framework)
@@ -130,7 +155,7 @@ RSpec.describe PersonEscortRecord do
     end
   end
 
-  describe '#build_responses' do
+  describe '#build_responses!' do
     it 'persists the person_escort_record' do
       framework = create(:framework)
       create(:framework_question, framework: framework)
@@ -257,6 +282,45 @@ RSpec.describe PersonEscortRecord do
       person_escort_record.build_responses!
     rescue ActiveRecord::RecordInvalid
       expect(FrameworkResponse.count).to be_zero
+    end
+  end
+
+  describe '#import_nomis_mappings!' do
+    before do
+      allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert])
+    end
+
+    it 'does nothing if no move associated to person escort record' do
+      framework = create(:framework)
+      profile = create(:profile)
+      alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
+      question = create(:framework_question, framework: framework, framework_nomis_codes: [alert_code])
+      response = create(:string_response, framework_question: question)
+      person_escort_record = create(:person_escort_record, framework: framework, profile: profile, framework_responses: [response])
+
+      expect { person_escort_record.import_nomis_mappings! }.not_to change(FrameworkNomisMapping, :count)
+    end
+
+    it 'does nothing if move is not from a prison' do
+      framework = create(:framework)
+      move = create(:move, :video_remand)
+      alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
+      question = create(:framework_question, framework: framework, framework_nomis_codes: [alert_code])
+      response = create(:string_response, framework_question: question)
+      person_escort_record = create(:person_escort_record, framework: framework, move: move, framework_responses: [response])
+
+      expect { person_escort_record.import_nomis_mappings! }.not_to change(FrameworkNomisMapping, :count)
+    end
+
+    it 'imports nomis mappings if move is a prison' do
+      framework = create(:framework)
+      move = create(:move)
+      alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
+      question = create(:framework_question, framework: framework, framework_nomis_codes: [alert_code])
+      response = create(:string_response, framework_question: question)
+      person_escort_record = create(:person_escort_record, framework: framework, move: move, framework_responses: [response])
+
+      expect { person_escort_record.import_nomis_mappings! }.to change(FrameworkNomisMapping, :count).by(1)
     end
   end
 

--- a/spec/serializers/framework_nomis_mapping_serializer_spec.rb
+++ b/spec/serializers/framework_nomis_mapping_serializer_spec.rb
@@ -51,33 +51,4 @@ RSpec.describe FrameworkNomisMappingSerializer do
   it 'contains a `expiry_date` attribute' do
     expect(result[:data][:attributes][:expiry_date]).to eq(framework_nomis_mapping.expiry_date)
   end
-
-  it 'contains a `responses` relationship' do
-    expect(result[:data][:relationships][:responses][:data]).to contain_exactly(
-      id: framework_response.id,
-      type: 'framework_responses',
-    )
-  end
-
-  context 'with include options' do
-    let(:includes) do
-      {
-        responses: :value_type,
-      }
-    end
-
-    let(:expected_json) do
-      [
-        {
-          id: framework_response.id,
-          type: 'framework_responses',
-          attributes: { value_type: framework_response.framework_question.response_type },
-        },
-      ]
-    end
-
-    it 'contains an included question' do
-      expect(result[:included]).to include_json(expected_json)
-    end
-  end
 end

--- a/spec/serializers/framework_nomis_mapping_serializer_spec.rb
+++ b/spec/serializers/framework_nomis_mapping_serializer_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkNomisMappingSerializer do
+  subject(:serializer) { described_class.new(framework_nomis_mapping) }
+
+  let(:framework_nomis_mapping) { create(:framework_nomis_mapping) }
+  let!(:framework_response) do
+    create(:string_response, framework_nomis_mappings: [framework_nomis_mapping])
+  end
+  let(:result) { ActiveModelSerializers::Adapter.create(serializer, include: includes).serializable_hash }
+  let(:includes) { {} }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('framework_nomis_mappings')
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eq(framework_nomis_mapping.id)
+  end
+
+  it 'contains a `code` attribute' do
+    expect(result[:data][:attributes][:code]).to eq(framework_nomis_mapping.code)
+  end
+
+  it 'contains a `code_type` attribute' do
+    expect(result[:data][:attributes][:code_type]).to eq(framework_nomis_mapping.code_type)
+  end
+
+  it 'contains a `code_description` attribute' do
+    expect(result[:data][:attributes][:code_description]).to eq(framework_nomis_mapping.code_description)
+  end
+
+  it 'contains a `comments` attribute' do
+    expect(result[:data][:attributes][:comments]).to eq(framework_nomis_mapping.comments)
+  end
+
+  it 'contains a `start_date` attribute' do
+    expect(result[:data][:attributes][:start_date]).to eq(framework_nomis_mapping.start_date)
+  end
+
+  it 'contains a `end_date` attribute' do
+    expect(result[:data][:attributes][:end_date]).to eq(framework_nomis_mapping.end_date)
+  end
+
+  it 'contains a `creation_date` attribute' do
+    expect(result[:data][:attributes][:creation_date]).to eq(framework_nomis_mapping.creation_date)
+  end
+
+  it 'contains a `expiry_date` attribute' do
+    expect(result[:data][:attributes][:expiry_date]).to eq(framework_nomis_mapping.expiry_date)
+  end
+
+  it 'contains a `responses` relationship' do
+    expect(result[:data][:relationships][:responses][:data]).to contain_exactly(
+      id: framework_response.id,
+      type: 'framework_responses',
+    )
+  end
+
+  context 'with include options' do
+    let(:includes) do
+      {
+        responses: :value_type,
+      }
+    end
+
+    let(:expected_json) do
+      [
+        {
+          id: framework_response.id,
+          type: 'framework_responses',
+          attributes: { value_type: framework_response.framework_question.response_type },
+        },
+      ]
+    end
+
+    it 'contains an included question' do
+      expect(result[:included]).to include_json(expected_json)
+    end
+  end
+end

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe FrameworkResponseSerializer do
     )
   end
 
+  it 'contains an empty `nomis_mappings` relationship if no nomis_mappings present' do
+    expect(result[:data][:relationships][:nomis_mappings][:data]).to be_empty
+  end
+
+  it 'contains a `nomis_mappings` relationship when nomis_mappings present' do
+    framework_nomis_mapping = create(:framework_nomis_mapping)
+    framework_response.update(framework_nomis_mappings: [framework_nomis_mapping])
+
+    expect(result[:data][:relationships][:nomis_mappings][:data]).to contain_exactly(
+      id: framework_nomis_mapping.id,
+      type: 'framework_nomis_mappings',
+    )
+  end
+
   context 'with include options' do
     let(:includes) do
       {

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe PersonEscortRecordSerializer do
     expect(result[:data][:attributes][:confirmed_at]).to eq(person_escort_record.confirmed_at)
   end
 
+  it 'contains a `created_at` attribute' do
+    expect(result[:data][:attributes][:created_at]).to eq(person_escort_record.created_at)
+  end
+
   it 'contains a `profile` relationship' do
     expect(result[:data][:relationships][:profile][:data]).to eq(
       id: person_escort_record.profile.id,
@@ -98,8 +102,9 @@ RSpec.describe PersonEscortRecordSerializer do
   end
 
   context 'with include options' do
-    let(:includes) { { responses: [:value, question: :key] } }
-    let(:framework_response) { build(:object_response) }
+    let(:includes) { { responses: [:value, question: :key, nomis_mappings: :code] } }
+    let(:framework_nomis_mapping) { create(:framework_nomis_mapping) }
+    let(:framework_response) { build(:object_response, framework_nomis_mappings: [framework_nomis_mapping]) }
     let(:person_escort_record) do
       create(:person_escort_record, framework_responses: [framework_response])
     end
@@ -115,6 +120,11 @@ RSpec.describe PersonEscortRecordSerializer do
           id: framework_response.framework_question.id,
           type: 'framework_questions',
           attributes: { key: framework_response.framework_question.key },
+        },
+        {
+          id: framework_nomis_mapping.id,
+          type: 'framework_nomis_mappings',
+          attributes: { code: framework_nomis_mapping.code },
         },
       ]
     end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -58,6 +58,8 @@
       :$ref: "../v1/framework.yaml#/Framework"
     :FrameworkFlag:
       :$ref: "../v1/framework_flag.yaml#/FrameworkFlag"
+    :FrameworkNomisMapping:
+      :$ref: "../v1/framework_nomis_mapping.yaml#/FrameworkNomisMapping"
     :FrameworkQuestion:
       :$ref: "../v1/framework_question.yaml#/FrameworkQuestion"
     :FrameworkResponse:

--- a/swagger/v1/framework_nomis_mapping.yaml
+++ b/swagger/v1/framework_nomis_mapping.yaml
@@ -1,0 +1,87 @@
+FrameworkNomisMapping:
+  type: object
+  required:
+  - id
+  - type
+  - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: framework_nomis_mappings
+      enum:
+      - framework_nomis_mappings
+      description: The type of this object - always `framework_nomis_mappings`
+    attributes:
+      type: object
+      required:
+      - code
+      - code_type
+      properties:
+        code:
+          example: 'XVL'
+          type: string
+          description: the code of the nomis mapping
+          readOnly: true
+        code_type:
+          type: string
+          example: 'alert'
+          enum:
+            - alert
+            - personal_care_need
+            - reasonable_adjustment
+          description: Indicates the type of nomis mapping
+          readOnly: true
+        code_description:
+          example: 'Violent'
+          type: string
+          description: the description of the nomis mapping
+          readOnly: true
+        comments:
+          type: string
+          example: 'Threatening to take staff hostage'
+          description: comments on the nomis mapping
+          readOnly: true
+        start_date:
+          example: "2019-08-08"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date
+            description: Date of when the nomis mapping started
+            readOnly: true
+        end_date:
+          example: "2019-08-08"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date
+            description: Date of when the nomis mapping ends
+            readOnly: true
+        creation_date:
+          example: "2019-08-08"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date
+            description: Date of when the nomis mapping was created
+            readOnly: true
+        expiry_date:
+          example: "2019-08-08"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date
+            description: Date of when the nomis mapping expires
+            readOnly: true
+    relationships:
+      type: object
+      required:
+      properties:
+        responses:
+          $ref: framework_response_reference.yaml#/FrameworkResponseReference
+          description: The framework responses associated with this framework_nomis_mapping

--- a/swagger/v1/framework_nomis_mapping.yaml
+++ b/swagger/v1/framework_nomis_mapping.yaml
@@ -78,10 +78,3 @@ FrameworkNomisMapping:
             format: date
             description: Date of when the nomis mapping expires
             readOnly: true
-    relationships:
-      type: object
-      required:
-      properties:
-        responses:
-          $ref: framework_response_reference.yaml#/FrameworkResponseReference
-          description: The framework responses associated with this framework_nomis_mapping

--- a/swagger/v1/framework_nomis_mapping_reference.yaml
+++ b/swagger/v1/framework_nomis_mapping_reference.yaml
@@ -1,0 +1,32 @@
+FrameworkNomisMappingReference:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      oneOf:
+      - type: object
+        description:  single object returned if resource is associated to only one framework_nomis_mapping
+      - type: 'null'
+      - type: array
+        description:  Multiple objects returned if resource is associated to multiple framework_nomis_mappings
+      example:
+        - id: ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154
+          type: framework_nomis_mappings
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          example: framework_nomis_mappings
+          enum:
+            - framework_nomis_mappings
+          description: The type of this object - always `framework_nomis_mappings`
+        id:
+          type: string
+          format: uuid
+          example: ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154
+          description:
+            The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v1/framework_response.yaml
+++ b/swagger/v1/framework_response.yaml
@@ -81,3 +81,6 @@ FrameworkResponse:
         flags:
           $ref: framework_flag_reference.yaml#/FrameworkFlagReference
           description: The framework flags associated with this framework_response
+        nomis_mappings:
+          $ref: framework_nomis_mapping_reference.yaml#/FrameworkNomisMappingReference
+          description: The framework nomis mappings associated with this framework_response

--- a/swagger/v1/framework_response_include_parameter.yaml
+++ b/swagger/v1/framework_response_include_parameter.yaml
@@ -10,5 +10,6 @@ FrameworkResponseIncludeParameter:
       - flags
       - person_escort_record
       - question
+      - nomis_mappings
       - question.descendants
   example: framework

--- a/swagger/v1/move_include_parameter.yaml
+++ b/swagger/v1/move_include_parameter.yaml
@@ -28,6 +28,7 @@ MoveIncludeParameter:
       - profile.person_escort_record.flags
       - profile.person_escort_record.framework
       - profile.person_escort_record.responses
+      - profile.person_escort_record.responses.nomis_mappings
       - profile.person_escort_record.responses.question
       - profile.person_escort_record.responses.question.descendants.**
   example: from_location

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -41,6 +41,14 @@ PersonEscortRecord:
             format: date-time
             description: Timestamp of when the person_escort_record was confirmed
             readOnly: true
+        created_at:
+          example: "2020-07-24T17:29:26.338Z"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of when the person_escort_record was created
+            readOnly: true
     meta:
       readOnly: true
       type: object

--- a/swagger/v1/person_escort_record_include_parameter.yaml
+++ b/swagger/v1/person_escort_record_include_parameter.yaml
@@ -12,6 +12,7 @@ PersonEscortRecordIncludeParameter:
       - profile.person
       - responses
       - responses.question
+      - responses.nomis_mappings
       - responses.question.descendants.**
       - flags
   example: framework

--- a/swagger/v2/move_include_parameter.yaml
+++ b/swagger/v2/move_include_parameter.yaml
@@ -22,6 +22,7 @@ MoveIncludeParameter:
       - profile.person_escort_record.flags
       - profile.person_escort_record.framework
       - profile.person_escort_record.responses
+      - profile.person_escort_record.responses.nomis_mappings
       - profile.person_escort_record.responses.question
       - profile.person_escort_record.responses.question.descendants.**
   example: from_location


### PR DESCRIPTION
### Jira link

[P4-2067](https://dsdmoj.atlassian.net/browse/P4-2067)

### What?

I have added/removed/altered:

- [x] Add NOMIS mapping serializer
- [x] Add NOMIS mappings includes and associations to relevant serializers
- [x] When creating the PER, import NOMIS mappings and associate them to the responses of the PER

### Why?

After responses are created, import NOMIS mappings. We can only import mappings if a move is associated to the PER and the from location is a prison.

Importing is not part of the initial transaction as it is a standalone action, which is not performant can be moved to a sidekiq job in the future. 

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)
- Changes an api that is used in production

