### PR TITLE
Add unfilled moves count to allocations meta

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -99,14 +99,15 @@ class Allocation < VersionedModel
       .joins("LEFT OUTER JOIN moves ON moves.allocation_id = allocations.id AND moves.status <> 'cancelled'")
       .group('allocations.id')
       # Need to wrap derived columns in pointless Arel.sql call to resolve annoying deprecation warning, even though this is safe :(
-      .pluck(Arel.sql('allocations.id, count(moves), count(moves) filter (where moves.profile_id is not null)'))
+      .pluck(Arel.sql('allocations.id, count(moves), count(moves) filter (where moves.profile_id is not null), count(moves) filter (where moves.profile_id is null)'))
 
     # Map array of returned rows/columns into a nicer hash structure keyed by id
     rows.each_with_object({}) do |row, totals_hash|
-      allocation_id, total_moves, filled_moves = *row
+      allocation_id, total_moves, filled_moves, unfilled_moves = *row
       totals_hash[allocation_id] = {
         total: total_moves,
         filled: filled_moves,
+        unfilled: unfilled_moves,
       }
     end
   end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -204,10 +204,12 @@ RSpec.describe Allocation do
           described_class.first.id => {
             total: 0,
             filled: 0,
+            unfilled: 0,
           },
           described_class.last.id => {
             total: 0,
             filled: 0,
+            unfilled: 0,
           },
         })
       end
@@ -225,10 +227,12 @@ RSpec.describe Allocation do
           described_class.first.id => {
             total: 2,
             filled: 1,
+            unfilled: 1,
           },
           described_class.last.id => {
             total: 2,
             filled: 2,
+            unfilled: 0,
           },
         })
       end

--- a/spec/requests/api/allocations_controller_index_spec.rb
+++ b/spec/requests/api/allocations_controller_index_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Api::AllocationsController do
                 'moves': {
                   'total': 1,
                   'filled': 1,
+                  'unfilled': 0,
                 },
               },
             },


### PR DESCRIPTION
### Jira link

P4-2340

### What?

- [x] Also include `unfilled` moves count in the allocation `meta` tag for `GET /allocations` endpoint

### Why?

- This allows further simplification of front end code and doesn't impact backend performance so feels like a nicer place to implement this logic.

### Have you? (optional)

- [ ] Updated API docs if necessary - `meta` tags are not documented, still need to consider if this is worth doing 🤔 

### Deployment risks (optional)

- Updates `meta` for production allocations api (which is currently ignored in production), the change ties in with ongoing front end work and has been discussed with @solidgoldpig 

