### PR TITLE
Use created_at field in range query when retrieving immutable resources

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,7 +3,9 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  include UpdatedAtRange
+  scope :created_at_range, ->(from, to) { where(created_at: from..to) }
+  scope :updated_at_range, ->(from, to) { where(updated_at: from..to) }
+
   class << self
     def retriable_transaction(**options, &block)
       retried ||= false

--- a/app/models/concerns/updated_at_range.rb
+++ b/app/models/concerns/updated_at_range.rb
@@ -1,9 +1,0 @@
-module UpdatedAtRange
-  extend ActiveSupport::Concern
-
-  included do
-    scope :updated_at_range, lambda { |from, to|
-      where(updated_at: from..to)
-    }
-  end
-end

--- a/app/services/feeds/event.rb
+++ b/app/services/feeds/event.rb
@@ -1,14 +1,14 @@
 module Feeds
   class Event
-    def initialize(updated_at_from = nil, updated_at_to = nil)
-      @updated_at_from = updated_at_from || Time.zone.yesterday.beginning_of_day
-      @updated_at_to = updated_at_to || Time.zone.yesterday.end_of_day
+    def initialize(created_at_from = nil, created_at_to = nil)
+      @created_at_from = created_at_from || Time.zone.yesterday.beginning_of_day
+      @created_at_to = created_at_to || Time.zone.yesterday.end_of_day
 
       @feed = []
     end
 
     def call
-      ::GenericEvent.includes(:eventable).updated_at_range(@updated_at_from, @updated_at_to).find_each do |event|
+      ::GenericEvent.includes(:supplier).created_at_range(@created_at_from, @created_at_to).find_each do |event|
         @feed << event.for_feed.to_json
       end
 

--- a/app/services/feeds/notification.rb
+++ b/app/services/feeds/notification.rb
@@ -1,14 +1,14 @@
 module Feeds
   class Notification
-    def initialize(updated_at_from = nil, updated_at_to = nil)
-      @updated_at_from = updated_at_from || Time.zone.yesterday.beginning_of_day
-      @updated_at_to = updated_at_to || Time.zone.yesterday.end_of_day
+    def initialize(created_at_from = nil, created_at_to = nil)
+      @created_at_from = created_at_from || Time.zone.yesterday.beginning_of_day
+      @created_at_to = created_at_to || Time.zone.yesterday.end_of_day
 
       @feed = []
     end
 
     def call
-      ::Notification.includes(:notification_type).updated_at_range(@updated_at_from, @updated_at_to).find_each do |notification|
+      ::Notification.created_at_range(@created_at_from, @created_at_to).find_each do |notification|
         @feed << notification.for_feed.to_json
       end
 

--- a/lib/tasks/feeds/event.rake
+++ b/lib/tasks/feeds/event.rake
@@ -3,34 +3,14 @@ namespace :feeds do
   task event: :environment do
     if ENV['REPORT_ON_DATE']
       report_on_date = Date.parse(ENV['REPORT_ON_DATE'])
-      updated_at_from = report_on_date.beginning_of_day
-      updated_at_to = report_on_date.end_of_day
+      created_at_from = report_on_date.beginning_of_day
+      created_at_to = report_on_date.end_of_day
 
-      feed = Feeds::Event.new(updated_at_from, updated_at_to).call
+      feed = Feeds::Event.new(created_at_from, created_at_to).call
       CloudDataFeed.new.write(feed, 'events.jsonl', report_on_date)
     else
       feed = Feeds::Event.new.call
       CloudDataFeed.new.write(feed, 'events.jsonl')
-    end
-  end
-
-  desc 'Exports the JSON starting from a certain date (inclusive)'
-  task events_from_date: :environment do
-    start_date_param = ENV.fetch('START_DATE', nil)
-
-    unless start_date_param
-      puts 'Please specify the START_DATE ENV variable.'
-      puts 'for example: START_DATE="2020-08-29"'
-      return
-    end
-
-    start_date = Date.parse(start_date_param)
-
-    (start_date..Time.zone.today).each do |day|
-      puts "Processing day #{day}"
-      feed = Feeds::Event.new(day.beginning_of_day, day.end_of_day).call
-
-      CloudDataFeed.new.write(feed, 'events.jsonl', day)
     end
   end
 end

--- a/lib/tasks/feeds/notification.rake
+++ b/lib/tasks/feeds/notification.rake
@@ -3,10 +3,10 @@ namespace :feeds do
   task notification: :environment do
     if ENV['REPORT_ON_DATE']
       report_on_date = Date.parse(ENV['REPORT_ON_DATE'])
-      updated_at_from = report_on_date.beginning_of_day
-      updated_at_to = report_on_date.end_of_day
+      created_at_from = report_on_date.beginning_of_day
+      created_at_to = report_on_date.end_of_day
 
-      feed = Feeds::Notification.new(updated_at_from, updated_at_to).call
+      feed = Feeds::Notification.new(created_at_from, created_at_to).call
 
       CloudDataFeed.new.write(feed, 'notifications.jsonl', report_on_date)
     else

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -74,4 +74,36 @@ RSpec.describe GenericEvent, type: :model do
       expect(described_class.from_event(event)).to be_a(GenericEvent::JourneyCancel)
     end
   end
+
+  describe '.updated_at_range scope' do
+    let(:updated_at_from) { Time.zone.yesterday.beginning_of_day }
+    let(:updated_at_to) { Time.zone.yesterday.end_of_day }
+
+    it 'returns the expected events' do
+      create(:event_move_cancel, updated_at: updated_at_from - 1.second)
+      create(:event_move_accept, updated_at: updated_at_to + 1.second)
+      on_start_event = create(:event_move_approve, updated_at: updated_at_from)
+      on_end_event = create(:event_move_start, updated_at: updated_at_to)
+
+      actual_events = described_class.updated_at_range(updated_at_from, updated_at_to)
+
+      expect(actual_events).to eq([on_start_event, on_end_event])
+    end
+  end
+
+  describe '.created_at_range scope' do
+    let(:created_at_from) { Time.zone.yesterday.beginning_of_day }
+    let(:created_at_to) { Time.zone.yesterday.end_of_day }
+
+    it 'returns the expected events' do
+      create(:event_move_cancel, created_at: created_at_from - 1.second)
+      create(:event_move_accept, created_at: created_at_to + 1.second)
+      on_start_event = create(:event_move_approve, created_at: created_at_from)
+      on_end_event = create(:event_move_start, created_at: created_at_to)
+
+      actual_events = described_class.created_at_range(created_at_from, created_at_to)
+
+      expect(actual_events).to eq([on_start_event, on_end_event])
+    end
+  end
 end

--- a/spec/services/feeds/event_spec.rb
+++ b/spec/services/feeds/event_spec.rb
@@ -1,20 +1,20 @@
 RSpec.describe Feeds::Event do
-  subject(:feed) { described_class.new(updated_at_from, updated_at_to) }
+  subject(:feed) { described_class.new(created_at_from, created_at_to) }
 
-  let(:updated_at_from) { Time.zone.now.beginning_of_day - 1.day }
-  let(:updated_at_to) { Time.zone.now.end_of_day - 1.day }
+  let(:created_at_from) { Time.zone.now.beginning_of_day - 1.day }
+  let(:created_at_to) { Time.zone.now.end_of_day - 1.day }
 
   describe '#call' do
-    let!(:on_start_event) { create(:event_move_cancel, updated_at: updated_at_from) }
-    let!(:on_end_event) { create(:event_journey_cancel, updated_at: updated_at_to) }
+    let!(:on_start_event) { create(:event_move_cancel, created_at: created_at_from) }
+    let!(:on_end_event) { create(:event_journey_cancel, created_at: created_at_to) }
 
     let(:expected_json) do
       [on_start_event, on_end_event].sort_by(&:id).map { |event| JSON.parse(event.for_feed.to_json) }
     end
 
     it 'returns correctly formatted feed' do
-      on_start_event.update(updated_at: updated_at_from)
-      on_end_event.update(updated_at: updated_at_to)
+      on_start_event.update(created_at: created_at_from)
+      on_end_event.update(created_at: created_at_to)
       actual = feed.call.split("\n").map { |event| JSON.parse(event) }
       expect(actual).to include_json(expected_json)
     end

--- a/spec/services/feeds/notification_spec.rb
+++ b/spec/services/feeds/notification_spec.rb
@@ -1,20 +1,20 @@
 RSpec.describe Feeds::Notification do
-  subject(:feed) { described_class.new(updated_at_from, updated_at_to) }
+  subject(:feed) { described_class.new(created_at_from, created_at_to) }
 
-  let(:updated_at_from) { Time.zone.now.beginning_of_day - 1.day }
-  let(:updated_at_to) { Time.zone.now.end_of_day - 1.day }
+  let(:created_at_from) { Time.zone.now.beginning_of_day - 1.day }
+  let(:created_at_to) { Time.zone.now.end_of_day - 1.day }
 
   describe '#call' do
-    let!(:on_start_notification) { create(:notification, updated_at: updated_at_from) }
-    let!(:on_end_notification) { create(:notification, updated_at: updated_at_to) }
+    let!(:on_start_notification) { create(:notification, created_at: created_at_from) }
+    let!(:on_end_notification) { create(:notification, created_at: created_at_to) }
 
     let(:expected_json) do
       [on_start_notification, on_end_notification].sort_by(&:id).map { |notification| JSON.parse(notification.for_feed.to_json) }
     end
 
     it 'returns correctly formatted feed' do
-      on_start_notification.update(updated_at: updated_at_from)
-      on_end_notification.update(updated_at: updated_at_to)
+      on_start_notification.update(created_at: created_at_from)
+      on_end_notification.update(created_at: created_at_to)
       actual = feed.call.split("\n").map { |notification| JSON.parse(notification) }
       expect(actual).to include_json(expected_json)
     end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

Notification and Event resources can reasonably be expected not to
change once they've been created.

We should control for these resources being in the feed using the
created_at rather than the updated_at since arbitrary updates to these
records might result from rake task migrations, etc, creating a large amount of data in the feed for that day.

- [x] Add created_at scope
- [x] Simplify scope adding to ApplicationRecord
- [x] Move to using created at for Notification feed
- [x] Move to using created at for Event feed

### Why?

This is one way in which we can protect ourselves from large numbers of updates to the feed for these resources.