### PR TITLE
Ensure that metadata is only provided for paginated subset of locations

### DIFF
--- a/app/controllers/api/populations_controller.rb
+++ b/app/controllers/api/populations_controller.rb
@@ -5,9 +5,9 @@ module Api
     before_action :validate_date_range_params, only: %i[index]
 
     def index
-      serializer_params = { populations: Population.free_spaces_date_range(locations, (date_from..date_to)) }
-
-      paginate locations, serializer: LocationFreeSpacesSerializer, params: serializer_params
+      paginate locations, serializer: LocationFreeSpacesSerializer do |paginated_locations, options|
+        options[:params] = Population.free_spaces_date_range(paginated_locations, (date_from..date_to))
+      end
     end
 
     def show

--- a/app/controllers/concerns/serializable.rb
+++ b/app/controllers/concerns/serializable.rb
@@ -8,6 +8,8 @@ module Serializable
 
     paginated_collection = paginate_collection(collection, options)
 
+    yield(paginated_collection, options) if block_given?
+
     options[:meta] = meta(paginated_collection, options)
     options[:links] = links(paginated_collection, options)
     options[:json] = build_serializer(paginated_collection, options)

--- a/app/serializers/location_free_spaces_serializer.rb
+++ b/app/serializers/location_free_spaces_serializer.rb
@@ -9,7 +9,7 @@ class LocationFreeSpacesSerializer
 
   meta do |object, params|
     {
-      populations: params[:populations][object.id],
+      populations: params[object.id],
     }
   end
 end

--- a/spec/serializers/location_free_spaces_serializer_spec.rb
+++ b/spec/serializers/location_free_spaces_serializer_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe LocationFreeSpacesSerializer do
     it 'contains a title attribute' do
       expect(attributes[:title]).to eql location.title
     end
+
+    it 'contains empty meta data' do
+      expect(meta).to eql({ populations: nil })
+    end
   end
 
   context 'with custom params' do

--- a/spec/serializers/location_free_spaces_serializer_spec.rb
+++ b/spec/serializers/location_free_spaces_serializer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LocationFreeSpacesSerializer do
+  subject(:serializer) { described_class.new(location, adapter_options) }
+
+  let(:location) { create(:location) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:result_data) { result[:data] }
+  let(:attributes) { result_data[:attributes] }
+  let(:meta) { result_data[:meta] }
+
+  context 'with no options' do
+    let(:adapter_options) { {} }
+
+    it 'contains a type property' do
+      expect(result_data[:type]).to eql 'locations'
+    end
+
+    it 'contains an id property' do
+      expect(result_data[:id]).to eql location.id
+    end
+
+    it 'contains a title attribute' do
+      expect(attributes[:title]).to eql location.title
+    end
+  end
+
+  context 'with custom params' do
+    let(:adapter_options) do
+      { params: {
+        location.id => { foo: 'bar' },
+      } }
+    end
+
+    it 'contains meta data' do
+      expect(meta).to eql({ populations: { foo: 'bar' } })
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

P4-1427

### What?

- [x] Only calculate location free spaces data for paginated subset of locations
- [x] Add missing spec coverage for `LocationFreeSpacesSerializer`

### Why?

- Whilst working on another story to add metadata for allocations I realised that the existing metadata implementation for `GET /location_free_spaces` was calculating free space data for every location, rather than just the ones currently selected according to the pagination parameters. Cleaned this up by adding callback support in the `paginate` method to expose the paginated collection and options prior to instantiating the serializer. Also simplified the structure for passing parameters as only one parameter is currently needed.

### Deployment risks (optional)

- Doesn't affect api output and is not yet used in production
