### PR TITLE
Add GET /populations/:id endpoint to return a population resource

### DIFF
--- a/app/controllers/api/populations_controller.rb
+++ b/app/controllers/api/populations_controller.rb
@@ -10,6 +10,12 @@ module Api
       paginate locations, serializer: LocationFreeSpacesSerializer, params: serializer_params
     end
 
+    def show
+      population = find_population
+
+      render_population(population, :ok)
+    end
+
   private
 
     PERMITTED_FILTER_PARAMS = %i[location_type nomis_agency_id supplier_id location_id region_id].freeze
@@ -42,6 +48,18 @@ module Api
 
     def locations
       @locations ||= Locations::Finder.new(filter_params, sort_params).call
+    end
+
+    def find_population
+      Population.find(params[:id])
+    end
+
+    def render_population(population, status)
+      render_json population, serializer: PopulationSerializer, include: included_relationships, status: status
+    end
+
+    def supported_relationships
+      PopulationSerializer::SUPPORTED_RELATIONSHIPS
     end
   end
 end

--- a/app/serializers/population_serializer.rb
+++ b/app/serializers/population_serializer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class PopulationSerializer
+  include JSONAPI::Serializer
+
+  set_type :populations
+
+  attributes :date,
+             :operational_capacity,
+             :usable_capacity,
+             :unlock,
+             :bedwatch,
+             :overnights_in,
+             :overnights_out,
+             :out_of_area_courts,
+             :discharges,
+             :free_spaces,
+             :updated_by,
+             :created_at,
+             :updated_at
+
+  belongs_to :location
+  has_many :moves_from, serializer: V2::MoveSerializer, &:moves_from
+  has_many :moves_to, serializer: V2::MoveSerializer, &:moves_to
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    location
+    moves_from
+    moves_to
+  ].freeze
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
     resources :framework_responses, only: %i[update]
 
     get 'locations_free_spaces', to: 'populations#index'
+    resources :populations, only: %i[show]
 
     namespace :reference do
       resources :allocation_complex_cases, only: :index

--- a/spec/factories/populations.rb
+++ b/spec/factories/populations.rb
@@ -12,5 +12,27 @@ FactoryBot.define do
     out_of_area_courts { Faker::Number.between(from: 1, to: 10) }
     discharges { Faker::Number.between(from: 1, to: 10) }
     updated_by { Faker::Name.name }
+
+    trait :with_moves_from do
+      after(:create) do |population|
+        create(
+          :move,
+          :prison_transfer,
+          from_location: population.location,
+          date: population.date,
+        )
+      end
+    end
+
+    trait :with_moves_to do
+      after(:create) do |population|
+        create(
+          :move,
+          :prison_transfer,
+          to_location: population.location,
+          date: population.date,
+        )
+      end
+    end
   end
 end

--- a/spec/requests/api/populations_controller_show_spec.rb
+++ b/spec/requests/api/populations_controller_show_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::PopulationsController do
+  include_context 'with supplier with spoofed access token'
+
+  subject(:get_population) do
+    get "/api/populations/#{population_id}", params: params, headers: headers
+  end
+
+  let(:response_json) { JSON.parse(response.body) }
+  let(:params) { {} }
+
+  describe 'GET /populations/:id' do
+    let(:population) { create(:population) }
+    let(:population_id) { population.id }
+
+    context 'when successful' do
+      let(:schema) { load_yaml_schema('get_population_responses.yaml') }
+      let(:data) { JSON.parse(PopulationSerializer.new(population).serializable_hash.to_json) }
+
+      before { get_population }
+
+      it_behaves_like 'an endpoint that responds with success 200'
+
+      it 'returns the correct data' do
+        expect(response_json).to include_json(data)
+      end
+    end
+
+    describe 'included relationships' do
+      context 'when not including the include query param' do
+        before { get_population }
+
+        it 'returns the default includes' do
+          returned_types = response_json['included']
+          expect(returned_types).to be_nil
+        end
+      end
+
+      context 'when including the include query param' do
+        let(:params) { { include: 'location,moves_from,moves_to' } }
+
+        before do
+          create(:move, :prison_transfer, date: population.date, from_location: population.location)
+          create(:move, :prison_transfer, date: population.date, to_location: population.location)
+          get_population
+        end
+
+        it 'includes the requested includes in the response' do
+          returned_types = response_json['included'].map { |r| r['type'] }
+          expect(returned_types).to contain_exactly('locations', 'moves', 'moves')
+        end
+      end
+
+      context 'when including an invalid include query param' do
+        let(:params) { { include: 'foo.bar,location' } }
+
+        let(:expected_error) do
+          {
+            'errors' => [
+              {
+                'detail' => match(/foo.bar/),
+                'title' => 'Bad request',
+              },
+            ],
+          }
+        end
+
+        before { get_population }
+
+        it 'returns a validation error' do
+          expect(response).to have_http_status(:bad_request)
+          expect(response_json).to include(expected_error)
+        end
+      end
+    end
+
+    context 'when not found' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+      let(:population_id) { 'foo' }
+      let(:detail_404) { "Couldn't find Population with 'id'=#{population_id}" }
+
+      before { get_population }
+
+      it_behaves_like 'an endpoint that responds with error 404'
+    end
+  end
+end

--- a/spec/serializers/population_serializer_spec.rb
+++ b/spec/serializers/population_serializer_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PopulationSerializer do
+  subject(:serializer) { described_class.new(population, adapter_options) }
+
+  let(:population) { create(:population) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:result_data) { result[:data] }
+  let(:attributes) { result_data[:attributes] }
+
+  context 'with no options' do
+    let(:adapter_options) { {} }
+
+    it 'contains a type property' do
+      expect(result_data[:type]).to eql 'populations'
+    end
+
+    it 'contains an id property' do
+      expect(result_data[:id]).to eql population.id
+    end
+
+    it 'contains a date attribute' do
+      expect(attributes[:date]).to eql population.date.iso8601
+    end
+
+    it 'contains an operational capacity' do
+      expect(attributes[:operational_capacity]).to eql population.operational_capacity
+    end
+
+    it 'contains a usable capacity attribute' do
+      expect(attributes[:usable_capacity]).to eql population.usable_capacity
+    end
+
+    it 'contains an unlock attribute' do
+      expect(attributes[:unlock]).to eql population.unlock
+    end
+
+    it 'contains a bedwatch attribute' do
+      expect(attributes[:bedwatch]).to eql population.bedwatch
+    end
+
+    it 'contains an overnights in attribute' do
+      expect(attributes[:overnights_in]).to eql population.overnights_in
+    end
+
+    it 'contains an overnights out attribute' do
+      expect(attributes[:overnights_out]).to eql population.overnights_out
+    end
+
+    it 'contains an out of area courts attribute' do
+      expect(attributes[:out_of_area_courts]).to eql population.out_of_area_courts
+    end
+
+    it 'contains a discharges attribute' do
+      expect(attributes[:discharges]).to eql population.discharges
+    end
+
+    it 'contains a free spaces attribute' do
+      expect(attributes[:free_spaces]).to eql population.free_spaces
+    end
+
+    it 'contains an updated by attribute' do
+      expect(attributes[:updated_by]).to eql population.updated_by
+    end
+
+    it 'contains a created_at attribute' do
+      expect(attributes[:created_at]).to eql population.created_at.iso8601
+    end
+
+    it 'contains an updated_at attribute' do
+      expect(attributes[:updated_at]).to eql population.updated_at.iso8601
+    end
+  end
+
+  describe 'location' do
+    let(:adapter_options) do
+      {
+        include: %i[location],
+      }
+    end
+    let(:expected_json) do
+      [
+        {
+          id: population.location.id,
+          type: 'locations',
+          attributes: { location_type: 'prison', title: population.location.title },
+        },
+      ]
+    end
+
+    it 'contains an included location' do
+      expect(result[:included]).to(include_json(expected_json))
+    end
+  end
+
+  describe 'moves_from' do
+    let(:adapter_options) do
+      { include: PopulationSerializer::SUPPORTED_RELATIONSHIPS }
+    end
+    let(:population) { create(:population, :with_moves_from) }
+    let(:move) { population.moves_from.first }
+
+    it 'contains a moves_from relationship' do
+      expect(result_data[:relationships][:moves_from][:data]).to contain_exactly(id: move.id, type: 'moves')
+    end
+
+    it 'contains an included move' do
+      expect(result[:included].map { |r| r[:type] }).to match_array(%w[moves locations])
+    end
+  end
+
+  describe 'moves_to' do
+    let(:adapter_options) do
+      { include: PopulationSerializer::SUPPORTED_RELATIONSHIPS }
+    end
+    let(:population) { create(:population, :with_moves_to) }
+    let(:move) { population.moves_to.first }
+
+    it 'contains a moves_to relationship' do
+      expect(result_data[:relationships][:moves_to][:data]).to contain_exactly(id: move.id, type: 'moves')
+    end
+
+    it 'contains an included move' do
+      expect(result[:included].map { |r| r[:type] }).to match_array(%w[moves locations])
+    end
+  end
+
+  context 'without moves_from' do
+    let(:adapter_options) { { include: PopulationSerializer::SUPPORTED_RELATIONSHIPS } }
+
+    it 'contains empty moves_from' do
+      expect(result_data[:relationships][:moves_from][:data]).to be_empty
+    end
+
+    it 'does not contain an included move' do
+      expect(result[:included].map { |r| r[:type] }).to match_array(%w[locations])
+    end
+  end
+
+  context 'without moves_to' do
+    let(:adapter_options) { { include: PopulationSerializer::SUPPORTED_RELATIONSHIPS } }
+
+    it 'contains empty moves_to' do
+      expect(result_data[:relationships][:moves_to][:data]).to be_empty
+    end
+  end
+end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -86,6 +86,8 @@
       :$ref: "../v1/person_reference.yaml#/PersonReference"
     :PersonEscortRecord:
       :$ref: "../v1/person_escort_record.yaml#/PersonEscortRecord"
+    :Population:
+      :$ref: "../v1/population.yaml#/Population"
     :PrisonTransferReason:
       :$ref: "../v1/prison_transfer_reason.yaml#/PrisonTransferReason"
     :ProfileIdentifier:
@@ -2812,6 +2814,41 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/error_responses.yaml#/422"
+  "/populations/{population_id}":
+    get:
+      summary: Returns population details for a given date and location
+      tags:
+        - Populations
+      parameters:
+        - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - "$ref": "../v2/accept_type_parameter.yaml#/Accept"
+        - "$ref": "../v1/population_id_parameter.yaml#/PopulationId"
+        - "$ref": "../v1/population_include_parameter.yaml#/PopulationIncludeParameter"
+      responses:
+        "200":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_population_responses.yaml#/200"
+        "401":
+          description: unauthorised
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/401"
+        "404":
+          description: not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/404"
+        "415":
+          description: invalid content type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/415"
   "/reference/allocation_complex_cases":
     get:
       summary: Returns a list of allocation complex cases

--- a/swagger/v1/get_population_responses.yaml
+++ b/swagger/v1/get_population_responses.yaml
@@ -1,0 +1,13 @@
+'200':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: population.yaml#/Population
+    included:
+      type: array
+      items:
+        anyOf:
+        - $ref: location.yaml#/Location
+        - $ref: "../v2/move.yaml#/Move"

--- a/swagger/v1/population.yaml
+++ b/swagger/v1/population.yaml
@@ -89,14 +89,10 @@ Population:
           $ref: location_reference.yaml#/LocationReference
           description: The location (prison) that the population information relates to
         moves_from:
-          type: array
-          items:
-            $ref: move_reference.yaml#/MoveReference
+          $ref: move_reference.yaml#/MoveReference
           description: The current scheduled prison transfers out of this location on the specified date
           readOnly: true
         moves_to:
-          type: array
-          items:
-            $ref: move_reference.yaml#/MoveReference
+          $ref: move_reference.yaml#/MoveReference
           description: The current scheduled prison transfers into this location on the specified date
           readOnly: true

--- a/swagger/v1/population.yaml
+++ b/swagger/v1/population.yaml
@@ -1,0 +1,102 @@
+Population:
+  type: object
+  required:
+  - type
+  - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: populations
+      enum:
+      - populations
+      description: The type of this object - always `populations`
+    attributes:
+      type: object
+      required:
+      - date
+      - operational_capacity
+      - usable_capacity
+      - unlock
+      - bedwatch
+      - overnights_in
+      - overnights_out
+      - out_of_area_courts
+      - discharges
+      properties:
+        date:
+          type: string
+          format: date
+          example: '2020-05-17'
+          description: Date for which population information applies
+        operational_capacity:
+          type: integer
+          example: 500
+          description: The designed maximum prisoner capacity for this location and date.
+        usable_capacity:
+          type: integer
+          example: 490
+          description: The current maximum prisoner capacity for this location and date.
+        unlock:
+          type: integer
+          example: 485
+          description: The current prisoner occupancy for this location and date (reduces availabilty).
+        bedwatch:
+          type: integer
+          example: 5
+          description: The number of watched beds for this location and date (reduces availabilty).
+        overnights_in:
+          type: integer
+          example: 2
+          description: The number of overnight arrivals for this location and date (reduces availabilty).
+        overnights_out:
+          type: integer
+          example: 1
+          description: The number of overnight departures for this location and date (increases availabilty).
+        out_of_area_courts:
+          type: integer
+          example: 3
+          description: The number of out of area court appearances for this location and date (increases availabilty).
+        discharges:
+          type: integer
+          example: 4
+          description: The of prisoners being discharged (released) for this location and date (increases availabilty).
+        updated_by:
+          oneOf:
+          - type: string
+          - type: 'null'
+          description: Optional name of the person providing population information
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of when the population was last created or updated
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp of when the population was created
+          readOnly: true
+    relationships:
+      type: object
+      required:
+      - location
+      properties:
+        location:
+          $ref: location_reference.yaml#/LocationReference
+          description: The location (prison) that the population information relates to
+        moves_from:
+          type: array
+          items:
+            $ref: move_reference.yaml#/MoveReference
+          description: The current scheduled prison transfers out of this location on the specified date
+          readOnly: true
+        moves_to:
+          type: array
+          items:
+            $ref: move_reference.yaml#/MoveReference
+          description: The current scheduled prison transfers into this location on the specified date
+          readOnly: true

--- a/swagger/v1/population_id_parameter.yaml
+++ b/swagger/v1/population_id_parameter.yaml
@@ -1,0 +1,9 @@
+PopulationId:
+  name: population_id
+  in: path
+  required: true
+  description: The ID of the population
+  schema:
+    type: string
+    format: uuid
+  example: 5b61f755-0fd7-4a91-b7a3-a33d751f985f

--- a/swagger/v1/population_include_parameter.yaml
+++ b/swagger/v1/population_include_parameter.yaml
@@ -1,0 +1,13 @@
+PopulationIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the population
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - location
+      - moves_from
+      - moves_to
+  example: location


### PR DESCRIPTION
### Jira link

P4-1427

### What?

- [x] Added a new endpoint to `GET /populations/:id`

### Why?

- This supports front end requirements to display population details for a given prison location and date.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- New api endpoint, so minimal risk
