### PR TITLE
Updates allocation_serializer to use v2 moves

### DIFF
--- a/app/serializers/allocation_serializer.rb
+++ b/app/serializers/allocation_serializer.rb
@@ -24,7 +24,7 @@ class AllocationSerializer
 
   has_one :from_location, serializer: LocationSerializer
   has_one :to_location, serializer: LocationSerializer
-  has_many :moves
+  has_many :moves, serializer: V2::MoveSerializer
 
   SUPPORTED_RELATIONSHIPS = %w[
     from_location


### PR DESCRIPTION
### Jira link

P4-

### What?

I have added/removed/altered:

- [x] Altered `AllocationsSerializer` so that it now uses `V2::MoveSerializer`

### Why?

I am doing this because:

- The old serializer pulls on the now-replaced person#latest_profile method which is going to be removed