### PR TITLE
[P4-2394] Adds incident fault classification enum to events

### DIFF
--- a/app/models/generic_event/incident.rb
+++ b/app/models/generic_event/incident.rb
@@ -3,14 +3,21 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     def self.inherited(child)
-      child.details_attributes :supplier_personnel_numbers, :vehicle_reg, :reported_at
+      child.details_attributes :supplier_personnel_numbers, :vehicle_reg, :reported_at, :fault_classification
       child.relationship_attributes :location_id
       child.eventable_types 'Move', 'Person'
+      child.enum fault_classification: {
+        not_supplier: 'not_supplier',
+        supplier: 'supplier',
+        investigation: 'investigation',
+      }
 
       child.include LocationValidations
       child.include SupplierPersonnelNumberValidations
 
       child.validates :reported_at, iso_date_time: true
+      child.validates :fault_classification, inclusion: { in: child.fault_classifications }
+
       super
     end
   end

--- a/app/models/generic_event/incident.rb
+++ b/app/models/generic_event/incident.rb
@@ -16,7 +16,7 @@ class GenericEvent
       child.include SupplierPersonnelNumberValidations
 
       child.validates :reported_at, iso_date_time: true
-      child.validates :fault_classification, inclusion: { in: child.fault_classifications }
+      child.validates :fault_classification, presence: true, inclusion: { in: child.fault_classifications }
 
       super
     end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
         supplier_personnel_numbers: [SecureRandom.uuid],
         vehicle_reg: Faker::Vehicle.license_plate,
         reported_at: Time.zone.now.iso8601,
+        fault_classification: 'investigation',
       }
     end
   end

--- a/spec/support/an_event_about_an_incident.rb
+++ b/spec/support/an_event_about_an_incident.rb
@@ -1,10 +1,19 @@
 RSpec.shared_examples 'an event about an incident' do
-  it_behaves_like 'an event with details', :supplier_personnel_numbers, :vehicle_reg, :reported_at
+  it_behaves_like 'an event with details', :supplier_personnel_numbers, :vehicle_reg, :reported_at, :fault_classification
   it_behaves_like 'an event with relationships', :location_id
   it_behaves_like 'an event with eventable types', 'Person', 'Move'
   it_behaves_like 'an event requiring a location', :location_id
 
+  let(:fault_classifications) do
+    %w[
+      not_supplier
+      supplier
+      investigation
+    ]
+  end
+
   it { is_expected.to validate_presence_of(:supplier_personnel_numbers) }
+  it { is_expected.to validate_inclusion_of(:fault_classification).in_array(fault_classifications) }
 
   context 'when reported_at is not a valid iso8601 date' do
     before do

--- a/spec/support/an_event_about_an_incident.rb
+++ b/spec/support/an_event_about_an_incident.rb
@@ -14,6 +14,7 @@ RSpec.shared_examples 'an event about an incident' do
 
   it { is_expected.to validate_presence_of(:supplier_personnel_numbers) }
   it { is_expected.to validate_inclusion_of(:fault_classification).in_array(fault_classifications) }
+  it { is_expected.to validate_presence_of(:fault_classification) }
 
   context 'when reported_at is not a valid iso8601 date' do
     before do


### PR DESCRIPTION
jira link: https://dsdmoj.atlassian.net/browse/P4-2394

Fault classification is needed on every request to create an incident
event.

- [x] Adds fault classification to the parent incident event model
- [x] Adds fault classification to the tests of the individual incident
  models via shared examples