### PR TITLE
Keep old implementation to rely on person escort record relationship

### DIFF
--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -19,7 +19,7 @@ class PersonEscortRecord < VersionedModel
   validates :profile, uniqueness: true
   validates :confirmed_at, presence: { if: :confirmed? }
 
-  has_many :framework_responses, as: :assessmentable, dependent: :destroy
+  has_many :framework_responses, dependent: :destroy
   has_many :generic_events, as: :eventable, dependent: :destroy # NB: polymorphic association
 
   belongs_to :framework


### PR DESCRIPTION
Revert to using old association, as if we use assessmentable now, between the time we run the rake task users will have a glitch where person escort record will not return any responses. Only switch to assessmentable when backfill is complete.