### PR TITLE
P4-2248 Stop using `person_escort_record` relationship on framework responses

### DIFF
--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -19,7 +19,7 @@ class PersonEscortRecord < VersionedModel
   validates :profile, uniqueness: true
   validates :confirmed_at, presence: { if: :confirmed? }
 
-  has_many :framework_responses, dependent: :destroy
+  has_many :framework_responses, as: :assessmentable, dependent: :destroy
   has_many :generic_events, as: :eventable, dependent: :destroy # NB: polymorphic association
 
   belongs_to :framework

--- a/app/services/framework_responses/bulk_updater.rb
+++ b/app/services/framework_responses/bulk_updater.rb
@@ -30,7 +30,7 @@ module FrameworkResponses
       [].tap do |updated_responses|
         validator = ActiveRecord::Import::Validator.new(FrameworkResponse)
 
-        FrameworkResponse.includes(framework_question: %i[framework_flags]).where(person_escort_record: assessment).find(response_values_hash.keys).each do |response|
+        FrameworkResponse.includes(framework_question: %i[framework_flags]).where(assessmentable: assessment).find(response_values_hash.keys).each do |response|
           new_value = response_values_hash[response.id]
           next if response.value == new_value && response.responded == true
 


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2448

Stop using the `person_escort_record` relationship on responses, although we still populate the `person_escort_record` value on creation. This is due to our deployment strategy, where we need to support both old and new pods, and the old pods will still be reading from the old column, so to avoid any glitched this change needs to be staggered. After this is fully deployed we can finally get rid of the PER column safely.