### PR TITLE
Import new conditional framework validation

### DIFF
--- a/app/services/frameworks/question.rb
+++ b/app/services/frameworks/question.rb
@@ -26,7 +26,7 @@ module Frameworks
 
     def required?(validations)
       validation_types = validations.flat_map { |validation| validation['type'] }
-      validation_types.any?('required')
+      validation_types.any?('required') || validation_types.any?('required_unless_nomis_mappings')
     end
 
     def build_options(options)

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/medical-professional-referral.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/medical-professional-referral.yml
@@ -15,7 +15,7 @@ options:
       label: Please give details
       validations:
       -
-        type: 'required'
+        type: 'required_unless_nomis_mappings'
         message: You must add more information
   -
     label: 'No'

--- a/spec/services/frameworks/question_spec.rb
+++ b/spec/services/frameworks/question_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe Frameworks::Question do
     end
 
     it 'allows followup comments to be required on an option' do
+      filepath = Rails.root.join(fixture_path, 'property-bag-type.yml')
+      question = FrameworkQuestion.new(section: 'property-information', key: 'property-bag-type')
+      described_class.new(filepath: filepath, questions: { 'property-bag-type' => question }).call
+
+      expect(question.followup_comment_options).to contain_exactly('UK currency')
+    end
+
+    it 'allows followup comments to be required on an option if there are no NOMIS mappings' do
       filepath = Rails.root.join(fixture_path, 'medical-professional-referral.yml')
       question = FrameworkQuestion.new(section: 'health', key: 'medical-professional-referral')
       described_class.new(filepath: filepath, questions: { 'medical-professional-referral' => question }).call


### PR DESCRIPTION
Read new validation from framework for conditional required validations on followup comments. This is just marked as
required on the question as well, as this validation is already handled in the detail object in framework responses, which checks for NOMIS mappings and does not require a followup comment.

