### PR TITLE
[P4-2423] Support eventable include when pulling on move timeline

### DIFF
--- a/app/serializers/generic_event_serializer.rb
+++ b/app/serializers/generic_event_serializer.rb
@@ -9,7 +9,7 @@ class GenericEventSerializer
 
   has_one :eventable, polymorphic: true
 
-  SUPPORTED_RELATIONSHIPS = %w[].freeze
+  SUPPORTED_RELATIONSHIPS = %w[eventable].freeze
 
   attribute :event_type do |object|
     object.type.try(:gsub, 'GenericEvent::', '')

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -56,6 +56,7 @@ module V2
       original_move
       supplier
       timeline_events
+      timeline_events.eventable
     ].freeze
 
     INCLUDED_FIELDS = {

--- a/spec/serializers/generic_event_serializer_spec.rb
+++ b/spec/serializers/generic_event_serializer_spec.rb
@@ -8,32 +8,41 @@ RSpec.describe GenericEventSerializer do
   let(:event) { create :event_move_cancel }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
 
-  context 'with no options' do
-    let(:adapter_options) { {} }
-    let(:expected_json) do
-      {
-        data: {
-          id: event.id,
-          type: 'events',
-          attributes: {
-            occurred_at: event.occurred_at.iso8601,
-            recorded_at: event.recorded_at.iso8601,
-            notes: 'Flibble',
-            event_type: 'MoveCancel',
-            details: {
-              cancellation_reason: 'made_in_error',
-              cancellation_reason_comment: 'It was a mistake',
-            },
-          },
-          relationships: {
-            eventable: { data: { type: 'moves', id: move.id } },
+  let(:expected_json) do
+    {
+      data: {
+        id: event.id,
+        type: 'events',
+        attributes: {
+          occurred_at: event.occurred_at.iso8601,
+          recorded_at: event.recorded_at.iso8601,
+          notes: 'Flibble',
+          event_type: 'MoveCancel',
+          details: {
+            cancellation_reason: 'made_in_error',
+            cancellation_reason_comment: 'It was a mistake',
           },
         },
-      }
-    end
+        relationships: {
+          eventable: { data: { type: 'moves', id: move.id } },
+        },
+      },
+    }
+  end
+
+  context 'with no options' do
+    let(:adapter_options) { {} }
     let(:move) { event.eventable }
 
     it { expect(result).to include_json(expected_json) }
     it { expect(result[:included]).to be_nil }
+  end
+
+  context 'with include eventable' do
+    let(:adapter_options) { { include: [:eventable] } }
+    let(:move) { event.eventable }
+
+    it { expect(result).to include_json(expected_json) }
+    it { expect(result[:included].map { |include| include[:type] }).to eq(%w[moves]) }
   end
 end

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe V2::MoveSerializer do
 
     it 'contains all included relationships' do
       expect(result[:included].map { |r| r[:type] })
-        .to match_array(%w[people ethnicities genders locations locations profiles moves documents prison_transfer_reasons court_hearings suppliers events])
+        .to match_array(%w[people ethnicities genders locations locations profiles moves documents prison_transfer_reasons court_hearings suppliers events moves])
     end
 
     # TODO: Remove me when we're done with location suppliers - this is used to distinguish between them


### PR DESCRIPTION
jira link: https://dsdmoj.atlassian.net/browse/P4-2423

Support eventable as an include in the move and generic event serializer

The frontend needs this for contextual information in the event
timeline.
