### PR TITLE
Remove profile from creation of person escort record

### DIFF
--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -4,11 +4,10 @@ module Api
   class PersonEscortRecordsController < ApiController
     after_action :send_notification, only: :update
 
-    # TODO: Remove profile id and transition to Move id, for now accept both
     NEW_PERMITTED_PER_PARAMS = [
       :type,
       attributes: [:version],
-      relationships: [profile: {}, move: {}],
+      relationships: [move: {}],
     ].freeze
 
     UPDATE_PERMITTED_PER_PARAMS = [
@@ -17,10 +16,8 @@ module Api
     ].freeze
 
     def create
-      # TODO: Remove profile id and transition to Move id, for now accept both
       person_escort_record = PersonEscortRecord.save_with_responses!(
         version: new_person_escort_record_params.dig(:attributes, :version),
-        profile_id: new_person_escort_record_params.dig(:relationships, :profile, :data, :id),
         move_id: new_person_escort_record_params.dig(:relationships, :move, :data, :id),
       )
 

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -39,15 +39,9 @@ class PersonEscortRecord < VersionedModel
            :confirmed?,
            to: :state_machine
 
-  def self.save_with_responses!(profile_id: nil, version: nil, move_id: nil)
-    # TODO: Remove profile id and transition to Move id, for now accept both
-    if move_id.present?
-      move = Move.find(move_id)
-      profile = move.profile
-    else
-      move = nil
-      profile = Profile.find(profile_id)
-    end
+  def self.save_with_responses!(version: nil, move_id: nil)
+    move = Move.find(move_id)
+    profile = move.profile
 
     framework = Framework.find_by!(version: version)
 

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -167,10 +167,12 @@ RSpec.describe PersonEscortRecord do
         person = create(:person)
         profile1 = create(:profile, person: person)
         profile2 = create(:profile, person: person)
+        move1 = create(:move, profile: profile1)
+        move2 = create(:move, profile: profile2)
         framework = create(:framework)
         framework_question = create(:framework_question, framework: framework, prefill: true)
-        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
-        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+        create(:person_escort_record, :confirmed, profile: profile1, move: move1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(move_id: move2.id, version: framework.version)
 
         expect(person_escort_record.framework_responses.first.value).to be_nil
       end
@@ -180,6 +182,8 @@ RSpec.describe PersonEscortRecord do
       let(:person) { create(:person) }
       let(:profile1) { create(:profile, person: person) }
       let(:profile2) { create(:profile, person: person) }
+      let(:move1) { create(:move, profile: profile1) }
+      let(:move2) { create(:move, profile: profile2) }
       let(:framework) { create(:framework) }
 
       before do
@@ -188,41 +192,42 @@ RSpec.describe PersonEscortRecord do
 
       it 'sets prefill_source on person escort record' do
         framework_question = create(:framework_question, framework: framework, prefill: true)
-        prefill_source = create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
-        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+        prefill_source = create(:person_escort_record, :confirmed, profile: profile1, move: move1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+
+        person_escort_record = described_class.save_with_responses!(move_id: move2.id, version: framework.version)
 
         expect(person_escort_record.prefill_source).to eq(prefill_source)
       end
 
       it 'does not prefill responses if no previous confirmed person_escort_record exists for person' do
-        other_profile = create(:profile)
+        move = create(:move)
         framework_question = create(:framework_question, framework: framework, prefill: true)
-        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
-        person_escort_record = described_class.save_with_responses!(profile_id: other_profile.id, version: framework.version)
+        create(:person_escort_record, :confirmed, profile: profile1, move: move1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(move_id: move.id, version: framework.version)
 
         expect(person_escort_record.framework_responses.first.value).to be_nil
       end
 
       it 'prefills responses from confirmed previous person escort record' do
         framework_question = create(:framework_question, framework: framework, prefill: true)
-        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
-        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+        create(:person_escort_record, :confirmed, profile: profile1, move: move1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(move_id: move2.id, version: framework.version)
 
         expect(person_escort_record.framework_responses.first.value).to eq('No')
       end
 
       it 'maintains responded value as false after prefill' do
         framework_question = create(:framework_question, framework: framework, prefill: true)
-        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
-        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+        create(:person_escort_record, :confirmed, profile: profile1, move: move1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(move_id: move2.id, version: framework.version)
 
         expect(person_escort_record.framework_responses.first).not_to be_responded
       end
 
       it 'sets prefilled value as true on responses' do
         framework_question = create(:framework_question, framework: framework, prefill: true)
-        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
-        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+        create(:person_escort_record, :confirmed, profile: profile1, move: move1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(move_id: move2.id, version: framework.version)
 
         expect(person_escort_record.framework_responses.first).to be_prefilled
       end
@@ -230,16 +235,16 @@ RSpec.describe PersonEscortRecord do
       it 'maps values correctly to question response' do
         framework_question1 = create(:framework_question, framework: framework, prefill: true)
         framework_question2 = create(:framework_question, framework: framework, prefill: true)
-        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question1, value: 'No'), create(:string_response, framework_question: framework_question2, value: 'Yes')])
-        described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+        create(:person_escort_record, :confirmed, profile: profile1, move: move1, framework_responses: [create(:string_response, framework_question: framework_question1, value: 'No'), create(:string_response, framework_question: framework_question2, value: 'Yes')])
+        described_class.save_with_responses!(move_id: move2.id, version: framework.version)
 
         expect(framework_question2.reload.framework_responses.first.value).to eq('Yes')
       end
 
       it 'does not prefill responses with previous empty values' do
         framework_question = create(:framework_question, framework: framework, prefill: true)
-        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: nil)])
-        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+        create(:person_escort_record, :confirmed, profile: profile1, move: move1, framework_responses: [create(:string_response, framework_question: framework_question, value: nil)])
+        person_escort_record = described_class.save_with_responses!(move_id: move2.id, version: framework.version)
 
         expect(person_escort_record.framework_responses.first.value).to be_nil
       end
@@ -248,8 +253,8 @@ RSpec.describe PersonEscortRecord do
         framework2 = create(:framework, version: '1.1.0')
         framework_question1 = create(:framework_question, framework: framework, prefill: true)
         framework_question2 = create(:framework_question, framework: framework2, prefill: true)
-        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question1, value: 'No')])
-        described_class.save_with_responses!(profile_id: profile2.id, version: framework2.version)
+        create(:person_escort_record, :confirmed, profile: profile1, move: move1, framework_responses: [create(:string_response, framework_question: framework_question1, value: 'No')])
+        described_class.save_with_responses!(move_id: move2.id, version: framework2.version)
 
         expect(framework_question2.reload.framework_responses.first.value).to be_nil
       end
@@ -258,8 +263,8 @@ RSpec.describe PersonEscortRecord do
         dependent_framework_question = create(:framework_question, :checkbox, framework: framework, prefill: true)
         framework_question = create(:framework_question, :add_multiple_items, framework: framework, dependents: [dependent_framework_question])
         value = [{ 'item' => 1, 'responses' => [{ 'value' => ['Level 1'], 'framework_question_id' => framework_question.dependents.first.id }] }.with_indifferent_access]
-        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:collection_response, :multiple_items, framework_question: framework_question, value: value)])
-        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+        create(:person_escort_record, :confirmed, profile: profile1, move: move1, framework_responses: [create(:collection_response, :multiple_items, framework_question: framework_question, value: value)])
+        person_escort_record = described_class.save_with_responses!(move_id: move2.id, version: framework.version)
 
         expect(person_escort_record.framework_responses.first.value).to eq(value)
       end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -41,10 +41,6 @@ RSpec.describe PersonEscortRecord do
   end
 
   describe '.save_with_responses!' do
-    it 'returns error if profile does not exist' do
-      expect { described_class.save_with_responses!(profile_id: 'some-id', version: '1.2') }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
     it 'returns error if move does not exist' do
       expect { described_class.save_with_responses!(move_id: 'some-id', version: '1.2') }.to raise_error(ActiveRecord::RecordNotFound)
     end
@@ -65,37 +61,29 @@ RSpec.describe PersonEscortRecord do
 
     it 'returns framework with version specified' do
       framework = create(:framework, version: '1.2.1')
-      profile = create(:profile)
-      described_class.save_with_responses!(profile_id: profile.id, version: '1.2.1')
+      move = create(:move)
+      described_class.save_with_responses!(move_id: move.id, version: '1.2.1')
 
       expect(described_class.last.framework).to eq(framework)
     end
 
     it 'returns error if wrong framework version passed' do
       create(:framework, version: '1.2.1')
-      profile = create(:profile)
+      move = create(:move)
 
-      expect { described_class.save_with_responses!(profile_id: profile.id, version: '1.0.1') }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { described_class.save_with_responses!(move_id: move.id, version: '1.0.1') }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'returns error if no framework version passed' do
       create(:framework, version: '1.0.0')
-      profile = create(:profile)
-      expect { described_class.save_with_responses!(profile_id: profile.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      move = create(:move)
+      expect { described_class.save_with_responses!(move_id: move.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'returns error if nil framework version passed' do
       create(:framework, version: '1.0.0')
-      profile = create(:profile)
-      expect { described_class.save_with_responses!(profile_id: profile.id, version: nil) }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it 'does not allow multiple person_escort_records on a profile' do
-      profile = create(:profile)
-      framework = create(:framework)
-      described_class.save_with_responses!(profile_id: profile.id, version: framework.version)
-
-      expect { described_class.save_with_responses!(profile_id: profile.id, version: framework.version) }.to raise_error(ActiveRecord::RecordInvalid)
+      move = create(:move)
+      expect { described_class.save_with_responses!(move_id: move.id, version: nil) }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'does not allow multiple person_escort_records on a profile through move' do
@@ -108,18 +96,18 @@ RSpec.describe PersonEscortRecord do
     end
 
     it 'sets initial status to unstarted' do
-      profile = create(:profile)
+      move = create(:move)
       framework = create(:framework)
 
-      expect(described_class.save_with_responses!(profile_id: profile.id, version: framework.version).status).to eq('unstarted')
+      expect(described_class.save_with_responses!(move_id: move.id, version: framework.version).status).to eq('unstarted')
     end
 
     it 'creates responses for framework questions' do
-      profile = create(:profile)
+      move = create(:move)
       framework = create(:framework)
       create(:framework_question, :checkbox, framework: framework)
       create(:framework_question, :checkbox, framework: framework)
-      person_escort_record = described_class.save_with_responses!(profile_id: profile.id, version: framework.version)
+      person_escort_record = described_class.save_with_responses!(move_id: move.id, version: framework.version)
 
       expect(person_escort_record.framework_responses.count).to eq(2)
     end
@@ -151,10 +139,10 @@ RSpec.describe PersonEscortRecord do
     end
 
     it 'sets correct response for framework questions' do
-      profile = create(:profile)
+      move = create(:move)
       framework = create(:framework)
       checkbox_question = create(:framework_question, :checkbox, framework: framework)
-      person_escort_record = described_class.save_with_responses!(profile_id: profile.id, version: framework.version)
+      person_escort_record = described_class.save_with_responses!(move_id: move.id, version: framework.version)
 
       expect(person_escort_record.framework_responses.first).to have_attributes(
         framework_question_id: checkbox_question.id,
@@ -163,10 +151,10 @@ RSpec.describe PersonEscortRecord do
     end
 
     it 'allows access to framework question through person escort record' do
-      profile = create(:profile)
+      move = create(:move)
       framework = create(:framework)
       create(:framework_question, :checkbox, framework: framework)
-      person_escort_record = described_class.save_with_responses!(profile_id: profile.id, version: framework.version)
+      person_escort_record = described_class.save_with_responses!(move_id: move.id, version: framework.version)
 
       expect(person_escort_record.framework_questions.count).to eq(1)
     end

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe Api::PersonEscortRecordsController do
             "version": framework_version,
           },
           "relationships": {
-            "profile": {
+            "move": {
               "data": {
-                "id": profile_id,
-                "type": 'profiles',
+                "id": move_id,
+                "type": 'moves',
               },
             },
           },
@@ -41,86 +41,6 @@ RSpec.describe Api::PersonEscortRecordsController do
     before { post_person_escort_record }
 
     context 'when successful' do
-      let(:schema) { load_yaml_schema('post_person_escort_record_responses.yaml') }
-      let(:data) do
-        {
-          "id": PersonEscortRecord.last.id,
-          "type": 'person_escort_records',
-          "attributes": {
-            "version": framework_version,
-            "status": 'not_started',
-            "confirmed_at": nil,
-            "nomis_sync_status": [],
-          },
-          "meta": {
-            'section_progress' => [
-              {
-                "key": 'risk-information',
-                "status": 'not_started',
-              },
-            ],
-          },
-          "relationships": {
-            "profile": {
-              "data": {
-                "id": profile_id,
-                "type": 'profiles',
-              },
-            },
-            "move": {
-              "data": {},
-            },
-            "framework": {
-              "data": {
-                "id": framework.id,
-                "type": 'frameworks',
-              },
-            },
-            "responses": {
-              "data": [
-                {
-                  "id": FrameworkResponse.last.id,
-                  "type": 'framework_responses',
-                },
-              ],
-            },
-            "flags": {
-              "data": [],
-            },
-            "prefill_source": {
-              "data": nil,
-            },
-          },
-        }
-      end
-
-      it_behaves_like 'an endpoint that responds with success 201'
-
-      it 'returns the correct data' do
-        expect(response_json).to include_json(data: data)
-      end
-    end
-
-    # TODO: Remove profile id and transition to Move id, for now accept both
-    context 'when successful with move' do
-      let(:person_escort_record_params) do
-        {
-          data: {
-            "type": 'person_escort_records',
-            "attributes": {
-              "version": framework_version,
-            },
-            "relationships": {
-              "move": {
-                "data": {
-                  "id": move_id,
-                  "type": 'moves',
-                },
-              },
-            },
-          },
-        }
-      end
       let(:schema) { load_yaml_schema('post_person_escort_record_responses.yaml') }
       let(:data) do
         {
@@ -290,9 +210,9 @@ RSpec.describe Api::PersonEscortRecordsController do
         it_behaves_like 'an endpoint that responds with error 400'
       end
 
-      context 'when the profile is not found' do
-        let(:profile_id) { 'foo-bar' }
-        let(:detail_404) { "Couldn't find Profile with 'id'=foo-bar" }
+      context 'when the move is not found' do
+        let(:move_id) { 'foo-bar' }
+        let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
 
         it_behaves_like 'an endpoint that responds with error 404'
       end
@@ -353,10 +273,10 @@ RSpec.describe Api::PersonEscortRecordsController do
             data: {
               "type": 'person_escort_records',
               "relationships": {
-                "profile": {
+                "move": {
                   "data": {
-                    "id": profile_id,
-                    "type": 'profiles',
+                    "id": move_id,
+                    "type": 'moves',
                   },
                 },
               },


### PR DESCRIPTION
We currently support both profile or move for creating a PER. Switch to only use the move to create a PER, as using a profile is deprecated, we will be associating the profile attached to the move instead. The move is required to access the location and other data required for creating the PER, which isn't available by just passing the profile.

~This is blocked until FE fully switches to using move.~ FE has now fully switch to use move to create the PER