### PR TITLE
Add support for including categories within PMU dashboard endpoint

### DIFF
--- a/app/controllers/api/populations_controller.rb
+++ b/app/controllers/api/populations_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_date_range_params, only: %i[index]
 
     def index
-      paginate locations, serializer: LocationFreeSpacesSerializer do |paginated_locations, options|
+      paginate locations, serializer: LocationFreeSpacesSerializer, include: included_relationships do |paginated_locations, options|
         options[:params] = Population.free_spaces_date_range(paginated_locations, (date_from..date_to))
       end
     end
@@ -63,7 +63,11 @@ module Api
     end
 
     def locations
-      @locations ||= Locations::Finder.new(filter_params, sort_params).call
+      @locations ||= Locations::Finder.new(
+        filter_params: filter_params,
+        sort_params: sort_params,
+        active_record_relationships: active_record_relationships,
+      ).call
     end
 
     def location_id
@@ -89,7 +93,11 @@ module Api
     end
 
     def supported_relationships
-      PopulationSerializer::SUPPORTED_RELATIONSHIPS
+      if action_name == 'index'
+        LocationFreeSpacesSerializer::SUPPORTED_RELATIONSHIPS
+      else
+        PopulationSerializer::SUPPORTED_RELATIONSHIPS
+      end
     end
   end
 end

--- a/app/controllers/api/reference/locations_controller.rb
+++ b/app/controllers/api/reference/locations_controller.rb
@@ -4,7 +4,7 @@ module Api
   module Reference
     class LocationsController < ApiController
       def index
-        locations = Locations::Finder.new(filter_params).call
+        locations = Locations::Finder.new(filter_params: filter_params, active_record_relationships: active_record_relationships).call
         paginate locations, serializer: LocationSerializer, include: included_relationships
       end
 

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CategorySerializer
+  include JSONAPI::Serializer
+
+  set_type :categories
+  set_id :key
+
+  attributes :title, :move_supported
+end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -4,7 +4,6 @@ class CategorySerializer
   include JSONAPI::Serializer
 
   set_type :categories
-  set_id :key
 
-  attributes :title, :move_supported
+  attributes :key, :title, :move_supported, :created_at, :updated_at
 end

--- a/app/serializers/location_free_spaces_serializer.rb
+++ b/app/serializers/location_free_spaces_serializer.rb
@@ -7,9 +7,13 @@ class LocationFreeSpacesSerializer
 
   attributes :title
 
+  belongs_to :category
+
   meta do |object, params|
     {
       populations: params[object.id],
     }
   end
+
+  SUPPORTED_RELATIONSHIPS = %w[category].freeze
 end

--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -2,25 +2,29 @@
 
 module Locations
   class Finder
-    attr_accessor :filter_params, :order_by, :order_direction
+    attr_accessor :filter_params, :order_by, :order_direction, :active_record_relationships
 
-    def initialize(filter_params, sort_params = {})
+    def initialize(filter_params:, sort_params: {}, active_record_relationships: [])
       self.filter_params = filter_params
       self.order_by = (sort_params[:by] || 'title').to_sym
       self.order_direction = (sort_params[:direction] || 'asc').to_sym
+      self.active_record_relationships = active_record_relationships
     end
 
     def call
       scope = apply_filters(Location)
+      scope = scope.includes(active_record_relationships)
       apply_ordering(scope)
     end
 
   private
 
     def apply_ordering(scope)
-      case @order_by
+      case order_by
       when :title
-        scope.order(@order_by => @order_direction)
+        scope.order(title: order_direction)
+      when :category
+        scope.left_joins(:category).order('categories.title' => order_direction, 'locations.title' => order_direction)
       else
         scope
       end

--- a/spec/requests/api/reference/categories_controller_index_spec.rb
+++ b/spec/requests/api/reference/categories_controller_index_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Api::Reference::CategoriesController do
               title: 'Cat A',
               created_at: cat_a.created_at.iso8601,
               updated_at: cat_a.updated_at.iso8601,
-            }
+            },
           },
           {
             id: cat_b.id,
@@ -41,9 +41,9 @@ RSpec.describe Api::Reference::CategoriesController do
               title: 'Cat B',
               created_at: cat_b.created_at.iso8601,
               updated_at: cat_b.updated_at.iso8601,
-            }
+            },
           },
-        ]
+        ],
       }
     end
 

--- a/spec/requests/api/reference/locations_controller_spec.rb
+++ b/spec/requests/api/reference/locations_controller_spec.rb
@@ -173,9 +173,12 @@ RSpec.describe Api::Reference::LocationsController do
 
       it 'delegates the query execution to Locations::Finder with the correct filters' do
         expect(Locations::Finder).to have_received(:new).with(
-          location_type: location.location_type,
-          nomis_agency_id: location.nomis_agency_id,
-          supplier_id: supplier.id,
+          filter_params: {
+            location_type: location.location_type,
+            nomis_agency_id: location.nomis_agency_id,
+            supplier_id: supplier.id,
+          },
+          active_record_relationships: nil,
         )
       end
 

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CategorySerializer do
+  subject(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+
+  let(:serializer) { described_class.new(category) }
+  let(:category) { build(:category, :not_supported) }
+
+  it 'return a serialized category' do
+    expect(result[:data][:id]).to eq(category.key)
+    expect(result[:data][:attributes]).to eq(
+      title: category.title,
+      move_supported: false,
+    )
+  end
+end

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -3,16 +3,38 @@
 require 'rails_helper'
 
 RSpec.describe CategorySerializer do
-  subject(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  subject(:serializer) { described_class.new(category) }
 
-  let(:serializer) { described_class.new(category) }
-  let(:category) { build(:category, :not_supported) }
+  let(:category) { create(:category, :not_supported) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:result_data) { result[:data] }
+  let(:attributes) { result_data[:attributes] }
 
-  it 'return a serialized category' do
-    expect(result[:data][:id]).to eq(category.key)
-    expect(result[:data][:attributes]).to eq(
-      title: category.title,
-      move_supported: false,
-    )
+  it 'contains a type property' do
+    expect(result_data[:type]).to eql 'categories'
+  end
+
+  it 'contains an id property' do
+    expect(result_data[:id]).to eql category.id
+  end
+
+  it 'contains a key attribute' do
+    expect(attributes[:key]).to eql category.key
+  end
+
+  it 'contains a title attribute' do
+    expect(attributes[:title]).to eql category.title
+  end
+
+  it 'contains a move_supported attribute' do
+    expect(attributes[:move_supported]).to eql category.move_supported
+  end
+
+  it 'contains a created_at attribute' do
+    expect(attributes[:created_at]).to eql category.created_at.iso8601
+  end
+
+  it 'contains an updated_at attribute' do
+    expect(attributes[:updated_at]).to eql category.updated_at.iso8601
   end
 end

--- a/spec/serializers/location_free_spaces_serializer_spec.rb
+++ b/spec/serializers/location_free_spaces_serializer_spec.rb
@@ -42,4 +42,31 @@ RSpec.describe LocationFreeSpacesSerializer do
       expect(meta).to eql({ populations: { foo: 'bar' } })
     end
   end
+
+  describe 'category' do
+    let(:adapter_options) { { include: described_class::SUPPORTED_RELATIONSHIPS } }
+
+    context 'with a category' do
+      let(:category) { create(:category) }
+      let(:location) { create(:location, category: category) }
+
+      it 'contains a category relationship' do
+        expect(result_data[:relationships][:category]).to eq(data: { id: category.id, type: 'categories' })
+      end
+
+      it 'contains an included category' do
+        expect(result[:included].map { |r| r[:type] }).to match_array(%w[categories])
+      end
+    end
+
+    context 'without a category' do
+      it 'contains an empty category' do
+        expect(result_data[:relationships][:category]).to eq(data: nil)
+      end
+
+      it 'does not contain an included category' do
+        expect(result[:included]).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

P4-2297 P4-2416

### What?

- [x] Add support for `include=category` and sorting by category title (and then location title) to the `/locations_free_spaces` API endpoint

### Why?

- The PMU dashboard of free spaces per location should be broken down by category. Reference data for each category and associated mapping of prisons to categories has been completed previously. This PR leverages that data and adds support for `include=category` query string parameter which the front end can now specify.

- Note that the `Locations::Finder` service has been updated to follow the new pattern from `Moves::Finder` of eager fetching only the required relations to match the requested list of includes - this both avoids an N+1 query when categories are included, and needlessly fetching all categories when they are not included. Also added support for sorting by category so that the data can be returned to the front end in a sensible order.

### Have you? (optional)

- [ ] Updated API docs if necessary - The PMU dashboard endpoint is intentionally not documented as it's only useful to the front end rather than suppliers

### Deployment risks (optional)

- Extends free spaces endpoint but this is a non destructive change and also use of this is hidden behind a feature flag in the front end