### PR TITLE
Revert "Bump prometheus_exporter from 0.5.3 to 0.6.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
-    prometheus_exporter (0.6.0)
+    prometheus_exporter (0.5.3)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-api#1143