### PR TITLE
[P4-2422] Adds support for dynamic anonymous event STI serializers

### DIFF
--- a/app/controllers/api/generic_events_controller.rb
+++ b/app/controllers/api/generic_events_controller.rb
@@ -17,7 +17,7 @@ module Api
       event = event_type.constantize.create!(event_attributes)
       run_event_logs
 
-      render_json event, serializer: GenericEventSerializer, status: :created
+      render_json event, serializer: event.class.serializer, status: :created
     end
 
   private
@@ -30,7 +30,7 @@ module Api
 
         attributes.merge!('supplier' => doorkeeper_application_owner) if doorkeeper_application_owner
         attributes.merge!('eventable' => eventable) if eventable_params
-        attributes['details'] = attributes['details'].slice(*event_type.constantize.details_attributes)
+        attributes['details'] = attributes['details']&.slice(*event_type.constantize.details_attributes) || {}
 
         attributes['details'].merge!(event_specific_relationships) if event_specific_relationships.any?
       end

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -29,7 +29,8 @@ module V2
     has_one :to_location,            serializer: LocationSerializer
 
     has_many :court_hearings, serializer: CourtHearingSerializer
-    has_many :timeline_events, serializer: GenericEventSerializer, &:all_events_for_timeline
+
+    has_many :timeline_events, serializer: ->(record, _params) { record.class.serializer }, &:all_events_for_timeline
 
     belongs_to :allocation, serializer: AllocationSerializer
     belongs_to :original_move, serializer: V2::MoveSerializer


### PR DESCRIPTION
### Jira link

P4-2422

### What?

The goal of this PR is to achieve dynamic serializers which support
includes and relationships for every event STI class which default to V2
relationships where possible.

In this vain we:

- [x] Update the `GenericEvent.relationship_attributes` DSL to support
  dynamic classes
- [x] Consume them in the `GenericEventController#create` endpoint
- [x] Consume them in the `V2::MoveSerializer`
- [x] Add tests for each of the consumers for events which define
  relationship_attributes and for those that don't define relationship_attributes

This enables `GET /api/events?include=from_location` if we need too. But mainly enables relationships that are currently in the jsonb details field to be surfaced automatically in the relationships section of the json:api document for the given event.

It automatically works on a collection and the classes are memoized only once (any additional object penalty affects only the startup of the application and only once).

### Why?

I am doing this because:

- This is for json:api compliance
- This will reduce the amount of work for the frontend