### PR TITLE
Add log warn to OAuth2::Errors

### DIFF
--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -29,6 +29,9 @@ module NomisClient
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
         Rails.logger.warn "Nomis Connection Error: #{e.message}"
         raise e
+      rescue OAuth2::Error => e
+        Rails.logger.warn "Nomis OAuth Client Error: #{e.message}"
+        raise e
       end
 
       def token


### PR DESCRIPTION
### Jira link

P4-2128

### What?

I have added/removed/altered:

- [x] Added logging to OAuth2::Errors raised through NomisClient
- [x] Added unit tests to cover OAuth2::Error logging and Faraday error logging

### Why?

I am doing this because:

- It will make it more clear where the error is coming from