### PR TITLE
Fix those pesky deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,7 +331,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.8.0)
       parser (>= 2.7.1.5)
-    rubocop-govuk (3.17.1)
+    rubocop-govuk (3.17.2)
       rubocop (= 0.87.1)
       rubocop-ast (= 0.8.0)
       rubocop-rails (= 2.8.1)


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Bumps rubocop-govuk to fix deprecation warning https://github.com/alphagov/rubocop-govuk/pull/118

### Why?

I am doing this because:

- To fix deprecation warnings