### PR TITLE
P4-2248 Remove person_escort_record_id from framework responses

### DIFF
--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -10,8 +10,6 @@ class FrameworkResponse < VersionedModel
   end
 
   belongs_to :framework_question
-  # TODO: remove once transition to assessment completed
-  belongs_to :person_escort_record, optional: true
   belongs_to :assessmentable, optional: true, polymorphic: true
   has_many :dependents, class_name: 'FrameworkResponse',
                         foreign_key: 'parent_id'

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -5,7 +5,6 @@ class FrameworkResponseSerializer
 
   set_type :framework_responses
 
-  belongs_to :person_escort_record
   belongs_to :assessment, polymorphic: true, &:assessmentable
   belongs_to :question, serializer: FrameworkQuestionSerializer, &:framework_question
   has_many :flags, serializer: FrameworkFlagSerializer, &:framework_flags
@@ -19,7 +18,6 @@ class FrameworkResponseSerializer
 
   SUPPORTED_RELATIONSHIPS = %w[
     assessment
-    person_escort_record
     nomis_mappings
     question.descendants
     flags

--- a/db/migrate/20201116095539_remove_person_escort_record_from_framework_responses.rb
+++ b/db/migrate/20201116095539_remove_person_escort_record_from_framework_responses.rb
@@ -1,0 +1,5 @@
+class RemovePersonEscortRecordFromFrameworkResponses < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :framework_responses, :person_escort_record_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_093301) do
+ActiveRecord::Schema.define(version: 2020_11_16_095539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -227,7 +227,6 @@ ActiveRecord::Schema.define(version: 2020_11_16_093301) do
   end
 
   create_table "framework_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "person_escort_record_id"
     t.uuid "framework_question_id", null: false
     t.text "value_text"
     t.jsonb "value_json"
@@ -242,7 +241,6 @@ ActiveRecord::Schema.define(version: 2020_11_16_093301) do
     t.index ["assessmentable_type", "assessmentable_id"], name: "index_responses_on_assessmentable_type_and_assessmentable_id"
     t.index ["framework_question_id"], name: "index_framework_responses_on_framework_question_id"
     t.index ["parent_id"], name: "index_framework_responses_on_parent_id"
-    t.index ["person_escort_record_id"], name: "index_framework_responses_on_person_escort_record_id"
     t.index ["value_json"], name: "index_framework_responses_on_value_json", using: :gin
   end
 
@@ -617,7 +615,6 @@ ActiveRecord::Schema.define(version: 2020_11_16_093301) do
   add_foreign_key "framework_flags", "framework_questions"
   add_foreign_key "framework_questions", "frameworks"
   add_foreign_key "framework_responses", "framework_questions"
-  add_foreign_key "framework_responses", "person_escort_records"
   add_foreign_key "generic_events", "suppliers"
   add_foreign_key "journeys", "locations", column: "from_location_id"
   add_foreign_key "journeys", "locations", column: "to_location_id"

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe FrameworkResponse do
   it { is_expected.to belong_to(:framework_question) }
-  it { is_expected.to belong_to(:person_escort_record).optional }
   it { is_expected.to belong_to(:assessmentable).optional }
   it { is_expected.to belong_to(:parent).optional }
 

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe FrameworkResponseSerializer do
 
   context 'with include options' do
     let(:includes) do
-      %i[person_escort_record assessment question]
+      %i[assessment question]
     end
     let(:framework_response) do
       create(:string_response, assessmentable: create(:person_escort_record))

--- a/swagger/v1/framework_response.yaml
+++ b/swagger/v1/framework_response.yaml
@@ -77,9 +77,6 @@ FrameworkResponse:
       required:
       - assessment
       properties:
-        person_escort_record:
-          $ref: person_escort_record_reference.yaml#/PersonEscortRecordReference
-          description: (Deprecated) The person_escort_record the responses refer to
         assessment:
           $ref: person_escort_record_reference.yaml#/PersonEscortRecordReference
           description: The assessment the responses refer to, current assessments supported include the Person Escort Record

--- a/swagger/v1/framework_response_include_parameter.yaml
+++ b/swagger/v1/framework_response_include_parameter.yaml
@@ -8,7 +8,7 @@ FrameworkResponseIncludeParameter:
     type: string
     enum:
       - flags
-      - person_escort_record
+      - assessment
       - question
       - nomis_mappings
       - question.descendants


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2448

Since we no longer need to populate/use the `person_escort_record_id` on framework responses, remove this column.