### PR TITLE
P4-2356 Surface pre-filling fields and relationships

### DIFF
--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -27,6 +27,7 @@ class PersonEscortRecord < VersionedModel
   has_many :framework_flags, through: :framework_responses
   belongs_to :profile
   belongs_to :move, optional: true
+  belongs_to :prefill_source, class_name: 'PersonEscortRecord', optional: true
 
   has_state_machine PersonEscortRecordStateMachine, on: :status
 

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -10,7 +10,7 @@ class FrameworkResponseSerializer
   has_many :flags, serializer: FrameworkFlagSerializer, &:framework_flags
   has_many :nomis_mappings, serializer: FrameworkNomisMappingSerializer, &:framework_nomis_mappings
 
-  attributes :value, :responded
+  attributes :value, :responded, :prefilled
 
   attribute :value_type do |object|
     object.framework_question.response_type

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -44,6 +44,7 @@ class MoveSerializer
     profile.person_escort_record
     profile.person_escort_record.flags
     profile.person_escort_record.framework
+    profile.person_escort_record.prefill_source
     profile.person_escort_record.responses
     profile.person_escort_record.responses.nomis_mappings
     profile.person_escort_record.responses.question

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -8,6 +8,7 @@ class PersonEscortRecordSerializer
   belongs_to :profile, serializer: V2::ProfileSerializer
   belongs_to :move, serializer: V2::MoveSerializer
   belongs_to :framework
+  belongs_to :prefill_source, serializer: PersonEscortRecordSerializer
 
   has_many :responses, serializer: FrameworkResponseSerializer do |object|
     object.framework_responses.includes(:framework_flags, :framework_nomis_mappings, framework_question: [:framework, dependents: :dependents])
@@ -42,5 +43,6 @@ class PersonEscortRecordSerializer
     responses.question.descendants.**
     flags
     events
+    prefill_source
   ].freeze
 end

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -44,6 +44,7 @@ module V2
       profile.person_escort_record.flags
       profile.person_escort_record.framework
       profile.person_escort_record.responses
+      profile.person_escort_record.prefill_source
       profile.person_escort_record.responses.nomis_mappings
       profile.person_escort_record.responses.question
       profile.person_escort_record.responses.question.descendants.**

--- a/db/migrate/20201021063632_add_prefilled_to_framework_responses.rb
+++ b/db/migrate/20201021063632_add_prefilled_to_framework_responses.rb
@@ -1,0 +1,5 @@
+class AddPrefilledToFrameworkResponses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :framework_responses, :prefilled, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20201021065138_add_prefill_source_to_person_escort_records.rb
+++ b/db/migrate/20201021065138_add_prefill_source_to_person_escort_records.rb
@@ -1,0 +1,5 @@
+class AddPrefillSourceToPersonEscortRecords < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :person_escort_records, :prefill_source, type: :uuid, index: true, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_21_055517) do
+ActiveRecord::Schema.define(version: 2020_10_21_065138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -211,6 +211,7 @@ ActiveRecord::Schema.define(version: 2020_10_21_055517) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "responded", default: false, null: false
+    t.boolean "prefilled", default: false, null: false
     t.index ["framework_question_id"], name: "index_framework_responses_on_framework_question_id"
     t.index ["parent_id"], name: "index_framework_responses_on_parent_id"
     t.index ["person_escort_record_id"], name: "index_framework_responses_on_person_escort_record_id"
@@ -464,8 +465,10 @@ ActiveRecord::Schema.define(version: 2020_10_21_055517) do
     t.datetime "confirmed_at"
     t.uuid "move_id"
     t.jsonb "nomis_sync_status", default: [], null: false
+    t.uuid "prefill_source_id"
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
     t.index ["move_id"], name: "index_person_escort_records_on_move_id"
+    t.index ["prefill_source_id"], name: "index_person_escort_records_on_prefill_source_id"
     t.index ["profile_id"], name: "index_person_escort_records_on_profile_id", unique: true
   end
 

--- a/spec/factories/person_escort_record.rb
+++ b/spec/factories/person_escort_record.rb
@@ -32,5 +32,9 @@ FactoryBot.define do
       status { PersonEscortRecord::PERSON_ESCORT_RECORD_CONFIRMED }
       confirmed_at { Time.zone.now }
     end
+
+    trait :prefilled do
+      association(:prefill_source, factory: :person_escort_record)
+    end
   end
 end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe PersonEscortRecord do
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:profile) }
   it { is_expected.to belong_to(:move).optional }
+  it { is_expected.to belong_to(:prefill_source).optional }
 
   it 'validates uniqueness of profile' do
     person_escort_record = build(:person_escort_record)

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe FrameworkResponseSerializer do
     expect(result[:data][:attributes][:value_type]).to eq(framework_response.framework_question.response_type)
   end
 
+  it 'contains a `prefilled` attribute' do
+    expect(result[:data][:attributes][:prefilled]).to eq(framework_response.prefilled)
+  end
+
   it 'contains a `person_escort_record` relationship' do
     expect(result[:data][:relationships][:person_escort_record][:data]).to eq(
       id: framework_response.person_escort_record.id,

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -91,13 +91,15 @@ RSpec.describe PersonEscortRecordSerializer do
     expect(result[:data][:relationships][:prefill_source][:data]).to be_nil
   end
 
-  it 'contains a`prefill_source` relationship with person_escort_record prefill_source' do
-    person_escort_record.update(prefill_source: create(:person_escort_record))
+  context 'with a prefill source' do
+    let(:person_escort_record) { create(:person_escort_record, :prefilled, move: move, profile: move.profile) }
 
-    expect(result[:data][:relationships][:prefill_source][:data]).to eq(
-      id: person_escort_record.prefill_source.id,
-      type: 'person_escort_records',
-    )
+    it 'contains a`prefill_source` relationship ' do
+      expect(result[:data][:relationships][:prefill_source][:data]).to eq(
+        id: person_escort_record.prefill_source.id,
+        type: 'person_escort_records',
+      )
+    end
   end
 
   describe 'meta' do
@@ -123,7 +125,7 @@ RSpec.describe PersonEscortRecordSerializer do
     let(:framework_nomis_mapping) { create(:framework_nomis_mapping) }
     let(:framework_response) { build(:object_response, framework_nomis_mappings: [framework_nomis_mapping]) }
     let(:person_escort_record) do
-      create(:person_escort_record, framework_responses: [framework_response], prefill_source: create(:person_escort_record))
+      create(:person_escort_record, :prefilled, framework_responses: [framework_response])
     end
 
     let(:expected_json) do

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -87,6 +87,19 @@ RSpec.describe PersonEscortRecordSerializer do
     )
   end
 
+  it 'contains a nil `prefill_source` relationship if no prefill_source present' do
+    expect(result[:data][:relationships][:prefill_source][:data]).to be_nil
+  end
+
+  it 'contains a`prefill_source` relationship with person_escort_record prefill_source' do
+    person_escort_record.update(prefill_source: create(:person_escort_record))
+
+    expect(result[:data][:relationships][:prefill_source][:data]).to eq(
+      id: person_escort_record.prefill_source.id,
+      type: 'person_escort_records',
+    )
+  end
+
   describe 'meta' do
     it 'includes section progress' do
       question = create(:framework_question, framework: person_escort_record.framework, section: 'risk-information')
@@ -106,11 +119,11 @@ RSpec.describe PersonEscortRecordSerializer do
   end
 
   context 'with include options' do
-    let(:includes) { ['responses', 'responses.question', 'responses.nomis_mappings'] }
+    let(:includes) { ['responses', 'prefill_source', 'responses.question', 'responses.nomis_mappings'] }
     let(:framework_nomis_mapping) { create(:framework_nomis_mapping) }
     let(:framework_response) { build(:object_response, framework_nomis_mappings: [framework_nomis_mapping]) }
     let(:person_escort_record) do
-      create(:person_escort_record, framework_responses: [framework_response])
+      create(:person_escort_record, framework_responses: [framework_response], prefill_source: create(:person_escort_record))
     end
 
     let(:expected_json) do
@@ -129,6 +142,11 @@ RSpec.describe PersonEscortRecordSerializer do
           id: framework_nomis_mapping.id,
           type: 'framework_nomis_mappings',
           attributes: { code: framework_nomis_mapping.code },
+        },
+        {
+          id: person_escort_record.prefill_source.id,
+          type: 'person_escort_records',
+          attributes: { created_at: person_escort_record.prefill_source.created_at.iso8601 },
         },
       )
     end

--- a/swagger/v1/framework_response.yaml
+++ b/swagger/v1/framework_response.yaml
@@ -67,6 +67,11 @@ FrameworkResponse:
           example: 'true'
           description: Indicates if response has been answered
           readOnly: true
+        prefilled:
+          type: boolean
+          example: 'true'
+          description: Indicates if a response has been prefilled on creation by an existing, confirmed person escort record's similar response
+          readOnly: true
     relationships:
       type: object
       required:

--- a/swagger/v1/move_include_parameter.yaml
+++ b/swagger/v1/move_include_parameter.yaml
@@ -27,6 +27,7 @@ MoveIncludeParameter:
       - profile.person_escort_record
       - profile.person_escort_record.flags
       - profile.person_escort_record.framework
+      - profile.person_escort_record.prefill_source
       - profile.person_escort_record.responses
       - profile.person_escort_record.responses.nomis_mappings
       - profile.person_escort_record.responses.question

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -112,6 +112,9 @@ PersonEscortRecord:
         framework:
           $ref: framework_reference.yaml#/FrameworkReference
           description: The framework associated with this person_escort_record
+        prefill_source:
+          $ref: person_escort_record_reference.yaml#/PersonEscortRecordReference
+          description: The person_escort_record the current person_escort_record has been prefilled from
         responses:
           $ref: framework_response_reference.yaml#/FrameworkResponseReference
           description: The framework response associated with this person_escort_record

--- a/swagger/v1/person_escort_record_include_parameter.yaml
+++ b/swagger/v1/person_escort_record_include_parameter.yaml
@@ -16,4 +16,5 @@ PersonEscortRecordIncludeParameter:
       - responses.question.descendants.**
       - flags
       - move
+      - prefill_source
   example: framework

--- a/swagger/v2/move_include_parameter.yaml
+++ b/swagger/v2/move_include_parameter.yaml
@@ -21,6 +21,7 @@ MoveIncludeParameter:
       - profile.person_escort_record
       - profile.person_escort_record.flags
       - profile.person_escort_record.framework
+      - profile.person_escort_record.prefill_source
       - profile.person_escort_record.responses
       - profile.person_escort_record.responses.nomis_mappings
       - profile.person_escort_record.responses.question


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2356

To surface if a response has been already prefilled by an existing person escort record similar response, add a new column `prefilled` to framework responses. This value will be set to true if on creation of a person escort record the value is set from a different response.

To capture the previous person escort record the current record is being prefilled from, add a new relationship to `prefill_source` on `person_escort_records`.

Surface this values in the relative serializers and update documentation.