### PR TITLE
Enforce the application to run under HTTPS in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # set to :info so that logging for synchroniser shows up in staging/preprod/production
   #


### PR DESCRIPTION
Set the `force_ssl` configuration flag to true to enforce the use of HTTPS in production