### PR TITLE
Ensure that empty Person reference values are saved as null

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :production do
 end
 
 gem 'activerecord-import', '~> 1.0', '>= 1.0.5'
+gem 'auto_strip_attributes', '~> 2.6'
 gem 'aws-sdk-s3', require: false
 gem 'bcrypt', require: false
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     application_insights (0.5.6)
     ast (2.4.1)
+    auto_strip_attributes (2.6.0)
+      activerecord (>= 4.0)
     aws-eventstream (1.1.0)
     aws-partitions (1.390.0)
     aws-sdk-core (3.109.2)
@@ -409,6 +411,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-import (~> 1.0, >= 1.0.5)
   appinsights!
+  auto_strip_attributes (~> 2.6)
   aws-sdk-s3
   bcrypt
   bootsnap (>= 1.1.0)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -32,6 +32,8 @@ class Person < VersionedModel
   validates :last_name, presence: true
   validates :first_names, presence: true
 
+  auto_strip_attributes :nomis_prison_number, :prison_number, :criminal_records_office, :police_national_computer
+
   def age
     # See: https://medium.com/@craigsheen/calculating-age-in-rails-9bb661f11303
     # rubocop:disable Rails/Date

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -28,4 +28,12 @@ namespace :data_maintenance do
   task fix_nil_allocations_estate: :environment do
     Allocation.where(estate: nil).update_all(estate: :adult_male)
   end
+
+  desc 'fix blank (empty string) person references that should be stored as null'
+  task fix_blank_person_references: :environment do
+    Person.where(nomis_prison_number: '').update_all(nomis_prison_number: nil)
+    Person.where(prison_number: '').update_all(prison_number: nil)
+    Person.where(criminal_records_office: '').update_all(criminal_records_office: nil)
+    Person.where(police_national_computer: '').update_all(police_national_computer: nil)
+  end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -24,35 +24,51 @@ RSpec.describe Person do
   end
 
   describe '#police_national_computer' do
-    subject!(:person) { create(:person, police_national_computer: 'FLIBBLE') }
-
     it 'is case insensitive' do
+      person = create(:person, police_national_computer: 'FLIBBLE')
       expect(described_class.where(police_national_computer: 'flibble')).to include(person)
+    end
+
+    it 'stores blank values as nil' do
+      person = create(:person, police_national_computer: '')
+      expect(person.reload.police_national_computer).to be_nil
     end
   end
 
   describe '#criminal_records_office' do
-    subject!(:person) { create(:person, criminal_records_office: 'FLIBBLE') }
-
     it 'is case insensitive' do
+      person = create(:person, criminal_records_office: 'FLIBBLE')
       expect(described_class.where(criminal_records_office: 'flibble')).to include(person)
+    end
+
+    it 'stores blank values as nil' do
+      person = create(:person, criminal_records_office: '')
+      expect(person.reload.criminal_records_office).to be_nil
     end
   end
 
   describe '#prison_number' do
-    subject!(:person) { create(:person, prison_number: 'FLIBBLE') }
-
     it 'is case insensitive' do
+      person = create(:person, prison_number: 'FLIBBLE')
       expect(described_class.where(prison_number: 'flibble')).to include(person)
+    end
+
+    it 'stores blank values as nil' do
+      person = create(:person, prison_number: '')
+      expect(person.reload.prison_number).to be_nil
     end
   end
 
   # TODO: Remove nomis_prison_number once we remove v1 from our system
   describe '#nomis_prison_number' do
-    subject!(:person) { create(:person, nomis_prison_number: 'FLIBBLE') }
-
     it 'is case insensitive' do
+      person = create(:person, nomis_prison_number: 'FLIBBLE')
       expect(described_class.where(nomis_prison_number: 'flibble')).to include(person)
+    end
+
+    it 'stores blank values as nil' do
+      person = create(:person, nomis_prison_number: '')
+      expect(person.reload.nomis_prison_number).to be_nil
     end
   end
 


### PR DESCRIPTION
### Jira link

P4-2456

### What?

- [x] Added `auto_strip_attributes` gem and annotations to `Person` model
- [x] Added `data_maintenance:fix_blank_person_references` rake task

### Why?

- We (or rather suppliers) don't want empty strings for Person reference values to be stored as empty string, but should instead be stored as `null. Added `auto_strip_attributes` gem as the easiest way to achieve this as it's likely we will want to add this to more models over time. The gem is very minimal (only 100 LOC) and well maintained so I think is justified to use. Also added a rake task to clean up historic values to be run in each environment after the fix has been deployed.

https://github.com/holli/auto_strip_attributes

### Deployment risks (optional)

- Rake task changes production data but only converts empty strings to null so is safe to run, and has been tested locally.
