### PR TITLE
Use custom event type for PER completion notifications

### DIFF
--- a/app/jobs/prepare_move_notifications_job.rb
+++ b/app/jobs/prepare_move_notifications_job.rb
@@ -56,6 +56,6 @@ private
       'update' => 'update_move',
       'update_status' => 'update_move_status',
       'destroy' => 'destroy_move',
-    }[action_name]
+    }[action_name] || action_name
   end
 end

--- a/app/jobs/prepare_person_escort_record_notifications_job.rb
+++ b/app/jobs/prepare_person_escort_record_notifications_job.rb
@@ -7,25 +7,6 @@ class PreparePersonEscortRecordNotificationsJob < ApplicationJob
     person_escort_record = PersonEscortRecord.find(topic_id)
     return unless (move = person_escort_record.move)
 
-    [move.supplier || move.suppliers].flatten.each do |supplier|
-      supplier.subscriptions.kept.each do |subscription|
-        next unless subscription.enabled? && subscription.callback_url.present?
-
-        NotifyWebhookJob.perform_later(
-          notification_id: build_notification(subscription, NotificationType::WEBHOOK, move).id,
-          queue_as: move_queue_priority(move),
-        )
-      end
-    end
-  end
-
-private
-
-  def build_notification(subscription, type_id, topic)
-    subscription.notifications.create!(
-      notification_type_id: type_id,
-      topic: topic,
-      event_type: 'confirm_person_escort_record',
-    )
+    PrepareMoveNotificationsJob.perform_now(topic_id: move.id, action_name: 'confirm_person_escort_record', queue_as: move_queue_priority(move))
   end
 end

--- a/app/jobs/prepare_person_escort_record_notifications_job.rb
+++ b/app/jobs/prepare_person_escort_record_notifications_job.rb
@@ -3,9 +3,29 @@
 class PreparePersonEscortRecordNotificationsJob < ApplicationJob
   include QueueDeterminer
 
-  def perform(topic_id:, action_name:, **_)
-    PersonEscortRecord.find(topic_id).profile.moves.find_each do |move|
-      PrepareMoveNotificationsJob.perform_now(topic_id: move.id, action_name: action_name, queue_as: move_queue_priority(move))
+  def perform(topic_id:, **_)
+    person_escort_record = PersonEscortRecord.find(topic_id)
+    return unless (move = person_escort_record.move)
+
+    [move.supplier || move.suppliers].flatten.each do |supplier|
+      supplier.subscriptions.kept.each do |subscription|
+        next unless subscription.enabled? && subscription.callback_url.present?
+
+        NotifyWebhookJob.perform_later(
+          notification_id: build_notification(subscription, NotificationType::WEBHOOK, move).id,
+          queue_as: move_queue_priority(move),
+        )
+      end
     end
+  end
+
+private
+
+  def build_notification(subscription, type_id, topic)
+    subscription.notifications.create!(
+      notification_type_id: type_id,
+      topic: topic,
+      event_type: 'confirm_person_escort_record',
+    )
   end
 end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -12,7 +12,7 @@ class Notifier
     when Profile
       PrepareProfileNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
     when PersonEscortRecord
-      PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
+      PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, queue_as: :notifications_medium)
     end
   end
 end

--- a/spec/jobs/prepare_move_notifications_job_spec.rb
+++ b/spec/jobs/prepare_move_notifications_job_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
     end
   end
 
+  context 'when confirming a person escort record' do
+    let(:action_name) { 'confirm_person_escort_record' }
+
+    it_behaves_like 'it creates a webhook notification record'
+    it_behaves_like 'it creates an email notification record'
+    it_behaves_like 'it schedules NotifyWebhookJob'
+    it_behaves_like 'it schedules NotifyEmailJob'
+  end
+
   context 'when creating a back-dated move' do
     let(:move) { create :move, from_location: location, date: 2.days.ago, supplier: supplier }
 

--- a/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe PreparePersonEscortRecordNotificationsJob, type: :job do
   let(:subscription) { create(:subscription) }
   let(:supplier) { create :supplier, name: 'test', subscriptions: [subscription] }
   let(:location) { create :location, suppliers: [supplier] }
-  let(:person_escort_record) { create(:person_escort_record) }
-  let!(:move) { create(:move, from_location: location, profile: person_escort_record.profile, supplier: supplier, date: Time.zone.today) }
 
   before do
     create(:notification_type, :webhook)
@@ -17,26 +15,22 @@ RSpec.describe PreparePersonEscortRecordNotificationsJob, type: :job do
     allow(NotifyEmailJob).to receive(:perform_later).and_call_original
   end
 
-  it 'creates a webhook notification' do
-    expect { perform }.to change(Notification.webhooks, :count).by(1)
+  context 'with an associated move' do
+    let(:move) { create(:move, from_location: location, supplier: supplier, date: Time.zone.today) }
+    let(:person_escort_record) { create(:person_escort_record, move: move) }
+
+    it 'creates a webhook notification' do
+      expect { perform }.to change(Notification.webhooks, :count).by(1)
+    end
+
+    it 'schedules a NotifyWebhookJob' do
+      perform
+      expect(NotifyWebhookJob).to have_received(:perform_later).with(notification_id: Notification.webhooks.last.id, queue_as: :notifications_high)
+    end
   end
 
-  it 'creates an email notification' do
-    expect { perform }.to change(Notification.emails, :count).by(1)
-  end
-
-  it 'schedules a NotifyWebhookJob' do
-    perform
-    expect(NotifyWebhookJob).to have_received(:perform_later).with(notification_id: Notification.webhooks.last.id, queue_as: :notifications_high)
-  end
-
-  it 'schedules a NotifyEmailJob' do
-    perform
-    expect(NotifyEmailJob).to have_received(:perform_later).with(notification_id: Notification.emails.last.id, queue_as: :notifications_high)
-  end
-
-  context 'when a profile does not have a move' do
-    let!(:move) { create(:move, from_location: location) }
+  context 'without an associated move' do
+    let(:person_escort_record) { create(:person_escort_record) }
 
     it 'does not create notifications' do
       expect { perform }.not_to change(Notification, :count)
@@ -45,11 +39,6 @@ RSpec.describe PreparePersonEscortRecordNotificationsJob, type: :job do
     it 'does not schedule a NotifyWebhookJob' do
       perform
       expect(NotifyWebhookJob).not_to have_received(:perform_later)
-    end
-
-    it 'does not schedule a NotifyEmailJob' do
-      perform
-      expect(NotifyEmailJob).not_to have_received(:perform_later)
     end
   end
 end

--- a/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
@@ -23,9 +23,18 @@ RSpec.describe PreparePersonEscortRecordNotificationsJob, type: :job do
       expect { perform }.to change(Notification.webhooks, :count).by(1)
     end
 
+    it 'creates an email notification' do
+      expect { perform }.to change(Notification.emails, :count).by(1)
+    end
+
     it 'schedules a NotifyWebhookJob' do
       perform
       expect(NotifyWebhookJob).to have_received(:perform_later).with(notification_id: Notification.webhooks.last.id, queue_as: :notifications_high)
+    end
+
+    it 'schedules a NotifyEmailJob' do
+      perform
+      expect(NotifyEmailJob).to have_received(:perform_later).with(notification_id: Notification.emails.last.id, queue_as: :notifications_high)
     end
   end
 
@@ -39,6 +48,11 @@ RSpec.describe PreparePersonEscortRecordNotificationsJob, type: :job do
     it 'does not schedule a NotifyWebhookJob' do
       perform
       expect(NotifyWebhookJob).not_to have_received(:perform_later)
+    end
+
+    it 'does not schedule a NotifyEmailJob' do
+      perform
+      expect(NotifyEmailJob).not_to have_received(:perform_later)
     end
   end
 end

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Notifier do
     let(:topic) { create(:person_escort_record) }
 
     it 'queues a job' do
-      expect(PreparePersonEscortRecordNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
+      expect(PreparePersonEscortRecordNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, queue_as: :notifications_medium)
     end
   end
 


### PR DESCRIPTION
### Jira link

P4-2485

### What?

- [x] Revised implementation of PER notifications to support a dedicated PER completion event type

### Why?

- Previously PER completions were triggering move update notifications for all moves related to the per profile; this is a legacy approach predating the new direct relationship between a PER and the associated move. We also want to use a dedicated event type of `confirm_person_escort_record` for PER completion notifications.

### Deployment risks (optional)

- Suppliers are not yet making use of PER webhooks, so this PR aims to improve the implementation prior to it being integrated with suppliers and then being harder to change.
