### PR TITLE
Cancellation reason and rejection reason should accept a list

### DIFF
--- a/app/services/moves/params_validator.rb
+++ b/app/services/moves/params_validator.rb
@@ -12,9 +12,14 @@ module Moves
       record.errors.add attr, 'is not a valid date.'
     end
 
+    validates_each :cancellation_reason, :rejection_reason, allow_nil: true do |record, attr, value|
+      values = value&.split(',') || []
+      if (values - Move.const_get(attr.to_s.pluralize.upcase)).any?
+        record.errors.add(attr, :inclusion)
+      end
+    end
+
     validates :move_type, inclusion: { in: Move.move_types }, allow_nil: true
-    validates :cancellation_reason, inclusion: { in: Move::CANCELLATION_REASONS }, allow_nil: true
-    validates :rejection_reason, inclusion: { in: Move::REJECTION_REASONS }, allow_nil: true
     validates :sort_direction, inclusion: %w[asc desc], allow_nil: true
     validates :sort_by,
               inclusion: %w[name from_location to_location prison_transfer_reason created_at date_from date],

--- a/spec/services/moves/params_validator_spec.rb
+++ b/spec/services/moves/params_validator_spec.rb
@@ -28,4 +28,74 @@ RSpec.describe Moves::ParamsValidator do
 
     it { is_expected.not_to be_valid }
   end
+
+  context 'with an empty cancellation reason' do
+    let(:filter_params) { { cancellation_reason: cancellation_reason } }
+    let(:cancellation_reason) { nil }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with a correct cancellation reason' do
+    let(:filter_params) { { cancellation_reason: cancellation_reason } }
+    let(:cancellation_reason) { 'other' }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with multiple correct cancellation reasons' do
+    let(:filter_params) { { cancellation_reason:  cancellation_reason } }
+    let(:cancellation_reason) { 'other,supplier_declined_to_move' }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with incorrect cancellation reason' do
+    let(:filter_params) { { cancellation_reason: cancellation_reason } }
+    let(:cancellation_reason) { 'boom' }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with multiple cancellation reasons, and one incorrect' do
+    let(:filter_params) { { cancellation_reason: cancellation_reason } }
+    let(:cancellation_reason) { 'other,i_am_incorrect' }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with an empty rejection reason' do
+    let(:filter_params) { { rejection_reason: rejection_reason } }
+    let(:rejection_reason) { nil }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with a correct rejection reason' do
+    let(:filter_params) { { rejection_reason: rejection_reason } }
+    let(:rejection_reason) { 'no_space_at_receiving_prison' }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with multiple correct rejection reasons' do
+    let(:filter_params) { { rejection_reason: rejection_reason } }
+    let(:rejection_reason) { 'no_space_at_receiving_prison,no_transport_available' }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with incorrect rejection reason' do
+    let(:filter_params) { { rejection_reason: rejection_reason } }
+    let(:rejection_reason) { 'boom' }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with multiple rejection reasons, and one incorrect' do
+    let(:filter_params) { { rejection_reason: rejection_reason } }
+    let(:rejection_reason) { 'no_space_at_receiving_prison,i_am_incorrect' }
+
+    it { is_expected.not_to be_valid }
+  end
 end


### PR DESCRIPTION
The filters for move should accept a list of comma delimited values for cancellation reason or rejection reason. Change param validator to validate two arrays instead of a string value being included in an array.

This needs to be confirmed and tested/released with FE as we don't allow the use of undefined.

