### PR TITLE
Tweak totals count for allocations metadata

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -96,10 +96,10 @@ class Allocation < VersionedModel
     # Isolate this query from any higher level query that may include existing joins on moves
     rows = unscoped.where(id: pluck(:id).uniq)
       # Join with matching (non cancelled) moves within the allocation (if any) so we can count them
-      .joins("LEFT OUTER JOIN moves ON moves.allocation_id = allocations.id AND moves.status <> 'cancelled'")
+      .joins('LEFT OUTER JOIN moves ON moves.allocation_id = allocations.id')
       .group('allocations.id')
       # Need to wrap derived columns in pointless Arel.sql call to resolve annoying deprecation warning, even though this is safe :(
-      .pluck(Arel.sql('allocations.id, count(moves), count(moves) filter (where moves.profile_id is not null), count(moves) filter (where moves.profile_id is null)'))
+      .pluck(Arel.sql("allocations.id, COUNT(moves), COUNT(moves) FILTER (WHERE moves.status <> 'cancelled' AND moves.profile_id IS NOT NULL), COUNT(moves) FILTER (WHERE moves.status <> 'cancelled' AND moves.profile_id IS NULL)"))
 
     # Map array of returned rows/columns into a nicer hash structure keyed by id
     rows.each_with_object({}) do |row, totals_hash|

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Allocation do
         described_class.first.moves.first.update(profile: nil)
       end
 
-      it 'contains correct total and filled move counts' do
+      it 'contains correct total, filled and unfilled move counts' do
         expect(move_totals).to eq({
           described_class.first.id => {
             total: 2,
@@ -233,6 +233,30 @@ RSpec.describe Allocation do
             total: 2,
             filled: 2,
             unfilled: 0,
+          },
+        })
+      end
+    end
+
+    context 'with cancelled moves' do
+      let!(:allocations) { create_list(:allocation, 2, :with_moves, moves_count: 2) }
+
+      before do
+        described_class.first.moves.first.update(status: 'cancelled', cancellation_reason: 'other')
+        described_class.last.moves.first.update(profile: nil, status: 'cancelled', cancellation_reason: 'other')
+      end
+
+      it 'excludes cancelled moves from filled and unfilled move counts' do
+        expect(move_totals).to eq({
+          described_class.first.id => {
+            total: 2, # Still two moves in total, ignoring status
+            filled: 1, # Excludes filled cancelled move
+            unfilled: 0,
+          },
+          described_class.last.id => {
+            total: 2,
+            filled: 1,
+            unfilled: 0, # Excludes unfilled cancelled move
           },
         })
       end

--- a/swagger/v1/allocation.yaml
+++ b/swagger/v1/allocation.yaml
@@ -161,6 +161,30 @@ Allocation:
           - type: 'null'
           description: In case 'other' is chosen as cancellation_reason, further details
             can be specified
+    meta:
+      description: Metadata per allocation is included only when calling the endpoint to return a list of allocations, not for a single allocation.
+      readOnly: true
+      type: object
+      properties:
+        moves:
+          type: object
+          required:
+            - total
+            - filled
+            - unfilled
+          properties:
+            total:
+              type: integer
+              example: 10
+              description: Total number of moves associated with this allocation, irrespective of move status (i.e. includes cancelled moves)
+            filled:
+              type: integer
+              example: 6
+              description: Number of non cancelled moves for this allocation with person/profile attached (i.e. excludes filled but cancelled moves)
+            unfilled:
+              type: integer
+              example: 4
+              description: Number of non cancelled moves for this allocation without person/profile attached (i.e. excludes unfilled but cancelled moves)
     relationships:
       type: object
       required:

--- a/swagger/v1/allocation.yaml
+++ b/swagger/v1/allocation.yaml
@@ -176,7 +176,7 @@ Allocation:
             total:
               type: integer
               example: 10
-              description: Total number of moves associated with this allocation, irrespective of move status (i.e. includes cancelled moves)
+              description: Total number of moves associated with this allocation. If the allocation is cancelled, this returns all moves irrespective of move status (i.e. includes cancelled moves). If the allocation is not yet cancelled then this total excludes cancelled moves that are part of the allocation.
             filled:
               type: integer
               example: 6


### PR DESCRIPTION
### Jira link

P4-2340 P4-2417

### What?

- [x] Amended logic for determining allocation total moves meta value
- [x] Added documentation for meta tag on allocations

### Why?

- The current front end implementation is showing `Move size` column by iterating over the moves associated with the allocation. When the allocation is not cancelled, this total excludes any cancelled moves (these would have been deleted from the allocation screen) so the allocation "size" should reflect the number of current moves.
- If an allocation is cancelled, all of the moves within the allocation are also cancelled. The front end implementation currently shows the total number of allocation moves regardless of move status for this scenario (i.e. including cancelled moves). This means that the move size could increase if the allocation has most of the moves removed and then the entire allocation is cancelled. However this mirrors the existing behaviour and is largely due to the limitation of being unable to distinguish moves deleted from the allocation vs moves that were cancelled when the allocation was cancelled. Showing a `Move size` column of `0` in the UI whilst technically correct, and consistent with the active allocations is less helpful for users trying to identify cancelled allocations based on move size.
- The `filled` and `unfilled` meta values retain the previous behaviour and do not consider cancelled moves. This means that when an allocation is cancelled (and all moves are automatically cancelled) both values will return 0. This is expected behaviour and the front end is being updated to instead show allocation progress column as `CANCELLED`.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Meta key is not yet used in production, so minimal risk

