### PR TITLE
[P4-2424] Fix supplier on new move events

### DIFF
--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -166,7 +166,7 @@ module Api::V2
         recorded_at: now,
         notes: 'Automatically generated event',
         details: {},
-        supplier_id: move.supplier_id,
+        supplier_id: doorkeeper_application_owner&.id,
       }
 
       if move.proposed?

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -63,6 +63,11 @@ RSpec.describe Api::MovesController do
       expect { do_post } .to change(Move, :count).by(1)
     end
 
+    it 'creates a GenericEvent without a supplier' do
+      do_post
+      expect(GenericEvent.last.supplier).to be(nil)
+    end
+
     context 'when the new move status is `proposed`' do
       before do
         move_attributes[:date_from] = Date.today.iso8601
@@ -114,6 +119,11 @@ RSpec.describe Api::MovesController do
         do_post
 
         expect(move.supplier).to eq(application.owner)
+      end
+
+      it 'creates a GenericEvent with a supplier' do
+        do_post
+        expect(GenericEvent::MoveRequested.last.supplier).to be_a(Supplier)
       end
     end
 


### PR DESCRIPTION
### Jira link

P4-2424

### What?

I have added/removed/altered:

- [x] Altered the supplier that gets associated with a move initial state event to be based on the application owner rather than the supplier of the move.

### Why?

I am doing this because:

- The UI needs to know the original creator of the move rather than the inferred supplier picked by the `SupplierChooser`