### PR TITLE
Removes negation prefixing on one of the enum options on incidents

### DIFF
--- a/app/models/generic_event/incident.rb
+++ b/app/models/generic_event/incident.rb
@@ -7,7 +7,7 @@ class GenericEvent
       child.relationship_attributes :location_id
       child.eventable_types 'Move', 'Person'
       child.enum fault_classification: {
-        not_supplier: 'not_supplier',
+        was_not_supplier: 'was_not_supplier',
         supplier: 'supplier',
         investigation: 'investigation',
       }

--- a/spec/support/an_event_about_an_incident.rb
+++ b/spec/support/an_event_about_an_incident.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'an event about an incident' do
 
   let(:fault_classifications) do
     %w[
-      not_supplier
+      was_not_supplier
       supplier
       investigation
     ]


### PR DESCRIPTION
The incident enum was causing a warning when eager loading in the rails
console on production. Declutter the console output to be a good boy
scout

https://blog.bigbinary.com/2019/03/06/rails-6-adds-negative-scopes-on-enum.html
