### PR TITLE
[P4-2430] Surface PII in person feed

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -10,6 +10,9 @@ class Person < VersionedModel
     police_national_computer
     prison_number
     latest_nomis_booking_id
+    first_names
+    last_name
+    date_of_birth
   ].freeze
 
   IDENTIFIER_TYPES = %i[

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -86,6 +86,9 @@ RSpec.describe Person do
         'prison_number' => person.prison_number,
         'latest_nomis_booking_id' => person.latest_nomis_booking_id,
         'age' => person.age,
+        'first_names' => person.first_names,
+        'last_name' => person.last_name,
+        'date_of_birth' => be_a(Date),
       }
     end
 


### PR DESCRIPTION
### Jira link

P4-2430

### What?

I have added/removed/altered:

- [x] Added first_names, last_name and date_of_birth to feed attributes

### Why?

Some PII information is needed by the journey pricing spreadsheet. This
PR adds that information and extends these fields for consumption by
the JPC from the next report run.

We already are returning all identifiers (prison_number, latest_nomis_booking_id, etc).