### PR TITLE
[P4-2422] Support smarter polymorphic serializer choice for eventable

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -164,7 +164,7 @@ class GenericEvent < ApplicationRecord
             named_relationship_key = attribute_key.to_s.sub('_id', '')
 
             new_serializer_class.set_type :events
-            new_serializer_class.has_one named_relationship_key, serializer: SerializerVersionChooser.call(attribute_type.to_s.singularize.camelize)
+            new_serializer_class.has_one named_relationship_key, serializer: SerializerVersionChooser.call(attribute_type)
           end
         end
     end

--- a/app/serializers/generic_event_serializer.rb
+++ b/app/serializers/generic_event_serializer.rb
@@ -8,6 +8,7 @@ class GenericEventSerializer
   attributes :occurred_at, :recorded_at, :notes, :details
 
   has_one :eventable, serializer: ->(record, _params) { SerializerVersionChooser.call(record.class) }
+  has_one :supplier
 
   SUPPORTED_RELATIONSHIPS = %w[eventable].freeze
 

--- a/app/serializers/generic_event_serializer.rb
+++ b/app/serializers/generic_event_serializer.rb
@@ -7,7 +7,7 @@ class GenericEventSerializer
 
   attributes :occurred_at, :recorded_at, :notes, :details
 
-  has_one :eventable, polymorphic: true
+  has_one :eventable, serializer: ->(record, _params) { SerializerVersionChooser.call(record.class) }
 
   SUPPORTED_RELATIONSHIPS = %w[eventable].freeze
 

--- a/app/services/serializer_version_chooser.rb
+++ b/app/services/serializer_version_chooser.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SerializerVersionChooser
+  DEFAULT_API_VERSION = 'V2'
+
+  def self.call(interpolatable)
+    serializer = "#{DEFAULT_API_VERSION}::#{interpolatable.to_s.singularize.camelize}Serializer"
+
+    serializer = if const_defined?(serializer)
+                   serializer
+                 else
+                   serializer.sub("#{DEFAULT_API_VERSION}::", '')
+                 end
+
+    serializer.constantize
+  end
+end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :generic_event do
     eventable { association(:move) }
+    supplier { association(:supplier) }
     occurred_at { Time.zone.now }
     recorded_at { Time.zone.now }
     notes { 'Flibble' }

--- a/spec/requests/api/generic_events_controller_create_spec.rb
+++ b/spec/requests/api/generic_events_controller_create_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe Api::GenericEventsController do
 
         expected_relationships = {
           'eventable' => { 'data' => { 'id' => event.eventable.id, 'type' => 'moves' } },
+          'supplier' => { 'data' => nil },
         }
 
         expect(resource_to_json.dig('data', 'relationships')).to eq(expected_relationships)
@@ -184,6 +185,7 @@ RSpec.describe Api::GenericEventsController do
         expected_relationships = {
           'eventable' => { 'data' => { 'id' => event.eventable.id, 'type' => 'moves' } },
           'from_location' => { 'data' => { 'id' => event.from_location.id, 'type' => 'locations' } },
+          'supplier' => { 'data' => nil },
         }
         expect(resource_to_json.dig('data', 'relationships')).to eq(expected_relationships)
       end
@@ -234,6 +236,7 @@ RSpec.describe Api::GenericEventsController do
         expected_relationships = {
           'eventable' => { 'data' => { 'id' => event.eventable.id, 'type' => 'moves' } },
           'previous_move' => { 'data' => { 'id' => event.previous_move.id, 'type' => 'moves' } },
+          'supplier' => { 'data' => nil },
         }
         expect(resource_to_json.dig('data', 'relationships')).to eq(expected_relationships)
       end
@@ -258,6 +261,20 @@ RSpec.describe Api::GenericEventsController do
         do_post
         event = GenericEvent.find(response_json.dig('data', 'id'))
         expect(event.supplier).to eq(supplier)
+      end
+
+      it 'returns the supplier of the event in the relationships' do
+        do_post
+
+        event = GenericEvent.last
+        resource_to_json = JSON.parse(event.class.serializer.new(event).serializable_hash.to_json)
+
+        expected_relationships = {
+          'eventable' => { 'data' => { 'id' => event.eventable.id, 'type' => 'moves' } },
+          'from_location' => { 'data' => { 'id' => event.from_location.id, 'type' => 'locations' } },
+          'supplier' => { 'data' => { 'id' => event.supplier.id, 'type' => 'suppliers' } },
+        }
+        expect(resource_to_json.dig('data', 'relationships')).to eq(expected_relationships)
       end
     end
 

--- a/spec/serializers/generic_event_serializer_spec.rb
+++ b/spec/serializers/generic_event_serializer_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe GenericEventSerializer do
           },
         },
         relationships: {
-          eventable: { data: { type: 'moves', id: move.id } },
+          eventable: { data: { type: 'moves', id: event.eventable.id } },
+          supplier: { data: { type: 'suppliers', id: event.supplier.id } },
         },
       },
     }
@@ -36,7 +37,6 @@ RSpec.describe GenericEventSerializer do
 
   context 'with no options' do
     let(:adapter_options) { {} }
-    let(:move) { event.eventable }
 
     it { expect(result).to include_json(expected_json) }
     it { expect(result[:included]).to be_nil }
@@ -50,7 +50,6 @@ RSpec.describe GenericEventSerializer do
 
   context 'with include eventable' do
     let(:adapter_options) { { include: [:eventable] } }
-    let(:move) { event.eventable }
 
     it { expect(result).to include_json(expected_json) }
     it { expect(result[:included].map { |include| include[:type] }).to eq(%w[moves]) }

--- a/spec/serializers/generic_event_serializer_spec.rb
+++ b/spec/serializers/generic_event_serializer_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe GenericEventSerializer do
   subject(:serializer) { described_class.new(event, adapter_options) }
 
+  before do
+    allow(SerializerVersionChooser).to receive(:call).and_call_original
+  end
+
   let(:event) { create :event_move_cancel }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
 
@@ -36,6 +40,12 @@ RSpec.describe GenericEventSerializer do
 
     it { expect(result).to include_json(expected_json) }
     it { expect(result[:included]).to be_nil }
+
+    it 'uses the SerializerVersionChooser' do
+      result
+      # Once for the relationship
+      expect(SerializerVersionChooser).to have_received(:call).with(Move).once
+    end
   end
 
   context 'with include eventable' do
@@ -44,5 +54,11 @@ RSpec.describe GenericEventSerializer do
 
     it { expect(result).to include_json(expected_json) }
     it { expect(result[:included].map { |include| include[:type] }).to eq(%w[moves]) }
+
+    it 'uses the SerializerVersionChooser' do
+      result
+      # Once for the relationship, once for the include
+      expect(SerializerVersionChooser).to have_received(:call).with(Move).twice
+    end
   end
 end

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -103,7 +103,10 @@ RSpec.describe V2::MoveSerializer do
         end
 
         it 'contains the correct relationships for the event include' do
-          event_relationships = { eventable: { data: { id: event.eventable_id, type: 'moves' } } }
+          event_relationships = {
+            eventable: { data: { id: event.eventable.id, type: 'moves' } },
+            supplier: { data: { id: event.supplier.id, type: 'suppliers' } },
+          }
 
           expect(included_event[:relationships]).to eq(event_relationships)
         end
@@ -124,6 +127,7 @@ RSpec.describe V2::MoveSerializer do
           event_relationships = {
             to_location: { data: { id: event.to_location.id, type: 'locations' } },
             eventable: { data: { id: event.eventable_id, type: 'moves' } },
+            supplier: { data: { id: event.supplier.id, type: 'suppliers' } },
           }
 
           expect(included_event[:relationships]).to eq(event_relationships)

--- a/spec/services/serializer_version_chooser_spec.rb
+++ b/spec/services/serializer_version_chooser_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SerializerVersionChooser do
+  subject(:chooser) { described_class.call(interpolatable) }
+
+  context 'when a version 2 serializer exists' do
+    let(:interpolatable) { Move }
+
+    it { is_expected.to eq(V2::MoveSerializer) }
+  end
+
+  context 'when an unversioned serializer exists' do
+    let(:interpolatable) { Location }
+
+    it { is_expected.to eq(LocationSerializer) }
+  end
+
+  context 'when the interpolatable is in snake case and plural form' do
+    let(:interpolatable) { :moves }
+
+    it { is_expected.to eq(V2::MoveSerializer) }
+  end
+
+  context 'when the serializer does not exist' do
+    let(:interpolatable) { Notifier }
+
+    it { expect { chooser }.to raise_error(NameError, /uninitialized constant NotifierSerializer/) }
+  end
+end


### PR DESCRIPTION
jira link: https://dsdmoj.atlassian.net/browse/P4-2422

We need to make sure that eventables that are being serialized as
includes and as relationships for the frontend are picking the correct
serializer version.

In order to achieve this we:

- [x] Extract choice of serializer version into `SerializerVersionChooser` service and add tests
- [x] Consume `SerializerVersionChooser` when picking the serializer
  class for polymorphic eventables in the `GenericEventSerializer`
- [x] Consume `SerializerVersionChooser` when picking the relation serializer
  class for STI relations