### PR TITLE
Add `completed_at` timestamp on PER when status transitions to complete

### DIFF
--- a/app/state_machines/person_escort_record_state_machine.rb
+++ b/app/state_machines/person_escort_record_state_machine.rb
@@ -11,6 +11,10 @@ class PersonEscortRecordStateMachine < FiniteMachine::Definition
     target.status = event.to
   end
 
+  on_after :calculate do
+    target.completed_at = Time.zone.now if completed? && target.completed_at.nil?
+  end
+
   on_after :confirm do
     target.confirmed_at = Time.zone.now
   end

--- a/db/migrate/20201106104806_add_completed_by_to_person_escort_records.rb
+++ b/db/migrate/20201106104806_add_completed_by_to_person_escort_records.rb
@@ -1,0 +1,5 @@
+class AddCompletedByToPersonEscortRecords < ActiveRecord::Migration[6.0]
+  def change
+    add_column :person_escort_records, :completed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_02_120213) do
+ActiveRecord::Schema.define(version: 2020_11_06_104806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -493,6 +493,7 @@ ActiveRecord::Schema.define(version: 2020_11_02_120213) do
     t.uuid "move_id"
     t.jsonb "nomis_sync_status", default: [], null: false
     t.uuid "prefill_source_id"
+    t.datetime "completed_at"
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
     t.index ["move_id"], name: "index_person_escort_records_on_move_id"
     t.index ["prefill_source_id"], name: "index_person_escort_records_on_prefill_source_id"

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -151,6 +151,7 @@ FactoryBot.define do
           profile: move.profile,
           status: evaluator.person_escort_record_status,
           confirmed_at: evaluator.person_escort_record_status == 'confirmed' ? Time.zone.now : nil,
+          completed_at: evaluator.person_escort_record_status == 'completed' ? Time.zone.now : nil,
         )
       end
     end

--- a/spec/factories/person_escort_record.rb
+++ b/spec/factories/person_escort_record.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
 
     trait :completed do
       status { PersonEscortRecord::PERSON_ESCORT_RECORD_COMPLETED }
+      completed_at { Time.zone.now }
     end
 
     trait :confirmed do


### PR DESCRIPTION
To capture stats on when users are *first* completing a PER, add a new timestamp to capture the first date/time a user completes the PER. If the PER moves back to in progress then completed again we don't overwrite the timestamp with the new value, but maintain the old one. This is only internal for now so won't be surfaced in serializers.