### PR TITLE
Add new endpoint POST /populations to support creating new populations

### DIFF
--- a/app/models/population.rb
+++ b/app/models/population.rb
@@ -1,4 +1,4 @@
-class Population < VersionedModel
+class Population < ApplicationRecord
   belongs_to :location
 
   validates :date, presence: true

--- a/app/models/population.rb
+++ b/app/models/population.rb
@@ -1,7 +1,7 @@
 class Population < ApplicationRecord
   belongs_to :location
 
-  validates :date, presence: true
+  validates :date, presence: true, uniqueness: { scope: :location_id }
   validates :operational_capacity, presence: true, numericality: { greater_than: 0 }
   validates :usable_capacity, presence: true, numericality: { greater_than: 0 }
   validates :unlock, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/population.rb
+++ b/app/models/population.rb
@@ -1,4 +1,4 @@
-class Population < ApplicationRecord
+class Population < VersionedModel
   belongs_to :location
 
   validates :date, presence: true
@@ -21,6 +21,14 @@ class Population < ApplicationRecord
 
   def free_spaces
     usable_capacity - unlock - bedwatch - overnights_in - moves_to.count + overnights_out + out_of_area_courts + discharges + moves_from.count
+  end
+
+  def save_uniquely!
+    save!
+    self
+  rescue PG::UniqueViolation, ActiveRecord::RecordNotUnique
+    errors.add(:date, :taken)
+    raise ActiveRecord::RecordInvalid, self
   end
 
   def self.free_spaces_date_range(locations, date_range)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
     resources :framework_responses, only: %i[update]
 
     get 'locations_free_spaces', to: 'populations#index'
-    resources :populations, only: %i[show]
+    resources :populations, only: %i[show create]
 
     namespace :reference do
       resources :allocation_complex_cases, only: :index

--- a/db/migrate/20201016104115_add_unique_index_on_populations.rb
+++ b/db/migrate/20201016104115_add_unique_index_on_populations.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnPopulations < ActiveRecord::Migration[6.0]
+  def change
+    add_index :populations, [:location_id, :date], name: 'index_on_population_uniqueness', unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_103849) do
+ActiveRecord::Schema.define(version: 2020_10_16_104115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -483,6 +483,7 @@ ActiveRecord::Schema.define(version: 2020_10_09_103849) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["date"], name: "index_populations_on_date"
+    t.index ["location_id", "date"], name: "index_on_population_uniqueness", unique: true
     t.index ["location_id"], name: "index_populations_on_location_id"
   end
 

--- a/spec/models/population_spec.rb
+++ b/spec/models/population_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Population do
   it { is_expected.to validate_numericality_of(:out_of_area_courts).is_greater_than_or_equal_to(0) }
   it { is_expected.to validate_numericality_of(:discharges).is_greater_than_or_equal_to(0) }
 
+  it 'validates uniqueness of date per location' do
+    population = build(:population)
+    expect(population).to validate_uniqueness_of(:date).scoped_to(:location_id)
+  end
+
   describe '#moves_from' do
     it 'includes non-cancelled prison transfer moves from same location on same date' do
       location = create(:location, :prison)

--- a/spec/models/population_spec.rb
+++ b/spec/models/population_spec.rb
@@ -129,6 +129,23 @@ RSpec.describe Population do
     end
   end
 
+  describe '.save_uniquely!' do
+    it 'saves population if no errors' do
+      population = build(:population)
+      population.save_uniquely!
+
+      expect(population).to be_persisted
+    end
+
+    it 'raises exception with existing populations for the same date and location' do
+      existing_population = create(:population)
+      new_population = build(:population, location: existing_population.location, date: existing_population.date)
+
+      expect { new_population.save_uniquely! }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(new_population.errors[:date]).to contain_exactly('has already been taken')
+    end
+  end
+
   describe '.free_spaces_date_range' do
     let!(:prison1) { create(:location, :prison) }
     let!(:prison2) { create(:location, :prison) }

--- a/spec/requests/api/populations_controller_create_spec.rb
+++ b/spec/requests/api/populations_controller_create_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::PopulationsController do
+  include_context 'with supplier with spoofed access token'
+
+  let(:response_json) { JSON.parse(response.body) }
+  let(:resource_to_json) { JSON.parse(PopulationSerializer.new(population).serializable_hash.to_json) }
+
+  describe 'POST /populations' do
+    subject(:post_populations) { post '/api/populations', params: { data: data }, headers: headers, as: :json }
+
+    let(:schema) { load_yaml_schema('post_populations_responses.yaml') }
+
+    let(:population_date) { Date.today }
+    let(:population_attributes) do
+      {
+        date: population_date,
+        operational_capacity: 200,
+        usable_capacity: 195,
+        unlock: 180,
+        bedwatch: 3,
+        overnights_in: 6,
+        overnights_out: 2,
+        out_of_area_courts: 1,
+        discharges: 7,
+        updated_by: 'Fulton McKay',
+      }
+    end
+
+    let!(:location) { create :location, :prison }
+
+    let(:data) do
+      {
+        type: 'populations',
+        attributes: population_attributes,
+        relationships: {
+          location: { data: { type: 'locations', id: location.id } },
+        },
+      }
+    end
+
+    context 'when successful' do
+      before { post_populations }
+
+      it_behaves_like 'an endpoint that responds with success 201'
+    end
+
+    describe 'creating populations' do
+      let(:population) { Population.find_by(location_id: location.id) }
+
+      it 'creates a population' do
+        expect { post_populations }.to change(Population, :count).by(1)
+      end
+
+      context 'with a real access token' do
+        let(:application) { create(:application, owner_id: supplier.id) }
+        let(:access_token) { create(:access_token, application: application).token }
+
+        it 'audits the supplier' do
+          post_populations
+          expect(population.versions.map(&:whodunnit)).to eq([supplier.id])
+        end
+      end
+
+      it 'returns the correct data' do
+        post_populations
+        expect(response_json).to include_json resource_to_json
+      end
+    end
+
+    context 'with a bad request' do
+      let(:data) { nil }
+
+      before { post_populations }
+
+      it_behaves_like 'an endpoint that responds with error 400'
+    end
+
+    context 'with a reference to a missing relationship' do
+      let(:location) { Location.new }
+      let(:detail_404) { "Couldn't find Location without an ID" }
+
+      before { post_populations }
+
+      it_behaves_like 'an endpoint that responds with error 404'
+    end
+
+    context 'with validation errors' do
+      let(:population_attributes) { attributes_for(:population).except(:date) }
+
+      let(:errors_422) do
+        [
+          {
+            'title' => 'Unprocessable entity',
+            'detail' => "Date can't be blank",
+            'source' => { 'pointer' => '/data/attributes/date' },
+            'code' => 'blank',
+          },
+        ]
+      end
+
+      before { post_populations }
+
+      it_behaves_like 'an endpoint that responds with error 422'
+    end
+
+    context 'when a population record already exists for same date and location' do
+      let(:errors_422) do
+        [
+          {
+            'title' => 'Unprocessable entity',
+            'detail' => 'Date has already been taken',
+            'source' => { 'pointer' => '/data/attributes/date' },
+            'code' => 'taken',
+          },
+        ]
+      end
+
+      before do
+        create(:population, date: population_date, location: location)
+        post_populations
+      end
+
+      it_behaves_like 'an endpoint that responds with error 422'
+    end
+  end
+end

--- a/spec/requests/api/populations_controller_create_spec.rb
+++ b/spec/requests/api/populations_controller_create_spec.rb
@@ -54,16 +54,6 @@ RSpec.describe Api::PopulationsController do
         expect { post_populations }.to change(Population, :count).by(1)
       end
 
-      context 'with a real access token' do
-        let(:application) { create(:application, owner_id: supplier.id) }
-        let(:access_token) { create(:access_token, application: application).token }
-
-        it 'audits the supplier' do
-          post_populations
-          expect(population.versions.map(&:whodunnit)).to eq([supplier.id])
-        end
-      end
-
       it 'returns the correct data' do
         post_populations
         expect(response_json).to include_json resource_to_json

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2814,6 +2814,57 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/error_responses.yaml#/422"
+  "/populations":
+    post:
+      summary: Creates a new population
+      tags:
+        - Populations
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: The population object to be created
+          schema:
+            "$ref": "../v1/population.yaml#/Population"
+      responses:
+        "201":
+          description: created
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_populations_responses.yaml#/201"
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_populations_responses.yaml#/400"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_populations_responses.yaml#/401"
+        "404":
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_populations_responses.yaml#/404"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_populations_responses.yaml#/415"
+        "422":
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_populations_responses.yaml#/422"
   "/populations/{population_id}":
     get:
       summary: Returns population details for a given date and location

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2828,6 +2828,7 @@
           description: The population object to be created
           schema:
             "$ref": "../v1/population.yaml#/Population"
+        - "$ref": "../v1/population_include_parameter.yaml#/PopulationIncludeParameter"
       responses:
         "201":
           description: created

--- a/swagger/v1/post_populations_responses.yaml
+++ b/swagger/v1/post_populations_responses.yaml
@@ -1,0 +1,52 @@
+'201':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: population.yaml#/Population
+'400':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError
+'404':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/ResourceNotFound
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnsupportedMediaType
+'422':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnprocessableEntity


### PR DESCRIPTION
### Jira link

P4-1427

### What?

- [x] Add a new endpoint `POST /populations` to create a new population record
- [x] Added a unique index on population date and location to prevent multiple populations being created

### Why?

- All the front end things need this

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- New endpoint, minimal risk
