### PR TITLE
P4-2325 Import `prefill` value from a Framework

### DIFF
--- a/app/services/frameworks/question.rb
+++ b/app/services/frameworks/question.rb
@@ -15,6 +15,7 @@ module Frameworks
     def call
       question.question_type = source['type']
       question.required = true if required?(source.fetch('validations', []))
+      question.prefill = source['prefill']
 
       build_options(source.fetch('options', []))
       build_followup_questions(followups: source.fetch('questions', []), value: nil)

--- a/db/migrate/20201021055517_add_prefill_to_framework_questions.rb
+++ b/db/migrate/20201021055517_add_prefill_to_framework_questions.rb
@@ -1,0 +1,5 @@
+class AddPrefillToFrameworkQuestions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :framework_questions, :prefill, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_16_104115) do
+ActiveRecord::Schema.define(version: 2020_10_21_055517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -196,6 +196,7 @@ ActiveRecord::Schema.define(version: 2020_10_16_104115) do
     t.uuid "parent_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "prefill"
     t.index ["framework_id"], name: "index_framework_questions_on_framework_id"
     t.index ["parent_id"], name: "index_framework_questions_on_parent_id"
   end

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/medical-details-information.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/medical-details-information.yml
@@ -1,5 +1,6 @@
 type: textarea
 question: Please provide the relevant medication details
+prefill: true
 validations:
   -
     type: 'required'

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/medical-professional-referral.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/medical-professional-referral.yml
@@ -1,5 +1,6 @@
 type: radio
 question: Has the detainee been referred to a medical professional?
+prefill: false
 options:
   -
     label: 'Yes'

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/medication-while-moving.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/medication-while-moving.yml
@@ -1,5 +1,6 @@
 type: radio
 question: Will the detainee need to take this medication while moving?
+prefill: false
 options:
   -
     label: 'Yes'

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/property-bag-seal-number.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/property-bag-seal-number.yml
@@ -1,5 +1,6 @@
 type: text
 question: Seal number
+prefill: true
 validations:
   -
     type: required

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/property-bag-type.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/property-bag-type.yml
@@ -1,6 +1,7 @@
 type: checkbox
 question: What type of property is in this bag?
 description: Property type
+prefill: true
 options:
   -
     label: Medication

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/regular-medication.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/regular-medication.yml
@@ -1,5 +1,6 @@
 type: radio
 question: Does the detainee need or have they been prescribed any medication?
+prefill: true
 options:
   -
     label: 'Yes'

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/sensitive-medication.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/sensitive-medication.yml
@@ -1,5 +1,6 @@
 type: radio
 question: Does the detainee have any sensitive medical or medication information that needs to be shared
+prefill: false
 options:
   -
     label: 'Yes'

--- a/spec/fixtures/files/frameworks/person-escort-record-1/questions/wheelchair-users.yml
+++ b/spec/fixtures/files/frameworks/person-escort-record-1/questions/wheelchair-users.yml
@@ -1,5 +1,6 @@
 type: radio
 question: Are they a wheelchair user?
+prefill: true
 options:
   -
     label: 'Yes'

--- a/spec/services/frameworks/question_spec.rb
+++ b/spec/services/frameworks/question_spec.rb
@@ -136,6 +136,24 @@ RSpec.describe Frameworks::Question do
       )
     end
 
+    it 'sets the prefill value on a question to true if prefill field value set to true' do
+      filepath = Rails.root.join(fixture_path, 'regular-medication.yml')
+      question = FrameworkQuestion.new(section: 'health', key: 'regular-medication')
+      questions = { 'regular-medication' => question }
+      described_class.new(filepath: filepath, questions: questions).call
+
+      expect(question).to be_prefill
+    end
+
+    it 'sets the prefill value on a question to false if prefill field value set to false' do
+      filepath = Rails.root.join(fixture_path, 'medical-professional-referral.yml')
+      question = FrameworkQuestion.new(section: 'health', key: 'medical-professional-referral')
+      questions = { 'medical-professional-referral' => question }
+      described_class.new(filepath: filepath, questions: questions).call
+
+      expect(question).not_to be_prefill
+    end
+
     context 'when question type is add_multiple_items' do
       it 'sets a question as required if required validation available' do
         filepath = Rails.root.join(fixture_path, 'property-bags.yml')
@@ -169,6 +187,25 @@ RSpec.describe Frameworks::Question do
         described_class.new(filepath: filepath, questions: questions).call
 
         expect(dependent_question.parent).to eq(question)
+      end
+
+      it 'does not set the prefill value on parent questions' do
+        filepath = Rails.root.join(fixture_path, 'property-bags.yml')
+        question = FrameworkQuestion.new(section: 'property-information', key: 'property-bags')
+        described_class.new(filepath: filepath, questions: { 'property-bags' => question }).call
+
+        expect(question.prefill).to be_nil
+      end
+
+      it 'sets prefill value on dependent questions' do
+        filepath = Rails.root.join(fixture_path, 'property-bag-type.yml')
+        question = FrameworkQuestion.new(section: 'property-information', key: 'property-bag-type')
+        questions = {
+          'property-bag-type' => question,
+        }
+        described_class.new(filepath: filepath, questions: questions).call
+
+        expect(question).to be_prefill
       end
     end
 


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2353

Add a new column `prefill` to framework questions and import this value when pulling in a new framework. This column will determine if a question response should be prefilled or not when creating the Person escort record, with an existing confirmed person escort record. This value can be `nil` to support add multiple questions which allow dependent questions to determine their `prefill` status.