### PR TITLE
[P4-2424] Add MoveRequested and MoveProposed events for timeline

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -46,8 +46,10 @@ class GenericEvent < ApplicationRecord
     MoveOperationHmcts
     MoveOperationSafeguard
     MoveOperationTornado
+    MoveProposed
     MoveRedirect
     MoveReject
+    MoveRequested
     MoveStart
     PerCourtAllDocumentationProvidedToSupplier
     PerCourtAssignCellInCustody

--- a/app/models/generic_event/move_proposed.rb
+++ b/app/models/generic_event/move_proposed.rb
@@ -1,0 +1,5 @@
+class GenericEvent
+  class MoveProposed < GenericEvent
+    eventable_types 'Move'
+  end
+end

--- a/app/models/generic_event/move_requested.rb
+++ b/app/models/generic_event/move_requested.rb
@@ -1,0 +1,5 @@
+class GenericEvent
+  class MoveRequested < GenericEvent
+    eventable_types 'Move'
+  end
+end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -20,6 +20,14 @@ FactoryBot.define do
     end
   end
 
+  factory :event_move_requested, parent: :generic_event, class: 'GenericEvent::MoveRequested' do
+    eventable { association(:move) }
+  end
+
+  factory :event_move_proposed, parent: :generic_event, class: 'GenericEvent::MoveProposed' do
+    eventable { association(:move) }
+  end
+
   factory :event_move_accept, parent: :generic_event, class: 'GenericEvent::MoveAccept' do
     eventable { association(:move) }
   end

--- a/spec/models/generic_event/move_proposed_spec.rb
+++ b/spec/models/generic_event/move_proposed_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe GenericEvent::MoveProposed do
+  subject(:generic_event) { build(:event_move_proposed) }
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Move]) }
+end

--- a/spec/models/generic_event/move_requested_spec.rb
+++ b/spec/models/generic_event/move_requested_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe GenericEvent::MoveRequested do
+  subject(:generic_event) { build(:event_move_requested) }
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Move]) }
+end

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -28,12 +28,13 @@ RSpec.describe Api::MovesController do
       {
         date: Date.today,
         time_due: Time.now,
-        status: 'requested',
+        status: status,
         additional_information: 'some more info',
         move_type: 'court_appearance',
       }
     end
 
+    let(:status) { 'requested' }
     let(:profile) { create(:profile) }
     let(:another_supplier) { create(:supplier) }
     let(:from_location) { create :location, suppliers: [another_supplier] }
@@ -62,6 +63,34 @@ RSpec.describe Api::MovesController do
       expect { do_post } .to change(Move, :count).by(1)
     end
 
+    context 'when the new move status is `proposed`' do
+      before do
+        move_attributes[:date_from] = Date.today.iso8601
+      end
+
+      let(:status) { 'proposed' }
+
+      it 'creates a MoveProposed event' do
+        expect { do_post }.to change(GenericEvent::MoveProposed, :count).by(1)
+      end
+    end
+
+    context 'when the new move status is `requested`' do
+      let(:status) { 'requested' }
+
+      it 'creates a MoveRequested event' do
+        expect { do_post }.to change(GenericEvent::MoveRequested, :count).by(1)
+      end
+    end
+
+    context 'when the new move status is `cancelled`' do
+      let(:status) { 'cancelled' }
+
+      it 'does not create any new events' do
+        expect { do_post }.not_to change(GenericEvent, :count)
+      end
+    end
+
     it 'sets the from_location supplier as the supplier on the move' do
       do_post
 
@@ -75,8 +104,10 @@ RSpec.describe Api::MovesController do
       it 'audits the supplier' do
         do_post
 
-        expect(move.versions.map(&:whodunnit)).to eq([nil])
-        expect(move.versions.map(&:supplier_id)).to eq([supplier.id])
+        # NB: Creation of the move and the associated event for the timeline generates multiple
+        # entries in the versions table.
+        expect(move.versions.map(&:whodunnit)).to eq([nil, nil])
+        expect(move.versions.map(&:supplier_id)).to eq([supplier.id, supplier.id])
       end
 
       it 'sets the application owner as the supplier on the move' do


### PR DESCRIPTION
### Jira link

P4-2424

### What?

These events need to be generated to indicate the starting point of the
move in the timeline and supplement the events that Martyn added for
Journeys which are now deprecated/not used anywhere.

### Why?

- This is needed to indicate the initial starting point in the events timeline

