### PR TITLE
[P4-2422] Surface event relationships: part 1

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -107,6 +107,19 @@ class GenericEvent < ApplicationRecord
     feed
   end
 
+  def relationships
+    return {} unless self.class.instance_variable_defined?(:@relationship_attributes)
+
+    self.class.relationship_attributes.each_with_object({}) do |(attribute_key, attribute_type), acc|
+      id = details[attribute_key]
+      named_relationship_key = attribute_key.to_s.sub('_id', '')
+
+      next if id.blank?
+
+      acc[named_relationship_key] = { type: attribute_type, id: id }
+    end
+  end
+
   def self.from_event(event)
     type = "GenericEvent::#{event.eventable_type}#{event.event_name.capitalize}"
 
@@ -133,19 +146,27 @@ class GenericEvent < ApplicationRecord
 
   # Relationship attributes live against the details but are expected in the json:api relationship section
   # so are defined separately
-  def self.relationship_attributes(*attributes)
+  def self.relationship_attributes(attributes)
     define_singleton_method(:relationship_attributes) do
       instance_variable_get('@relationship_attributes')
     end
     instance_variable_set('@relationship_attributes', attributes)
 
-    attributes.each do |attribute_key|
+    attributes.each do |attribute_key, attribute_type|
+      named_relationship_key = attribute_key.to_s.sub('_id', '')
+
       define_method(attribute_key) do
         details[attribute_key]
       end
 
       define_method("#{attribute_key}=") do |attribute_value|
         details[attribute_key] = attribute_value
+      end
+
+      define_method(named_relationship_key) do
+        id = details[attribute_key]
+        model = attribute_type.to_s.singularize.camelize
+        model.constantize.find_by(id: id)
       end
     end
   end

--- a/app/models/generic_event/incident.rb
+++ b/app/models/generic_event/incident.rb
@@ -4,7 +4,7 @@ class GenericEvent
 
     def self.inherited(child)
       child.details_attributes :supplier_personnel_numbers, :vehicle_reg, :reported_at, :fault_classification
-      child.relationship_attributes :location_id
+      child.relationship_attributes location_id: :locations
       child.eventable_types 'Move', 'Person'
       child.enum fault_classification: {
         was_not_supplier: 'was_not_supplier',

--- a/app/models/generic_event/journey_lockout.rb
+++ b/app/models/generic_event/journey_lockout.rb
@@ -2,14 +2,10 @@ class GenericEvent
   class JourneyLockout < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :from_location_id
 
-    relationship_attributes :from_location_id
+    relationship_attributes from_location_id: :locations
 
     include JourneyEventValidations
     include LocationValidations
-
-    def from_location
-      Location.find_by(id: from_location_id)
-    end
 
     def for_feed
       super.tap do |common_feed_attributes|

--- a/app/models/generic_event/journey_lodging.rb
+++ b/app/models/generic_event/journey_lodging.rb
@@ -2,14 +2,10 @@ class GenericEvent
   class JourneyLodging < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :to_location_id
 
-    relationship_attributes :to_location_id
+    relationship_attributes to_location_id: :locations
 
     include JourneyEventValidations
     include LocationValidations
-
-    def to_location
-      Location.find_by(id: to_location_id)
-    end
 
     def for_feed
       super.tap do |common_feed_attributes|

--- a/app/models/generic_event/move_cross_supplier_pick_up.rb
+++ b/app/models/generic_event/move_cross_supplier_pick_up.rb
@@ -1,6 +1,6 @@
 class GenericEvent
   class MoveCrossSupplierPickUp < GenericEvent
-    relationship_attributes :previous_move_id
+    relationship_attributes previous_move_id: :moves
     eventable_types 'Move'
 
     validates_each :previous_move_id do |_record, _attr, value|

--- a/app/models/generic_event/move_lockout.rb
+++ b/app/models/generic_event/move_lockout.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :from_location_id
 
     details_attributes :authorised_at, :authorised_by, :reason
-    relationship_attributes :from_location_id
+    relationship_attributes from_location_id: :locations
 
     include MoveEventValidations
     include AuthoriserValidations

--- a/app/models/generic_event/move_lodging_end.rb
+++ b/app/models/generic_event/move_lodging_end.rb
@@ -2,7 +2,7 @@ class GenericEvent
   class MoveLodgingEnd < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include MoveEventValidations
     include LocationValidations

--- a/app/models/generic_event/move_lodging_start.rb
+++ b/app/models/generic_event/move_lodging_start.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :reason
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include MoveEventValidations
     include LocationValidations

--- a/app/models/generic_event/move_redirect.rb
+++ b/app/models/generic_event/move_redirect.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :to_location_id
 
     details_attributes :move_type, :reason
-    relationship_attributes :to_location_id
+    relationship_attributes to_location_id: :locations
 
     enum reason: {
       no_space: 'no_space',
@@ -18,10 +18,6 @@ class GenericEvent
     include LocationValidations
 
     validates :reason, inclusion: { in: reasons }, if: -> { reason.present? }
-
-    def to_location
-      Location.find_by(id: to_location_id)
-    end
 
     def trigger
       eventable.to_location = to_location

--- a/app/models/generic_event/per_court_all_documentation_provided_to_supplier.rb
+++ b/app/models/generic_event/per_court_all_documentation_provided_to_supplier.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :court_location_id
 
     details_attributes :subtype
-    relationship_attributes :court_location_id
+    relationship_attributes court_location_id: :locations
 
     include PersonEscortRecordEventValidations
     include LocationValidations

--- a/app/models/generic_event/per_court_assign_cell_in_custody.rb
+++ b/app/models/generic_event/per_court_assign_cell_in_custody.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :court_cell_number
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include CourtCellValidations

--- a/app/models/generic_event/per_court_cell_share_risk_assessment.rb
+++ b/app/models/generic_event/per_court_cell_share_risk_assessment.rb
@@ -2,7 +2,7 @@ class GenericEvent
   class PerCourtCellShareRiskAssessment < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include LocationValidations

--- a/app/models/generic_event/per_court_excessive_delay_not_due_to_supplier.rb
+++ b/app/models/generic_event/per_court_excessive_delay_not_due_to_supplier.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :subtype, :vehicle_reg, :ended_at, :authorised_by, :authorised_at
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include AuthoriserValidations

--- a/app/models/generic_event/per_court_hearing.rb
+++ b/app/models/generic_event/per_court_hearing.rb
@@ -4,7 +4,7 @@ class GenericEvent
 
     details_attributes :is_virtual, :is_trial, :court_listing_at, :started_at, :ended_at, :agreed_at, :court_outcome
 
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     eventable_types 'PersonEscortRecord'
 

--- a/app/models/generic_event/per_court_pre_release_checks_completed.rb
+++ b/app/models/generic_event/per_court_pre_release_checks_completed.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :supplier_personnel_number
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include SupplierPersonnelNumberValidations

--- a/app/models/generic_event/per_court_ready_in_custody.rb
+++ b/app/models/generic_event/per_court_ready_in_custody.rb
@@ -2,7 +2,7 @@ class GenericEvent
   class PerCourtReadyInCustody < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include LocationValidations

--- a/app/models/generic_event/per_court_release.rb
+++ b/app/models/generic_event/per_court_release.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :supplier_personnel_number
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include SupplierPersonnelNumberValidations

--- a/app/models/generic_event/per_court_release_on_bail.rb
+++ b/app/models/generic_event/per_court_release_on_bail.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :supplier_personnel_number
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include SupplierPersonnelNumberValidations

--- a/app/models/generic_event/per_court_return_to_custody_area_from_dock.rb
+++ b/app/models/generic_event/per_court_return_to_custody_area_from_dock.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :court_cell_number
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include LocationValidations

--- a/app/models/generic_event/per_court_return_to_custody_area_from_visitor_area.rb
+++ b/app/models/generic_event/per_court_return_to_custody_area_from_visitor_area.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :court_cell_number
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include LocationValidations

--- a/app/models/generic_event/per_court_take_from_custody_to_dock.rb
+++ b/app/models/generic_event/per_court_take_from_custody_to_dock.rb
@@ -2,7 +2,7 @@ class GenericEvent
   class PerCourtTakeFromCustodyToDock < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include LocationValidations

--- a/app/models/generic_event/per_court_take_to_see_visitors.rb
+++ b/app/models/generic_event/per_court_take_to_see_visitors.rb
@@ -2,7 +2,7 @@ class GenericEvent
   class PerCourtTakeToSeeVisitors < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include LocationValidations

--- a/app/models/generic_event/per_court_task.rb
+++ b/app/models/generic_event/per_court_task.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :supplier_personnel_number
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include PersonEscortRecordEventValidations
     include LocationValidations

--- a/app/models/generic_event/per_medical_aid.rb
+++ b/app/models/generic_event/per_medical_aid.rb
@@ -4,7 +4,7 @@ class GenericEvent
 
     details_attributes :advised_at, :advised_by, :treated_at, :treated_by, :supplier_personnel_number, :vehicle_reg
 
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     include LocationValidations
     include PersonEscortRecordEventValidations

--- a/app/models/generic_event/per_prisoner_welfare.rb
+++ b/app/models/generic_event/per_prisoner_welfare.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :given_at, :outcome, :subtype, :vehicle_reg, :supplier_personnel_number
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
 
     enum outcome: {
       accepted: 'accepted',

--- a/app/models/generic_event/person_move_booked_into_receiving_establishment.rb
+++ b/app/models/generic_event/person_move_booked_into_receiving_establishment.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :supplier_personnel_number
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
     eventable_types 'Move', 'Person'
 
     include LocationValidations

--- a/app/models/generic_event/person_move_vehicle_broke_down.rb
+++ b/app/models/generic_event/person_move_vehicle_broke_down.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :supplier_personnel_numbers, :vehicle_reg, :reported_at, :postcode
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
     eventable_types 'Move', 'Person'
 
     include LocationValidations

--- a/app/models/generic_event/person_move_vehicle_systems_failed.rb
+++ b/app/models/generic_event/person_move_vehicle_systems_failed.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :supplier_personnel_numbers, :vehicle_reg, :reported_at, :postcode
-    relationship_attributes :location_id
+    relationship_attributes location_id: :locations
     eventable_types 'Move', 'Person'
 
     include LocationValidations

--- a/spec/models/generic_event/journey_lockout_spec.rb
+++ b/spec/models/generic_event/journey_lockout_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe GenericEvent::JourneyLockout do
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
 
-  it_behaves_like 'an event with relationships', :from_location_id
+  it_behaves_like 'an event with relationships', from_location_id: :locations
   it_behaves_like 'an event requiring a location', :from_location_id
 
   describe '#from_location' do

--- a/spec/models/generic_event/journey_lodging_spec.rb
+++ b/spec/models/generic_event/journey_lodging_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe GenericEvent::JourneyLodging do
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
 
-  it_behaves_like 'an event with relationships', :to_location_id
+  it_behaves_like 'an event with relationships', to_location_id: :locations
   it_behaves_like 'an event requiring a location', :to_location_id
 
   describe '#to_location' do

--- a/spec/models/generic_event/move_lockout_spec.rb
+++ b/spec/models/generic_event/move_lockout_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GenericEvent::MoveLockout do
   end
 
   it_behaves_like 'an event with details', :authorised_at, :authorised_by, :reason
-  it_behaves_like 'an event with relationships', :from_location_id
+  it_behaves_like 'an event with relationships', from_location_id: :locations
   it_behaves_like 'a move event'
   it_behaves_like 'an authorised event'
   it_behaves_like 'an event requiring a location', :from_location_id

--- a/spec/models/generic_event/move_lodging_end_spec.rb
+++ b/spec/models/generic_event/move_lodging_end_spec.rb
@@ -3,6 +3,6 @@ RSpec.describe GenericEvent::MoveLodgingEnd do
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Move]) }
 
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
 end

--- a/spec/models/generic_event/move_lodging_start_spec.rb
+++ b/spec/models/generic_event/move_lodging_start_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe GenericEvent::MoveLodgingStart do
   end
 
   it_behaves_like 'an event with details', :reason
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Move]) }

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GenericEvent::MoveRedirect do
   end
 
   it_behaves_like 'an event with details', :move_type, :reason
-  it_behaves_like 'an event with relationships', :to_location_id
+  it_behaves_like 'an event with relationships', to_location_id: :locations
   it_behaves_like 'a move event'
   it_behaves_like 'an event requiring a location', :to_location_id
 

--- a/spec/models/generic_event/per_court_all_documentation_provided_to_supplier_spec.rb
+++ b/spec/models/generic_event/per_court_all_documentation_provided_to_supplier_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GenericEvent::PerCourtAllDocumentationProvidedToSupplier do
   end
 
   it_behaves_like 'an event with details', :subtype
-  it_behaves_like 'an event with relationships', :court_location_id
+  it_behaves_like 'an event with relationships', court_location_id: :locations
   it_behaves_like 'an event requiring a location', :court_location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }

--- a/spec/models/generic_event/per_court_assign_cell_in_custody_spec.rb
+++ b/spec/models/generic_event/per_court_assign_cell_in_custody_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GenericEvent::PerCourtAssignCellInCustody do
   subject(:generic_event) { build(:event_per_court_assign_cell_in_custody) }
 
   it_behaves_like 'an event with details', :court_cell_number
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }

--- a/spec/models/generic_event/per_court_cell_share_risk_assessment_spec.rb
+++ b/spec/models/generic_event/per_court_cell_share_risk_assessment_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe GenericEvent::PerCourtCellShareRiskAssessment do
   subject(:generic_event) { build(:event_per_court_cell_share_risk_assessment) }
 
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }

--- a/spec/models/generic_event/per_court_excessive_delay_not_due_to_supplier_spec.rb
+++ b/spec/models/generic_event/per_court_excessive_delay_not_due_to_supplier_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GenericEvent::PerCourtExcessiveDelayNotDueToSupplier do
   end
 
   it_behaves_like 'an event with details', :subtype, :vehicle_reg, :ended_at, :authorised_by, :authorised_at
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }

--- a/spec/models/generic_event/per_court_hearing_spec.rb
+++ b/spec/models/generic_event/per_court_hearing_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GenericEvent::PerCourtHearing do
   subject(:generic_event) { build(:event_per_court_hearing) }
 
   it_behaves_like 'an event with details', :is_virtual, :is_trial, :court_listing_at, :started_at, :ended_at, :agreed_at, :court_outcome
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event with eventable types', 'PersonEscortRecord'
   it_behaves_like 'an event requiring a location', :location_id
 

--- a/spec/models/generic_event/per_court_pre_release_checks_completed_spec.rb
+++ b/spec/models/generic_event/per_court_pre_release_checks_completed_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GenericEvent::PerCourtPreReleaseChecksCompleted do
   subject(:generic_event) { build(:event_per_court_pre_release_checks_completed) }
 
   it_behaves_like 'an event with details', :supplier_personnel_number
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
 

--- a/spec/models/generic_event/per_court_ready_in_custody_spec.rb
+++ b/spec/models/generic_event/per_court_ready_in_custody_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe GenericEvent::PerCourtReadyInCustody do
   subject(:generic_event) { build(:event_per_court_ready_in_custody) }
 
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }

--- a/spec/models/generic_event/per_court_release_on_bail_spec.rb
+++ b/spec/models/generic_event/per_court_release_on_bail_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GenericEvent::PerCourtReleaseOnBail do
   subject(:generic_event) { build(:event_per_court_release_on_bail) }
 
   it_behaves_like 'an event with details', :supplier_personnel_number
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
 

--- a/spec/models/generic_event/per_court_release_spec.rb
+++ b/spec/models/generic_event/per_court_release_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GenericEvent::PerCourtRelease do
   subject(:generic_event) { build(:event_per_court_release) }
 
   it_behaves_like 'an event with details', :supplier_personnel_number
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
 

--- a/spec/models/generic_event/per_court_return_to_custody_area_from_dock_spec.rb
+++ b/spec/models/generic_event/per_court_return_to_custody_area_from_dock_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GenericEvent::PerCourtReturnToCustodyAreaFromDock do
   end
 
   it_behaves_like 'an event with details', :court_cell_number
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }

--- a/spec/models/generic_event/per_court_return_to_custody_area_from_visitor_area_spec.rb
+++ b/spec/models/generic_event/per_court_return_to_custody_area_from_visitor_area_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GenericEvent::PerCourtReturnToCustodyAreaFromVisitorArea do
   end
 
   it_behaves_like 'an event with details', :court_cell_number
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }

--- a/spec/models/generic_event/per_court_take_from_custody_to_dock_spec.rb
+++ b/spec/models/generic_event/per_court_take_from_custody_to_dock_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe GenericEvent::PerCourtTakeFromCustodyToDock do
   subject(:generic_event) { build(:event_per_court_take_from_custody_to_dock) }
 
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }

--- a/spec/models/generic_event/per_court_take_to_see_visitors_spec.rb
+++ b/spec/models/generic_event/per_court_take_to_see_visitors_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe GenericEvent::PerCourtTakeToSeeVisitors do
   subject(:generic_event) { build(:event_per_court_take_to_see_visitors) }
 
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }

--- a/spec/models/generic_event/per_court_task_spec.rb
+++ b/spec/models/generic_event/per_court_task_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GenericEvent::PerCourtTask do
   subject(:generic_event) { build(:event_per_court_task) }
 
   it_behaves_like 'an event with details', :supplier_personnel_number
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
 

--- a/spec/models/generic_event/per_medical_aid_spec.rb
+++ b/spec/models/generic_event/per_medical_aid_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GenericEvent::PerMedicalAid do
   subject(:generic_event) { build(:event_per_medical_aid) }
 
   it_behaves_like 'an event with details', :advised_at, :advised_by, :treated_at, :treated_by, :supplier_personnel_number, :vehicle_reg
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
 

--- a/spec/models/generic_event/per_prisoner_welfare_spec.rb
+++ b/spec/models/generic_event/per_prisoner_welfare_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GenericEvent::PerPrisonerWelfare do
   end
 
   it_behaves_like 'an event with details', :given_at, :outcome, :subtype, :vehicle_reg, :supplier_personnel_number
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
 

--- a/spec/models/generic_event/person_move_booked_into_receiving_establishment_spec.rb
+++ b/spec/models/generic_event/person_move_booked_into_receiving_establishment_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GenericEvent::PersonMoveBookedIntoReceivingEstablishment do
   subject(:generic_event) { build(:event_person_move_booked_into_receiving_establishment) }
 
   it_behaves_like 'an event with details', :supplier_personnel_number
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event with eventable types', 'Person', 'Move'
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'

--- a/spec/models/generic_event/person_move_vehicle_broke_down_spec.rb
+++ b/spec/models/generic_event/person_move_vehicle_broke_down_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GenericEvent::PersonMoveVehicleBrokeDown do
   subject(:generic_event) { build(:event_person_move_vehicle_broke_down) }
 
   it_behaves_like 'an event with details', :supplier_personnel_numbers, :vehicle_reg, :reported_at, :postcode
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event with eventable types', 'Person', 'Move'
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event that specifies a vehicle registration'

--- a/spec/models/generic_event/person_move_vehicle_systems_failed_spec.rb
+++ b/spec/models/generic_event/person_move_vehicle_systems_failed_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe GenericEvent::PersonMoveVehicleSystemsFailed do
   subject(:generic_event) { build(:event_person_move_vehicle_systems_failed) }
 
   it_behaves_like 'an event with details', :supplier_personnel_numbers, :vehicle_reg, :reported_at, :postcode
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event with eventable types', 'Person', 'Move'
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event that specifies a vehicle registration'

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -44,6 +44,36 @@ RSpec.describe GenericEvent, type: :model do
     end
   end
 
+  describe '#relationships' do
+    context 'when the event defines relationships' do
+      subject(:generic_event) { build(:event_move_redirect) }
+
+      it 'returns the correct json:api relationships' do
+        expect(generic_event.relationships).to eq('to_location' => { type: :locations, id: generic_event.details['to_location_id'] })
+      end
+    end
+
+    context 'when the event does not define relationships' do
+      subject(:generic_event) { build(:event_move_cancel) }
+
+      it 'returns no relationships' do
+        expect(generic_event.relationships).to eq({})
+      end
+    end
+
+    context 'when the event defines relationships that are missing from the details' do
+      subject(:generic_event) { build(:event_move_redirect) }
+
+      before do
+        generic_event.details.delete(:to_location_id)
+      end
+
+      it 'returns no relationships' do
+        expect(generic_event.relationships).to eq({})
+      end
+    end
+  end
+
   describe '#for_feed' do
     subject(:generic_event) { create(:event_move_cancel, supplier: create(:supplier, key: 'serco')) }
 

--- a/spec/support/an_event_about_an_incident.rb
+++ b/spec/support/an_event_about_an_incident.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples 'an event about an incident' do
   it_behaves_like 'an event with details', :supplier_personnel_numbers, :vehicle_reg, :reported_at, :fault_classification
-  it_behaves_like 'an event with relationships', :location_id
+  it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event with eventable types', 'Person', 'Move'
   it_behaves_like 'an event requiring a location', :location_id
 

--- a/spec/support/an_event_with_relationships.rb
+++ b/spec/support/an_event_with_relationships.rb
@@ -1,7 +1,7 @@
-RSpec.shared_examples 'an event with relationships' do |*attributes|
+RSpec.shared_examples 'an event with relationships' do |attributes|
   describe '.relationship_attributes' do
     it 'sets the correct attributes' do
-      expect(described_class.relationship_attributes).to contain_exactly(*attributes)
+      expect(described_class.relationship_attributes).to eq(attributes)
     end
   end
 end


### PR DESCRIPTION
jira link: https://dsdmoj.atlassian.net/browse/P4-2422

The goal of this PR is to enable surfacing generic event relationships
that are currently stored in the details attribute to be in the
relationship section in the serialized generic event.

In order to achieve that we have to first know the type of each
relationship so we add type information to the relationship_attributes
call.

We also need a method that takes all of that information for the current
event STI instance and pulls out the relationships that we're
interested in for consumption by the frontend later.

- [x] Updates GenericEvent#relationship_attributes dsl to also take a
  type
- [x] Updates all GenericEvent STI classes to pass their relationship
  type where necessary
- [x] Adds GenericEvent#relationships method to render relationship
  information
- [x] Updates all tests to reflect change to relationship attributes
- [x] Removes some now-redundant relationship methods which were used to
  retrieve the relationship