### PR TITLE
P4 2409 import hospitals

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -12,6 +12,7 @@ class Location < ApplicationRecord
   LOCATION_TYPE_FOREIGN_NATIONAL_PRISON = 'foreign_national_prison'
   LOCATION_TYPE_VOLUNTARY_HOSTEL = 'voluntary_hostel'
   LOCATION_TYPE_HIGH_SECURITY_HOSPITAL = 'high_security_hospital'
+  LOCATION_TYPE_HOSPITAL = 'hospital'
   LOCATION_TYPE_IMMIGRATION_DETENTION_CENTRE = 'immigration_detention_centre'
 
   enum location_type: {
@@ -26,6 +27,7 @@ class Location < ApplicationRecord
     foreign_national_prison: LOCATION_TYPE_FOREIGN_NATIONAL_PRISON,
     voluntary_hostel: LOCATION_TYPE_VOLUNTARY_HOSTEL,
     high_security_hospital: LOCATION_TYPE_HIGH_SECURITY_HOSPITAL,
+    hospital: LOCATION_TYPE_HOSPITAL,
     immigration_detention_centre: LOCATION_TYPE_IMMIGRATION_DETENTION_CENTRE,
   }
 
@@ -41,6 +43,7 @@ class Location < ApplicationRecord
     'FNP' => LOCATION_TYPE_FOREIGN_NATIONAL_PRISON,
     'HOST' => LOCATION_TYPE_VOLUNTARY_HOSTEL,
     'HSHOSP' => LOCATION_TYPE_HIGH_SECURITY_HOSPITAL,
+    'HOSPITAL' => LOCATION_TYPE_HOSPITAL,
     'IMDC' => LOCATION_TYPE_IMMIGRATION_DETENTION_CENTRE,
   }.freeze
 

--- a/app/services/moves/move_type_validator.rb
+++ b/app/services/moves/move_type_validator.rb
@@ -41,7 +41,7 @@ module Moves
     end
 
     def validate_hospital_to_location
-      record.errors.add(:to_location, "must be a high security hospital location for #{human_move_type} move") unless record.to_location&.high_security_hospital?
+      record.errors.add(:to_location, "must be a hospital or high security hospital location for #{human_move_type} move") unless record.to_location&.high_security_hospital? || record.to_location&.hospital?
     end
 
     def validate_not_detained_to_location

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -24,11 +24,18 @@ FactoryBot.define do
       nomis_agency_id { 'GUICCT' }
     end
 
-    trait :hospital do
+    trait :high_security_hospital do
       sequence(:key) { |x| "secure_hospital_#{x}" }
       title { "#{Faker::Address.city} Secure Hospital" }
       location_type { Location::LOCATION_TYPE_HIGH_SECURITY_HOSPITAL }
       nomis_agency_id { 'GUISH' }
+    end
+
+    trait :hospital do
+      sequence(:key) { |x| "hospital_#{x}" }
+      title { "#{Faker::Address.city} Hospital" }
+      location_type { Location::LOCATION_TYPE_HOSPITAL }
+      nomis_agency_id { 'GUIHOSP' }
     end
 
     trait :police do

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -52,7 +52,7 @@ FactoryBot.define do
     trait :hospital do
       move_type { 'hospital' }
       association(:from_location, :police, factory: :location)
-      association(:to_location, :hospital, factory: :location)
+      association(:to_location, :high_security_hospital, factory: :location)
     end
 
     # Move statuses

--- a/spec/fixtures/files/nomis/get_locations_200.json
+++ b/spec/fixtures/files/nomis/get_locations_200.json
@@ -58,5 +58,10 @@
     "agencyId":"DRP1",
     "description":"An example DRP",
     "agencyType":"DRRPROV"
+  },
+  {
+    "agencyId":"HOSP1",
+    "description":"An example hospital",
+    "agencyType":"HOSPITAL"
   }
 ]

--- a/spec/lib/nomis_client/locations_spec.rb
+++ b/spec/lib/nomis_client/locations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NomisClient::Locations, with_nomis_client_authentication: true do
     let(:response_body) { file_fixture('nomis/get_locations_200.json').read }
 
     it 'has the correct number of results' do
-      expect(response.count).to eq 11
+      expect(response.count).to eq 12
     end
 
     it 'returns POLICE agencies' do
@@ -21,6 +21,11 @@ RSpec.describe NomisClient::Locations, with_nomis_client_authentication: true do
     it 'returns the correct data for the first COURT match' do
       expect(response[3])
         .to eq(key: 'abdrct', nomis_agency_id: 'ABDRCT', title: 'Aberdare County Court', location_type: 'court', can_upload_documents: false)
+    end
+
+    it 'returns the correct data for the first HOSPITAL match' do
+      expect(response[11])
+          .to eq(key: 'hosp1', nomis_agency_id: 'HOSP1', title: 'An example hospital', location_type: 'hospital', can_upload_documents: false)
     end
 
     it 'does not return locations with unwanted agency types' do

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Api::MoveEventsController do
           let(:errors_422) do
             [{
               'title' => 'Unprocessable entity',
-              'detail' => 'To location must be a high security hospital location for hospital move',
+              'detail' => 'To location must be a hospital or high security hospital location for hospital move',
             }]
           end
         end

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Api::MoveEventsController do
 
     context 'with a hospital move' do
       let(:move) { create(:move, :hospital) }
-      let(:new_location) { create(:location, :hospital) }
+      let(:new_location) { create(:location, :high_security_hospital) }
 
       it 'updates the move to_location' do
         expect(move.reload.to_location).to eql(new_location)

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Api::MovesController do
 
       context 'with explicit court_other `move_type`' do
         let(:move_attributes) { attributes_for(:move, move_type: 'court_other') }
-        let(:to_location) { create :location, :hospital, suppliers: [supplier] }
+        let(:to_location) { create :location, :high_security_hospital, suppliers: [supplier] }
 
         it_behaves_like 'an endpoint that responds with success 201' do
           before { post_moves }
@@ -297,7 +297,7 @@ RSpec.describe Api::MovesController do
 
       context 'with explicit hospital `move_type`' do
         let(:move_attributes) { attributes_for(:move, move_type: 'hospital') }
-        let(:to_location) { create :location, :hospital, suppliers: [supplier] }
+        let(:to_location) { create :location, :high_security_hospital, suppliers: [supplier] }
 
         it_behaves_like 'an endpoint that responds with success 201' do
           before { post_moves }

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe Api::MovesController do
 
     context 'with explicit court_other `move_type`' do
       let(:move_attributes) { attributes_for(:move, move_type: 'court_other') }
-      let(:to_location) { create :location, :hospital, suppliers: [supplier] }
+      let(:to_location) { create :location, :high_security_hospital, suppliers: [supplier] }
 
       it_behaves_like 'an endpoint that responds with success 201' do
         before { do_post }
@@ -311,7 +311,7 @@ RSpec.describe Api::MovesController do
 
     context 'with explicit hospital `move_type`' do
       let(:move_attributes) { attributes_for(:move, move_type: 'hospital') }
-      let(:to_location) { create :location, :hospital, suppliers: [supplier] }
+      let(:to_location) { create :location, :high_security_hospital, suppliers: [supplier] }
 
       it_behaves_like 'an endpoint that responds with success 201' do
         before { do_post }

--- a/spec/services/moves/move_type_validator_spec.rb
+++ b/spec/services/moves/move_type_validator_spec.rb
@@ -74,15 +74,20 @@ RSpec.describe Moves::MoveTypeValidator do
       expect(target).to be_valid
     end
 
+    it 'validates `to_location` is a hospital' do
+      target.to_location = build(:location, :hospital)
+      expect(target).to be_valid
+    end
+
     it 'validates `to_location` is not nil' do
       target.to_location = nil
       expect(target).not_to be_valid
     end
 
-    it 'has an error if `to_location` is not a high security hospital' do
+    it 'has an error if `to_location` is not a high security hospital or hospital' do
       target.to_location = build(:location, :court)
       expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
-      expect(target.errors[:to_location]).to match_array('must be a high security hospital location for hospital move')
+      expect(target.errors[:to_location]).to match_array('must be a hospital or high security hospital location for hospital move')
     end
   end
 

--- a/spec/services/moves/move_type_validator_spec.rb
+++ b/spec/services/moves/move_type_validator_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Moves::MoveTypeValidator do
     let(:move_type) { 'hospital' }
 
     it 'validates `to_location` is a high_security_hospital' do
-      target.to_location = build(:location, :hospital)
+      target.to_location = build(:location, :high_security_hospital)
       expect(target).to be_valid
     end
 

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -3105,6 +3105,7 @@
               - community_rehabilitation_company
               - foreign_national_prison
               - voluntary_hostel
+              - hospital
               - high_security_hospital
               - immigration_detention_centre
         - name: filter[nomis_agency_id]

--- a/swagger/v1/location.yaml
+++ b/swagger/v1/location.yaml
@@ -41,6 +41,7 @@ Location:
           - community_rehabilitation_company
           - foreign_national_prison
           - voluntary_hostel
+          - hospital
           - high_security_hospital
           - immigration_detention_centre
           example: court


### PR DESCRIPTION
### Jira link

P4-2409

### What?

I have added/removed/altered:

- [x] Add hospital location type

### Why?

I am doing this because:

- so we can import hospitals


### Deployment risks (optional)

- TODO: run `rake reference_data:create_locations` on all environments after deployment

