### PR TITLE
Sort in memory and add eager load profiles

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -37,7 +37,7 @@ class Person < VersionedModel
   end
 
   def latest_profile
-    profiles.order(:updated_at).last
+    profiles.max_by(&:updated_at)
   end
 
   def attach_image(image_blob)

--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -4,7 +4,7 @@ module Allocations
   class Finder
     attr_reader :filter_params, :search_params
 
-    ALLOCATION_INCLUDES = [from_location: :suppliers, to_location: :suppliers, moves: %i[from_location to_location court_hearings profile person]].freeze
+    ALLOCATION_INCLUDES = [from_location: :suppliers, to_location: :suppliers, moves: [:from_location, :to_location, :court_hearings, person: %i[gender ethnicity profiles], profile: %i[person_escort_record documents]]].freeze
 
     def initialize(filters: {}, ordering: {}, search: {})
       @search_params = search


### PR DESCRIPTION
Avoid doing extra queries which ignore eager loading by sorting in memory, also add missing includes to allocation endpoint. Locally this cut down API calls from over 8seconds to 1.7seconds for 100 allocations