### PR TITLE
[P4-2422]  Remove relationships from details in GenericEventSerializer

### DIFF
--- a/app/serializers/generic_event_serializer.rb
+++ b/app/serializers/generic_event_serializer.rb
@@ -5,7 +5,7 @@ class GenericEventSerializer
 
   set_type :events
 
-  attributes :occurred_at, :recorded_at, :notes, :details
+  attributes :occurred_at, :recorded_at, :notes
 
   has_one :eventable, serializer: ->(record, _params) { SerializerVersionChooser.call(record.class) }
   has_one :supplier
@@ -14,5 +14,15 @@ class GenericEventSerializer
 
   attribute :event_type do |object|
     object.type.try(:gsub, 'GenericEvent::', '')
+  end
+
+  attribute :details do |record, _params|
+    record.details.deep_dup.tap do |details|
+      if record.class.instance_variable_defined?(:@relationship_attributes)
+        record.class.relationship_attributes.each do |attribute_key, _attribute_type|
+          details.delete(attribute_key)
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/generic_events_controller_create_spec.rb
+++ b/spec/requests/api/generic_events_controller_create_spec.rb
@@ -189,6 +189,16 @@ RSpec.describe Api::GenericEventsController do
         }
         expect(resource_to_json.dig('data', 'relationships')).to eq(expected_relationships)
       end
+
+      it 'excludes the from_location from the details in the response' do
+        do_post
+
+        event = GenericEvent.last
+        resource_to_json = JSON.parse(event.class.serializer.new(event).serializable_hash.to_json)
+
+        expected_details = { 'authorised_at' => event.authorised_at, 'authorised_by' => 'PMU', 'reason' => 'no_space' }
+        expect(resource_to_json.dig('data', 'attributes', 'details')).to eq(expected_details)
+      end
     end
 
     context 'when the event has an additional relationship with a v2 implementation' do
@@ -239,6 +249,16 @@ RSpec.describe Api::GenericEventsController do
           'supplier' => { 'data' => nil },
         }
         expect(resource_to_json.dig('data', 'relationships')).to eq(expected_relationships)
+      end
+
+      it 'excludes the previous_move from the details in the response' do
+        do_post
+
+        event = GenericEvent.last
+        resource_to_json = JSON.parse(event.class.serializer.new(event).serializable_hash.to_json)
+
+        expected_details = {}
+        expect(resource_to_json.dig('data', 'attributes', 'details')).to eq(expected_details)
       end
     end
 

--- a/spec/serializers/generic_event_serializer_spec.rb
+++ b/spec/serializers/generic_event_serializer_spec.rb
@@ -60,4 +60,39 @@ RSpec.describe GenericEventSerializer do
       expect(SerializerVersionChooser).to have_received(:call).with(Move).twice
     end
   end
+
+  context 'with an event that defines relationship attributes' do
+    subject(:serializer) { event.class.serializer.new(event, adapter_options) }
+
+    let(:event) { create :event_move_redirect }
+    let(:adapter_options) { {} }
+
+    let(:expected_json) do
+      {
+        data: {
+          id: event.id,
+          type: 'events',
+          attributes: {
+            occurred_at: event.occurred_at.iso8601,
+            recorded_at: event.recorded_at.iso8601,
+            notes: 'Flibble',
+            event_type: 'MoveRedirect',
+            details: {
+              reason: 'no_space',
+              move_type: 'court_appearance',
+            },
+          },
+          relationships: {
+            eventable: { data: { id: event.eventable.id, type: 'moves' } },
+            to_location: { data: { id: event.to_location.id, type: 'locations' } },
+            supplier: { data: { type: 'suppliers', id: event.supplier.id } },
+          },
+        },
+      }
+    end
+
+    it 'returns an event without the relationships in the details' do
+      expect(result).to eq(expected_json)
+    end
+  end
 end


### PR DESCRIPTION
jira link: https://dsdmoj.atlassian.net/browse/P4-2422

Now we're compliant and have relationships in the correct json:api
location of the response when surfacing events we need to remove these
relationships from the details attribute dynamically for all events

I've done this separately to reduce review complexity.

Leaving this would be confusing for the frontend