### PR TITLE
Re enable commit tracking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ references:
         curl -sL https://sentry.io/get-cli/ | bash
         export SENTRY_RELEASE=$(sentry-cli releases propose-version)
         sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
+        sentry-cli releases set-commits $SENTRY_RELEASE --auto
         sentry-cli releases finalize $SENTRY_RELEASE
         sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
       environment:


### PR DESCRIPTION
### Jira link

n/A

### What?

I have added/removed/altered:

- [ ] Re-enable sentry commit tracking, after addressing the issue.

### Why?

I am doing this because:
- the underlying issue was addressed (deleting the bogus/test release details from sentry)
-
-

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

