### PR TITLE
P4 2339 validate prisoner category

### DIFF
--- a/spec/factories/profile.rb
+++ b/spec/factories/profile.rb
@@ -44,4 +44,44 @@ FactoryBot.define do
       ]
     end
   end
+
+  trait :category_a do
+    category { 'Cat A' }
+    category_code { 'A' }
+  end
+
+  trait :category_h do
+    category { 'Cat A-Hi' }
+    category_code { 'H' }
+  end
+
+  trait :category_e do
+    category { 'Cat A-Ex' }
+    category_code { 'E' }
+  end
+
+  trait :category_b do
+    category { 'Cat B' }
+    category_code { 'B' }
+  end
+
+  trait :category_c do
+    category { 'Cat C' }
+    category_code { 'C' }
+  end
+
+  trait :category_d do
+    category { 'Cat D' }
+    category_code { 'D' }
+  end
+
+  trait :category_u do
+    category { 'Unsentenced' }
+    category_code { 'U' }
+  end
+
+  trait :category_unknown do
+    category { nil }
+    category_code { nil }
+  end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -172,6 +172,40 @@ RSpec.describe Move do
     expect(build(:move, date_from: '2020-03-04', date_to: '2020-03-04')).to be_valid
   end
 
+  context 'when the profile has a prisoner category' do
+    it 'prevents a category A prisoner from being moved' do
+      expect(build(:move, profile: build(:profile, :category_a))).not_to be_valid
+    end
+
+    it 'prevents a category A-Hi prisoner from being moved' do
+      expect(build(:move, profile: build(:profile, :category_h))).not_to be_valid
+    end
+
+    it 'prevents a category A-Ex prisoner from being moved' do
+      expect(build(:move, profile: build(:profile, :category_e))).not_to be_valid
+    end
+
+    it 'allows a category B prisoner' do
+      expect(build(:move, profile: build(:profile, :category_b))).to be_valid
+    end
+
+    it 'allows a category C prisoner' do
+      expect(build(:move, profile: build(:profile, :category_c))).to be_valid
+    end
+
+    it 'allows a category D prisoner' do
+      expect(build(:move, profile: build(:profile, :category_d))).to be_valid
+    end
+
+    it 'allows an unsentenced category prisoner' do
+      expect(build(:move, profile: build(:profile, :category_u))).to be_valid
+    end
+
+    it 'allows an unknown category prisoner' do
+      expect(build(:move, profile: build(:profile, :category_unknown))).to be_valid
+    end
+  end
+
   context 'when a Move for a Person has already been created' do
     let(:move) { create(:move) }
 

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -513,6 +513,32 @@ RSpec.describe Api::MovesController do
         end
       end
     end
+
+    context 'when the profile is for a Cat A prisoner' do
+      let(:profile) { create(:profile, :category_a) }
+      let(:errors_422) do
+        [
+          {
+            'title' => 'Unprocessable entity',
+            'detail' => "Profile person is a category 'a' prisoner and cannot be moved using this service",
+            'source' => { 'pointer' => '/data/attributes/profile' },
+            'code' => 'unsupported_prisoner_category',
+          },
+        ]
+      end
+
+      it_behaves_like 'an endpoint that responds with error 422' do
+        before { do_post }
+      end
+    end
+
+    context 'when the profile is for a Cat B prisoner' do
+      let(:profile) { create(:profile, :category_b) }
+
+      it_behaves_like 'an endpoint that responds with success 201' do
+        before { do_post }
+      end
+    end
   end
 
   def do_post

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -519,6 +519,50 @@ RSpec.describe Api::MovesController do
       end
     end
 
+    context 'when the profile is for a Cat A prisoner' do
+      let(:cat_a_profile) { create(:profile, :category_a) }
+      let(:move_params) do
+        {
+          type: 'moves',
+          attributes: {
+            status: 'requested',
+          },
+          relationships: { profile: { data: { id: cat_a_profile.id, type: 'profiles' } } },
+        }
+      end
+      let(:errors_422) do
+        [
+          {
+            'title' => 'Unprocessable entity',
+            'detail' => "Profile person is a category 'a' prisoner and cannot be moved using this service",
+            'source' => { 'pointer' => '/data/attributes/profile' },
+            'code' => 'unsupported_prisoner_category',
+          },
+        ]
+      end
+
+      it_behaves_like 'an endpoint that responds with error 422' do
+        before { do_patch }
+      end
+    end
+
+    context 'when the profile is for a Cat B prisoner' do
+      let(:cat_b_profile) { create(:profile, :category_b) }
+      let(:move_params) do
+        {
+          type: 'moves',
+          attributes: {
+            status: 'requested',
+          },
+          relationships: { profile: { data: { id: cat_b_profile.id, type: 'profiles' } } },
+        }
+      end
+
+      it_behaves_like 'an endpoint that responds with success 200' do
+        before { do_patch }
+      end
+    end
+
     def do_patch
       patch "/api/moves/#{move_id}", params: patch_params, headers: headers, as: :json
     end


### PR DESCRIPTION
### Jira link

P4-2339

### What?

I have added/removed/altered:

- [x] Added validation of prisoner category 

### Why?

I am doing this because:

- Cat-A prisoners (and associated categories H and E) should not be moved by BaSM

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

