### PR TITLE
P4-2447 Add `assessmentable` association to responses

### DIFF
--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -22,13 +22,13 @@ class FrameworkQuestion < VersionedModel
   has_many :framework_responses
   has_and_belongs_to_many :framework_nomis_codes, autosave: true
 
-  def build_responses(question: self, person_escort_record:, questions:, previous_responses: {})
-    response = build_response(question, person_escort_record, previous_responses[question.key])
+  def build_responses(question: self, assessmentable:, questions:, previous_responses: {})
+    response = build_response(question, assessmentable, previous_responses[question.key])
     return response if question.dependents.empty? || question.question_type == 'add_multiple_items'
 
     question.dependents.each do |dependent_question|
       # NB: to avoid extra queries use original set of questions
-      dependent_response = build_responses(question: questions[dependent_question.id], person_escort_record: person_escort_record, questions: questions, previous_responses: previous_responses)
+      dependent_response = build_responses(question: questions[dependent_question.id], assessmentable: assessmentable, questions: questions, previous_responses: previous_responses)
       dependent_response_values = dependent_response.slice(:type, :framework_question, :dependents, :person_escort_record, :assessmentable, :value, :prefilled)
       response.dependents.build(dependent_response_values)
     end
@@ -49,7 +49,7 @@ class FrameworkQuestion < VersionedModel
     end
   end
 
-  def build_response(question, person_escort_record, previous_response = nil)
+  def build_response(question, assessmentable, previous_response = nil)
     klass =
       case question.question_type
       when 'radio'
@@ -62,6 +62,6 @@ class FrameworkQuestion < VersionedModel
         FrameworkResponse::String
       end
 
-    klass.new(framework_question: question, assessmentable: person_escort_record, person_escort_record: person_escort_record, value: previous_response, prefilled: previous_response.present?)
+    klass.new(framework_question: question, assessmentable: assessmentable, person_escort_record: assessmentable, value: previous_response, prefilled: previous_response.present?)
   end
 end

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -29,7 +29,7 @@ class FrameworkQuestion < VersionedModel
     question.dependents.each do |dependent_question|
       # NB: to avoid extra queries use original set of questions
       dependent_response = build_responses(question: questions[dependent_question.id], person_escort_record: person_escort_record, questions: questions, previous_responses: previous_responses)
-      dependent_response_values = dependent_response.slice(:type, :framework_question, :dependents, :person_escort_record, :value, :prefilled)
+      dependent_response_values = dependent_response.slice(:type, :framework_question, :dependents, :person_escort_record, :assessmentable, :value, :prefilled)
       response.dependents.build(dependent_response_values)
     end
 
@@ -62,6 +62,6 @@ class FrameworkQuestion < VersionedModel
         FrameworkResponse::String
       end
 
-    klass.new(framework_question: question, person_escort_record: person_escort_record, value: previous_response, prefilled: previous_response.present?)
+    klass.new(framework_question: question, assessmentable: person_escort_record, person_escort_record: person_escort_record, value: previous_response, prefilled: previous_response.present?)
   end
 end

--- a/app/models/framework_response/collection.rb
+++ b/app/models/framework_response/collection.rb
@@ -51,7 +51,7 @@ class FrameworkResponse
       MultipleItemsCollection.new(
         collection: collection,
         questions: framework_question.dependents,
-        person_escort_record: person_escort_record,
+        assessmentable: assessmentable,
       )
     end
 

--- a/app/models/framework_response/multiple_item_object.rb
+++ b/app/models/framework_response/multiple_item_object.rb
@@ -4,17 +4,17 @@ class FrameworkResponse
   class MultipleItemObject
     include ActiveModel::Validations
 
-    attr_accessor :questions, :item, :responses, :person_escort_record
+    attr_accessor :questions, :item, :responses, :assessmentable
 
     validates :item, presence: true, numericality: { only_integer: true }
     validates :responses, presence: true
     validate :multiple_response_objects
     validate :required_questions
 
-    def initialize(attributes: {}, questions: [], person_escort_record:)
+    def initialize(attributes: {}, questions: [], assessmentable:)
       attributes = attributes.presence || {}
       @questions = questions
-      @person_escort_record = person_escort_record
+      @assessmentable = assessmentable
 
       attributes.deep_symbolize_keys! if attributes.respond_to?(:deep_symbolize_keys!)
       @item = attributes[:item]
@@ -49,7 +49,7 @@ class FrameworkResponse
         framework_question = questions.find { |question| question.id == response[:framework_question_id] }
         next unless framework_question
 
-        framework_response = framework_question.build_response(framework_question, person_escort_record)
+        framework_response = framework_question.build_response(framework_question, assessmentable)
 
         framework_response.value = response[:value]
         framework_response

--- a/app/models/framework_response/multiple_items_collection.rb
+++ b/app/models/framework_response/multiple_items_collection.rb
@@ -8,12 +8,12 @@ class FrameworkResponse
 
     validate :multiple_item_objects
 
-    def initialize(collection:, person_escort_record:, questions: [])
+    def initialize(collection:, assessmentable:, questions: [])
       @collection = Array(collection).map do |item|
         MultipleItemObject.new(
           attributes: item,
           questions: questions,
-          person_escort_record: person_escort_record,
+          assessmentable: assessmentable,
         )
       end
     end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -64,7 +64,7 @@ class PersonEscortRecord < VersionedModel
       questions.values.each do |question|
         next unless question.parent_id.nil?
 
-        response = question.build_responses(person_escort_record: self, questions: questions, previous_responses: previous_responses)
+        response = question.build_responses(assessmentable: self, questions: questions, previous_responses: previous_responses)
         framework_responses.build(response.slice(:type, :framework_question, :dependents, :value, :prefilled, :person_escort_record, :assessmentable))
       end
 

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -19,7 +19,7 @@ class PersonEscortRecord < VersionedModel
   validates :profile, uniqueness: true
   validates :confirmed_at, presence: { if: :confirmed? }
 
-  has_many :framework_responses, dependent: :destroy
+  has_many :framework_responses, as: :assessmentable, dependent: :destroy
   has_many :generic_events, as: :eventable, dependent: :destroy # NB: polymorphic association
 
   belongs_to :framework
@@ -65,7 +65,7 @@ class PersonEscortRecord < VersionedModel
         next unless question.parent_id.nil?
 
         response = question.build_responses(person_escort_record: self, questions: questions, previous_responses: previous_responses)
-        framework_responses.build(response.slice(:type, :framework_question, :dependents, :value, :prefilled))
+        framework_responses.build(response.slice(:type, :framework_question, :dependents, :value, :prefilled, :person_escort_record, :assessmentable))
       end
 
       PersonEscortRecord.import([self], validate: false, recursive: true, all_or_none: true, validate_uniqueness: true, on_duplicate_key_update: { conflict_target: [:id] })

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -77,7 +77,7 @@ class PersonEscortRecord < VersionedModel
   def import_nomis_mappings!
     return unless move&.from_location&.prison?
 
-    FrameworkNomisMappings::Importer.new(person_escort_record: self).call
+    FrameworkNomisMappings::Importer.new(assessmentable: self).call
   end
 
   def section_progress

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -6,6 +6,7 @@ class FrameworkResponseSerializer
   set_type :framework_responses
 
   belongs_to :person_escort_record
+  belongs_to :assessment, polymorphic: true, &:assessmentable
   belongs_to :question, serializer: FrameworkQuestionSerializer, &:framework_question
   has_many :flags, serializer: FrameworkFlagSerializer, &:framework_flags
   has_many :nomis_mappings, serializer: FrameworkNomisMappingSerializer, &:framework_nomis_mappings
@@ -17,6 +18,7 @@ class FrameworkResponseSerializer
   end
 
   SUPPORTED_RELATIONSHIPS = %w[
+    assessment
     person_escort_record
     nomis_mappings
     question.descendants

--- a/db/migrate/20201109110657_add_assessmentable_to_framework_responses.rb
+++ b/db/migrate/20201109110657_add_assessmentable_to_framework_responses.rb
@@ -1,0 +1,7 @@
+class AddAssessmentableToFrameworkResponses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :framework_responses, :assessmentable_id, :uuid
+    add_column :framework_responses, :assessmentable_type, :string
+    add_index :framework_responses, [:assessmentable_type, :assessmentable_id], name: 'index_responses_on_assessmentable_type_and_assessmentable_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_06_104806) do
+ActiveRecord::Schema.define(version: 2020_11_09_110657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -237,6 +237,9 @@ ActiveRecord::Schema.define(version: 2020_11_06_104806) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "responded", default: false, null: false
     t.boolean "prefilled", default: false, null: false
+    t.uuid "assessmentable_id"
+    t.string "assessmentable_type"
+    t.index ["assessmentable_type", "assessmentable_id"], name: "index_responses_on_assessmentable_type_and_assessmentable_id"
     t.index ["framework_question_id"], name: "index_framework_responses_on_framework_question_id"
     t.index ["parent_id"], name: "index_framework_responses_on_parent_id"
     t.index ["person_escort_record_id"], name: "index_framework_responses_on_person_escort_record_id"

--- a/lib/tasks/refresh_framework_responses.rake
+++ b/lib/tasks/refresh_framework_responses.rake
@@ -1,0 +1,6 @@
+namespace :framework_responses do
+  desc 'Populate assessmentable association on framework_responses'
+  task refresh_data: :environment do
+    FrameworkResponse.update_all("assessmentable_type = 'PersonEscortRecord', assessmentable_id = person_escort_record_id")
+  end
+end

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -3,7 +3,12 @@
 FactoryBot.define do
   factory :framework_response do
     association(:framework_question)
-    association(:person_escort_record)
+    # TODO: remove once transition to assessment completed
+    before(:create) do |response, evaluator|
+      person_escort_record = evaluator.assessmentable || evaluator.person_escort_record || build(:person_escort_record)
+      response.person_escort_record = person_escort_record
+      response.assessmentable = person_escort_record
+    end
   end
 
   factory :object_response, parent: :framework_response, class: 'FrameworkResponse::Object' do

--- a/spec/factories/person_escort_record.rb
+++ b/spec/factories/person_escort_record.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
           create(
             :string_response,
             framework_question: question,
-            person_escort_record: person_escort_record,
+            assessmentable: person_escort_record,
           )
         end
       end

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe FrameworkQuestion do
       expect(response.framework_question).to eq(question2)
     end
 
+    # TODO: remove once transition to assessment complete
     it 'builds response associated to correct person_escort_record' do
       question = create(:framework_question)
       person_escort_record = create(:person_escort_record)
@@ -41,6 +42,17 @@ RSpec.describe FrameworkQuestion do
       )
 
       expect(response.person_escort_record).to eq(person_escort_record)
+    end
+
+    it 'builds response associated to correct assessment' do
+      question = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
+
+      expect(response.assessmentable).to eq(person_escort_record)
     end
 
     it 'builds response and defaults to current question' do
@@ -90,6 +102,7 @@ RSpec.describe FrameworkQuestion do
       expect(response.dependents).to be_empty
     end
 
+    # TODO: remove once transition to assessment complete
     it 'sets person_escort_record on dependent responses' do
       person_escort_record = create(:person_escort_record)
       question = create(:framework_question)
@@ -100,6 +113,18 @@ RSpec.describe FrameworkQuestion do
       )
 
       expect(response.dependents.first.person_escort_record).to eq(person_escort_record)
+    end
+
+    it 'sets assessment on dependent responses' do
+      person_escort_record = create(:person_escort_record)
+      question = create(:framework_question)
+      create(:framework_question, :checkbox, parent: question)
+      response = question.build_responses(
+        person_escort_record: person_escort_record,
+        questions: questions,
+      )
+
+      expect(response.dependents.first.assessmentable).to eq(person_escort_record)
     end
 
     it 'sets correct types on dependent responses' do

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe FrameworkQuestion do
       question2 = create(:framework_question)
       person_escort_record = create(:person_escort_record)
       response = question1.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
         question: question2,
       )
@@ -37,7 +37,7 @@ RSpec.describe FrameworkQuestion do
       question = create(:framework_question)
       person_escort_record = create(:person_escort_record)
       response = question.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
       )
 
@@ -48,7 +48,7 @@ RSpec.describe FrameworkQuestion do
       question = create(:framework_question)
       person_escort_record = create(:person_escort_record)
       response = question.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
       )
 
@@ -59,7 +59,7 @@ RSpec.describe FrameworkQuestion do
       question = create(:framework_question)
       person_escort_record = create(:person_escort_record)
       response = question.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
       )
 
@@ -72,7 +72,7 @@ RSpec.describe FrameworkQuestion do
       create(:framework_question, :checkbox, parent: question)
       create(:framework_question, :textarea, parent: question)
       response = question.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
       )
 
@@ -84,7 +84,7 @@ RSpec.describe FrameworkQuestion do
       question = create(:framework_question)
       dependent_question = create(:framework_question, :checkbox, parent: question)
       response = question.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
       )
 
@@ -95,7 +95,7 @@ RSpec.describe FrameworkQuestion do
       person_escort_record = create(:person_escort_record)
       question = create(:framework_question, :add_multiple_items)
       response = question.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
       )
 
@@ -108,7 +108,7 @@ RSpec.describe FrameworkQuestion do
       question = create(:framework_question)
       create(:framework_question, :checkbox, parent: question)
       response = question.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
       )
 
@@ -120,7 +120,7 @@ RSpec.describe FrameworkQuestion do
       question = create(:framework_question)
       create(:framework_question, :checkbox, parent: question)
       response = question.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
       )
 
@@ -133,7 +133,7 @@ RSpec.describe FrameworkQuestion do
       create(:framework_question, :checkbox, followup_comment: true, parent: question)
       create(:framework_question, :textarea, parent: question)
       response = question.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
       )
 
@@ -150,7 +150,7 @@ RSpec.describe FrameworkQuestion do
       create(:framework_question, parent: child_question)
       create(:framework_question, parent: child_question)
       response = parent_question.build_responses(
-        person_escort_record: person_escort_record,
+        assessmentable: person_escort_record,
         questions: questions,
       )
 
@@ -168,7 +168,7 @@ RSpec.describe FrameworkQuestion do
         }
         person_escort_record = create(:person_escort_record)
         response = question1.build_responses(
-          person_escort_record: person_escort_record,
+          assessmentable: person_escort_record,
           questions: questions,
           question: question2,
           previous_responses: previous_responses,
@@ -186,7 +186,7 @@ RSpec.describe FrameworkQuestion do
           dependent_question.key => ['Level 1'],
         }
         response = question.build_responses(
-          person_escort_record: person_escort_record,
+          assessmentable: person_escort_record,
           questions: questions,
           previous_responses: previous_responses,
         )
@@ -203,7 +203,7 @@ RSpec.describe FrameworkQuestion do
           dependent_question.key => ['Level 1'],
         }
         response = question.build_responses(
-          person_escort_record: person_escort_record,
+          assessmentable: person_escort_record,
           questions: questions,
           previous_responses: previous_responses,
         )
@@ -219,7 +219,7 @@ RSpec.describe FrameworkQuestion do
           question.key => value,
         }
         response = question.build_responses(
-          person_escort_record: person_escort_record,
+          assessmentable: person_escort_record,
           questions: questions,
           previous_responses: previous_responses,
         )

--- a/spec/models/framework_response/multiple_item_object_spec.rb
+++ b/spec/models/framework_response/multiple_item_object_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
     it 'ignores other keys passed in' do
       questions = [create(:framework_question)]
       attributes = { items: 1, responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).not_to be_valid
       expect(object.errors.messages[:item]).to eq(["can't be blank", 'is not a number'])
@@ -18,7 +18,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
     it 'validates the presence of an item' do
       questions = [create(:framework_question)]
       attributes = { responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).not_to be_valid
       expect(object.errors.messages[:item]).to eq(["can't be blank", 'is not a number'])
@@ -27,7 +27,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
     it 'validates that item attribute is a number' do
       questions = [create(:framework_question)]
       attributes = { item: 'some-item', responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).not_to be_valid
       expect(object.errors.messages[:item]).to eq(['is not a number'])
@@ -36,7 +36,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
     it 'validates that item attribute is an integer' do
       questions = [create(:framework_question)]
       attributes = { item: 1.1, responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).not_to be_valid
       expect(object.errors.messages[:item]).to eq(['must be an integer'])
@@ -45,7 +45,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
     it 'validates the presence of a responses key' do
       questions = [create(:framework_question)]
       attributes = { item: 1, response: [{ value: 'Yes', framework_question_id: questions.first.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).not_to be_valid
       expect(object.errors.messages[:responses]).to eq(["can't be blank"])
@@ -56,7 +56,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       question2 = create(:framework_question)
       questions = [question1, question2]
       attributes = { item: 1, responses: [] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).not_to be_valid
       expect(object.errors.messages[:responses]).to eq(["can't be blank"])
@@ -66,7 +66,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       questions = [create(:framework_question)]
       attributes = { item: 1, responses: { value: 'Yes', framework_question_id: questions.first.id } }
 
-      expect { described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record) }.to raise_error(FrameworkResponse::ValueTypeError)
+      expect { described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record) }.to raise_error(FrameworkResponse::ValueTypeError)
     end
 
     it 'validates responses include value key if multiple responses supplied and question required' do
@@ -74,7 +74,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       question2 = create(:framework_question)
       questions = [question1, question2]
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }, { framework_question_id: question1.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).not_to be_valid
       expect(object.errors.messages[:"responses[1].value"]).to eq(["can't be blank"])
@@ -85,7 +85,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       question2 = create(:framework_question)
       questions = [question1, question2]
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }, { framework_question_id: question1.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).to be_valid
     end
@@ -95,7 +95,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       question2 = create(:framework_question)
       questions = [question1, question2]
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }, { value: ['Level 1'] }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).not_to be_valid
       expect(object.errors.messages[:responses]).to eq(['provide a value for all required questions'])
@@ -106,7 +106,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       question2 = create(:framework_question)
       questions = [question1, question2]
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }, { value: ['Level 1'] }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).to be_valid
     end
@@ -116,7 +116,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       question2 = create(:framework_question)
       questions = [question1, question2]
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }, { value: ['Level 1'], framework_question_id: 'some-id' }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).to be_valid
     end
@@ -126,7 +126,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       question2 = create(:framework_question)
       questions = [question1, question2]
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id, values: 'Some value' }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).to be_valid
     end
@@ -134,7 +134,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
     it 'validates response if value for response is invalid' do
       questions = [create(:framework_question, :checkbox)]
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: questions.first.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect { object.valid? }.to raise_error(FrameworkResponse::ValueTypeError)
     end
@@ -142,7 +142,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
     it 'does not validate the response if value for response is valid' do
       questions = [create(:framework_question, :checkbox)]
       attributes = { item: 1, responses: [{ value: ['Level 1'], framework_question_id: questions.first.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).to be_valid
     end
@@ -150,7 +150,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
     it 'validates response if value for response is required' do
       questions = [create(:framework_question, :checkbox, required: true)]
       attributes = { item: 1, responses: [{ value: nil, framework_question_id: questions.first.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).not_to be_valid
       expect(object.errors.messages[:"responses[0].value"]).to eq(["can't be blank"])
@@ -161,7 +161,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       question2 = create(:framework_question)
       questions = [question1, question2]
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).not_to be_valid
       expect(object.errors.messages[:responses]).to eq(['provide a value for all required questions'])
@@ -172,7 +172,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
       question2 = create(:framework_question)
       questions = [question1, question2]
       attributes = { item: 1, responses: [{ value: 'Yes', framework_question_id: question2.id }] }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object).to be_valid
     end
@@ -190,14 +190,14 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
           { value: 'No', framework_question_id: question2.id },
         ],
       }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object.as_json).to eq(attributes)
     end
 
     it 'returns an empty hash if nothing passed in' do
       questions = [create(:framework_question, :checkbox, required: true)]
-      object = described_class.new(attributes: {}, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: {}, questions: questions, assessmentable: person_escort_record)
 
       expect(object.as_json).to be_empty
     end
@@ -208,7 +208,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
         item: nil,
         responses: nil,
       }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object.as_json).to be_empty
     end
@@ -221,7 +221,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
         item: 1,
         responses: [{ value: ['Level 1'], framework_question_id: question1.id }, { framework_question_id: question2.id }],
       }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object.as_json).to eq({
         item: 1,
@@ -240,7 +240,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
         item: 1,
         responses: [{ value: ['Level 1'], framework_question_id: question1.id }, { value: 'Yes' }],
       }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object.as_json).to eq({
         item: 1,
@@ -258,7 +258,7 @@ RSpec.describe FrameworkResponse::MultipleItemObject, type: :model do
         item: 1,
         responses: [{ value: ['Level 1'], framework_question_id: question1.id }, { value: 'Yes', framework_question_id: 'some-id' }],
       }
-      object = described_class.new(attributes: attributes, questions: questions, person_escort_record: person_escort_record)
+      object = described_class.new(attributes: attributes, questions: questions, assessmentable: person_escort_record)
 
       expect(object.as_json).to eq({
         item: 1,

--- a/spec/models/framework_response/multiple_items_collection_spec.rb
+++ b/spec/models/framework_response/multiple_items_collection_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FrameworkResponse::MultipleItemsCollection, type: :model do
       response2 = { value: 'Yes', framework_question_id: question2.id }
       collection = [{ item: 1, responses: [response2] }, { item: 2, responses: [response1, response2] }]
 
-      collection = described_class.new(collection: collection, person_escort_record: person_escort_record, questions: questions)
+      collection = described_class.new(collection: collection, assessmentable: person_escort_record, questions: questions)
 
       expect(collection).not_to be_valid
       expect(collection.errors.messages[:"items[1].responses[0].value"]).to eq(['Level 3 are not valid options'])
@@ -25,7 +25,7 @@ RSpec.describe FrameworkResponse::MultipleItemsCollection, type: :model do
       response = { value: 'Level 3', framework_question_id: question.id }
       collection = [{ item: 1, responses: [response] }]
 
-      collection = described_class.new(collection: collection, person_escort_record: person_escort_record, questions: [question])
+      collection = described_class.new(collection: collection, assessmentable: person_escort_record, questions: [question])
 
       expect { collection.valid? }.to raise_error(FrameworkResponse::ValueTypeError)
     end
@@ -37,7 +37,7 @@ RSpec.describe FrameworkResponse::MultipleItemsCollection, type: :model do
       response = { value: ['Level 1'], framework_question_id: question.id }
       collection = [{ item: 1, responses: [response] }]
 
-      collection = described_class.new(collection: collection, person_escort_record: person_escort_record, questions: [question])
+      collection = described_class.new(collection: collection, assessmentable: person_escort_record, questions: [question])
       expect(collection.to_a.first).to be_a(FrameworkResponse::MultipleItemObject)
     end
 
@@ -47,12 +47,12 @@ RSpec.describe FrameworkResponse::MultipleItemsCollection, type: :model do
       response2 = { value: ['Level 2'], framework_question_id: question.id }
       collection = [{ item: 1, responses: [response2] }, { item: 2, responses: [response1] }]
 
-      collection = described_class.new(collection: collection, person_escort_record: person_escort_record, questions: [question])
+      collection = described_class.new(collection: collection, assessmentable: person_escort_record, questions: [question])
       expect(collection.to_a.count).to eq(2)
     end
 
     it 'returns an empty array if collection is empty' do
-      collection = described_class.new(collection: [], person_escort_record: person_escort_record)
+      collection = described_class.new(collection: [], assessmentable: person_escort_record)
 
       expect(collection.to_a).to be_empty
     end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe FrameworkResponse do
 
       it 'updates person escort record status if some answers provided' do
         response1 = create(:string_response, value: nil)
-        create(:string_response, value: nil, person_escort_record: response1.person_escort_record)
+        create(:string_response, value: nil, assessmentable: response1.person_escort_record)
         response1.update_with_flags!('Yes')
 
         expect(response1.person_escort_record).to be_in_progress

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe FrameworkResponse do
   it { is_expected.to belong_to(:framework_question) }
   it { is_expected.to belong_to(:person_escort_record) }
+  it { is_expected.to belong_to(:assessmentable).optional }
   it { is_expected.to belong_to(:parent).optional }
 
   it { is_expected.to have_many(:dependents) }

--- a/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Api::FrameworkResponsesController do
     let(:person_escort_record) { create(:person_escort_record, :in_progress) }
     let(:per_id) { person_escort_record.id }
 
-    let(:framework_response) { create(:string_response, person_escort_record: person_escort_record, value: 'No') }
-    let(:other_framework_response) { create(:string_response, person_escort_record: person_escort_record, value: 'Yes') }
+    let(:framework_response) { create(:string_response, assessmentable: person_escort_record, value: 'No') }
+    let(:other_framework_response) { create(:string_response, assessmentable: person_escort_record, value: 'Yes') }
     let(:framework_response_id) { framework_response.id }
     let(:other_framework_response_id) { other_framework_response.id }
 
@@ -62,11 +62,11 @@ RSpec.describe Api::FrameworkResponsesController do
       end
 
       context 'when responses are combined' do
-        let(:string_response) { create(:string_response, person_escort_record: person_escort_record, value: 'No') }
-        let(:array_response) { create(:array_response, person_escort_record: person_escort_record) }
-        let(:object_response) { create(:object_response, :details, person_escort_record: person_escort_record) }
-        let(:details_response) { create(:collection_response, :details, person_escort_record: person_escort_record) }
-        let(:multiple_items_response) { create(:collection_response, :multiple_items, framework_question: multiple_question, value: nil, person_escort_record: person_escort_record) }
+        let(:string_response) { create(:string_response, assessmentable: person_escort_record, value: 'No') }
+        let(:array_response) { create(:array_response, assessmentable: person_escort_record) }
+        let(:object_response) { create(:object_response, :details, assessmentable: person_escort_record) }
+        let(:details_response) { create(:collection_response, :details, assessmentable: person_escort_record) }
+        let(:multiple_items_response) { create(:collection_response, :multiple_items, framework_question: multiple_question, value: nil, assessmentable: person_escort_record) }
 
         let(:question1) { create(:framework_question) }
         let(:question2) { create(:framework_question, :checkbox) }
@@ -201,9 +201,9 @@ RSpec.describe Api::FrameworkResponsesController do
       end
 
       context 'with a nested invalid value' do
-        let(:framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
+        let(:framework_response) { create(:collection_response, :multiple_items, assessmentable: person_escort_record) }
         let(:framework_question) { framework_response.framework_question.dependents.first }
-        let(:other_framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
+        let(:other_framework_response) { create(:collection_response, :multiple_items, assessmentable: person_escort_record) }
         let(:other_framework_question) { other_framework_response.framework_question.dependents.first }
 
         let(:value) do
@@ -240,9 +240,9 @@ RSpec.describe Api::FrameworkResponsesController do
       end
 
       context 'with a nested incorrect value type' do
-        let(:framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
+        let(:framework_response) { create(:collection_response, :multiple_items, assessmentable: person_escort_record) }
         let(:framework_question) { framework_response.framework_question.dependents.first }
-        let(:other_framework_response) { create(:collection_response, :multiple_items, person_escort_record: person_escort_record) }
+        let(:other_framework_response) { create(:collection_response, :multiple_items, assessmentable: person_escort_record) }
         let(:other_framework_question) { other_framework_response.framework_question.dependents.first }
 
         let(:value) do
@@ -282,7 +282,7 @@ RSpec.describe Api::FrameworkResponsesController do
 
       context 'when person_escort_record confirmed' do
         let(:person_escort_record) { create(:person_escort_record, :confirmed) }
-        let(:detail_403) { "Can't update framework_responses because person_escort_record is confirmed" }
+        let(:detail_403) { "Can't update framework_responses because assessment is confirmed" }
 
         it_behaves_like 'an endpoint that responds with error 403'
       end

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -285,9 +285,9 @@ RSpec.describe Api::FrameworkResponsesController do
 
       context 'when person_escort_record confirmed' do
         let(:person_escort_record) { create(:person_escort_record, :confirmed) }
-        let(:framework_response) { create(:string_response, person_escort_record: person_escort_record) }
+        let(:framework_response) { create(:string_response, assessmentable: person_escort_record) }
         let(:detail_403) do
-          "Can't update framework_responses because person_escort_record is confirmed"
+          "Can't update framework_responses because assessment is confirmed"
         end
 
         it_behaves_like 'an endpoint that responds with error 403'

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -9,9 +9,13 @@ RSpec.describe Api::PersonEscortRecordsController do
     let(:response_json) { JSON.parse(response.body) }
     let(:framework_question) { build(:framework_question, section: 'risk-information') }
     let(:flag) { build(:framework_flag, framework_question: framework_question) }
-    let(:framework_response) { build(:string_response, framework_question: framework_question, responded: true, framework_flags: [flag]) }
     let(:framework) { create(:framework, framework_questions: [framework_question]) }
-    let(:person_escort_record) { create(:person_escort_record, framework_responses: [framework_response]) }
+    let(:person_escort_record) do
+      person_escort_record = create(:person_escort_record)
+      create(:string_response, framework_question: framework_question, responded: true, framework_flags: [flag], assessmentable: person_escort_record, person_escort_record: person_escort_record)
+
+       person_escort_record
+     end
     let(:person_escort_record_id) { person_escort_record.id }
 
     before do
@@ -52,7 +56,7 @@ RSpec.describe Api::PersonEscortRecordsController do
             "responses": {
               "data": [
                 {
-                  "id": framework_response.id,
+                  "id": person_escort_record.framework_responses.first.id,
                   "type": 'framework_responses',
                 },
               ],

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Api::PersonEscortRecordsController do
     let(:framework) { create(:framework, framework_questions: [framework_question]) }
     let(:person_escort_record) do
       person_escort_record = create(:person_escort_record)
-      create(:string_response, framework_question: framework_question, responded: true, framework_flags: [flag], assessmentable: person_escort_record, person_escort_record: person_escort_record)
+      create(:string_response, framework_question: framework_question, responded: true, framework_flags: [flag], assessmentable: person_escort_record)
 
-       person_escort_record
-     end
+      person_escort_record
+    end
     let(:person_escort_record_id) { person_escort_record.id }
 
     before do

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -33,9 +33,17 @@ RSpec.describe FrameworkResponseSerializer do
     expect(result[:data][:attributes][:prefilled]).to eq(framework_response.prefilled)
   end
 
+  # TODO: remove once transition to assessment is complete
   it 'contains a `person_escort_record` relationship' do
     expect(result[:data][:relationships][:person_escort_record][:data]).to eq(
       id: framework_response.person_escort_record.id,
+      type: 'person_escort_records',
+    )
+  end
+
+  it 'contains a `assessment` relationship' do
+    expect(result[:data][:relationships][:assessment][:data]).to eq(
+      id: framework_response.assessmentable.id,
       type: 'person_escort_records',
     )
   end
@@ -77,16 +85,16 @@ RSpec.describe FrameworkResponseSerializer do
 
   context 'with include options' do
     let(:includes) do
-      %i[person_escort_record question]
+      %i[person_escort_record assessment question]
     end
     let(:framework_response) do
-      create(:string_response, person_escort_record: create(:person_escort_record))
+      create(:string_response, assessmentable: create(:person_escort_record))
     end
 
     let(:expected_json) do
       [
         {
-          id: framework_response.person_escort_record.id,
+          id: framework_response.assessmentable.id,
           type: 'person_escort_records',
           attributes: { status: 'not_started' },
         },

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -64,8 +64,7 @@ RSpec.describe PersonEscortRecordSerializer do
   end
 
   it 'contains a`responses` relationship with framework responses' do
-    question = create(:framework_question)
-    response = person_escort_record.framework_responses.create!(type: 'FrameworkResponse::String', framework_question: question)
+    response = create(:string_response, assessmentable: person_escort_record)
 
     expect(result[:data][:relationships][:responses][:data]).to contain_exactly(
       id: response.id,
@@ -123,10 +122,12 @@ RSpec.describe PersonEscortRecordSerializer do
   context 'with include options' do
     let(:includes) { ['responses', 'prefill_source', 'responses.question', 'responses.nomis_mappings'] }
     let(:framework_nomis_mapping) { create(:framework_nomis_mapping) }
-    let(:framework_response) { build(:object_response, framework_nomis_mappings: [framework_nomis_mapping]) }
     let(:person_escort_record) do
-      create(:person_escort_record, :prefilled, framework_responses: [framework_response])
+      person_escort_record = create(:person_escort_record, :prefilled)
+      create(:object_response, framework_nomis_mappings: [framework_nomis_mapping], assessmentable: person_escort_record)
+      person_escort_record
     end
+    let(:framework_response) { person_escort_record.framework_responses.first }
 
     let(:expected_json) do
       UnorderedArray(

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe PersonEscortRecordSerializer do
 
   it 'contains a`flags` relationship with framework response flags' do
     flag = create(:framework_flag)
-    create(:string_response, person_escort_record: person_escort_record, framework_flags: [flag])
+    create(:string_response, assessmentable: person_escort_record, framework_flags: [flag])
 
     expect(result[:data][:relationships][:flags][:data]).to contain_exactly(
       id: flag.id,
@@ -104,7 +104,7 @@ RSpec.describe PersonEscortRecordSerializer do
   describe 'meta' do
     it 'includes section progress' do
       question = create(:framework_question, framework: person_escort_record.framework, section: 'risk-information')
-      create(:string_response, value: nil, framework_question: question, person_escort_record: person_escort_record)
+      create(:string_response, value: nil, framework_question: question, assessmentable: person_escort_record)
 
       expect(result[:data][:meta][:section_progress]).to contain_exactly(
         key: 'risk-information',

--- a/spec/services/framework_responses/bulk_updater_spec.rb
+++ b/spec/services/framework_responses/bulk_updater_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe FrameworkResponses::BulkUpdater do
   it 'marks values as responded' do
     per = create(:person_escort_record)
-    response1 = create(:string_response, person_escort_record: per, value: nil)
-    response2 = create(:string_response, person_escort_record: per, value: nil)
+    response1 = create(:string_response, assessmentable: per, value: nil)
+    response2 = create(:string_response, assessmentable: per, value: nil)
     described_class.new(per, { response1.id => 'Yes', response2.id => 'No' }).call
 
     expect(response1.reload).to be_responded
@@ -15,8 +15,8 @@ RSpec.describe FrameworkResponses::BulkUpdater do
 
   it 'marks values as responded if they have been prefilled' do
     per = create(:person_escort_record)
-    response1 = create(:string_response, person_escort_record: per, value: 'Yes', prefilled: true, responded: false)
-    response2 = create(:string_response, person_escort_record: per, value: 'No', prefilled: true, responded: false)
+    response1 = create(:string_response, assessmentable: per, value: 'Yes', prefilled: true, responded: false)
+    response2 = create(:string_response, assessmentable: per, value: 'No', prefilled: true, responded: false)
     described_class.new(per, { response1.id => 'Yes', response2.id => 'No' }).call
 
     expect(response1.reload).to be_responded
@@ -25,8 +25,8 @@ RSpec.describe FrameworkResponses::BulkUpdater do
 
   it 'updates response values' do
     per = create(:person_escort_record)
-    response1 = create(:string_response, person_escort_record: per, value: nil)
-    response2 = create(:string_response, person_escort_record: per, value: nil)
+    response1 = create(:string_response, assessmentable: per, value: nil)
+    response2 = create(:string_response, assessmentable: per, value: nil)
     described_class.new(per, { response1.id => 'Yes', response2.id => 'No' }).call
 
     expect(response1.reload.value).to eq('Yes')
@@ -37,8 +37,8 @@ RSpec.describe FrameworkResponses::BulkUpdater do
     per = create(:person_escort_record)
     flag1 = create(:framework_flag)
     flag2 = create(:framework_flag)
-    response1 = create(:string_response, value: nil, framework_question: flag1.framework_question, person_escort_record: per)
-    response2 = create(:string_response, value: nil, framework_question: flag2.framework_question, person_escort_record: per)
+    response1 = create(:string_response, value: nil, framework_question: flag1.framework_question, assessmentable: per)
+    response2 = create(:string_response, value: nil, framework_question: flag2.framework_question, assessmentable: per)
     described_class.new(per, { response1.id => 'Yes', response2.id => 'No' }).call
 
     expect(response1.reload.framework_flags).to contain_exactly(flag1)
@@ -50,8 +50,8 @@ RSpec.describe FrameworkResponses::BulkUpdater do
     framework_question = create(:framework_question)
     flag1 = create(:framework_flag, framework_question: framework_question)
     flag2 = create(:framework_flag, framework_question: framework_question)
-    response1 = create(:string_response, framework_question: framework_question, framework_flags: [flag1, flag2], person_escort_record: per)
-    response2 = create(:string_response, framework_question: framework_question, framework_flags: [flag1, flag2], person_escort_record: per)
+    response1 = create(:string_response, framework_question: framework_question, framework_flags: [flag1, flag2], assessmentable: per)
+    response2 = create(:string_response, framework_question: framework_question, framework_flags: [flag1, flag2], assessmentable: per)
     described_class.new(per, { response1.id => 'No', response2.id => 'Yes' }).call
 
     expect(response1.reload.framework_flags).to be_empty
@@ -61,12 +61,12 @@ RSpec.describe FrameworkResponses::BulkUpdater do
   context 'when dependent responses' do
     it 'clears dependent responses if value changed' do
       per = create(:person_escort_record)
-      parent1_response = create(:string_response, person_escort_record: per)
-      parent2_response = create(:string_response, person_escort_record: per)
+      parent1_response = create(:string_response, assessmentable: per)
+      parent2_response = create(:string_response, assessmentable: per)
       child1_question = create(:framework_question, dependent_value: 'Yes', parent: parent1_response.framework_question)
       child2_question = create(:framework_question, dependent_value: 'Yes', parent: parent2_response.framework_question)
-      child_response1 = create(:string_response, framework_question: child1_question, parent: parent1_response, person_escort_record: per)
-      child_response2 = create(:string_response, framework_question: child2_question, parent: parent2_response, person_escort_record: per)
+      child_response1 = create(:string_response, framework_question: child1_question, parent: parent1_response, assessmentable: per)
+      child_response2 = create(:string_response, framework_question: child2_question, parent: parent2_response, assessmentable: per)
       described_class.new(per, { parent1_response.id => 'No', parent2_response.id => 'No' }).call
 
       [child_response1, child_response2].each do |response|
@@ -77,7 +77,7 @@ RSpec.describe FrameworkResponses::BulkUpdater do
     context 'with transaction failure' do
       it 'raises an error if transaction fails twice' do
         per = create(:person_escort_record)
-        response = create(:string_response, person_escort_record: per, value: nil)
+        response = create(:string_response, assessmentable: per, value: nil)
         allow(FrameworkResponse).to receive(:import).and_raise(ActiveRecord::PreparedStatementCacheExpired).twice
 
         expect { described_class.new(per, { response.id => 'Yes' }).call }.to raise_error(ActiveRecord::PreparedStatementCacheExpired)
@@ -85,7 +85,7 @@ RSpec.describe FrameworkResponses::BulkUpdater do
 
       it 'retries the transaction if it fails only once and updates responses' do
         per = create(:person_escort_record)
-        response = create(:string_response, person_escort_record: per, value: nil)
+        response = create(:string_response, assessmentable: per, value: nil)
 
         # Allow update to fail first time, and second time to complete transaction
         return_values = [:raise, true]
@@ -104,16 +104,16 @@ RSpec.describe FrameworkResponses::BulkUpdater do
   context 'with validation error' do
     it 'raises BulkUpdateErrors' do
       per = create(:person_escort_record)
-      response1 = create(:string_response, person_escort_record: per, value: nil)
-      response2 = create(:string_response, person_escort_record: per, value: nil)
+      response1 = create(:string_response, assessmentable: per, value: nil)
+      response2 = create(:string_response, assessmentable: per, value: nil)
 
       expect { described_class.new(per, { response1.id => 'Foo', response2.id => 'No' }).call }.to raise_error(FrameworkResponses::BulkUpdateError)
     end
 
     it 'does not update responses' do
       per = create(:person_escort_record)
-      response1 = create(:string_response, person_escort_record: per, value: nil)
-      response2 = create(:string_response, person_escort_record: per, value: nil)
+      response1 = create(:string_response, assessmentable: per, value: nil)
+      response2 = create(:string_response, assessmentable: per, value: nil)
       described_class.new(per, { response1.id => 'Foo', response2.id => 'No' }).call
 
     rescue FrameworkResponses::BulkUpdateError
@@ -125,7 +125,7 @@ RSpec.describe FrameworkResponses::BulkUpdater do
   context 'with person_escort_record status' do
     it 'does not change person escort record status answers provided invalid' do
       per = create(:person_escort_record)
-      response = create(:string_response, value: nil, person_escort_record: per)
+      response = create(:string_response, value: nil, assessmentable: per)
 
       expect { described_class.new(per, { response.id => %w[Yes] }).call }.to raise_error(FrameworkResponses::BulkUpdateError)
       expect(per.reload).to be_unstarted
@@ -133,8 +133,8 @@ RSpec.describe FrameworkResponses::BulkUpdater do
 
     it 'updates person escort record status if some answers provided' do
       per = create(:person_escort_record)
-      response1 = create(:string_response, value: nil, person_escort_record: per)
-      create(:string_response, value: nil, person_escort_record: per)
+      response1 = create(:string_response, value: nil, assessmentable: per)
+      create(:string_response, value: nil, assessmentable: per)
       described_class.new(per, { response1.id => 'Yes' }).call
 
       expect(per.reload).to be_in_progress

--- a/swagger/v1/framework_response.yaml
+++ b/swagger/v1/framework_response.yaml
@@ -75,11 +75,14 @@ FrameworkResponse:
     relationships:
       type: object
       required:
-      - person_escort_record
+      - assessment
       properties:
         person_escort_record:
           $ref: person_escort_record_reference.yaml#/PersonEscortRecordReference
-          description: The person_escort_record the responses refer to
+          description: (Deprecated) The person_escort_record the responses refer to
+        assessment:
+          $ref: person_escort_record_reference.yaml#/PersonEscortRecordReference
+          description: The assessment the responses refer to, current assessments supported include the Person Escort Record
         question:
           $ref: framework_question_reference.yaml#/FrameworkQuestionReference
           description: The question this response is for


### PR DESCRIPTION
### Jira link

[P4-2447](https://dsdmoj.atlassian.net/browse/P4-2447)

### What?

I have added/removed/altered:

- [x] Added a new polymorphic association to Framework responses called assessmentable
- [x] Renamed all associations to assessmentable whilst keeping backward compatibility to `person_escort_record`
- [x] Exposed assessmentable in framework response serializer and added appropriate includes
- [x] Add rake task to backfill data on existing framework responses

### Why?

To add the Youth Risk Assessment, we need to be able to support multiple types of assessments on framework responses. Adding a new polymorphic association helps achieve this goal. Since this is a breaking change, we will first roll out support for this new relationship, whilst maintaining the old one. After we backfill all the data on production using the rake task included, and the frontend client starts utilising the new relationship, we can folllowup with a PR to remove the old relationship.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Hopefully this shouldn't affect existing data, but rather adds a new relationship whilst keeping the old one
- Changes an api that is used in production

