### PR TITLE
Remove support for included moves with GET /allocations

### DIFF
--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -70,7 +70,7 @@ module Api
         filters: filter_params,
         ordering: sort_params,
         search: search_params,
-        active_record_relationships: active_record_relationships
+        active_record_relationships: active_record_relationships,
       ).call
     end
 

--- a/app/serializers/allocations_serializer.rb
+++ b/app/serializers/allocations_serializer.rb
@@ -6,4 +6,11 @@ class AllocationsSerializer < AllocationSerializer
       moves: params[object.id],
     }
   end
+
+  INCLUDED_FIELDS = {
+    allocations: attributes_to_serialize.keys + %i[from_location to_location],
+    locations: LocationSerializer.attributes_to_serialize.keys,
+  }.freeze
+
+  SUPPORTED_RELATIONSHIPS = %w[from_location to_location].freeze
 end

--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -2,11 +2,9 @@
 
 module Allocations
   class Finder
-    attr_reader :filter_params, :search_params
+    attr_reader :filter_params, :search_params, :active_record_relationships
 
-    ALLOCATION_INCLUDES = [from_location: :suppliers, to_location: :suppliers, moves: [:from_location, :to_location, :court_hearings, person: %i[gender ethnicity profiles], profile: %i[person_escort_record documents]]].freeze
-
-    def initialize(filters: {}, ordering: {}, search: {})
+    def initialize(filters: {}, ordering: {}, search: {}, active_record_relationships: [])
       @search_params = search
       @filter_params = filters
       @order_by = (ordering[:by] || 'date').to_sym
@@ -16,10 +14,12 @@ module Allocations
                            # default if no 'by' parameter is date descending
                            :desc
                          end
+      @active_record_relationships = active_record_relationships
     end
 
     def call
-      scope = apply_filters(Allocation.includes(ALLOCATION_INCLUDES))
+      scope = Allocation.includes(active_record_relationships)
+      scope = apply_filters(scope)
       scope = apply_search(scope)
       apply_ordering(scope)
     end

--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -12,8 +12,8 @@ module Locations
     end
 
     def call
-      scope = apply_filters(Location)
-      scope = scope.includes(active_record_relationships)
+      scope = Location.includes(active_record_relationships)
+      scope = apply_filters(scope)
       apply_ordering(scope)
     end
 

--- a/spec/requests/api/allocations_controller_index_spec.rb
+++ b/spec/requests/api/allocations_controller_index_spec.rb
@@ -69,7 +69,13 @@ RSpec.describe Api::AllocationsController do
 
         it 'delegates the query execution to Allocations::Finder with the correct filters' do
           get_allocations
-          expect(Allocations::Finder).to have_received(:new).with(filters: { date_from: date_from.to_s, from_locations: location.id, status: 'unfilled' }, ordering: {}, search: {})
+
+          expect(Allocations::Finder).to have_received(:new).with(
+            filters: { date_from: date_from.to_s, from_locations: location.id, status: 'unfilled' },
+            ordering: {},
+            search: {},
+            active_record_relationships: nil
+          )
         end
       end
 
@@ -86,7 +92,13 @@ RSpec.describe Api::AllocationsController do
 
         it 'delegates the query execution to Allocations::Finder with the correct sorting' do
           get_allocations
-          expect(Allocations::Finder).to have_received(:new).with(filters: {}, ordering: { by: 'moves_count', direction: 'desc' }, search: {})
+
+          expect(Allocations::Finder).to have_received(:new).with(
+            filters: {},
+            ordering: { by: 'moves_count', direction: 'desc' },
+            search: {},
+            active_record_relationships: nil
+          )
         end
       end
 
@@ -102,7 +114,13 @@ RSpec.describe Api::AllocationsController do
 
         it 'delegates the query execution to Allocations::Finder with the correct sorting' do
           get_allocations
-          expect(Allocations::Finder).to have_received(:new).with(filters: {}, ordering: {}, search: { location: 'nott' })
+
+          expect(Allocations::Finder).to have_received(:new).with(
+            filters: {},
+            ordering: {},
+            search: { location: 'nott' },
+            active_record_relationships: nil
+          )
         end
       end
     end

--- a/spec/requests/api/allocations_controller_index_spec.rb
+++ b/spec/requests/api/allocations_controller_index_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Api::AllocationsController do
             filters: { date_from: date_from.to_s, from_locations: location.id, status: 'unfilled' },
             ordering: {},
             search: {},
-            active_record_relationships: nil
+            active_record_relationships: nil,
           )
         end
       end
@@ -97,7 +97,7 @@ RSpec.describe Api::AllocationsController do
             filters: {},
             ordering: { by: 'moves_count', direction: 'desc' },
             search: {},
-            active_record_relationships: nil
+            active_record_relationships: nil,
           )
         end
       end
@@ -119,7 +119,7 @@ RSpec.describe Api::AllocationsController do
             filters: {},
             ordering: {},
             search: { location: 'nott' },
-            active_record_relationships: nil
+            active_record_relationships: nil,
           )
         end
       end

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -3,7 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Allocations::Finder do
-  subject(:allocation_finder) { described_class.new(filters: filter_params, ordering: sort_params, search: search_params) }
+  subject(:allocation_finder) do
+    described_class.new(
+      filters: filter_params,
+      ordering: sort_params,
+      search: search_params,
+      active_record_relationships: active_record_relationships
+    )
+  end
 
   let(:from_location) { create :location }
   let(:to_location) { create :location }
@@ -12,6 +19,7 @@ RSpec.describe Allocations::Finder do
   let(:filter_params) { {} }
   let(:sort_params) { {} }
   let(:search_params) { {} }
+  let(:active_record_relationships) { [] }
 
   describe 'filtering' do
     context 'with matching date range' do
@@ -47,6 +55,7 @@ RSpec.describe Allocations::Finder do
     context 'with matching from_locations' do
       let!(:other_allocation) { create(:allocation, to_location: to_location) }
       let(:filter_params) { { from_locations: from_location.id } }
+      let(:active_record_relationships) { %i[from_location] }
 
       it 'returns allocations matching specified from_location' do
         expect(allocation_finder.call).to contain_exactly(allocation)
@@ -56,6 +65,7 @@ RSpec.describe Allocations::Finder do
     context 'with matching to_locations' do
       let!(:other_allocation) { create(:allocation, from_location: from_location) }
       let(:filter_params) { { to_locations: to_location.id } }
+      let(:active_record_relationships) { %i[to_location] }
 
       it 'returns allocations matching specified to_location' do
         expect(allocation_finder.call).to contain_exactly(allocation)

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Allocations::Finder do
       filters: filter_params,
       ordering: sort_params,
       search: search_params,
-      active_record_relationships: active_record_relationships
+      active_record_relationships: active_record_relationships,
     )
   end
 

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -211,7 +211,7 @@
           schema:
             type: string
           example: Bloggs
-        - "$ref": "../v1/allocation_include_parameter.yaml#/AllocationIncludeParameter"
+        - "$ref": "../v1/allocations_include_parameter.yaml#/AllocationsIncludeParameter"
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"
       responses:

--- a/swagger/v1/allocations_include_parameter.yaml
+++ b/swagger/v1/allocations_include_parameter.yaml
@@ -1,0 +1,12 @@
+AllocationsIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the allocation
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - from_location
+      - to_location
+  example: from_location


### PR DESCRIPTION
### Jira link

P4-2443

### What?

- [x] Reduce support for `includes` on `GET /allocations` endpoint

### Why?

- Previous work to introduce metadata for various moves count for this endpoint means that the front end code no longer needs to retrieve moves when fetching a list of allocations. The `Allocations::Finder` service was still preemptively including a worst case list of database level includes to avoid N+1 queries but most of those includes are no longer necessary now. Instead the database level includes are derived from the JSONAPI requested includes, with only `from_location` and `to_location` relationships now supported. Also tweaked the `AllocationsSerializer` to ensure that nested resources are not queried. The overall effect is a dramatic improvement in performance for this endpoint.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Affects `GET /allocations` endpoint, but the previously supported includes are no longer used in the front end, having been removed in a previous PR.
