### PR TITLE
Remove inclusion test for boolean column on categories

### DIFF
--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -11,5 +11,4 @@ RSpec.describe Category do
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_uniqueness_of(:key) }
   it { is_expected.to validate_presence_of(:title) }
-  it { is_expected.to validate_inclusion_of(:move_supported).in_array([true, false]) }
 end


### PR DESCRIPTION
To avoid warning message when running tests, where inclusion is not possible to fully test on booleans, remove test.
The warning message in full:
```
************************************************************************
Warning from shoulda-matchers:

You are using `validate_inclusion_of` to assert that a boolean column
allows boolean values and disallows non-boolean ones. Be aware that it
is not possible to fully test this, as boolean columns will
automatically convert non-boolean values to boolean ones. Hence, you
should consider removing this test.
************************************************************************
```

