### PR TITLE
[P4-2507] Adjust supplier on move initial status events

### DIFF
--- a/app/controllers/api/journeys_controller.rb
+++ b/app/controllers/api/journeys_controller.rb
@@ -147,11 +147,11 @@ module Api
         supplier_id: supplier.id,
       }
 
-      if action_name == "update"
+      if action_name == 'update'
         GenericEvent::JourneyUpdate.create!(event_attributes)
       end
 
-      if action_name == "create"
+      if action_name == 'create'
         GenericEvent::JourneyCreate.create!(event_attributes)
       end
     end

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -18,7 +18,7 @@ namespace :events do
 
     puts "Deleting #{generic_event_ids.count} generic_events..."
     GenericEvent.where(id: generic_event_ids).delete_all
-end
+  end
 
   desc 'tweak supplier to be based on doorkeeper token rather than the move supplier for initial state events'
   task tweak_supplier: :environment do
@@ -29,7 +29,7 @@ end
 
     events = GenericEvent.joins(
       # Handle polymorphic event model join
-      'INNER JOIN moves ON moves.id = generic_events.eventable_id'
+      'INNER JOIN moves ON moves.id = generic_events.eventable_id',
     ).load.where(type: ['GenericEvent::MoveProposed', 'GenericEvent::MoveRequested'])
 
     report = {
@@ -42,7 +42,7 @@ end
 
     events.find_each do |event|
       # PaperTrail::Version model rows have an event column which is always one of "create" or "update" (only ever one create)
-      initial_version =  event.eventable.versions.find_by(event: "create")
+      initial_version =  event.eventable.versions.find_by(event: 'create')
 
       supplier_different = initial_version.supplier_id != event.supplier_id
 
@@ -57,7 +57,7 @@ end
       if supplier_different
         report[:events_changed] += 1
       else
-        report[:events_unchanged] += 1 
+        report[:events_unchanged] += 1
       end
 
       if supplier_different

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -18,5 +18,53 @@ namespace :events do
 
     puts "Deleting #{generic_event_ids.count} generic_events..."
     GenericEvent.where(id: generic_event_ids).delete_all
+end
+
+  desc 'tweak supplier to be based on doorkeeper token rather than the move supplier for initial state events'
+  task tweak_supplier: :environment do
+    dry_run = ENV.fetch('DRY_RUN', 'true') == 'true'
+
+    puts "DRY_RUN: #{dry_run}"
+    puts
+
+    events = GenericEvent.joins(
+      # Handle polymorphic event model join
+      'INNER JOIN moves ON moves.id = generic_events.eventable_id'
+    ).load.where(type: ['GenericEvent::MoveProposed', 'GenericEvent::MoveRequested'])
+
+    report = {
+      total_events: events.length,
+      events_changed: 0,
+      events_unchanged: 0,
+      move_proposed_events: 0,
+      move_requested_events: 0,
+    }
+
+    events.find_each do |event|
+      # PaperTrail::Version model rows have an event column which is always one of "create" or "update" (only ever one create)
+      initial_version =  event.eventable.versions.find_by(event: "create")
+
+      supplier_different = initial_version.supplier_id != event.supplier_id
+
+      if event.type == 'GenericEvent::MoveProposed'
+        report[:move_proposed_events] += 1
+      end
+
+      if event.type == 'GenericEvent::MoveRequested'
+        report[:move_requested_events] += 1
+      end
+
+      if supplier_different
+        report[:events_changed] += 1
+      else
+        report[:events_unchanged] += 1 
+      end
+
+      if supplier_different
+        event.update(supplier_id: initial_version&.supplier_id) unless dry_run
+      end
+    end
+
+    puts JSON.pretty_generate(report)
   end
 end

--- a/lib/tasks/fake_data/journeys.rb
+++ b/lib/tasks/fake_data/journeys.rb
@@ -33,7 +33,7 @@ module Tasks
           # make some intermediate journeys which might or might not be billable
           intermediate_location = random_location(current_location)
           create_initial_move_event(timestamp, intermediate_location)
- 
+
           # randomly create some events with intermediate journeys
           case random_event # add some random events to the journeys
           when :redirect_move_billable # billable redirect move (not journey) to intermediate_location, e.g. "PMU requested redirect whilst en route"
@@ -76,7 +76,7 @@ module Tasks
         )
       end
 
-      def create_initial_move_event(timestamp, location)
+      def create_initial_move_event(timestamp, _location)
         initial_transition_events = [GenericEvent::MoveProposed, GenericEvent::MoveRequested]
         initial_transition_events.sample.create(
           eventable: move,

--- a/lib/tasks/fake_data/journeys.rb
+++ b/lib/tasks/fake_data/journeys.rb
@@ -32,22 +32,19 @@ module Tasks
         while journey_counter < number_of_journeys
           # make some intermediate journeys which might or might not be billable
           intermediate_location = random_location(current_location)
-
+          create_initial_move_event(timestamp, intermediate_location)
+ 
           # randomly create some events with intermediate journeys
           case random_event # add some random events to the journeys
           when :redirect_move_billable # billable redirect move (not journey) to intermediate_location, e.g. "PMU requested redirect whilst en route"
-            create_redirect_move_event(
-              timestamp,
-              ['requested by PMU for operational reasons', 'requested by prison because no space', 'requested by police because of security concerns'].sample,
-              intermediate_location,
-            )
+            create_redirect_move_event(timestamp, intermediate_location)
 
             # billable journey for redirection to intermediate_location
             create_journey(timestamp, current_location, intermediate_location, true)
 
             # subsequent redirect event back to to_location to make sure events remain consistent with move record; no journey record is required
             timestamp += rand(30..90).minutes
-            create_redirect_move_event(timestamp, 'redirecting back to original destination following earlier redirect', to_location)
+            create_redirect_move_event(timestamp, to_location)
           else
             # 50% chance of a conventional intermediate journey
             create_journey(timestamp, current_location, intermediate_location, true)
@@ -79,22 +76,31 @@ module Tasks
         )
       end
 
-      def create_redirect_move_event(timestamp, notes, location)
-        move.events.create!(
-          event_name: 'redirect',
-          client_timestamp: timestamp,
+      def create_initial_move_event(timestamp, location)
+        initial_transition_events = [GenericEvent::MoveProposed, GenericEvent::MoveRequested]
+        initial_transition_events.sample.create(
+          eventable: move,
+          occurred_at: timestamp,
+          recorded_at: timestamp,
+          notes: 'Created from fake data',
+          details: { fake: true },
+          supplier_id: supplier.id,
+        )
+      end
+
+      def create_redirect_move_event(timestamp, location)
+        GenericEvent::MoveRedirect.create(
+          eventable: move,
+          occurred_at: timestamp,
+          recorded_at: timestamp,
+          notes: 'Created from fake data',
           details: {
             fake: true,
-            supplier_id: supplier.id,
-            event_params: {
-              attributes: {
-                notes: notes,
-              },
-              relationships: {
-                to_location: { data: { id: location.id } },
-              },
-            },
+            to_location_id: location.id,
+            reason: GenericEvent::MoveRedirect.reasons.keys.sample,
+            move_type: Move.move_types.keys.sample,
           },
+          supplier_id: supplier.id,
         )
       end
 

--- a/spec/lib/tasks/fake_data/journeys_spec.rb
+++ b/spec/lib/tasks/fake_data/journeys_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe Tasks::FakeData::Journeys do
     end
 
     it 'creates a redirect event' do
-      expect(move.events.where(event_name: 'redirect').exists?).to be true
+      event = GenericEvent::MoveRedirect.find_by(eventable_type: 'Move', eventable_id: move.id)
+      expect(event).to be_a(GenericEvent::MoveRedirect)
     end
   end
 end

--- a/spec/requests/api/journeys_controller_create_spec.rb
+++ b/spec/requests/api/journeys_controller_create_spec.rb
@@ -86,10 +86,6 @@ RSpec.describe Api::JourneysController do
         expect(response_json).to include_json(data: data)
       end
 
-      it 'creates a `create` event' do
-        expect { do_post }.to change { Event.where(event_name: 'create', eventable_type: 'Journey').count }.by(1)
-      end
-
       it 'creates a JourneyCreate generic event' do
         expect { do_post }.to change(GenericEvent::JourneyCreate, :count).by(1)
       end

--- a/spec/requests/api/journeys_controller_update_spec.rb
+++ b/spec/requests/api/journeys_controller_update_spec.rb
@@ -74,10 +74,6 @@ RSpec.describe Api::JourneysController do
           expect(journey.client_timestamp).to eql Time.zone.parse('2020-05-04T08:00:00Z')
         end
 
-        it 'creates a `update` event' do
-          expect { do_patch }.to change { Event.where(event_name: 'update', eventable_type: 'Journey').count }.by(1)
-        end
-
         it 'creates a JourneyUpdate generic event' do
           expect { do_patch }.to change(GenericEvent::JourneyUpdate, :count).by(1)
         end


### PR DESCRIPTION
### Jira link

P4-2507

### What?

I have added/removed/altered:

- [x] Removes automatic creation of old event model events
- [x] Updates fake data generator to generate initial status events
- [x] Adds rake task for enumerating and correcting initial status events (`MoveProposed`, `MoveRequested`) that have the wrong supplier_id

### Why?

This corrects a UI issue for the frontend where the presented data on the timeline indicates the wrong information about who created the move.
It also corrects cruft that should have been removed previously.