### PR TITLE
[P4-1976] Support include alias for event timeline

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -196,6 +196,15 @@ class Move < VersionedModel
     end
   end
 
+  def all_events_for_timeline
+    eventable_ids = [id, profile&.person_escort_record_id, profile&.person_id].compact
+    eventable_ids += journeys.pluck(:id)
+
+    eventable_types = %w[Move PersonEscortRecord Person Journey]
+
+    GenericEvent.where(eventable_type: eventable_types, eventable_id: eventable_ids).applied_order
+  end
+
 private
 
   def date_to_after_date_from

--- a/app/serializers/journey_serializer.rb
+++ b/app/serializers/journey_serializer.rb
@@ -11,15 +11,10 @@ class JourneySerializer
   has_one :from_location, serializer: LocationSerializer
   has_one :to_location, serializer: LocationSerializer
 
-  has_many :events, serializer: GenericEventSerializer do |object|
-    object.generic_events.applied_order
-  end
-
   SUPPORTED_RELATIONSHIPS = %w[
     from_location
     from_location.suppliers
     to_location
     to_location.suppliers
-    events
   ].freeze
 end

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -16,9 +16,6 @@ class PersonEscortRecordSerializer
   has_many :flags, serializer: FrameworkFlagSerializer do |object|
     object.framework_flags.includes(framework_question: :dependents)
   end
-  has_many :events, serializer: GenericEventSerializer do |object|
-    object.generic_events.applied_order
-  end
 
   attributes :confirmed_at, :created_at, :nomis_sync_status
 
@@ -42,7 +39,6 @@ class PersonEscortRecordSerializer
     responses.nomis_mappings
     responses.question.descendants.**
     flags
-    events
     prefill_source
   ].freeze
 end

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -22,16 +22,14 @@ module V2
                :time_due,
                :updated_at
 
-    has_one :profile, serializer: V2::ProfileSerializer
-    has_one :from_location, serializer: LocationSerializer
-    has_one :to_location, serializer: LocationSerializer
+    has_one :from_location,          serializer: LocationSerializer
     has_one :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
-    has_one :supplier, serializer: SupplierSerializer
+    has_one :profile,                serializer: V2::ProfileSerializer
+    has_one :supplier,               serializer: SupplierSerializer
+    has_one :to_location,            serializer: LocationSerializer
 
     has_many :court_hearings, serializer: CourtHearingSerializer
-    has_many :events, serializer: GenericEventSerializer do |object|
-      object.generic_events.applied_order
-    end
+    has_many :timeline_events, serializer: GenericEventSerializer, &:all_events_for_timeline
 
     belongs_to :allocation, serializer: AllocationSerializer
     belongs_to :original_move, serializer: V2::MoveSerializer
@@ -57,7 +55,7 @@ module V2
       allocation
       original_move
       supplier
-      events
+      timeline_events
     ].freeze
 
     INCLUDED_FIELDS = {

--- a/app/serializers/v2/person_serializer.rb
+++ b/app/serializers/v2/person_serializer.rb
@@ -22,10 +22,7 @@ module V2
     # NB without lazy_load_data: true this relationship will trigger an N+1 database query,
     # unless it is included in the includes list
     has_many :profiles, serializer: ProfileSerializer, lazy_load_data: true
-    has_many :events, serializer: GenericEventSerializer do |object|
-      object.generic_events.applied_order
-    end
 
-    SUPPORTED_RELATIONSHIPS = %w[ethnicity gender profiles events].freeze
+    SUPPORTED_RELATIONSHIPS = %w[ethnicity gender profiles].freeze
   end
 end

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -134,6 +134,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_journey do
+      after(:create) do |move|
+        create(:journey, from_location: move.from_location, to_location: move.to_location, move: move)
+      end
+    end
+
     trait :with_person_escort_record do
       transient do
         person_escort_record_status { 'unstarted' }

--- a/spec/factories/profile.rb
+++ b/spec/factories/profile.rb
@@ -5,6 +5,12 @@ FactoryBot.define do
     association(:person, factory: :person_without_profiles)
   end
 
+  trait :with_person_escort_record do
+    after(:create) do |profile|
+      create(:person_escort_record, profile: profile)
+    end
+  end
+
   trait :with_documents do
     after(:create) do |profile|
       create_list(:document, 1, documentable: profile)

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -672,4 +672,38 @@ RSpec.describe Move do
       end
     end
   end
+
+  describe '#all_events_for_timeline' do
+    subject(:all_events_for_timeline) { move.all_events_for_timeline }
+
+    let(:move) { create(:move, :with_journey, profile: create(:profile, :with_person_escort_record)) }
+    let(:now) { Time.zone.now }
+
+    context 'when there are no events' do
+      it 'returns an empty Array' do
+        expect(move.all_events_for_timeline).to eq([])
+      end
+    end
+
+    context 'when there are events for each eventable' do
+      let!(:first_event) { create(:event_move_cancel, eventable: move, occurred_at: now + 2.seconds) }
+      let!(:second_event) { create(:event_person_move_death_in_custody, eventable: move.profile.person, occurred_at: now + 1.second) }
+      let!(:third_event) { create(:event_move_approve, eventable: move, occurred_at: now) }
+      let!(:fourth_event) { create(:event_per_court_cell_share_risk_assessment, eventable: move.profile.person_escort_record, occurred_at: now - 1.second) }
+      let!(:fifth_event) { create(:event_journey_person_boards_vehicle, eventable: move.journeys.first, occurred_at: now - 2.seconds) }
+
+      it 'returns generic events in the correct order' do
+        expect(all_events_for_timeline.pluck(:id)).to eq([fifth_event, fourth_event, third_event, second_event, first_event].map(&:id))
+      end
+    end
+
+    context 'when there are events for only one eventable' do
+      let!(:first_event) { create(:event_move_cancel, eventable: move, occurred_at: now + 2.seconds) }
+      let!(:second_event) { create(:event_move_approve, eventable: move, occurred_at: now) }
+
+      it 'returns generic events in the correct order' do
+        expect(all_events_for_timeline.pluck(:id)).to eq([second_event, first_event].map(&:id))
+      end
+    end
+  end
 end

--- a/spec/serializers/journey_serializer_spec.rb
+++ b/spec/serializers/journey_serializer_spec.rb
@@ -66,41 +66,4 @@ RSpec.describe JourneySerializer do
       expect(result[:included]).to(include_json(expected_json))
     end
   end
-
-  describe 'generic_events' do
-    let(:adapter_options) { { include: %i[events] } }
-
-    context 'with generic events' do
-      let(:now) { Time.zone.now }
-      let!(:first_event) { create(:event_journey_uncancel, eventable: journey, occurred_at: now + 2.seconds) }
-      let!(:second_event) { create(:event_journey_cancel, eventable: journey, occurred_at: now + 1.second) }
-      let!(:third_event) { create(:event_journey_start, eventable: journey, occurred_at: now) }
-
-      let(:expected_event_relationships) do
-        [
-          { id: third_event.id, type: 'events' },
-          { id: second_event.id, type: 'events' },
-          { id: first_event.id, type: 'events' },
-        ]
-      end
-
-      it 'contains event relationships in the correct order' do
-        expect(result[:data][:relationships][:events]).to eq(data: expected_event_relationships)
-      end
-
-      it 'contains included events in the correct order' do
-        expect(result[:included].map { |event| event[:id] }).to match_array([third_event.id, second_event.id, first_event.id])
-      end
-    end
-
-    context 'without generic events' do
-      it 'contains an empty allocation' do
-        expect(result[:data][:relationships][:events]).to eq(data: [])
-      end
-
-      it 'does not contain an included event' do
-        expect(result[:included]).to be_blank
-      end
-    end
-  end
 end

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -157,41 +157,4 @@ RSpec.describe PersonEscortRecordSerializer do
       expect(result[:included]).to include_json(expected_json)
     end
   end
-
-  describe 'generic_events' do
-    let(:includes) { %i[events] }
-
-    context 'with generic events' do
-      let(:now) { Time.zone.now }
-      let!(:first_event) { create(:event_per_court_hearing, eventable: person_escort_record, occurred_at: now + 2.seconds) }
-      let!(:second_event) { create(:event_per_court_cell_share_risk_assessment, eventable: person_escort_record, occurred_at: now + 1.second) }
-      let!(:third_event) { create(:event_per_court_all_documentation_provided_to_supplier, eventable: person_escort_record, occurred_at: now) }
-
-      let(:expected_event_relationships) do
-        [
-          { id: third_event.id, type: 'events' },
-          { id: second_event.id, type: 'events' },
-          { id: first_event.id, type: 'events' },
-        ]
-      end
-
-      it 'contains event relationships in the correct order' do
-        expect(result[:data][:relationships][:events]).to eq(data: expected_event_relationships)
-      end
-
-      it 'contains included events in the correct order' do
-        expect(result[:included].map { |event| event[:id] }).to match_array([third_event.id, second_event.id, first_event.id])
-      end
-    end
-
-    context 'without generic events' do
-      it 'contains an empty allocation' do
-        expect(result[:data][:relationships][:events]).to eq(data: [])
-      end
-
-      it 'does not contain an included event' do
-        expect(result[:included]).to be_blank
-      end
-    end
-  end
 end

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -78,35 +78,32 @@ RSpec.describe V2::MoveSerializer do
   end
 
   describe 'generic_events' do
-    let(:adapter_options) { { include: %i[events] } }
+    let(:adapter_options) { { include: %i[timeline_events] } }
 
     context 'with generic events' do
       let(:move) { create(:move) }
       let(:now) {  Time.zone.now }
-      let!(:first_event) { create(:event_move_cancel, eventable: move, occurred_at: now + 2.seconds) }
-      let!(:second_event) { create(:event_move_start, eventable: move, occurred_at: now + 1.second) }
-      let!(:third_event) { create(:event_move_approve, eventable: move, occurred_at: now) }
+
+      let!(:event) { create(:event_move_cancel, eventable: move, occurred_at: now + 1.second) }
 
       let(:expected_event_relationships) do
         [
-          { id: third_event.id, type: 'events' },
-          { id: second_event.id, type: 'events' },
-          { id: first_event.id, type: 'events' },
+          { id: event.id, type: 'events' },
         ]
       end
 
-      it 'contains event relationships in the correct order' do
-        expect(result[:data][:relationships][:events]).to eq(data: expected_event_relationships)
+      it 'contains timeline_events relationship in the correct order' do
+        expect(result[:data][:relationships][:timeline_events]).to eq(data: expected_event_relationships)
       end
 
       it 'contains included events in the correct order' do
-        expect(result[:included].map { |event| event[:id] }).to match_array([third_event.id, second_event.id, first_event.id])
+        expect(result[:included].map { |event| event[:id] }).to eq([event.id])
       end
     end
 
     context 'without generic events' do
       it 'contains an empty allocation' do
-        expect(result[:data][:relationships][:events]).to eq(data: [])
+        expect(result[:data][:relationships][:timeline_events]).to eq(data: [])
       end
 
       it 'does not contain an included event' do

--- a/spec/serializers/v2/person_serializer_spec.rb
+++ b/spec/serializers/v2/person_serializer_spec.rb
@@ -110,41 +110,4 @@ RSpec.describe V2::PersonSerializer do
       end
     end
   end
-
-  describe 'generic_events' do
-    let(:adapter_options) { { include: %i[events] } }
-
-    context 'with generic events' do
-      let(:now) { Time.zone.now }
-      let!(:first_event) { create(:event_person_move_assault, eventable: person, occurred_at: now + 2.seconds) }
-      let!(:second_event) { create(:event_person_move_serious_injury, eventable: person, occurred_at: now + 1.second) }
-      let!(:third_event) { create(:event_person_move_death_in_custody, eventable: person, occurred_at: now) }
-
-      let(:expected_event_relationships) do
-        [
-          { id: third_event.id, type: 'events' },
-          { id: second_event.id, type: 'events' },
-          { id: first_event.id, type: 'events' },
-        ]
-      end
-
-      it 'contains event relationships in the correct order' do
-        expect(result[:data][:relationships][:events]).to eq(data: expected_event_relationships)
-      end
-
-      it 'contains included events in the correct order' do
-        expect(result[:included].map { |event| event[:id] }).to match_array([third_event.id, second_event.id, first_event.id])
-      end
-    end
-
-    context 'without generic events' do
-      it 'contains an empty allocation' do
-        expect(result[:data][:relationships][:events]).to eq(data: [])
-      end
-
-      it 'does not contain an included event' do
-        expect(result[:included]).to be_blank
-      end
-    end
-  end
 end

--- a/swagger/v1/get_journey.yaml
+++ b/swagger/v1/get_journey.yaml
@@ -62,6 +62,3 @@ GetJourney:
         to_location:
           $ref: location_reference.yaml#/LocationReference
           description: The location that the journey is going to
-        events:
-          $ref: event_reference.yaml#/EventReference
-          description: Event about this record

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -121,6 +121,3 @@ PersonEscortRecord:
         flags:
           $ref: framework_flag_reference.yaml#/FrameworkFlagReference
           description: The framework flags associated with this person_escort_record
-        events:
-          $ref: event_reference.yaml#/EventReference
-          description: Event about this record

--- a/swagger/v1/post_journey.yaml
+++ b/swagger/v1/post_journey.yaml
@@ -48,6 +48,3 @@ PostJourney:
         supplier:
           $ref: supplier_reference.yaml#/SupplierReference
           description: The supplier that is performing the journey. This is optional - if not specified the user account will be used.
-        events:
-          $ref: event_reference.yaml#/EventReference
-          description: Event about this record

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -140,6 +140,6 @@ Move:
         prison_transfer_reason:
           $ref: "../v1/prison_transfer_reason_reference.yaml#/PrisonTransferReasonReference"
           description: The reason for this prison transfer
-        events:
+        timeline_events:
           $ref: "../v1/event_reference.yaml#/EventReference"
-          description: Event about this record
+          description: Aliased events about this record and its nested relationships

--- a/swagger/v2/person.yaml
+++ b/swagger/v2/person.yaml
@@ -69,6 +69,3 @@ Person:
         ethnicity:
           $ref: "../v1/ethnicity_reference.yaml#/EthnicityReference"
           description: Person's ethnicity
-        events:
-          $ref: "../v1/event_reference.yaml#/EventReference"
-          description: Event about this record


### PR DESCRIPTION
jira link: https://dsdmoj.atlassian.net/browse/P4-1976

We need to support surfacing events for the event timeline in the
frontend.

This commit removes the originally-implemented surfacing of events in
favour of a more efficient [alias](https://jsonapi.org/format/#fetching-includes).

This aliased relationship only applies to the single move _not_ the collection move
serializer once @martyn-w has successfully merged his [PR](https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1067).

- [x] Removes surfacing events from Journey, Person and
  PersonEscortRecord serializers and their swagger documentation
- [x] Adds surfacing events via nested alias on the Move serializer