### PR TITLE
Add support for custom move count metadata on `GET /allocations`

### DIFF
--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -8,7 +8,9 @@ module Api
       allocations_params = Allocations::ParamsValidator.new(filter_params, sort_params)
       if allocations_params.valid?
         allocations = Allocations::Finder.new(filters: filter_params, ordering: sort_params, search: search_params).call
-        paginate allocations, serializer: AllocationSerializer, include: included_relationships
+        paginate allocations, serializer: AllocationsSerializer, include: included_relationships do |paginated_allocations, options|
+          options[:params] = paginated_allocations.move_totals
+        end
       else
         render json: { error: allocations_params.errors }, status: :bad_request
       end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -94,7 +94,7 @@ class Allocation < VersionedModel
 
   def self.move_totals
     # Isolate this query from any higher level query that may include existing joins on moves
-    rows = Allocation.where(id: pluck(:id))
+    rows = unscoped.where(id: pluck(:id).uniq)
       # Join with matching (non cancelled) moves within the allocation (if any) so we can count them
       .joins("LEFT OUTER JOIN moves ON moves.allocation_id = allocations.id AND moves.status <> 'cancelled'")
       .group('allocations.id')

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -94,7 +94,7 @@ class Allocation < VersionedModel
 
   def self.move_totals
     # Isolate this query from any higher level query that may include existing joins on moves
-    rows = where(id: pluck(:id))
+    rows = Allocation.where(id: pluck(:id))
       # Join with matching (non cancelled) moves within the allocation (if any) so we can count them
       .joins("LEFT OUTER JOIN moves ON moves.allocation_id = allocations.id AND moves.status <> 'cancelled'")
       .group('allocations.id')

--- a/app/serializers/allocations_serializer.rb
+++ b/app/serializers/allocations_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AllocationsSerializer < AllocationSerializer
+  meta do |object, params|
+    {
+      moves: params[object.id],
+    }
+  end
+end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Allocation do
     context 'without associated moves' do
       let!(:allocations) { create_list(:allocation, 2) }
 
-      it 'contains zero total and filled move counts' do 
+      it 'contains zero total and filled move counts' do
         expect(move_totals).to eq({
           described_class.first.id => {
             total: 0,
@@ -220,7 +220,7 @@ RSpec.describe Allocation do
         described_class.first.moves.update(profile: nil)
       end
 
-      it 'contains correct total and filled move counts' do 
+      it 'contains correct total and filled move counts' do
         expect(move_totals).to eq({
           described_class.first.id => {
             total: 1,

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -192,4 +192,46 @@ RSpec.describe Allocation do
       expect(allocation).to be_unfilled
     end
   end
+
+  describe '.move_totals' do
+    subject(:move_totals) { described_class.all.move_totals }
+
+    context 'without associated moves' do
+      let!(:allocations) { create_list(:allocation, 2) }
+
+      it 'contains zero total and filled move counts' do 
+        expect(move_totals).to eq({
+          described_class.first.id => {
+            total: 0,
+            filled: 0,
+          },
+          described_class.last.id => {
+            total: 0,
+            filled: 0,
+          },
+        })
+      end
+    end
+
+    context 'with associated moves' do
+      let!(:allocations) { create_list(:allocation, 2, :with_moves) }
+
+      before do
+        described_class.first.moves.update(profile: nil)
+      end
+
+      it 'contains correct total and filled move counts' do 
+        expect(move_totals).to eq({
+          described_class.first.id => {
+            total: 1,
+            filled: 0,
+          },
+          described_class.last.id => {
+            total: 1,
+            filled: 1,
+          },
+        })
+      end
+    end
+  end
 end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -214,21 +214,21 @@ RSpec.describe Allocation do
     end
 
     context 'with associated moves' do
-      let!(:allocations) { create_list(:allocation, 2, :with_moves) }
+      let!(:allocations) { create_list(:allocation, 2, :with_moves, moves_count: 2) }
 
       before do
-        described_class.first.moves.update(profile: nil)
+        described_class.first.moves.first.update(profile: nil)
       end
 
       it 'contains correct total and filled move counts' do
         expect(move_totals).to eq({
           described_class.first.id => {
-            total: 1,
-            filled: 0,
+            total: 2,
+            filled: 1,
           },
           described_class.last.id => {
-            total: 1,
-            filled: 1,
+            total: 2,
+            filled: 2,
           },
         })
       end

--- a/spec/requests/api/allocations_controller_index_spec.rb
+++ b/spec/requests/api/allocations_controller_index_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe Api::AllocationsController do
         {
           data: [
             {
-              "id": allocation.id,
-              "type": 'allocations',
-              "meta": {
-                "moves": {
-                  "total": 1,
-                  "filled": 1,
+              'id': allocation.id,
+              'type': 'allocations',
+              'meta': {
+                'moves': {
+                  'total': 1,
+                  'filled': 1,
                 },
               },
             },

--- a/spec/requests/api/allocations_controller_index_spec.rb
+++ b/spec/requests/api/allocations_controller_index_spec.rb
@@ -20,6 +20,31 @@ RSpec.describe Api::AllocationsController do
       it_behaves_like 'an endpoint that responds with success 200'
     end
 
+    describe 'meta data' do
+      let!(:allocation) { create(:allocation, :with_moves) }
+      let(:expected_json) do
+        {
+          data: [
+            {
+              "id": allocation.id,
+              "type": 'allocations',
+              "meta": {
+                "moves": {
+                  "total": 1,
+                  "filled": 1,
+                },
+              },
+            },
+          ],
+        }
+      end
+
+      it 'includes total and filled moves count' do
+        get_allocations
+        expect(response_json).to include_json(expected_json)
+      end
+    end
+
     describe 'finding results' do
       before do
         allocations_finder = instance_double('Allocations::Finder', call: Allocation.all)

--- a/spec/serializers/allocations_serializer_spec.rb
+++ b/spec/serializers/allocations_serializer_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AllocationsSerializer do
+  subject(:serializer) { described_class.new(allocation, adapter_options) }
+
+  let(:allocation) { create(:allocation) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:result_data) { result[:data] }
+  let(:meta) { result_data[:meta] }
+
+  context 'with no options' do
+    let(:adapter_options) { {} }
+
+    it 'contains a type property' do
+      expect(result_data[:type]).to eql 'allocations'
+    end
+
+    it 'contains an id property' do
+      expect(result_data[:id]).to eql allocation.id
+    end
+
+    # Other attributes are as per AllocationSerializer, so no need to repeat everything here
+
+    it 'contains empty meta data' do
+      expect(meta).to eql({ moves: nil })
+    end
+  end
+
+  context 'with custom params' do
+    let(:adapter_options) do
+      { params: {
+        allocation.id => { foo: 'bar' },
+      } }
+    end
+
+    it 'contains meta data' do
+      expect(meta).to eql({ moves: { foo: 'bar' } })
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

P4-2340

### What?

- [x] Add support for custom move count metadata on `GET /allocations`
- [x] Add new `move_totals` class method to `Allocation` model to calculate a hash of allocation id to total and filled moves count
- [x] Include this additional data as a param when calling `AllocationsSerializer` - this descends from `AllocationSerializer` to add custom `meta` tag.

### Why?

- This will allow the front end to use the provided count of total and filled moves per allocation, rather than having to request all of the associated move and profile resources per allocation and derive this calculation. Once the meta data is implemented within the front end the list of supported includes on the `GET /allocations` endpoint can be trimmed back to something more sensible - and ideally remove support for requesting moves entirely as this is a slow operation.
- This does add an extra query to derive the aggregated totals but it's extremely fast so shouldn't affect production performance significantly - during local testing against a snapshot of staging it takes around 6ms for ~400 allocations.
- It's not possible to add optional `meta` tags with the serializer library we're using so I've added a custom serializer for the `GET /allocations` endpoint; this derives from `AllocationSerializer` so currently has the same attributes and relationships but will likely be modified further to remove support for some includes in future once the front end no longer has a dependency on those.

### Have you? (optional)

- [ ] Updated API docs if necessary - not sure how/if we need to represent `meta` tags in API documentation 🤔 

### Deployment risks (optional)

- Extends existing API with `meta` tags so shouldn't be a breaking change for front end. Have tagged as breaking just in case though so we can test this works without the corresponding front end changes being made.

