### PR TITLE
Add custom serializer for prefill source with fewer fields

### DIFF
--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -8,7 +8,7 @@ class PersonEscortRecordSerializer
   belongs_to :profile, serializer: V2::ProfileSerializer
   belongs_to :move, serializer: V2::MoveSerializer
   belongs_to :framework
-  belongs_to :prefill_source, serializer: PersonEscortRecordSerializer
+  belongs_to :prefill_source, serializer: PrefillSourceSerializer
 
   has_many :responses, serializer: FrameworkResponseSerializer do |object|
     object.framework_responses.includes(:framework_flags, :framework_nomis_mappings, framework_question: [:framework, dependents: :dependents])

--- a/app/serializers/prefill_source_serializer.rb
+++ b/app/serializers/prefill_source_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PrefillSourceSerializer
+  include JSONAPI::Serializer
+
+  set_type :person_escort_records
+
+  attributes :confirmed_at, :created_at, :nomis_sync_status
+
+  attribute :status do |object|
+    object.status == 'unstarted' ? 'not_started' : object.status
+  end
+end

--- a/spec/serializers/prefill_source_serializer_spec.rb
+++ b/spec/serializers/prefill_source_serializer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PrefillSourceSerializer do
+  subject(:serializer) { described_class.new(person_escort_record) }
+
+  let(:move) { create(:move) }
+  let(:person_escort_record) { create(:person_escort_record, move: move, profile: move.profile) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('person_escort_records')
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eq(person_escort_record.id)
+  end
+
+  it 'contains a `status` attribute' do
+    expect(result[:data][:attributes][:status]).to eq('not_started')
+  end
+
+  it 'contains a `confirmed_at` attribute' do
+    expect(result[:data][:attributes][:confirmed_at]).to eq(person_escort_record.confirmed_at)
+  end
+
+  it 'contains a `created_at` attribute' do
+    expect(result[:data][:attributes][:created_at]).to eq(person_escort_record.created_at.iso8601)
+  end
+
+  it 'contains a `nomis_sync_status` attribute' do
+    expect(result[:data][:attributes][:nomis_sync_status]).to eq(person_escort_record.nomis_sync_status)
+  end
+end


### PR DESCRIPTION
### Jira link

P4-2480

### What?

- [x] Use a custom lightweight serializer for person escort record prefill source

### Why?

- The front end currently only requires the `confirmed_at` attribute for the previously filled person escort record. However the prefill source is currently using the same `PersonEscortRecordSerializer` which requires lots of additional queries to fetch associated framework questions and responses, none of which are then consumed by the front end client.

- Since prefilling was introduced, observed performance in production has dipped significantly as fetching a move is now effectively returning two complete PER resources. The new lightweight serializer for the prefilled PER is effectively a subset of the PER serializer, but contains only those attributes which can be served directly from the prefill PER record and without any additional queries. This should support the existing front end code with no changes, yet perform much faster in the production environment.

### Deployment risks (optional)

- Changes an api that is used in production

