### PR TITLE
P4-2248 Stop writing to person_escort_record_id in responses

### DIFF
--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -29,7 +29,7 @@ class FrameworkQuestion < VersionedModel
     question.dependents.each do |dependent_question|
       # NB: to avoid extra queries use original set of questions
       dependent_response = build_responses(question: questions[dependent_question.id], assessmentable: assessmentable, questions: questions, previous_responses: previous_responses)
-      dependent_response_values = dependent_response.slice(:type, :framework_question, :dependents, :person_escort_record, :assessmentable, :value, :prefilled)
+      dependent_response_values = dependent_response.slice(:type, :framework_question, :dependents, :assessmentable, :value, :prefilled)
       response.dependents.build(dependent_response_values)
     end
 
@@ -62,6 +62,6 @@ class FrameworkQuestion < VersionedModel
         FrameworkResponse::String
       end
 
-    klass.new(framework_question: question, assessmentable: assessmentable, person_escort_record: assessmentable, value: previous_response, prefilled: previous_response.present?)
+    klass.new(framework_question: question, assessmentable: assessmentable, value: previous_response, prefilled: previous_response.present?)
   end
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -11,7 +11,7 @@ class FrameworkResponse < VersionedModel
 
   belongs_to :framework_question
   # TODO: remove once transition to assessment completed
-  belongs_to :person_escort_record
+  belongs_to :person_escort_record, optional: true
   belongs_to :assessmentable, optional: true, polymorphic: true
   has_many :dependents, class_name: 'FrameworkResponse',
                         foreign_key: 'parent_id'

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -65,7 +65,7 @@ class PersonEscortRecord < VersionedModel
         next unless question.parent_id.nil?
 
         response = question.build_responses(assessmentable: self, questions: questions, previous_responses: previous_responses)
-        framework_responses.build(response.slice(:type, :framework_question, :dependents, :value, :prefilled, :person_escort_record, :assessmentable))
+        framework_responses.build(response.slice(:type, :framework_question, :dependents, :value, :prefilled, :assessmentable))
       end
 
       PersonEscortRecord.import([self], validate: false, recursive: true, all_or_none: true, validate_uniqueness: true, on_duplicate_key_update: { conflict_target: [:id] })

--- a/db/migrate/20201116093301_change_person_escort_record_to_optional_on_framework_responses.rb
+++ b/db/migrate/20201116093301_change_person_escort_record_to_optional_on_framework_responses.rb
@@ -1,0 +1,5 @@
+class ChangePersonEscortRecordToOptionalOnFrameworkResponses < ActiveRecord::Migration[6.0]
+  def change
+    change_column :framework_responses, :person_escort_record_id, :uuid, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_09_110657) do
+ActiveRecord::Schema.define(version: 2020_11_16_093301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -227,7 +227,7 @@ ActiveRecord::Schema.define(version: 2020_11_09_110657) do
   end
 
   create_table "framework_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "person_escort_record_id", null: false
+    t.uuid "person_escort_record_id"
     t.uuid "framework_question_id", null: false
     t.text "value_text"
     t.jsonb "value_json"

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -3,12 +3,7 @@
 FactoryBot.define do
   factory :framework_response do
     association(:framework_question)
-    # TODO: remove once transition to assessment completed
-    before(:create) do |response, evaluator|
-      person_escort_record = evaluator.assessmentable || evaluator.person_escort_record || build(:person_escort_record)
-      response.person_escort_record = person_escort_record
-      response.assessmentable = person_escort_record
-    end
+    association(:assessmentable, factory: :person_escort_record)
   end
 
   factory :object_response, parent: :framework_response, class: 'FrameworkResponse::Object' do

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -32,18 +32,6 @@ RSpec.describe FrameworkQuestion do
       expect(response.framework_question).to eq(question2)
     end
 
-    # TODO: remove once transition to assessment complete
-    it 'builds response associated to correct person_escort_record' do
-      question = create(:framework_question)
-      person_escort_record = create(:person_escort_record)
-      response = question.build_responses(
-        assessmentable: person_escort_record,
-        questions: questions,
-      )
-
-      expect(response.person_escort_record).to eq(person_escort_record)
-    end
-
     it 'builds response associated to correct assessment' do
       question = create(:framework_question)
       person_escort_record = create(:person_escort_record)
@@ -100,19 +88,6 @@ RSpec.describe FrameworkQuestion do
       )
 
       expect(response.dependents).to be_empty
-    end
-
-    # TODO: remove once transition to assessment complete
-    it 'sets person_escort_record on dependent responses' do
-      person_escort_record = create(:person_escort_record)
-      question = create(:framework_question)
-      create(:framework_question, :checkbox, parent: question)
-      response = question.build_responses(
-        assessmentable: person_escort_record,
-        questions: questions,
-      )
-
-      expect(response.dependents.first.person_escort_record).to eq(person_escort_record)
     end
 
     it 'sets assessment on dependent responses' do

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe FrameworkResponse do
   it { is_expected.to belong_to(:framework_question) }
-  it { is_expected.to belong_to(:person_escort_record) }
+  it { is_expected.to belong_to(:person_escort_record).optional }
   it { is_expected.to belong_to(:assessmentable).optional }
   it { is_expected.to belong_to(:parent).optional }
 
@@ -386,15 +386,15 @@ RSpec.describe FrameworkResponse do
         response = create(:string_response, value: nil)
 
         expect { response.update_with_flags!(%w[Yes]) }.to raise_error(FrameworkResponse::ValueTypeError)
-        expect(response.person_escort_record).to be_unstarted
+        expect(response.assessmentable).to be_unstarted
       end
 
       it 'updates person escort record status if some answers provided' do
         response1 = create(:string_response, value: nil)
-        create(:string_response, value: nil, assessmentable: response1.person_escort_record)
+        create(:string_response, value: nil, assessmentable: response1.assessmentable)
         response1.update_with_flags!('Yes')
 
-        expect(response1.person_escort_record).to be_in_progress
+        expect(response1.assessmentable).to be_in_progress
       end
 
       it 'does not allow updating responses if person_escort_record status is confirmed' do

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -267,7 +267,6 @@ RSpec.describe PersonEscortRecord do
 
       expect(person_escort_record.framework_responses.first).to have_attributes(
         framework_question_id: radio_question.id,
-        person_escort_record_id: person_escort_record.id,
         assessmentable_id: person_escort_record.id,
         type: 'FrameworkResponse::String',
       )
@@ -300,7 +299,6 @@ RSpec.describe PersonEscortRecord do
 
       expect(dependent_response).to have_attributes(
         framework_question_id: child_question.id,
-        person_escort_record_id: person_escort_record.id,
         assessmentable_id: person_escort_record.id,
         type: 'FrameworkResponse::Array',
       )
@@ -329,7 +327,6 @@ RSpec.describe PersonEscortRecord do
 
       expect(dependent_response).to have_attributes(
         framework_question_id: grand_child_question.id,
-        person_escort_record_id: person_escort_record.id,
         assessmentable_id: person_escort_record.id,
         type: 'FrameworkResponse::String',
       )
@@ -398,7 +395,6 @@ RSpec.describe PersonEscortRecord do
 
       expect(person_escort_record.framework_responses.first).to have_attributes(
         framework_question_id: radio_question.id,
-        person_escort_record_id: person_escort_record.id,
         assessmentable_id: person_escort_record.id,
         type: 'FrameworkResponse::String',
       )

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -33,14 +33,6 @@ RSpec.describe FrameworkResponseSerializer do
     expect(result[:data][:attributes][:prefilled]).to eq(framework_response.prefilled)
   end
 
-  # TODO: remove once transition to assessment is complete
-  it 'contains a `person_escort_record` relationship' do
-    expect(result[:data][:relationships][:person_escort_record][:data]).to eq(
-      id: framework_response.person_escort_record.id,
-      type: 'person_escort_records',
-    )
-  end
-
   it 'contains a `assessment` relationship' do
     expect(result[:data][:relationships][:assessment][:data]).to eq(
       id: framework_response.assessmentable.id,


### PR DESCRIPTION
* Make the `person_escort_record_id` column optional, but keep for now to support staggered release
* Stop writing to the `person_escort_record_id` column when populating responses