### PR TITLE
Add new service and YAML file to import category reference data

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -6,5 +6,5 @@ class Category < ApplicationRecord
 
   validates :key, presence: true, uniqueness: true
   validates :title, presence: true
-  validates :move_supported, presence: true
+  validates :move_supported, inclusion: { in: [true, false] }
 end

--- a/app/services/categories/importer.rb
+++ b/app/services/categories/importer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Categories
+  class Importer
+    attr_accessor :items
+
+    def initialize(items)
+      self.items = items.with_indifferent_access
+    end
+
+    def call
+      items.each do |key, details|
+        category = Category.find_or_initialize_by(key: key.to_s)
+        category.locations = Location.where(nomis_agency_id: details[:locations])
+        category.update(title: details[:title], move_supported: details[:move_supported])
+      end
+    end
+  end
+end

--- a/lib/tasks/data/categories.yml
+++ b/lib/tasks/data/categories.yml
@@ -1,0 +1,208 @@
+---
+  A:
+    title: Category A
+    move_supported: false
+    locations:
+  B:
+    title: Category B
+    move_supported: true
+    locations:
+    - FKI
+    - FNI
+    - GHI
+    - GTI
+    - IWI
+    - LLI
+    - LGI
+    - RHI
+    - SLI
+    - WDI
+    - WRI
+    - MRI
+    - WHI
+  BTH:
+    title: Category B Therapeutic
+    move_supported: true
+    locations:
+    - GNI
+  C:
+    title: Category C
+    move_supported: true
+    locations:
+    - HCI
+    - MSI
+    - CWI
+    - BXI
+    - BRI
+    - HPI
+    - ISI
+    - LTI
+    - MTI
+    - WII
+    - WLI
+    - FSI
+    - HMI
+    - LHI
+    - MDI
+    - OWI
+    - ONI
+    - RNI
+    - SFI
+    - SKI
+    - SNI
+    - WEI
+    - BCI
+    - HHI
+    - LFI
+    - NLI
+    - RSI
+    - WMI
+    - CLI
+    - DAI
+    - EEI
+    - GMI
+  CVPU:
+    title: Category C VPU
+    move_supported: true
+    locations:
+    - WTI
+    - ASI
+    - VEI
+    - UKI
+  CYOI:
+    title: Category C / YOI
+    move_supported: true
+    locations:
+    - SHI
+    - HII
+    - PDI
+    - RCI
+  D:
+    title: Category D
+    move_supported: true
+    locations:
+    - HBI
+    - HDI
+    - NSI
+    - SUI
+    - HVI
+    - KMI
+    - KVI
+    - TCI
+    - FDI
+    - LYI
+    - SPI
+    - EHI
+    - UPI
+  E:
+    title: Category A Ex
+    move_supported: false
+    locations:
+  EL:
+    title: Eligible
+    move_supported: true
+    locations:
+  FEM:
+    title: Female
+    move_supported: true
+    locations:
+    - BZI
+    - DWI
+    - DHI
+    - EWI
+    - FHI
+    - LNI
+    - NHI
+    - PFI
+    - SDI
+    - STI
+  FEMO:
+    title: Female Open
+    move_supported: true
+    locations:
+    - ESI
+    - AGI
+  GRANTED:
+    title: Parole Granted
+    move_supported: true
+    locations:
+  H:
+    title: Cat A Hi
+    move_supported: false
+    locations:
+  HI:
+    title: High
+    move_supported: true
+    locations:
+  I:
+    title: YOI Closed
+    move_supported: true
+    locations:
+  IMM:
+    title: Immigration
+    move_supported: true
+    locations:
+    - MHI
+  LOC:
+    title: Local
+    move_supported: true
+    locations:
+    - BFI
+    - BAI
+    - CDI
+    - HOI
+    - PVI
+    - PBI
+    - TSI
+    - WWI
+    - WSI
+    - MRI
+    - WHI
+    - BMI
+    - DNI
+    - DGI
+    - HEI
+    - HLI
+    - LEI
+    - LCI
+    - LII
+    - NMI
+    - ACI
+    - DMI
+    - FBI
+    - LPI
+    - PNI
+    - BLI
+    - BNI
+    - EYI
+    - EXI
+    - LWI
+    - WCI
+    - BWI
+    - CFI
+    - SWI
+    - NWI
+  YJB:
+    title: YJB
+    move_supported: true
+    locations:
+    - WYI
+    - WNI
+    - CKI
+  YOI:
+    title: YOI
+    move_supported: true
+    locations:
+    - FMI
+    - AYI
+    - DTI
+  YOIA:
+    title: Adult and YOI
+    move_supported: true
+    locations:
+    - PRI
+  YOIL:
+    title: Local YOI
+    move_supported: true
+    locations:
+    - BSI

--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -31,6 +31,12 @@ namespace :reference_data do
     AllocationComplexCases::Importer.new.call
   end
 
+  desc 'create categories'
+  task create_categories: :environment do
+    categories = YAML.safe_load(File.read('./lib/tasks/data/categories.yml'))
+    Categories::Importer.new(categories).call
+  end
+
   desc 'create NOMIS alert mappings'
   task create_nomis_alerts: :environment do
     NomisAlerts::Importer.new(alert_codes: NomisClient::AlertCodes.get).call
@@ -74,6 +80,7 @@ namespace :reference_data do
        reference_data:create_assessment_questions
        reference_data:create_allocation_complex_cases
        reference_data:create_nomis_alerts
+       reference_data:create_categories
        reference_data:create_regions
        reference_data:create_suppliers
        reference_data:create_supplier_locations

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -11,5 +11,5 @@ RSpec.describe Category do
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_uniqueness_of(:key) }
   it { is_expected.to validate_presence_of(:title) }
-  it { is_expected.to validate_presence_of(:move_supported) }
+  it { is_expected.to validate_inclusion_of(:move_supported).in_array([true, false]) }
 end

--- a/spec/services/categories/importer_spec.rb
+++ b/spec/services/categories/importer_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Categories::Importer do
+  subject(:importer) { described_class.new(input_data) }
+
+  let!(:location1) { create :location, nomis_agency_id: 'FOO' }
+  let!(:location2) { create :location, nomis_agency_id: 'BAR' }
+  let!(:location3) { create :location, nomis_agency_id: 'BAZ' }
+
+  let(:input_data) do
+    {
+      'A': {
+        title: 'Category A',
+        move_supported: false,
+        locations: nil,
+      },
+      'B': {
+        title: 'Category B',
+        move_supported: true,
+        locations: %w[FOO BAR],
+      },
+      'C': {
+        title: 'Category C',
+        move_supported: true,
+        locations: %w[BAZ BUZZ],
+      },
+    }
+  end
+
+  let(:categoryA) { Category.find_by(key: 'A') }
+  let(:categoryB) { Category.find_by(key: 'B') }
+  let(:categoryC) { Category.find_by(key: 'C') }
+
+  context 'with no existing records' do
+    it 'creates all the input items' do
+      expect { importer.call }.to change(Category, :count).by(3)
+    end
+
+    it 'populates correct title' do
+      importer.call
+
+      expect(categoryA.title).to eq 'Category A'
+    end
+
+    it 'populates correct move_supported flag' do
+      importer.call
+
+      expect(categoryA).not_to be_move_supported
+    end
+
+    it 'links to correct locations' do
+      importer.call
+
+      expect(categoryB.locations.map(&:nomis_agency_id)).to match_array %w[FOO BAR]
+    end
+
+    it 'does not link to missing locations' do
+      importer.call
+
+      expect(categoryC.locations.map(&:nomis_agency_id)).to match %w[BAZ]
+    end
+
+    it 'does not link to nil locations' do
+      importer.call
+
+      expect(categoryA.locations).to be_empty
+    end
+  end
+
+  context 'with one existing record' do
+    before do
+      create(:category, key: 'A', title: 'Category A')
+    end
+
+    it 'creates only the missing items' do
+      expect { importer.call }.to change(Category, :count).by(2)
+    end
+  end
+
+  context 'with one existing record with the wrong name' do
+    let!(:existing) { create(:category, :not_supported, key: 'C', title: 'Wrong', locations: [location1]) }
+
+    it 'updates the title of the existing record' do
+      importer.call
+      expect(existing.reload.title).to eq 'Category C'
+    end
+
+    it 'updates the move_supported flag of the existing record' do
+      importer.call
+      expect(existing.reload).to be_move_supported
+    end
+
+    it 'updates links to correct locations' do
+      importer.call
+      expect(existing.reload.locations.map(&:nomis_agency_id)).to match %w[BAZ]
+    end
+  end
+end

--- a/spec/services/categories/importer_spec.rb
+++ b/spec/services/categories/importer_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Categories::Importer do
     it 'does not link to missing locations' do
       importer.call
 
-      expect(categoryC.locations.map(&:nomis_agency_id)).to match %w[BAZ]
+      expect(categoryC.locations.map(&:nomis_agency_id)).to match_array %w[BAZ]
     end
 
     it 'does not link to nil locations' do
@@ -94,7 +94,7 @@ RSpec.describe Categories::Importer do
 
     it 'updates links to correct locations' do
       importer.call
-      expect(existing.reload.locations.map(&:nomis_agency_id)).to match %w[BAZ]
+      expect(existing.reload.locations.map(&:nomis_agency_id)).to match_array %w[BAZ]
     end
   end
 end


### PR DESCRIPTION
### Jira link

P4-1421

### What?

- [x] Add new `Categories::Importer` service
- [x] Add new `categories.yaml` reference data file and associated rake task to import (`rails reference_data:create_locations`)

### Why?

- This data will be used to categories locations within the PMU dashboard and also to associate prisoners with their correct category so that moves for category A prisoners can be prevented. The reference data is therefore a combination of the known categories within Nomis plus some additional ones used within PMU to group locations.

### Deployment risks (optional)

- Adds new data that is not yet used (future PR's will add this category data to PMU locations dashboard)

