### PR TITLE
IM-60 Retry long transactions if they fail

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,4 +4,17 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   include UpdatedAtRange
+  class << self
+    def retriable_transaction(**options, &block)
+      retried ||= false
+      transaction(**options, &block)
+    rescue ActiveRecord::PreparedStatementCacheExpired
+      if retried
+        raise
+      else
+        retried = true
+        retry
+      end
+    end
+  end
 end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -62,7 +62,7 @@ class PersonEscortRecord < VersionedModel
   end
 
   def build_responses!
-    ActiveRecord::Base.transaction do
+    ApplicationRecord.retriable_transaction do
       save!
 
       questions = framework_questions.includes(:dependents).index_by(&:id)

--- a/app/services/framework_nomis_mappings/importer.rb
+++ b/app/services/framework_nomis_mappings/importer.rb
@@ -14,7 +14,7 @@ module FrameworkNomisMappings
     def call
       return unless person_escort_record && framework_responses.any? && framework_nomis_codes.any?
 
-      ActiveRecord::Base.transaction do
+      ApplicationRecord.retriable_transaction do
         return unless persist_framework_nomis_mappings.any?
 
         framework_responses.includes(:framework_nomis_mappings).each do |response|

--- a/app/services/framework_responses/bulk_updater.rb
+++ b/app/services/framework_responses/bulk_updater.rb
@@ -18,7 +18,7 @@ module FrameworkResponses
       return if updated_responses.empty?
 
       # Ensure atomic behaviour as we don't want partial inconsistent updates
-      ActiveRecord::Base.transaction do
+      ApplicationRecord.retriable_transaction do
         apply_bulk_response_changes(updated_responses)
         apply_person_escort_record_changes
       end


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/IM-60

When deploying migrations, the database schema becomes invalid. If there were transactions midway during such a deploy a
`ActiveRecord::PreparedStatementCacheExpired` error is thrown. To avoid those errors on deploy, wrap all long running transacions with a custom retriable transaction, which retries once if this error is raised, but fails if it fails another time. All transactions to be retried are safe, but are long running so are prone to raise such errors on deploy.

Reference: https://flexport.engineering/avoiding-activerecord-preparedstatementcacheexpired-errors-4499a4f961cf