### PR TITLE
[P4-2422] Removes presenter method

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -106,19 +106,6 @@ class GenericEvent < ApplicationRecord
     feed
   end
 
-  def relationships
-    return {} unless self.class.instance_variable_defined?(:@relationship_attributes)
-
-    self.class.relationship_attributes.each_with_object({}) do |(attribute_key, attribute_type), acc|
-      id = details[attribute_key]
-      named_relationship_key = attribute_key.to_s.sub('_id', '')
-
-      next if id.blank?
-
-      acc[named_relationship_key] = { type: attribute_type, id: id }
-    end
-  end
-
   def self.from_event(event)
     type = "GenericEvent::#{event.eventable_type}#{event.event_name.capitalize}"
 

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -44,36 +44,6 @@ RSpec.describe GenericEvent, type: :model do
     end
   end
 
-  describe '#relationships' do
-    context 'when the event defines relationships' do
-      subject(:generic_event) { build(:event_move_redirect) }
-
-      it 'returns the correct json:api relationships' do
-        expect(generic_event.relationships).to eq('to_location' => { type: :locations, id: generic_event.details['to_location_id'] })
-      end
-    end
-
-    context 'when the event does not define relationships' do
-      subject(:generic_event) { build(:event_move_cancel) }
-
-      it 'returns no relationships' do
-        expect(generic_event.relationships).to eq({})
-      end
-    end
-
-    context 'when the event defines relationships that are missing from the details' do
-      subject(:generic_event) { build(:event_move_redirect) }
-
-      before do
-        generic_event.details.delete(:to_location_id)
-      end
-
-      it 'returns no relationships' do
-        expect(generic_event.relationships).to eq({})
-      end
-    end
-  end
-
   describe '#for_feed' do
     subject(:generic_event) { create(:event_move_cancel, supplier: create(:supplier, key: 'serco')) }
 


### PR DESCRIPTION
jira link: https://dsdmoj.atlassian.net/browse/P4-2422

We ended up leaning on our json:api serializer gem to render the
relationships. This enables us to automatically support includes on each
of the anonymous serializers and is significantly cleaner.

This does mean that the method removed in this commit is no longer used.