### PR TITLE
Improve eager loading of Locations::Finder suppliers

### DIFF
--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -31,7 +31,6 @@ module Locations
     end
 
     def apply_filters(scope)
-      scope = scope.includes(:suppliers)
       scope = scope.where(filter_params.slice(:location_type, :nomis_agency_id))
       scope = apply_supplier_filters(scope)
       scope = apply_location_filters(scope)
@@ -46,7 +45,7 @@ module Locations
     def apply_supplier_filters(scope)
       return scope unless filter_params.key?(:supplier_id)
 
-      scope = scope.where(suppliers: { id: split_params(:supplier_id) })
+      scope = scope.includes(:suppliers).where(suppliers: { id: split_params(:supplier_id) })
       scope.merge(SupplierLocation.effective_on(Time.zone.today))
     end
 

--- a/spec/services/locations/finder_spec.rb
+++ b/spec/services/locations/finder_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Locations::Finder do
   describe 'filtering' do
     context 'with a supplier' do
       let(:filter_params) { { supplier_id: supplier.id } }
-      let(:active_record_relationships) { %i[suppliers] }
 
       before do
         create(:location) # Not linked to supplier


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

- [x] Only eager load `suppliers` relationship if absolutely necessary in `Locations::Finder`

### Why?

- This was previously loading the suppliers relationship for all requests, irrespective of whether suppliers filters were requested. If suppliers are not requested in the API includes and the supplier filter isn't used then there's no need to perform an additional join on suppliers.