### PR TITLE
Use PER instead of assessmentable for updating framework responses

### DIFF
--- a/app/services/framework_responses/bulk_updater.rb
+++ b/app/services/framework_responses/bulk_updater.rb
@@ -30,7 +30,7 @@ module FrameworkResponses
       [].tap do |updated_responses|
         validator = ActiveRecord::Import::Validator.new(FrameworkResponse)
 
-        FrameworkResponse.includes(framework_question: %i[framework_flags]).where(assessmentable: assessment).find(response_values_hash.keys).each do |response|
+        FrameworkResponse.includes(framework_question: %i[framework_flags]).where(person_escort_record: assessment).find(response_values_hash.keys).each do |response|
           new_value = response_values_hash[response.id]
           next if response.value == new_value && response.responded == true
 


### PR DESCRIPTION
To avoid any glitches in the FE before backfilling, use old column on framework bulk updates as well.