### PR TITLE
Fix method name for rendering NOMIS error

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -29,7 +29,7 @@ class ApiController < ApplicationController
   # Nomis connection errors:
   rescue_from Faraday::ConnectionFailed, with: :render_connection_error
   rescue_from Faraday::TimeoutError, with: :render_timeout_error
-  rescue_from OAuth2::Error, with: :nomis_bad_gateway
+  rescue_from OAuth2::Error, with: :render_nomis_bad_gateway
 
   def current_user
     return Doorkeeper::Application.new unless authentication_enabled?

--- a/spec/requests/api/people_controller_show_v2_spec.rb
+++ b/spec/requests/api/people_controller_show_v2_spec.rb
@@ -82,6 +82,19 @@ RSpec.describe Api::PeopleController do
         end
       end
 
+      context 'with a NOMIS error' do
+        let(:query_params) { '?include=category' }
+        let(:latest_nomis_booking_id) { 123 }
+
+        before do
+          oauth2_response = instance_double('OAuth2::Response', body: '{"error":"server_error","error_description":"Internal Server Error"}', parsed: {}, status: '', 'error=': '')
+          allow(NomisClient::BookingDetails).to receive(:get).and_raise(OAuth2::Error, oauth2_response)
+          get "/api/people/#{person.id}#{query_params}", params: params, headers: headers
+        end
+
+        it_behaves_like 'an endpoint that responds with error 502'
+      end
+
       context 'when including an invalid include query param' do
         let(:query_params) { '?include=foo.bar,profiles' }
 

--- a/spec/support/responds_with_error_502.rb
+++ b/spec/support/responds_with_error_502.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an endpoint that responds with error 502' do
+  let(:response_json) { JSON.parse(response.body) }
+  let(:errors_502) do
+    [
+      {
+        'title' => 'Nomis Bad Gateway Error',
+        'detail' => /OAuth2::Error/,
+      },
+    ]
+  end
+
+  it 'returns bad request error code' do
+    expect(response).to have_http_status(:bad_gateway)
+  end
+
+  it 'returns errors in the body of the response' do
+    expect(JSON.parse(response.body)).to include_json(errors: errors_502)
+  end
+
+  it 'returns a valid 502 JSON response' do
+    expect(JSON::Validator.validate!(schema, response_json, strict: true, fragment: '#/502')).to be true
+  end
+
+  it 'sets the correct content type header' do
+    expect(response.headers['Content-Type']).to match(Regexp.escape(ApiController::CONTENT_TYPE))
+  end
+end


### PR DESCRIPTION
To fix https://sentry.io/organizations/ministryofjustice/issues/2024795868/?project=2014776&referrer=slack
Amend method name and add test for NOMIS OAuth2 errors when NOMIS responds with a 500