### PR TITLE
P4-2211 Details optional if NOMIS mappings present on response

### DIFF
--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -29,10 +29,11 @@ class FrameworkResponse
   private
 
     def details_collection(collection)
+      details_options = framework_nomis_mappings.any? ? [] : framework_question.followup_comment_options
       DetailsCollection.new(
         collection: collection,
         question_options: framework_question.options,
-        details_options: framework_question.followup_comment_options,
+        details_options: details_options,
       )
     end
 

--- a/app/models/framework_response/object.rb
+++ b/app/models/framework_response/object.rb
@@ -25,10 +25,11 @@ class FrameworkResponse
   private
 
     def details_object(attributes:)
+      details_options = framework_nomis_mappings.any? ? [] : framework_question.followup_comment_options
       DetailsObject.new(
         attributes: attributes,
         question_options: framework_question.options,
-        details_options: framework_question.followup_comment_options,
+        details_options: details_options,
       )
     end
 

--- a/spec/models/framework_response/collection_spec.rb
+++ b/spec/models/framework_response/collection_spec.rb
@@ -174,6 +174,44 @@ RSpec.describe FrameworkResponse::Collection do
         expect(response).to be_valid
       end
     end
+
+    context 'with NOMIS mappings' do
+      it 'does not validate required followup comments if mappings present' do
+        question = create(
+          :framework_question,
+          :checkbox,
+          followup_comment: true,
+          followup_comment_options: %w[Level 1],
+        )
+        response = create(:collection_response, :details, value: [{ 'option' => 'Level 1' }], framework_question: question, framework_nomis_mappings: [create(:framework_nomis_mapping)])
+
+        expect(response).to be_valid
+      end
+
+      it 'does not validate optional followup comments if mappings present' do
+        question = create(
+          :framework_question,
+          :checkbox,
+          followup_comment: true,
+          followup_comment_options: [],
+        )
+        response = create(:collection_response, :details, value: [{ 'option' => 'Level 1' }], framework_question: question, framework_nomis_mappings: [create(:framework_nomis_mapping)])
+
+        expect(response).to be_valid
+      end
+
+      it 'does not validate optional followup comments if no mappings present' do
+        question = create(
+          :framework_question,
+          :checkbox,
+          followup_comment: true,
+          followup_comment_options: [],
+        )
+        response = create(:collection_response, :details, value: [{ 'option' => 'Level 1' }], framework_question: question)
+
+        expect(response).to be_valid
+      end
+    end
   end
 
   describe '#value' do

--- a/spec/models/framework_response/object_spec.rb
+++ b/spec/models/framework_response/object_spec.rb
@@ -121,6 +121,41 @@ RSpec.describe FrameworkResponse::Object do
         expect(response).to be_valid
       end
     end
+
+    context 'with NOMIS mappings' do
+      it 'does not validate required followup comments if mappings present' do
+        question = create(
+          :framework_question,
+          followup_comment: true,
+          followup_comment_options: %w[Yes],
+        )
+        response = create(:object_response, :details, value: { 'option' => 'Yes' }, framework_question: question, framework_nomis_mappings: [create(:framework_nomis_mapping)])
+
+        expect(response).to be_valid
+      end
+
+      it 'does not validate optional followup comments if mappings present' do
+        question = create(
+          :framework_question,
+          followup_comment: true,
+          followup_comment_options: [],
+        )
+        response = create(:object_response, :details, value: { 'option' => 'Yes' }, framework_question: question, framework_nomis_mappings: [create(:framework_nomis_mapping)])
+
+        expect(response).to be_valid
+      end
+
+      it 'does not validate optional followup comments if no mappings present' do
+        question = create(
+          :framework_question,
+          followup_comment: true,
+          followup_comment_options: [],
+        )
+        response = create(:object_response, :details, value: { 'option' => 'Yes' }, framework_question: question)
+
+        expect(response).to be_valid
+      end
+    end
   end
 
   describe '#value' do


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2211

Do not validate comments on responses if there are any NOMIS mappings attached to the response. To avoid users having to fill in "see above" in required give details boxes when NOMIS mappings are available, make this box optional.