### PR TITLE
Ensure the right version of tzdata is used in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ RUN addgroup -g $APPUID -S appgroup && \
 
 RUN apk add --update --no-cache git tzdata postgresql-dev
 
+# Fix incompatibility with slim tzdata from 2020b onwards
+RUN wget https://data.iana.org/time-zones/tzdb/tzdata.zi -O /usr/share/zoneinfo/tzdata.zi && \
+    /usr/sbin/zic -b fat /usr/share/zoneinfo/tzdata.zi
+
 WORKDIR /app
 COPY --chown=appuser:appgroup --from=build-stage /usr/local/bundle /usr/local/bundle
 COPY --chown=appuser:appgroup . /app


### PR DESCRIPTION
### Jira link

P4-XXXX

### What?

I have added/removed/altered:

- [x] Include the full version of tzdata in the Docker image so the 'London' timezone works correctly in the docker containers. Follows this SO answer https://stackoverflow.com/questions/64581249/rails-activesupport-time-and-timezone-error-on-alpine-linux

### Why?

I am doing this because:

- The API is using the wrong time and that has impact on the data we store and communicate to suppliers.

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

