### PR TITLE
Update swagger documentation to use Move instead of Profile

### DIFF
--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2624,7 +2624,7 @@
       - name: body
         in: body
         required: true
-        description: The `person_escort_record` object to be created. Requires the `version` of the framework of questions, as well as the `profile` of the person.
+        description: The `person_escort_record` object to be created. Requires the `version` of the framework of questions, as well as the `move` already associated to a `profile` for a person.
         schema:
           "$ref": "../v1/post_person_escort_record.yaml#/PostPersonEscortRecord"
       responses:

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -100,9 +100,8 @@ PersonEscortRecord:
     relationships:
       type: object
       required:
-        - profile
+        - move
         - framework
-        - responses
       properties:
         profile:
           $ref: profile_reference.yaml#/ProfileReference

--- a/swagger/v1/person_escort_record_include_parameter.yaml
+++ b/swagger/v1/person_escort_record_include_parameter.yaml
@@ -15,4 +15,5 @@ PersonEscortRecordIncludeParameter:
       - responses.nomis_mappings
       - responses.question.descendants.**
       - flags
+      - move
   example: framework

--- a/swagger/v1/post_person_escort_record.yaml
+++ b/swagger/v1/post_person_escort_record.yaml
@@ -28,8 +28,8 @@ PostPersonEscortRecord:
     relationships:
       type: object
       required:
-        - profile
+        - move
       properties:
-        profile:
-          $ref: profile_reference.yaml#/ProfileReference
-          description: The profile of the person being moved
+        move:
+          $ref: move_reference.yaml#/MoveReference
+          description: The move of the person being moved, already associated to the profile.


### PR DESCRIPTION
To create Person escort record, switch documentation to use move instead of profile, however we still surface a profile in
relationships.