### PR TITLE
Add schema migration and model for categories

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Category < ApplicationRecord
+  has_many :locations
+  has_many :profiles
+
+  validates :key, presence: true, uniqueness: true
+  validates :title, presence: true
+  validates :move_supported, presence: true
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -49,6 +49,7 @@ class Location < ApplicationRecord
 
   NOMIS_TYPES_WITH_DOCUMENTS = %w[STC SCH].freeze
 
+  belongs_to :category, optional: true
   has_many :supplier_locations
   has_many :suppliers, through: :supplier_locations
   has_and_belongs_to_many :regions

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -24,6 +24,8 @@ class Profile < VersionedModel
 
   before_validation :set_assessment_answers
 
+  # TODO: uncomment this when category attribute is removed from model
+  # belongs_to :category, optional: true
   belongs_to :person, touch: true
 
   has_many :moves, dependent: :nullify

--- a/db/migrate/20201030095815_create_categories.rb
+++ b/db/migrate/20201030095815_create_categories.rb
@@ -1,0 +1,14 @@
+class CreateCategories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :categories, id: :uuid do |t|
+      t.string :key, null: false
+      t.string :title, null: false
+      t.boolean :move_supported, null: false
+      t.timestamps
+    end
+    add_index :categories, :key, unique: true
+
+    add_reference :locations, :category, type: :uuid, foreign_key: true, index: true
+    add_reference :profiles, :category, type: :uuid, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_22_072140) do
+ActiveRecord::Schema.define(version: 2020_10_30_095815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -73,6 +73,15 @@ ActiveRecord::Schema.define(version: 2020_10_22_072140) do
     t.datetime "updated_at", null: false
     t.string "key", null: false
     t.datetime "disabled_at"
+  end
+
+  create_table "categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "key", null: false
+    t.string "title", null: false
+    t.boolean "move_supported", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["key"], name: "index_categories_on_key", unique: true
   end
 
   create_table "court_hearings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -309,6 +318,8 @@ ActiveRecord::Schema.define(version: 2020_10_22_072140) do
     t.string "key", null: false
     t.datetime "disabled_at"
     t.boolean "can_upload_documents", default: false, null: false
+    t.uuid "category_id"
+    t.index ["category_id"], name: "index_locations_on_category_id"
   end
 
   create_table "locations_regions", id: false, force: :cascade do |t|
@@ -531,7 +542,9 @@ ActiveRecord::Schema.define(version: 2020_10_22_072140) do
     t.integer "latest_nomis_booking_id"
     t.string "category"
     t.string "category_code"
+    t.uuid "category_id"
     t.index ["category_code"], name: "index_profiles_on_category_code"
+    t.index ["category_id"], name: "index_profiles_on_category_id"
     t.index ["updated_at"], name: "index_profiles_on_updated_at"
   end
 
@@ -605,6 +618,7 @@ ActiveRecord::Schema.define(version: 2020_10_22_072140) do
   add_foreign_key "journeys", "locations", column: "to_location_id"
   add_foreign_key "journeys", "moves"
   add_foreign_key "journeys", "suppliers"
+  add_foreign_key "locations", "categories"
   add_foreign_key "locations_regions", "locations"
   add_foreign_key "locations_regions", "regions"
   add_foreign_key "moves", "allocations"
@@ -620,6 +634,7 @@ ActiveRecord::Schema.define(version: 2020_10_22_072140) do
   add_foreign_key "person_escort_records", "moves"
   add_foreign_key "person_escort_records", "profiles"
   add_foreign_key "populations", "locations"
+  add_foreign_key "profiles", "categories"
   add_foreign_key "profiles", "people", name: "profiles_person_id"
   add_foreign_key "subscriptions", "suppliers"
   add_foreign_key "supplier_locations", "locations"

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :category do
+    sequence(:key) { |x| "key_#{x}" }
+    title { "Category #{Faker::Alphanumeric.alpha(number: 1)}" }
+    move_supported { true }
+
+    trait :not_supported do
+      move_supported { false }
+    end
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Category do
+  subject(:category) { build(:category) }
+
+  it { is_expected.to have_many(:locations) }
+  it { is_expected.to have_many(:profiles) }
+
+  it { is_expected.to validate_presence_of(:key) }
+  it { is_expected.to validate_uniqueness_of(:key) }
+  it { is_expected.to validate_presence_of(:title) }
+  it { is_expected.to validate_presence_of(:move_supported) }
+end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Location do
+  it { is_expected.to belong_to(:category).optional }
   it { is_expected.to have_many(:supplier_locations) }
   it { is_expected.to have_many(:suppliers).through(:supplier_locations) }
   it { is_expected.to have_many(:moves_from) }

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Profile, type: :model do
+  xit { is_expected.to belong_to(:category).optional }
   it { is_expected.to belong_to(:person).required }
   it { is_expected.to have_many(:documents) }
   it { is_expected.to have_many(:moves) } # NB: a profile can be re-used across multiple moves


### PR DESCRIPTION
### Jira link

P4-2416 P4-1421

### What?

- [x] Create category table and associated model, factory, specs.
- [x] Add relationship between category and locations, profiles.

### Why?

- This will be used to determine prisoner category (via profile) in order to block moving category A prisoners. It will also be used to provide a breakdown by prison (location) category in the PMU dashboards. This PR adds a skeleton implementation of the model for now to unblock work on both streams.

See also: https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1090

### Have you? (optional)

- [ ] Updated API docs if necessary - Not in this PR, will come when associated endpoints are added/updated

### Deployment risks (optional)

- Changes data structures but new relationships are optional so do not effect existing behaviour

