### PR TITLE
Remove redundant move scope

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -116,8 +116,6 @@ class Move < VersionedModel
 
   delegate :suppliers, to: :from_location
 
-  scope :not_cancelled, -> { where.not(status: MOVE_STATUS_CANCELLED) }
-
   attr_accessor :version
 
   # TODO: Temporary method to apply correct validation rules when creating v2 move


### PR DESCRIPTION

### Jira link

P4-<TODO>

### What?

- [x] Remove redundant `not_cancelled` move scope

### Why?

- I noticed a few deprecation warnings about this - since we have `cancelled` already defined as a valid status enum value, then this scope is automatically generated - and in fact the code is ignored and replaced by the generated version so it's been doing nothing all this time. There is also some existing indirect coverage of this in both move and allocation model specs so it's very safe to remove.