### PR TITLE
P4-2301 Add NOMIS sync status to Person Escort Record

### DIFF
--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -81,13 +81,7 @@ class PersonEscortRecord < VersionedModel
   def import_nomis_mappings!
     return unless move&.from_location&.prison?
 
-    framework_nomis_codes = framework_responses.includes(:framework_nomis_codes).flat_map(&:framework_nomis_codes)
-
-    FrameworkNomisMappings::Importer.new(
-      person: profile.person,
-      framework_responses: framework_responses,
-      framework_nomis_codes: framework_nomis_codes,
-    ).call
+    FrameworkNomisMappings::Importer.new(person_escort_record: self).call
   end
 
   def section_progress

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -16,7 +16,7 @@ class PersonEscortRecordSerializer
     object.framework_flags.includes(framework_question: :dependents)
   end
 
-  attributes :confirmed_at, :created_at
+  attributes :confirmed_at, :created_at, :nomis_sync_status
 
   attribute :version do |object|
     object.framework.version

--- a/app/services/framework_nomis_mappings/alerts.rb
+++ b/app/services/framework_nomis_mappings/alerts.rb
@@ -16,12 +16,7 @@ module FrameworkNomisMappings
   private
 
     def imported_alerts
-      @imported_alerts ||= begin
-        alerts = NomisClient::Alerts.get([prison_number])
-        nomis_sync_status.set_success
-
-        alerts
-      end
+      @imported_alerts ||= NomisClient::Alerts.get([prison_number]).tap { nomis_sync_status.set_success }
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, OAuth2::Error => e
       Rails.logger.warn "Importing Framework alert mappings Error: #{e.message}"
       nomis_sync_status.set_failure(message: e.message)

--- a/app/services/framework_nomis_mappings/alerts.rb
+++ b/app/services/framework_nomis_mappings/alerts.rb
@@ -1,9 +1,10 @@
 module FrameworkNomisMappings
   class Alerts
-    attr_reader :prison_number
+    attr_reader :prison_number, :nomis_sync_status
 
-    def initialize(prison_number:)
+    def initialize(prison_number:, nomis_sync_status: FrameworkNomisMappings::NomisSyncStatus.new(resource_type: 'alerts'))
       @prison_number = prison_number
+      @nomis_sync_status = nomis_sync_status
     end
 
     def call
@@ -15,9 +16,15 @@ module FrameworkNomisMappings
   private
 
     def imported_alerts
-      @imported_alerts ||= NomisClient::Alerts.get([prison_number])
+      @imported_alerts ||= begin
+        alerts = NomisClient::Alerts.get([prison_number])
+        nomis_sync_status.set_success
+
+        alerts
+      end
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, OAuth2::Error => e
       Rails.logger.warn "Importing Framework alert mappings Error: #{e.message}"
+      nomis_sync_status.set_failure(message: e.message)
 
       []
     end

--- a/app/services/framework_nomis_mappings/nomis_sync_status.rb
+++ b/app/services/framework_nomis_mappings/nomis_sync_status.rb
@@ -1,0 +1,32 @@
+module FrameworkNomisMappings
+  class NomisSyncStatus
+    SUCCESS = 'success'.freeze
+    FAILED = 'failed'.freeze
+
+    attr_reader :resource_type, :status, :synced_at, :message
+
+    def initialize(resource_type:)
+      @resource_type = resource_type
+    end
+
+    def set_success
+      @status = SUCCESS
+      @synced_at = Time.zone.now
+    end
+
+    def set_failure(message: nil)
+      @status = FAILED
+      @synced_at = Time.zone.now
+      @message = message
+    end
+
+    def as_json(_options = {})
+      {
+        resource_type: resource_type,
+        status: status,
+        synced_at: synced_at,
+        message: message,
+      }
+    end
+  end
+end

--- a/app/services/framework_nomis_mappings/personal_care_needs.rb
+++ b/app/services/framework_nomis_mappings/personal_care_needs.rb
@@ -17,11 +17,8 @@ module FrameworkNomisMappings
   private
 
     def imported_personal_care_needs
-      @imported_personal_care_needs ||= begin
-        personal_care_needs = NomisClient::PersonalCareNeeds.get(nomis_offender_numbers: [prison_number], personal_care_types: PERSONAL_CARE_NEED_CODES)
+      @imported_personal_care_needs ||= NomisClient::PersonalCareNeeds.get(nomis_offender_numbers: [prison_number], personal_care_types: PERSONAL_CARE_NEED_CODES).tap do
         nomis_sync_status.set_success
-
-        personal_care_needs
       end
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, OAuth2::Error => e
       Rails.logger.warn "Importing Framework personal care needs mappings Error: #{e.message}"

--- a/app/services/framework_nomis_mappings/personal_care_needs.rb
+++ b/app/services/framework_nomis_mappings/personal_care_needs.rb
@@ -1,10 +1,11 @@
 module FrameworkNomisMappings
   class PersonalCareNeeds
     PERSONAL_CARE_NEED_CODES = 'SC,MATSTAT,PHY,PSYCH,DISAB'.freeze
-    attr_reader :prison_number
+    attr_reader :prison_number, :nomis_sync_status
 
-    def initialize(prison_number:)
+    def initialize(prison_number:, nomis_sync_status: FrameworkNomisMappings::NomisSyncStatus.new(resource_type: 'personal_care_needs'))
       @prison_number = prison_number
+      @nomis_sync_status = nomis_sync_status
     end
 
     def call
@@ -16,9 +17,15 @@ module FrameworkNomisMappings
   private
 
     def imported_personal_care_needs
-      @imported_personal_care_needs ||= NomisClient::PersonalCareNeeds.get(nomis_offender_numbers: [prison_number], personal_care_types: PERSONAL_CARE_NEED_CODES)
+      @imported_personal_care_needs ||= begin
+        personal_care_needs = NomisClient::PersonalCareNeeds.get(nomis_offender_numbers: [prison_number], personal_care_types: PERSONAL_CARE_NEED_CODES)
+        nomis_sync_status.set_success
+
+        personal_care_needs
+      end
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, OAuth2::Error => e
       Rails.logger.warn "Importing Framework personal care needs mappings Error: #{e.message}"
+      nomis_sync_status.set_failure(message: e.message)
 
       []
     end

--- a/app/services/framework_nomis_mappings/reasonable_adjustments.rb
+++ b/app/services/framework_nomis_mappings/reasonable_adjustments.rb
@@ -1,10 +1,11 @@
 module FrameworkNomisMappings
   class ReasonableAdjustments
-    attr_reader :booking_id, :nomis_codes
+    attr_reader :booking_id, :nomis_codes, :nomis_sync_status
 
-    def initialize(booking_id:, nomis_codes:)
+    def initialize(booking_id:, nomis_codes:, nomis_sync_status: FrameworkNomisMappings::NomisSyncStatus.new(resource_type: 'reasonable_adjustments'))
       @booking_id = booking_id
       @nomis_codes = nomis_codes
+      @nomis_sync_status = nomis_sync_status
     end
 
     def call
@@ -16,9 +17,15 @@ module FrameworkNomisMappings
   private
 
     def imported_reasonable_adjustments
-      @imported_reasonable_adjustments ||= NomisClient::ReasonableAdjustments.get(booking_id: booking_id, reasonable_adjustment_types: nomis_codes.pluck(:code).compact.uniq.join(','))
+      @imported_reasonable_adjustments ||= begin
+        reasonable_adjustments = NomisClient::ReasonableAdjustments.get(booking_id: booking_id, reasonable_adjustment_types: nomis_codes.pluck(:code).compact.uniq.join(','))
+        nomis_sync_status.set_success
+
+        reasonable_adjustments
+      end
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, OAuth2::Error => e
       Rails.logger.warn "Importing Framework reasonable adjustment mappings Error: #{e.message}"
+      nomis_sync_status.set_failure(message: e.message)
 
       []
     end

--- a/app/services/framework_nomis_mappings/reasonable_adjustments.rb
+++ b/app/services/framework_nomis_mappings/reasonable_adjustments.rb
@@ -17,11 +17,8 @@ module FrameworkNomisMappings
   private
 
     def imported_reasonable_adjustments
-      @imported_reasonable_adjustments ||= begin
-        reasonable_adjustments = NomisClient::ReasonableAdjustments.get(booking_id: booking_id, reasonable_adjustment_types: nomis_codes.pluck(:code).compact.uniq.join(','))
+      @imported_reasonable_adjustments ||= NomisClient::ReasonableAdjustments.get(booking_id: booking_id, reasonable_adjustment_types: nomis_codes.pluck(:code).compact.uniq.join(',')).tap do
         nomis_sync_status.set_success
-
-        reasonable_adjustments
       end
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, OAuth2::Error => e
       Rails.logger.warn "Importing Framework reasonable adjustment mappings Error: #{e.message}"

--- a/db/migrate/20201007043824_add_nomis_sync_status_to_person_escort_records.rb
+++ b/db/migrate/20201007043824_add_nomis_sync_status_to_person_escort_records.rb
@@ -1,0 +1,5 @@
+class AddNomisSyncStatusToPersonEscortRecords < ActiveRecord::Migration[6.0]
+  def change
+    add_column :person_escort_records, :nomis_sync_status, :jsonb, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_01_043655) do
+ActiveRecord::Schema.define(version: 2020_10_07_043824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -462,6 +462,7 @@ ActiveRecord::Schema.define(version: 2020_10_01_043655) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "confirmed_at"
     t.uuid "move_id"
+    t.jsonb "nomis_sync_status", default: [], null: false
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
     t.index ["move_id"], name: "index_person_escort_records_on_move_id"
     t.index ["profile_id"], name: "index_person_escort_records_on_profile_id", unique: true

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -134,6 +134,21 @@ RSpec.describe PersonEscortRecord do
       expect(person_escort_record.framework_responses.first.framework_nomis_mappings.count).to eq(1)
     end
 
+    it 'updates nomis sync status if successful' do
+      move = create(:move)
+      framework = create(:framework)
+      alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
+      create(:framework_question, framework: framework, framework_nomis_codes: [alert_code])
+      allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert])
+      person_escort_record = described_class.save_with_responses!(move_id: move.id, version: framework.version)
+
+      expect(person_escort_record.nomis_sync_status).to include_json(
+        [
+          { 'resource_type' => 'alerts', 'status' => 'success' },
+        ],
+      )
+    end
+
     it 'sets correct response for framework questions' do
       profile = create(:profile)
       framework = create(:framework)

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Api::PersonEscortRecordsController do
             "version": framework_version,
             "status": 'not_started',
             "confirmed_at": nil,
+            "nomis_sync_status": [],
           },
           "meta": {
             'section_progress' => [
@@ -123,6 +124,7 @@ RSpec.describe Api::PersonEscortRecordsController do
             "version": framework_version,
             "status": 'not_started',
             "confirmed_at": nil,
+            "nomis_sync_status": [],
           },
           "meta": {
             'section_progress' => [

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe PersonEscortRecordSerializer do
     expect(result[:data][:attributes][:created_at]).to eq(person_escort_record.created_at.iso8601)
   end
 
+  it 'contains a `nomis_sync_status` attribute' do
+    expect(result[:data][:attributes][:nomis_sync_status]).to eq(person_escort_record.nomis_sync_status)
+  end
+
   it 'contains a `profile` relationship' do
     expect(result[:data][:relationships][:profile][:data]).to eq(
       id: person_escort_record.profile.id,

--- a/spec/services/framework_nomis_mappings/importer_spec.rb
+++ b/spec/services/framework_nomis_mappings/importer_spec.rb
@@ -207,6 +207,7 @@ RSpec.describe FrameworkNomisMappings::Importer do
 
   it 'does not set a status if no importing attempted' do
     person_escort_record = create(:person_escort_record, framework_responses: [create(:string_response)], profile: person.profiles.first)
+    described_class.new(person_escort_record: person_escort_record).call
 
     expect(person_escort_record.nomis_sync_status).to be_empty
   end

--- a/spec/services/framework_nomis_mappings/importer_spec.rb
+++ b/spec/services/framework_nomis_mappings/importer_spec.rb
@@ -97,16 +97,14 @@ RSpec.describe FrameworkNomisMappings::Importer do
   end
 
   it 'persists all alerts, reasonable adjustments and personal care needs from NOMIS clients as NOMIS mappings' do
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
-    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+    person_escort_record = create(:person_escort_record, framework_responses: [framework_response1, framework_response2], profile: person.profiles.first)
 
-    expect { described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call }.to change(FrameworkNomisMapping, :count).by(6)
+    expect { described_class.new(person_escort_record: person_escort_record).call }.to change(FrameworkNomisMapping, :count).by(6)
   end
 
   it 'associates NOMIS mappings correctly to framework responses' do
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
-    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
-    described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call
+    person_escort_record = create(:person_escort_record, framework_responses: [framework_response1, framework_response2], profile: person.profiles.first)
+    described_class.new(person_escort_record: person_escort_record).call
 
     expect(framework_response1.framework_nomis_mappings.pluck(:code)).to contain_exactly('VI', 'VI')
   end
@@ -115,35 +113,31 @@ RSpec.describe FrameworkNomisMappings::Importer do
     alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
     question = create(:framework_question, framework_nomis_codes: [alert_code])
     framework_response2 = create(:string_response, framework_question: question)
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
-    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
-    described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call
+    person_escort_record = create(:person_escort_record, framework_responses: [framework_response1, framework_response2], profile: person.profiles.first)
+    described_class.new(person_escort_record: person_escort_record).call
 
     expect(framework_response1.framework_nomis_mappings.pluck(:code, :code_type)).to contain_exactly(%w[VI alert], %w[VI alert])
     expect(framework_response2.framework_nomis_mappings.pluck(:code, :code_type)).to contain_exactly(%w[VI alert], %w[VI alert])
   end
 
   it 'associates multiple NOMIS mappings to a fallback question response' do
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
-    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
-    described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call
+    person_escort_record = create(:person_escort_record, framework_responses: [framework_response1, framework_response2], profile: person.profiles.first)
+    described_class.new(person_escort_record: person_escort_record).call
 
     expect(framework_response2.framework_nomis_mappings.pluck(:code)).to contain_exactly('VI', 'DA', 'PEEP', 'BA')
   end
 
   it 'associates NOMIS mapping codes to responses scoped to NOMIS mapping type' do
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
-    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
-    described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call
+    person_escort_record = create(:person_escort_record, framework_responses: [framework_response1, framework_response2], profile: person.profiles.first)
+    described_class.new(person_escort_record: person_escort_record).call
 
     expect(framework_response1.framework_nomis_mappings.pluck(:code_type).uniq).to contain_exactly('alert')
     expect(framework_response2.framework_nomis_mappings.pluck(:code_type).uniq).to contain_exactly('reasonable_adjustment', 'personal_care_need')
   end
 
   it 'does not associate NOMIS mappings mapped to a fallback if none exist' do
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id])
-    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
-    described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call
+    person_escort_record = create(:person_escort_record, framework_responses: [framework_response1], profile: person.profiles.first)
+    described_class.new(person_escort_record: person_escort_record).call
 
     expect(framework_response1.framework_nomis_mappings.pluck(:code)).to contain_exactly('VI', 'VI')
   end
@@ -151,39 +145,69 @@ RSpec.describe FrameworkNomisMappings::Importer do
   it 'persists other NOMIS mappings if one import fails' do
     oauth2_response = instance_double('OAuth2::Response', body: '{}', parsed: {}, status: '', 'error=': '')
     allow(NomisClient::Alerts).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
-    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+    person_escort_record = create(:person_escort_record, framework_responses: [framework_response1, framework_response2], profile: person.profiles.first)
 
-    expect { described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call }.to change(FrameworkNomisMapping, :count).by(4)
+    expect { described_class.new(person_escort_record: person_escort_record).call }.to change(FrameworkNomisMapping, :count).by(4)
   end
 
   it 'does nothing if no NOMIS mappings present for a person' do
     allow(NomisClient::Alerts).to receive(:get).and_return([])
     allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([])
     allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return([])
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
-    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+    person_escort_record = create(:person_escort_record, framework_responses: [framework_response1, framework_response2], profile: person.profiles.first)
 
-    expect { described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call }.not_to change(FrameworkNomisMapping, :count)
+    expect { described_class.new(person_escort_record: person_escort_record).call }.not_to change(FrameworkNomisMapping, :count)
   end
 
-  it 'does nothing if no person present' do
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
-    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
-
-    expect { described_class.new(person: nil, framework_responses: framework_responses, framework_nomis_codes: framework_nomis_codes).call }.not_to change(FrameworkNomisMapping, :count)
+  it 'does nothing if no person_escort_record present' do
+    expect { described_class.new(person_escort_record: nil).call }.not_to change(FrameworkNomisMapping, :count)
   end
 
   it 'does nothing if no framework responses present' do
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
-    framework_nomis_codes = framework_responses.flat_map(&:framework_nomis_codes)
+    person_escort_record = create(:person_escort_record, framework_responses: [], profile: person.profiles.first)
 
-    expect { described_class.new(person: person, framework_responses: [], framework_nomis_codes: framework_nomis_codes).call }.not_to change(FrameworkNomisMapping, :count)
+    expect { described_class.new(person_escort_record: person_escort_record).call }.not_to change(FrameworkNomisMapping, :count)
   end
 
   it 'does nothing if no framework NOMIS codes present' do
-    framework_responses = FrameworkResponse.where(id: [framework_response1.id, framework_response2.id])
+    person_escort_record = create(:person_escort_record, framework_responses: [create(:string_response)], profile: person.profiles.first)
 
-    expect { described_class.new(person: person, framework_responses: framework_responses, framework_nomis_codes: []).call }.not_to change(FrameworkNomisMapping, :count)
+    expect { described_class.new(person_escort_record: person_escort_record).call }.not_to change(FrameworkNomisMapping, :count)
+  end
+
+  it 'persists the NOMIS status sync attribute on the person escort record' do
+    person_escort_record = create(:person_escort_record, framework_responses: [framework_response1, framework_response2], profile: person.profiles.first)
+
+    described_class.new(person_escort_record: person_escort_record).call
+
+    expect(person_escort_record.nomis_sync_status).to include_json(
+      [
+        { 'resource_type' => 'alerts', 'status' => 'success' },
+        { 'resource_type' => 'personal_care_needs', 'status' => 'success' },
+        { 'resource_type' => 'reasonable_adjustments', 'status' => 'success' },
+      ],
+    )
+  end
+
+  it 'sets different sync statuses per NOMIS client attribute on the person escort record' do
+    oauth2_response = instance_double('OAuth2::Response', body: '{}', parsed: {}, status: '', 'error=': '')
+    allow(NomisClient::Alerts).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
+
+    person_escort_record = create(:person_escort_record, framework_responses: [framework_response1, framework_response2], profile: person.profiles.first)
+    described_class.new(person_escort_record: person_escort_record).call
+
+    expect(person_escort_record.nomis_sync_status).to include_json(
+      [
+        { 'resource_type' => 'alerts', 'status' => 'failed' },
+        { 'resource_type' => 'personal_care_needs', 'status' => 'success' },
+        { 'resource_type' => 'reasonable_adjustments', 'status' => 'success' },
+      ],
+    )
+  end
+
+  it 'does not set a status if no importing attempted' do
+    person_escort_record = create(:person_escort_record, framework_responses: [create(:string_response)], profile: person.profiles.first)
+
+    expect(person_escort_record.nomis_sync_status).to be_empty
   end
 end

--- a/spec/services/framework_nomis_mappings/nomis_sync_status_spec.rb
+++ b/spec/services/framework_nomis_mappings/nomis_sync_status_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkNomisMappings::NomisSyncStatus do
+  describe '#set_success' do
+    it 'sets the `status` as "success"' do
+      nomis_sync_status = described_class.new(resource_type: 'some_resource')
+      nomis_sync_status.set_success
+
+      expect(nomis_sync_status.status).to eq(described_class::SUCCESS)
+    end
+
+    it 'sets the `synced_at` timestamp' do
+      nomis_sync_status = described_class.new(resource_type: 'some_resource')
+      sync_at_timstamp = Time.zone.now
+      allow(Time).to receive(:now).and_return(sync_at_timstamp)
+      nomis_sync_status.set_success
+
+      expect(nomis_sync_status.synced_at).to eq(sync_at_timstamp)
+    end
+  end
+
+  describe '#set_failure' do
+    it 'sets the `status` as "failed"' do
+      nomis_sync_status = described_class.new(resource_type: 'some_resource')
+      nomis_sync_status.set_failure
+
+      expect(nomis_sync_status.status).to eq(described_class::FAILED)
+    end
+
+    it 'sets the `synced_at` timestamp' do
+      nomis_sync_status = described_class.new(resource_type: 'some_resource')
+      sync_at_timstamp = Time.zone.now
+      allow(Time).to receive(:now).and_return(sync_at_timstamp)
+      nomis_sync_status.set_failure
+
+      expect(nomis_sync_status.synced_at).to eq(sync_at_timstamp)
+    end
+
+    it 'sets the error `message`' do
+      nomis_sync_status = described_class.new(resource_type: 'some_resource')
+      nomis_sync_status.set_failure(message: 'BOOM!')
+
+      expect(nomis_sync_status.message).to eq('BOOM!')
+    end
+  end
+
+  describe '#as_json' do
+    it 'returns the attributes of nomis sync status as json' do
+      nomis_sync_status = described_class.new(resource_type: 'some_resource')
+
+      expect(nomis_sync_status.as_json).to eq(
+        resource_type: 'some_resource',
+        status: nil,
+        synced_at: nil,
+        message: nil,
+      )
+    end
+
+    it 'returns the attributes of nomis sync status if set as json' do
+      nomis_sync_status = described_class.new(resource_type: 'some_resource')
+      sync_at_timstamp = Time.zone.now
+      allow(Time).to receive(:now).and_return(sync_at_timstamp)
+      nomis_sync_status.set_success
+
+      expect(nomis_sync_status.as_json).to eq(
+        resource_type: 'some_resource',
+        status: described_class::SUCCESS,
+        synced_at: sync_at_timstamp,
+        message: nil,
+      )
+    end
+  end
+end

--- a/spec/services/framework_nomis_mappings/personal_care_needs_spec.rb
+++ b/spec/services/framework_nomis_mappings/personal_care_needs_spec.rb
@@ -74,6 +74,42 @@ RSpec.describe FrameworkNomisMappings::PersonalCareNeeds do
     expect(mappings).to be_empty
   end
 
+  context 'with NOMIS sync status' do
+    it 'sets the NOMIS sync status as successful if NOMIS client is successful' do
+      allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([nomis_personal_care_need])
+      mappings = described_class.new(prison_number: 'A9127EK')
+      mappings.call
+
+      expect(mappings.nomis_sync_status.status).to eq(FrameworkNomisMappings::NomisSyncStatus::SUCCESS)
+    end
+
+    it 'sets the NOMIS sync status as successful if NOMIS client is successful but no personal care needs returned' do
+      allow(NomisClient::PersonalCareNeeds).to receive(:get).and_return([])
+      mappings = described_class.new(prison_number: 'A9127EK')
+      mappings.call
+
+      expect(mappings.nomis_sync_status.status).to eq(FrameworkNomisMappings::NomisSyncStatus::SUCCESS)
+    end
+
+    it 'sets the NOMIS sync status as failed if NOMIS client throws an error' do
+      oauth2_response = instance_double('OAuth2::Response', body: '{}', parsed: {}, status: '', 'error=': '')
+      allow(NomisClient::PersonalCareNeeds).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
+      mappings = described_class.new(prison_number: 'A9127EK')
+      mappings.call
+
+      expect(mappings.nomis_sync_status.status).to eq(FrameworkNomisMappings::NomisSyncStatus::FAILED)
+    end
+
+    it 'sets the NOMIS sync failure message if NOMIS client throws an error' do
+      oauth2_response = instance_double('OAuth2::Response', body: '{"error": "BOOM"}', parsed: {}, status: '', 'error=': '')
+      allow(NomisClient::PersonalCareNeeds).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
+      mappings = described_class.new(prison_number: 'A9127EK')
+      mappings.call
+
+      expect(mappings.nomis_sync_status.message).to match(/BOOM/)
+    end
+  end
+
   def nomis_personal_care_need(start_date: '2010-06-21', end_date: '2100-06-21', problem_status: 'ON')
     {
       problem_code: 'ACCU9',

--- a/spec/services/framework_nomis_mappings/reasonable_adjustments_spec.rb
+++ b/spec/services/framework_nomis_mappings/reasonable_adjustments_spec.rb
@@ -78,6 +78,42 @@ RSpec.describe FrameworkNomisMappings::ReasonableAdjustments do
     expect(mappings).to be_empty
   end
 
+  context 'with NOMIS sync status' do
+    it 'sets the NOMIS sync status as successful if NOMIS client is successful' do
+      allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return([nomis_reasonable_adjustment])
+      mappings = described_class.new(booking_id: 111_111, nomis_codes: nomis_codes)
+      mappings.call
+
+      expect(mappings.nomis_sync_status.status).to eq(FrameworkNomisMappings::NomisSyncStatus::SUCCESS)
+    end
+
+    it 'sets the NOMIS sync status as successful if NOMIS client is successful but no personal care needs returned' do
+      allow(NomisClient::ReasonableAdjustments).to receive(:get).and_return([])
+      mappings = described_class.new(booking_id: 111_111, nomis_codes: nomis_codes)
+      mappings.call
+
+      expect(mappings.nomis_sync_status.status).to eq(FrameworkNomisMappings::NomisSyncStatus::SUCCESS)
+    end
+
+    it 'sets the NOMIS sync status as failed if NOMIS client throws an error' do
+      oauth2_response = instance_double('OAuth2::Response', body: '{}', parsed: {}, status: '', 'error=': '')
+      allow(NomisClient::ReasonableAdjustments).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
+      mappings = described_class.new(booking_id: 111_111, nomis_codes: nomis_codes)
+      mappings.call
+
+      expect(mappings.nomis_sync_status.status).to eq(FrameworkNomisMappings::NomisSyncStatus::FAILED)
+    end
+
+    it 'sets the NOMIS sync failure message if NOMIS client throws an error' do
+      oauth2_response = instance_double('OAuth2::Response', body: '{"error": "BOOM"}', parsed: {}, status: '', 'error=': '')
+      allow(NomisClient::ReasonableAdjustments).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
+      mappings = described_class.new(booking_id: 111_111, nomis_codes: nomis_codes)
+      mappings.call
+
+      expect(mappings.nomis_sync_status.message).to match(/BOOM/)
+    end
+  end
+
   def nomis_reasonable_adjustment(start_date: '2010-06-21', end_date: '2100-06-21')
     {
       treatment_code: 'DA',

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -33,6 +33,29 @@ PersonEscortRecord:
           type: string
           example: '1.0.1'
           description: Determines the version of framework questions of the `person_escort_record`
+        nomis_sync_status:
+          type: array
+          items:
+            type: object
+            properties:
+              resource_type:
+                type: string
+                enum:
+                  - alerts
+                  - personal_care_needs
+                  - reasonable_adjustments
+              status:
+                type: string
+                enum:
+                  - success
+                  - failed
+              synced_at:
+                type: string
+                format: date-time
+              message:
+                type: string
+          readOnly: true
+          description: A list of all NOMIS resources imported when creating the person escort record, and the status of the import, either successful or failed. The timestamp and error message are also included.
         confirmed_at:
           example: "2020-07-24T17:29:26.338Z"
           oneOf:


### PR DESCRIPTION
### Jira link

[P4-2301](https://dsdmoj.atlassian.net/browse/P4-2301)

### What?

- [x] Added new `nomis_sync_status` to Person escort record
- [x] Record status of each NOMIS import when creating the PER
- [x] Surface new jsonb column in Person escort record serializer

### Why?
To surface any NOMIS resource importing failures on PER creation, add a new column on the PER: 'nomis_sync_status' which lists all the resources imported, and their status, timestamp as well as error message if available. This will allow the FE to render a warning message if any NOMIS resources have not been successfully associated to the responses, and to allow the user to check any missing resources in NOMIS itself instead.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production, but importing is still not available in production until all features are released

