### PR TITLE
Protect against empty attributes when creating a move

### DIFF
--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -73,7 +73,7 @@ module Api::V2
     end
 
     def common_move_attributes
-      move_params[:attributes].tap do |attributes|
+      move_params.fetch(:attributes, {}).tap do |attributes|
         attributes[:profile] = profile unless profile_attributes.nil?
         attributes[:court_hearings] = court_hearings unless court_hearing_attributes.nil?
         attributes[:prison_transfer_reason] = prison_transfer_reason unless prison_transfer_reason_attributes.nil?

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -455,6 +455,34 @@ RSpec.describe Api::MovesController do
       end
     end
 
+    context 'when no attributes specified' do
+      let(:move_attributes) { nil }
+      let(:errors_422) do
+        [
+          { 'title' => 'Unprocessable entity', 'detail' => 'Supplier must exist', 'source' => { 'pointer' => '/data/attributes/supplier' }, 'code' => 'blank' },
+          { 'title' => 'Unprocessable entity', 'detail' => 'Move type is not included in the list', 'source' => { 'pointer' => '/data/attributes/move_type' }, 'code' => 'inclusion' },
+        ]
+      end
+
+      it_behaves_like 'an endpoint that responds with error 422' do
+        before { do_post }
+      end
+    end
+
+    context 'when no attributes or relationships specified' do
+      let(:data) { { type: 'moves' } }
+      let(:errors_422) do
+        [
+          { 'title' => 'Unprocessable entity', 'detail' => 'Supplier must exist', 'source' => { 'pointer' => '/data/attributes/supplier' }, 'code' => 'blank' },
+          { 'title' => 'Unprocessable entity', 'detail' => 'From location must exist', 'source' => { 'pointer' => '/data/attributes/from_location' }, 'code' => 'blank' },
+        ]
+      end
+
+      it_behaves_like 'an endpoint that responds with error 422' do
+        before { do_post }
+      end
+    end
+
     context 'when a move is a duplicate' do
       let(:move_attributes) { attributes_for(:move).merge(move_type: 'court_appearance', date: move.date) }
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/IM-53
Default to an empty hash if empty attributes are supplied on move creation, or empty attributes but with relationships, to avoid the API returning a 500 error.
