### PR TITLE
Remove unused category

### DIFF
--- a/lib/tasks/data/categories.yml
+++ b/lib/tasks/data/categories.yml
@@ -130,10 +130,6 @@
     title: Cat A Hi
     move_supported: false
     locations:
-  HI:
-    title: High
-    move_supported: true
-    locations:
   I:
     title: YOI Closed
     move_supported: true


### PR DESCRIPTION
### Jira link

P4-1421

### What?

- [x] Remove unused category from reference data YAML file

### Why?

- This was originally from returned Nomis data but apparently isn't actually a prison category.