### PR TITLE
Add capability of running every/each feed on a specific date

### DIFF
--- a/lib/tasks/feeds/event.rake
+++ b/lib/tasks/feeds/event.rake
@@ -1,9 +1,17 @@
 namespace :feeds do
   desc 'Exports a JSON feed of yesterday\'s events to s3'
   task event: :environment do
-    feed = Feeds::Event.new.call
+    if ENV['REPORT_ON_DATE']
+      report_on_date = Date.parse(ENV['REPORT_ON_DATE'])
+      updated_at_from = report_on_date.beginning_of_day
+      updated_at_to = report_on_date.end_of_day
 
-    CloudDataFeed.new.write(feed, 'events.jsonl')
+      feed = Feeds::Event.new(updated_at_from, updated_at_to).call
+      CloudDataFeed.new.write(feed, 'events.jsonl', report_on_date)
+    else
+      feed = Feeds::Event.new.call
+      CloudDataFeed.new.write(feed, 'events.jsonl')
+    end
   end
 
   desc 'Exports the JSON starting from a certain date (inclusive)'

--- a/lib/tasks/feeds/journey.rake
+++ b/lib/tasks/feeds/journey.rake
@@ -1,8 +1,18 @@
 namespace :feeds do
   desc 'Exports a JSON feed of yesterday\'s journeys to s3'
   task journey: :environment do
-    feed_journeys = Feeds::Journey.new.call
+    if ENV['REPORT_ON_DATE']
+      report_on_date = Date.parse(ENV['REPORT_ON_DATE'])
+      updated_at_from = report_on_date.beginning_of_day
+      updated_at_to = report_on_date.end_of_day
 
-    CloudDataFeed.new.write(feed_journeys, 'journeys.jsonl')
+      feed = Feeds::Journey.new(updated_at_from, updated_at_to).call
+
+      CloudDataFeed.new.write(feed, 'journeys.jsonl', report_on_date)
+    else
+      feed = Feeds::Journey.new.call
+
+      CloudDataFeed.new.write(feed, 'journeys.jsonl')
+    end
   end
 end

--- a/lib/tasks/feeds/move.rake
+++ b/lib/tasks/feeds/move.rake
@@ -1,8 +1,16 @@
 namespace :feeds do
   desc 'Exports a JSON feed of yesterday\'s moves to s3'
   task move: :environment do
-    feed = Feeds::Move.new.call
+    if ENV['REPORT_ON_DATE']
+      report_on_date = Date.parse(ENV['REPORT_ON_DATE'])
+      updated_at_from = report_on_date.beginning_of_day
+      updated_at_to = report_on_date.end_of_day
 
-    CloudDataFeed.new.write(feed, 'moves.jsonl')
+      feed = Feeds::Move.new(updated_at_from, updated_at_to).call
+      CloudDataFeed.new.write(feed, 'moves.jsonl', report_on_date)
+    else
+      feed = Feeds::Move.new.call
+      CloudDataFeed.new.write(feed, 'moves.jsonl')
+    end
   end
 end

--- a/lib/tasks/feeds/notification.rake
+++ b/lib/tasks/feeds/notification.rake
@@ -1,8 +1,18 @@
 namespace :feeds do
   desc 'Exports a JSON feed of yesterday\'s notifications to s3'
   task notification: :environment do
-    feed = Feeds::Notification.new.call
+    if ENV['REPORT_ON_DATE']
+      report_on_date = Date.parse(ENV['REPORT_ON_DATE'])
+      updated_at_from = report_on_date.beginning_of_day
+      updated_at_to = report_on_date.end_of_day
 
-    CloudDataFeed.new.write(feed, 'notifications.jsonl')
+      feed = Feeds::Notification.new(updated_at_from, updated_at_to).call
+
+      CloudDataFeed.new.write(feed, 'notifications.jsonl', report_on_date)
+    else
+      feed = Feeds::Notification.new.call
+
+      CloudDataFeed.new.write(feed, 'notifications.jsonl')
+    end
   end
 end

--- a/lib/tasks/feeds/person.rake
+++ b/lib/tasks/feeds/person.rake
@@ -1,8 +1,16 @@
 namespace :feeds do
   desc 'Exports a JSON feed of yesterday\'s people to s3'
   task person: :environment do
-    feed = Feeds::Person.new.call
+    if ENV['REPORT_ON_DATE']
+      report_on_date = Date.parse(ENV['REPORT_ON_DATE'])
+      updated_at_from = report_on_date.beginning_of_day
+      updated_at_to = report_on_date.end_of_day
 
-    CloudDataFeed.new.write(feed, 'people.jsonl')
+      feed = Feeds::Person.new(updated_at_from, updated_at_to).call
+      CloudDataFeed.new.write(feed, 'people.jsonl', report_on_date)
+    else
+      feed = Feeds::Person.new.call
+      CloudDataFeed.new.write(feed, 'people.jsonl')
+    end
   end
 end

--- a/lib/tasks/feeds/profile.rake
+++ b/lib/tasks/feeds/profile.rake
@@ -1,8 +1,16 @@
 namespace :feeds do
   desc 'Exports a JSON feed of yesterday\'s profiles to s3'
   task profile: :environment do
-    feed = Feeds::Profile.new.call
+    if ENV['REPORT_ON_DATE']
+      report_on_date = Date.parse(ENV['REPORT_ON_DATE'])
+      updated_at_from = report_on_date.beginning_of_day
+      updated_at_to = report_on_date.end_of_day
 
-    CloudDataFeed.new.write(feed, 'profiles.jsonl')
+      feed = Feeds::Profile.new(updated_at_from, updated_at_to).call
+      CloudDataFeed.new.write(feed, 'profiles.jsonl', report_on_date)
+    else
+      feed = Feeds::Profile.new.call
+      CloudDataFeed.new.write(feed, 'profiles.jsonl')
+    end
   end
 end


### PR DESCRIPTION
### Jira link

P4-2420

### What?

Enables running each report feed for the hub and jpc on a specific date.

This change enables specifying the REPORT_ON_DATE for all or for each of
the feeds

### Why?

We need this because of a reporting error in which migrations created
updates to every profile in the profiles table in production. We need to
rerun the report feeds that failed to generate for the relevant date.
