### PR TITLE
P4-2354 Prefill Person Escort Records on Creation

### DIFF
--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -29,7 +29,7 @@ class FrameworkQuestion < VersionedModel
     question.dependents.each do |dependent_question|
       # NB: to avoid extra queries use original set of questions
       dependent_response = build_responses(question: questions[dependent_question.id], person_escort_record: person_escort_record, questions: questions, previous_responses: previous_responses)
-      dependent_response_values = dependent_response.slice(:type, :framework_question_id, :dependents, :person_escort_record, :value, :prefilled)
+      dependent_response_values = dependent_response.slice(:type, :framework_question, :dependents, :person_escort_record, :value, :prefilled)
       response.dependents.build(dependent_response_values)
     end
 
@@ -62,6 +62,6 @@ class FrameworkQuestion < VersionedModel
         FrameworkResponse::String
       end
 
-    klass.new(framework_question_id: question.id, person_escort_record: person_escort_record, value: previous_response, prefilled: previous_response.present?)
+    klass.new(framework_question: question, person_escort_record: person_escort_record, value: previous_response, prefilled: previous_response.present?)
   end
 end

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -22,14 +22,14 @@ class FrameworkQuestion < VersionedModel
   has_many :framework_responses
   has_and_belongs_to_many :framework_nomis_codes, autosave: true
 
-  def build_responses(question: self, person_escort_record:, questions:)
-    response = build_response(question, person_escort_record)
+  def build_responses(question: self, person_escort_record:, questions:, previous_responses: {})
+    response = build_response(question, person_escort_record, previous_responses[question.key])
     return response if question.dependents.empty? || question.question_type == 'add_multiple_items'
 
     question.dependents.each do |dependent_question|
       # NB: to avoid extra queries use original set of questions
-      dependent_response = build_responses(question: questions[dependent_question.id], person_escort_record: person_escort_record, questions: questions)
-      dependent_response_values = dependent_response.slice(:type, :framework_question_id, :dependents, :person_escort_record)
+      dependent_response = build_responses(question: questions[dependent_question.id], person_escort_record: person_escort_record, questions: questions, previous_responses: previous_responses)
+      dependent_response_values = dependent_response.slice(:type, :framework_question_id, :dependents, :person_escort_record, :value)
       response.dependents.build(dependent_response_values)
     end
 
@@ -49,7 +49,7 @@ class FrameworkQuestion < VersionedModel
     end
   end
 
-  def build_response(question, person_escort_record)
+  def build_response(question, person_escort_record, previous_response = nil)
     klass =
       case question.question_type
       when 'radio'
@@ -62,6 +62,6 @@ class FrameworkQuestion < VersionedModel
         FrameworkResponse::String
       end
 
-    klass.new(framework_question_id: question.id, person_escort_record: person_escort_record)
+    klass.new(framework_question_id: question.id, person_escort_record: person_escort_record, value: previous_response, prefilled: previous_response.present?)
   end
 end

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -29,7 +29,7 @@ class FrameworkQuestion < VersionedModel
     question.dependents.each do |dependent_question|
       # NB: to avoid extra queries use original set of questions
       dependent_response = build_responses(question: questions[dependent_question.id], person_escort_record: person_escort_record, questions: questions, previous_responses: previous_responses)
-      dependent_response_values = dependent_response.slice(:type, :framework_question_id, :dependents, :person_escort_record, :value)
+      dependent_response_values = dependent_response.slice(:type, :framework_question_id, :dependents, :person_escort_record, :value, :prefilled)
       response.dependents.build(dependent_response_values)
     end
 

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -39,6 +39,12 @@ class FrameworkResponse < VersionedModel
     self.framework_flags = framework_question.framework_flags.select { |flag| option_selected?(flag.question_value) }
   end
 
+  def prefill_value
+    return unless framework_question.prefill
+
+    value
+  end
+
   def self.requires_value?(value, record)
     return false if value.present? || !record.framework_question.required
 

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -68,6 +68,7 @@ class FrameworkResponse < VersionedModel
       descendant.assign_attributes(
         value: nil,
         responded: false,
+        prefilled: false,
         framework_flags: [],
       )
 
@@ -75,7 +76,7 @@ class FrameworkResponse < VersionedModel
     end
 
     # Retain the class to avoid any clashes in implementation as this is utilising STI
-    FrameworkResponse.import(descendants, validate: false, recursive: true, all_or_none: true, on_duplicate_key_update: %i[value_json value_text responded])
+    FrameworkResponse.import(descendants, validate: false, recursive: true, all_or_none: true, on_duplicate_key_update: %i[value_json value_text responded prefilled])
   end
 
   def self.descendants_tree(ids)

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -27,7 +27,7 @@ class FrameworkResponse
     end
 
     def prefill_value
-      return [] unless multiple_items?
+      return super unless multiple_items?
 
       value.each_with_object([]) do |item, prefill_items|
         item['responses'] = responses_to_prefill(item['responses'])

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -26,6 +26,16 @@ class FrameworkResponse
       value.map { |v| v['option'] }.include?(option)
     end
 
+    def prefill_value
+      return [] unless multiple_items?
+
+      value.each_with_object([]) do |item, prefill_items|
+        item['responses'] = responses_to_prefill(item['responses'])
+
+        prefill_items << item unless item['responses'].empty?
+      end
+    end
+
   private
 
     def details_collection(collection)
@@ -73,6 +83,10 @@ class FrameworkResponse
 
     def value_type_valid?(raw_value)
       raw_value.is_a?(::Array) && raw_value.all?(::Hash)
+    end
+
+    def responses_to_prefill(responses)
+      responses.select { |response| framework_question.dependents.find(response['framework_question_id']).prefill }
     end
   end
 end

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -86,7 +86,10 @@ class FrameworkResponse
     end
 
     def responses_to_prefill(responses)
-      responses.select { |response| framework_question.dependents.find(response['framework_question_id']).prefill }
+      responses.select do |response|
+        question = framework_question.dependents.find { |dependent| dependent.id == response['framework_question_id'] }
+        question&.prefill
+      end
     end
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -18,6 +18,7 @@ class Person < VersionedModel
 
   has_many :profiles, dependent: :destroy
   has_many :moves, through: :profiles
+  has_many :person_escort_records, through: :profiles
   has_many :generic_events, as: :eventable, dependent: :destroy # NB: polymorphic association
 
   belongs_to :ethnicity, optional: true
@@ -60,5 +61,9 @@ class Person < VersionedModel
     feed_attributes.merge!('age' => age) if age
 
     feed_attributes
+  end
+
+  def latest_person_escort_record
+    person_escort_records.where(status: 'confirmed').order(confirmed_at: :desc).first
   end
 end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -63,6 +63,7 @@ class PersonEscortRecord < VersionedModel
 
   def build_responses!
     ApplicationRecord.retriable_transaction do
+      self.prefill_source = previous_per
       save!
 
       questions = framework_questions.includes(:dependents).index_by(&:id)

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -71,7 +71,7 @@ class PersonEscortRecord < VersionedModel
         next unless question.parent_id.nil?
 
         response = question.build_responses(person_escort_record: self, questions: questions, previous_responses: previous_responses)
-        framework_responses.build(response.slice(:type, :framework_question_id, :dependents, :value))
+        framework_responses.build(response.slice(:type, :framework_question_id, :dependents, :value, :prefilled))
       end
 
       PersonEscortRecord.import([self], validate: false, recursive: true, all_or_none: true, validate_uniqueness: true, on_duplicate_key_update: { conflict_target: [:id] })

--- a/app/services/framework_responses/bulk_updater.rb
+++ b/app/services/framework_responses/bulk_updater.rb
@@ -32,7 +32,7 @@ module FrameworkResponses
 
         FrameworkResponse.includes(framework_question: %i[framework_flags]).where(person_escort_record: person_escort_record).find(response_values_hash.keys).each do |response|
           new_value = response_values_hash[response.id]
-          next if response.value == new_value
+          next if response.value == new_value && response.responded == true
 
           response.value = new_value
           if validator.valid_model?(response)

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -132,6 +132,59 @@ RSpec.describe FrameworkQuestion do
       dependent_responses = response.dependents
       expect(dependent_responses.first.dependents.size).to eq(2)
     end
+
+    context 'with previous_responses' do
+      it 'builds response with correct value' do
+        question1 = create(:framework_question)
+        question2 = create(:framework_question)
+        previous_responses = {
+          question1.key => 'Yes',
+          question2.key => 'No',
+        }
+        person_escort_record = create(:person_escort_record)
+        response = question1.build_responses(
+          person_escort_record: person_escort_record,
+          questions: questions,
+          question: question2,
+          previous_responses: previous_responses,
+        )
+
+        expect(response.value).to eq('No')
+      end
+
+      it 'builds response dependents with correct value' do
+        person_escort_record = create(:person_escort_record)
+        question = create(:framework_question)
+        dependent_question = create(:framework_question, :checkbox, parent: question)
+        previous_responses = {
+          question.key => 'Yes',
+          dependent_question.key => ['Level 1'],
+        }
+        response = question.build_responses(
+          person_escort_record: person_escort_record,
+          questions: questions,
+          previous_responses: previous_responses,
+        )
+
+        expect(response.dependents.first.value).to contain_exactly('Level 1')
+      end
+
+      it 'builds response for multiple item question with correct value' do
+        person_escort_record = create(:person_escort_record)
+        question = create(:framework_question, :add_multiple_items)
+        value = [{ 'item' => 1, 'responses' => [{ 'value' => ['Level 1'], 'framework_question_id' => question.dependents.first.id }] }.with_indifferent_access]
+        previous_responses = {
+          question.key => value,
+        }
+        response = question.build_responses(
+          person_escort_record: person_escort_record,
+          questions: questions,
+          previous_responses: previous_responses,
+        )
+
+        expect(response.value).to eq(value)
+      end
+    end
   end
 
   describe '#build_response' do
@@ -210,6 +263,55 @@ RSpec.describe FrameworkQuestion do
       )
 
       expect(response).to be_a(FrameworkResponse::Collection)
+    end
+
+    it 'sets prefilled value to false if no value set' do
+      question = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_response(
+        question,
+        person_escort_record,
+      )
+
+      expect(response).not_to be_prefilled
+    end
+
+    context 'with previous response value' do
+      it 'builds a response with the value set' do
+        question = create(:framework_question)
+        person_escort_record = create(:person_escort_record)
+        response = question.build_response(
+          question,
+          person_escort_record,
+          'Yes',
+        )
+
+        expect(response.value).to eq('Yes')
+      end
+
+      it 'sets prefilled value to true' do
+        question = create(:framework_question)
+        person_escort_record = create(:person_escort_record)
+        response = question.build_response(
+          question,
+          person_escort_record,
+          'Yes',
+        )
+
+        expect(response).to be_prefilled
+      end
+
+      it 'sets prefilled value to false if empty value supplied' do
+        question = create(:framework_question, :checkbox, followup_comment: true)
+        person_escort_record = create(:person_escort_record)
+        response = question.build_response(
+          question,
+          person_escort_record,
+          [],
+        )
+
+        expect(response).not_to be_prefilled
+      end
     end
   end
 

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -169,6 +169,23 @@ RSpec.describe FrameworkQuestion do
         expect(response.dependents.first.value).to contain_exactly('Level 1')
       end
 
+      it 'sets prefilled value on dependents' do
+        person_escort_record = create(:person_escort_record)
+        question = create(:framework_question)
+        dependent_question = create(:framework_question, :checkbox, parent: question)
+        previous_responses = {
+          question.key => 'Yes',
+          dependent_question.key => ['Level 1'],
+        }
+        response = question.build_responses(
+          person_escort_record: person_escort_record,
+          questions: questions,
+          previous_responses: previous_responses,
+        )
+
+        expect(response.dependents.first).to be_prefilled
+      end
+
       it 'builds response for multiple item question with correct value' do
         person_escort_record = create(:person_escort_record)
         question = create(:framework_question, :add_multiple_items)

--- a/spec/models/framework_response/collection_spec.rb
+++ b/spec/models/framework_response/collection_spec.rb
@@ -334,10 +334,17 @@ RSpec.describe FrameworkResponse::Collection do
   end
 
   describe '#prefill_value' do
-    it 'returns nothing if collection not multiple items' do
+    it 'returns default if collection not multiple items and question is not to be prefilled' do
       response = create(:collection_response, :details)
 
-      expect(response.prefill_value).to be_empty
+      expect(response.prefill_value).to be_nil
+    end
+
+    it 'returns default if collection not multiple items and question is to be prefilled' do
+      framework_question = create(:framework_question, followup_comment: true, prefill: true)
+      response = create(:collection_response, :details, framework_question: framework_question)
+
+      expect(response.prefill_value).to eq([{ 'details' => 'some comment', 'option' => 'Level 1' }, { 'details' => 'another comment', 'option' => 'Level 2' }])
     end
 
     it 'returns nothing if no multiple item dependent questions should be prefilled' do

--- a/spec/models/framework_response/collection_spec.rb
+++ b/spec/models/framework_response/collection_spec.rb
@@ -332,4 +332,57 @@ RSpec.describe FrameworkResponse::Collection do
       expect(response.option_selected?('Level 3')).to be(false)
     end
   end
+
+  describe '#prefill_value' do
+    it 'returns nothing if collection not multiple items' do
+      response = create(:collection_response, :details)
+
+      expect(response.prefill_value).to be_empty
+    end
+
+    it 'returns nothing if no multiple item dependent questions should be prefilled' do
+      dependent_question = create(:framework_question, :checkbox, prefill: false)
+      question = create(:framework_question, :add_multiple_items, dependents: [dependent_question])
+      response = create(
+        :collection_response,
+        :multiple_items,
+        framework_question: question,
+        value: [{ 'item' => '1', responses: [{ 'value' => ['Level 1'], framework_question_id: dependent_question.id }] }],
+      )
+
+      expect(response.prefill_value).to be_empty
+    end
+
+    it 'returns response value if all multiple item dependent questions should be prefilled' do
+      dependent_question = create(:framework_question, :checkbox, prefill: true)
+      question = create(:framework_question, :add_multiple_items, dependents: [dependent_question])
+      value = [{ 'item' => '1', responses: [{ 'value' => ['Level 1'], framework_question_id: dependent_question.id }] }.with_indifferent_access]
+      response = create(
+        :collection_response,
+        :multiple_items,
+        framework_question: question,
+        value: value,
+      )
+
+      expect(response.prefill_value).to eq(value)
+    end
+
+    it 'returns the response value of the multiple item dependent questions that should be prefilled' do
+      dependent_question1 = create(:framework_question, :checkbox, prefill: true)
+      dependent_question2 = create(:framework_question, prefill: false)
+      question = create(:framework_question, :add_multiple_items, dependents: [dependent_question1, dependent_question2])
+      value = [
+        { 'item' => '1', responses: [{ 'value' => ['Level 1'], framework_question_id: dependent_question1.id }] },
+        { 'item' => '2', responses: [{ 'value' => ['Level 2'], framework_question_id: dependent_question1.id }, { 'value' => 'Yes', framework_question_id: dependent_question2.id }] },
+      ]
+      response = create(:collection_response, :multiple_items, framework_question: question, value: value)
+
+      expect(response.prefill_value).to eq(
+        [
+          { 'item' => '1', responses: [{ 'value' => ['Level 1'], framework_question_id: dependent_question1.id }] }.with_indifferent_access,
+          { 'item' => '2', responses: [{ 'value' => ['Level 2'], framework_question_id: dependent_question1.id }] }.with_indifferent_access,
+        ],
+      )
+    end
+  end
 end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -360,6 +360,24 @@ RSpec.describe FrameworkResponse do
 
         expect(child_response.reload.responded).to be(true)
       end
+
+      it 'sets prefilled to false on dependent responses if value changed' do
+        parent_response = create(:collection_response, :details)
+        child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, responded: true, prefilled: true)
+        parent_response.update_with_flags!([option: 'Level 2'])
+
+        expect(child_response.reload.prefilled).to be(false)
+      end
+
+      it 'does not set prefilled to false on dependent responses if value not changed' do
+        parent_response = create(:collection_response, :details)
+        child_question = create(:framework_question, :checkbox, followup_comment: true, dependent_value: 'Level 1', parent: parent_response.framework_question)
+        child_response = create(:collection_response, :details, framework_question: child_question, parent: parent_response, responded: true, prefilled: true)
+        parent_response.update_with_flags!([option: 'Level 1'])
+
+        expect(child_response.reload.prefilled).to be(true)
+      end
     end
 
     context 'with person_escort_record status' do
@@ -423,9 +441,16 @@ RSpec.describe FrameworkResponse do
       expect(response.responded).to be(true)
     end
 
-    it 'sets the responded value to update on update with value' do
+    it 'sets the responded value to true on update with value' do
       response = create(:string_response, value: 'Yes')
       response.update(value: nil)
+
+      expect(response.responded).to be(true)
+    end
+
+    it 'sets the responded value to true on update with a prefilled value' do
+      response = create(:string_response, value: 'Yes', prefilled: true, responded: false)
+      response.update(value: 'Yes')
 
       expect(response.responded).to be(true)
     end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -92,72 +92,6 @@ RSpec.describe FrameworkResponse do
     end
   end
 
-  describe '.requires_value?' do
-    it 'returns false if value present' do
-      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
-      response = create(:string_response, value: 'some value', parent: create(:string_response), framework_question: question)
-
-      expect(described_class.requires_value?(response.value, response)).to be(false)
-    end
-
-    it 'returns false if question not required' do
-      question = create(:framework_question, options: [], required: false)
-      response = create(:string_response, value: nil, framework_question: question)
-
-      expect(described_class.requires_value?(response.value, response)).to be(false)
-    end
-
-    it 'returns true if question required, value is empty and is not dependent' do
-      question = create(:framework_question, options: [], required: true)
-      response = create(:string_response, value: nil, framework_question: question)
-
-      expect(described_class.requires_value?(response.value, response)).to be(true)
-    end
-
-    it 'returns true if record is dependent, required and missing value' do
-      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
-      response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
-
-      expect(described_class.requires_value?(response.value, response)).to be(true)
-    end
-
-    it 'returns false if record is dependent but parent response does not match' do
-      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
-      parent_response = create(:string_response, value: 'No')
-      response = create(:string_response, value: nil, parent: parent_response, framework_question: question)
-
-      expect(described_class.requires_value?(response.value, response)).to be(false)
-    end
-  end
-
-  describe '#responded' do
-    it 'sets the responded value to false on creation with empty value' do
-      response = create(:string_response, value: nil)
-
-      expect(response.responded).to be(false)
-    end
-
-    it 'sets the responded value to false on creation with value' do
-      response = create(:string_response, value: 'Yes')
-
-      expect(response.responded).to be(false)
-    end
-
-    it 'sets the responded value to true on update with empty value' do
-      response = create(:string_response, value: nil)
-      response.update(value: 'Yes')
-
-      expect(response.responded).to be(true)
-    end
-
-    it 'sets the responded value to update on update with value' do
-      response = create(:string_response, value: 'Yes')
-      response.update(value: nil)
-
-      expect(response.responded).to be(true)
-    end
-  end
-
   describe '#update_with_flags!' do
     it 'updates response value' do
       response = create(:string_response, value: nil)
@@ -451,6 +385,87 @@ RSpec.describe FrameworkResponse do
         expect { response.update_with_flags!('No') }.to raise_error(ActiveRecord::ReadOnlyRecord)
         expect(response.reload.value).to eq('Yes')
       end
+    end
+  end
+
+  describe '#prefill_value' do
+    it 'returns the value of the response if response should be prefilled' do
+      question = create(:framework_question, prefill: true)
+      response = create(:string_response, framework_question: question, value: 'No')
+
+      expect(response.prefill_value).to eq('No')
+    end
+
+    it 'does not return the value of the response if response should not be prefilled' do
+      response = create(:string_response, value: 'No')
+
+      expect(response.prefill_value).to be_nil
+    end
+  end
+
+  describe '#responded' do
+    it 'sets the responded value to false on creation with empty value' do
+      response = create(:string_response, value: nil)
+
+      expect(response.responded).to be(false)
+    end
+
+    it 'sets the responded value to false on creation with value' do
+      response = create(:string_response, value: 'Yes')
+
+      expect(response.responded).to be(false)
+    end
+
+    it 'sets the responded value to true on update with empty value' do
+      response = create(:string_response, value: nil)
+      response.update(value: 'Yes')
+
+      expect(response.responded).to be(true)
+    end
+
+    it 'sets the responded value to update on update with value' do
+      response = create(:string_response, value: 'Yes')
+      response.update(value: nil)
+
+      expect(response.responded).to be(true)
+    end
+  end
+
+  describe '.requires_value?' do
+    it 'returns false if value present' do
+      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
+      response = create(:string_response, value: 'some value', parent: create(:string_response), framework_question: question)
+
+      expect(described_class.requires_value?(response.value, response)).to be(false)
+    end
+
+    it 'returns false if question not required' do
+      question = create(:framework_question, options: [], required: false)
+      response = create(:string_response, value: nil, framework_question: question)
+
+      expect(described_class.requires_value?(response.value, response)).to be(false)
+    end
+
+    it 'returns true if question required, value is empty and is not dependent' do
+      question = create(:framework_question, options: [], required: true)
+      response = create(:string_response, value: nil, framework_question: question)
+
+      expect(described_class.requires_value?(response.value, response)).to be(true)
+    end
+
+    it 'returns true if record is dependent, required and missing value' do
+      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
+      response = create(:string_response, value: nil, parent: create(:string_response), framework_question: question)
+
+      expect(described_class.requires_value?(response.value, response)).to be(true)
+    end
+
+    it 'returns false if record is dependent but parent response does not match' do
+      question = create(:framework_question, dependent_value: 'Yes', options: [], required: true)
+      parent_response = create(:string_response, value: 'No')
+      response = create(:string_response, value: nil, parent: parent_response, framework_question: question)
+
+      expect(described_class.requires_value?(response.value, response)).to be(false)
     end
   end
 end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -231,6 +231,14 @@ RSpec.describe PersonEscortRecord do
         expect(person_escort_record.framework_responses.first).not_to be_responded
       end
 
+      it 'sets prefilled value as true on responses' do
+        framework_question = create(:framework_question, framework: framework, prefill: true)
+        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+
+        expect(person_escort_record.framework_responses.first).to be_prefilled
+      end
+
       it 'maps values correctly to question response' do
         framework_question1 = create(:framework_question, framework: framework, prefill: true)
         framework_question2 = create(:framework_question, framework: framework, prefill: true)

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -198,6 +198,14 @@ RSpec.describe PersonEscortRecord do
         enable_feature!(:prefill)
       end
 
+      it 'sets prefill_source on person escort record' do
+        framework_question = create(:framework_question, framework: framework, prefill: true)
+        prefill_source = create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+
+        expect(person_escort_record.prefill_source).to eq(prefill_source)
+      end
+
       it 'does not prefill responses if no previous confirmed person_escort_record exists for person' do
         other_profile = create(:profile)
         framework_question = create(:framework_question, framework: framework, prefill: true)

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -170,6 +170,96 @@ RSpec.describe PersonEscortRecord do
 
       expect(person_escort_record.framework_questions.count).to eq(1)
     end
+
+    # TODO: remove when prefill flag removed
+    context 'with prefill feature flag disabled' do
+      it 'does not prefill responses from confirmed previous person escort record' do
+        disable_feature!(:prefill)
+
+        person = create(:person)
+        profile1 = create(:profile, person: person)
+        profile2 = create(:profile, person: person)
+        framework = create(:framework)
+        framework_question = create(:framework_question, framework: framework, prefill: true)
+        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+
+        expect(person_escort_record.framework_responses.first.value).to be_nil
+      end
+    end
+
+    context 'with prefill feature flag enabled' do
+      let(:person) { create(:person) }
+      let(:profile1) { create(:profile, person: person) }
+      let(:profile2) { create(:profile, person: person) }
+      let(:framework) { create(:framework) }
+
+      before do
+        enable_feature!(:prefill)
+      end
+
+      it 'does not prefill responses if no previous confirmed person_escort_record exists for person' do
+        other_profile = create(:profile)
+        framework_question = create(:framework_question, framework: framework, prefill: true)
+        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(profile_id: other_profile.id, version: framework.version)
+
+        expect(person_escort_record.framework_responses.first.value).to be_nil
+      end
+
+      it 'prefills responses from confirmed previous person escort record' do
+        framework_question = create(:framework_question, framework: framework, prefill: true)
+        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+
+        expect(person_escort_record.framework_responses.first.value).to eq('No')
+      end
+
+      it 'maintains responded value as false after prefill' do
+        framework_question = create(:framework_question, framework: framework, prefill: true)
+        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: 'No')])
+        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+
+        expect(person_escort_record.framework_responses.first).not_to be_responded
+      end
+
+      it 'maps values correctly to question response' do
+        framework_question1 = create(:framework_question, framework: framework, prefill: true)
+        framework_question2 = create(:framework_question, framework: framework, prefill: true)
+        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question1, value: 'No'), create(:string_response, framework_question: framework_question2, value: 'Yes')])
+        described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+
+        expect(framework_question2.reload.framework_responses.first.value).to eq('Yes')
+      end
+
+      it 'does not prefill responses with previous empty values' do
+        framework_question = create(:framework_question, framework: framework, prefill: true)
+        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question, value: nil)])
+        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+
+        expect(person_escort_record.framework_responses.first.value).to be_nil
+      end
+
+      it 'does not prefill responses with no previous question' do
+        framework2 = create(:framework, version: '1.1.0')
+        framework_question1 = create(:framework_question, framework: framework, prefill: true)
+        framework_question2 = create(:framework_question, framework: framework2, prefill: true)
+        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:string_response, framework_question: framework_question1, value: 'No')])
+        described_class.save_with_responses!(profile_id: profile2.id, version: framework2.version)
+
+        expect(framework_question2.reload.framework_responses.first.value).to be_nil
+      end
+
+      it 'prefills responses for add_multiple_items questions' do
+        dependent_framework_question = create(:framework_question, :checkbox, framework: framework, prefill: true)
+        framework_question = create(:framework_question, :add_multiple_items, framework: framework, dependents: [dependent_framework_question])
+        value = [{ 'item' => 1, 'responses' => [{ 'value' => ['Level 1'], 'framework_question_id' => framework_question.dependents.first.id }] }.with_indifferent_access]
+        create(:person_escort_record, :confirmed, profile: profile1, framework_responses: [create(:collection_response, :multiple_items, framework_question: framework_question, value: value)])
+        person_escort_record = described_class.save_with_responses!(profile_id: profile2.id, version: framework.version)
+
+        expect(person_escort_record.framework_responses.first.value).to eq(value)
+      end
+    end
   end
 
   describe '#build_responses!' do
@@ -464,6 +554,18 @@ RSpec.describe PersonEscortRecord do
         {
           key: 'risk',
           status: 'completed',
+        },
+      )
+    end
+
+    it 'returns a section as `not_started` if all responded values are false even if prefilled' do
+      person_escort_record = create(:person_escort_record, :prefilled)
+      create_response(person_escort_record: person_escort_record, section: 'risk', value: 'No', responded: false, prefilled: true)
+
+      expect(person_escort_record.section_progress).to contain_exactly(
+        {
+          key: 'risk',
+          status: 'not_started',
         },
       )
     end

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -6,12 +6,17 @@ RSpec.describe Api::PersonEscortRecordsController do
   describe 'POST /person_escort_records' do
     include_context 'with supplier with spoofed access token'
 
+    subject(:post_person_escort_record) do
+      post '/api/v1/person_escort_records', params: person_escort_record_params, headers: headers, as: :json
+    end
+
     let(:response_json) { JSON.parse(response.body) }
-    let(:profile) { create(:profile) }
+    let(:person) { create(:person) }
+    let(:profile) { create(:profile, person: person) }
     let(:profile_id) { profile.id }
     let(:move) { create(:move, profile: profile) }
     let(:move_id) { move.id }
-    let(:framework) { create(:framework, framework_questions: [build(:framework_question, section: 'risk-information')]) }
+    let(:framework) { create(:framework, framework_questions: [build(:framework_question, section: 'risk-information', prefill: true)]) }
     let(:framework_version) { framework.version }
 
     let(:person_escort_record_params) do
@@ -33,9 +38,7 @@ RSpec.describe Api::PersonEscortRecordsController do
       }
     end
 
-    before do
-      post '/api/v1/person_escort_records', params: person_escort_record_params, headers: headers, as: :json
-    end
+    before { post_person_escort_record }
 
     context 'when successful' do
       let(:schema) { load_yaml_schema('post_person_escort_record_responses.yaml') }
@@ -83,6 +86,9 @@ RSpec.describe Api::PersonEscortRecordsController do
             },
             "flags": {
               "data": [],
+            },
+            "prefill_source": {
+              "data": nil,
             },
           },
         }
@@ -163,6 +169,106 @@ RSpec.describe Api::PersonEscortRecordsController do
             },
             "flags": {
               "data": [],
+            },
+            "prefill_source": {
+              "data": nil,
+            },
+          },
+        }
+      end
+
+      it_behaves_like 'an endpoint that responds with success 201'
+
+      it 'returns the correct data' do
+        expect(response_json).to include_json(data: data)
+      end
+    end
+
+    context 'when prefilling from previous person escort record' do
+      subject(:post_person_escort_record) do
+        enable_feature!(:prefill)
+        previous_pesron_escort_record
+
+        post '/api/v1/person_escort_records', params: person_escort_record_params, headers: headers, as: :json
+      end
+
+      let(:previous_profile) { create(:profile, person: person) }
+      let(:previous_pesron_escort_record) do
+        create(:person_escort_record, :confirmed, profile: previous_profile, framework_responses: [create(:string_response, framework_question: framework.framework_questions.first)])
+      end
+      let(:person_escort_record_params) do
+        {
+          data: {
+            "type": 'person_escort_records',
+            "attributes": {
+              "version": framework_version,
+            },
+            "relationships": {
+              "move": {
+                "data": {
+                  "id": move_id,
+                  "type": 'moves',
+                },
+              },
+            },
+          },
+        }
+      end
+      let(:schema) { load_yaml_schema('post_person_escort_record_responses.yaml') }
+      let(:new_person_escort_record) { PersonEscortRecord.order(created_at: :desc).first }
+      let(:data) do
+        {
+          "id": new_person_escort_record.id,
+          "type": 'person_escort_records',
+          "attributes": {
+            "version": framework_version,
+            "status": 'not_started',
+            "confirmed_at": nil,
+            "nomis_sync_status": [],
+          },
+          "meta": {
+            'section_progress' => [
+              {
+                "key": 'risk-information',
+                "status": 'not_started',
+              },
+            ],
+          },
+          "relationships": {
+            "profile": {
+              "data": {
+                "id": profile_id,
+                "type": 'profiles',
+              },
+            },
+            "move": {
+              "data": {
+                "id": move_id,
+                "type": 'moves',
+              },
+            },
+            "framework": {
+              "data": {
+                "id": framework.id,
+                "type": 'frameworks',
+              },
+            },
+            "responses": {
+              "data": [
+                {
+                  "id": new_person_escort_record.reload.framework_responses.last.id,
+                  "type": 'framework_responses',
+                },
+              ],
+            },
+            "flags": {
+              "data": [],
+            },
+            "prefill_source": {
+              "data": {
+                "id": previous_pesron_escort_record.id,
+                "type": 'person_escort_records',
+              },
             },
           },
         }

--- a/spec/services/framework_responses/bulk_updater_spec.rb
+++ b/spec/services/framework_responses/bulk_updater_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe FrameworkResponses::BulkUpdater do
     expect(response2.reload).to be_responded
   end
 
+  it 'marks values as responded if they have been prefilled' do
+    per = create(:person_escort_record)
+    response1 = create(:string_response, person_escort_record: per, value: 'Yes', prefilled: true, responded: false)
+    response2 = create(:string_response, person_escort_record: per, value: 'No', prefilled: true, responded: false)
+    described_class.new(per, { response1.id => 'Yes', response2.id => 'No' }).call
+
+    expect(response1.reload).to be_responded
+    expect(response2.reload).to be_responded
+  end
+
   it 'updates response values' do
     per = create(:person_escort_record)
     response1 = create(:string_response, person_escort_record: per, value: nil)

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -1,0 +1,13 @@
+module FeatureFlags
+  def enable_feature!(feature_name)
+    allow(Flipper).to receive(:enabled?).with(feature_name).and_return(true)
+  end
+
+  def disable_feature!(feature_name)
+    allow(Flipper).to receive(:enabled?).with(feature_name).and_return(false)
+  end
+end
+
+RSpec.configure do |config|
+  config.include FeatureFlags
+end


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2354

Allow Person escort records to be pre-filled by a previous, confirmed Person escort record if it exists on the same person.
If the feature flag is enabled for pre-fill, the previous person escort record is retrieved and is set on the `prefill_source` of a Person escort record.
To map previous responses to current responses, question keys are used to build a hash map to the response. This is injected into the response builder for creation.

A response is added to the hash map if a question should be pre-filled. Add multiple items questions are slightly different as the parent question does not hold the pre-fill value, but the dependent questions themselves. This allows flexibility in multiple item questions, where not all questions should adhere to the same rules. To build the multiple item value, dependent questions are traversed to retrieve the pre-fill value, then used to determine if the value should be added to the final responses value for an item.
Feature flag support was also added to tests, to enable testing the Flipper feature flags.

Documentation has already been added for `prefill_source` on the PER and `prefilled` value on responses.
