### PR TITLE
Remove conflicting sentry command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,11 +123,10 @@ references:
         curl -sL https://sentry.io/get-cli/ | bash
         export SENTRY_RELEASE=$(sentry-cli releases propose-version)
         sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
-        sentry-cli releases set-commits $SENTRY_RELEASE --auto
         sentry-cli releases finalize $SENTRY_RELEASE
         sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
       environment:
-            SENTRY_ENVIRONMENT: <<parameters.env>>
+        SENTRY_ENVIRONMENT: <<parameters.env>>
   _rspec: &rspec
     run:
       name: Run rspec tests


### PR DESCRIPTION
### Jira link

n/a

### What?

I have added/removed/altered:

- [ ] Removing call to map commits to the release


### Why?

I am doing this because:

- There is an issue with pushing commit information to sentry [in certain conditions](https://github.com/getsentry/sentry-cli/issues/792). Removing this call for now as a workaround. 


### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

