### PR TITLE
[P4-1981] Adds location relationships for the event feed

### DIFF
--- a/app/models/concerns/location_feed.rb
+++ b/app/models/concerns/location_feed.rb
@@ -1,0 +1,16 @@
+module LocationFeed
+  def for_feed
+    super.tap do |common_feed_attributes|
+      location_key = self.class::LOCATION_ATTRIBUTE_KEY.to_s
+      location_method = location_key.sub('_id', '')
+      prefix = location_key == 'location_id' ? nil : location_key.sub('_location_id', '')
+
+      feed_details = common_feed_attributes['details']
+        .deep_dup
+        .except(location_key)
+      feed_details.merge!(public_send(location_method).for_feed(prefix: prefix))
+
+      common_feed_attributes['details'] = feed_details
+    end
+  end
+end

--- a/app/models/concerns/location_feed.rb
+++ b/app/models/concerns/location_feed.rb
@@ -5,12 +5,10 @@ module LocationFeed
       location_method = location_key.sub('_id', '')
       prefix = location_key == 'location_id' ? nil : location_key.sub('_location_id', '')
 
-      feed_details = common_feed_attributes['details']
-        .deep_dup
-        .except(location_key)
-      feed_details.merge!(public_send(location_method).for_feed(prefix: prefix))
+      updated_location = public_send(location_method).for_feed(prefix: prefix)
 
-      common_feed_attributes['details'] = feed_details
+      common_feed_attributes['details'].merge!(updated_location)
+      common_feed_attributes['details'].delete(location_key)
     end
   end
 end

--- a/app/models/generic_event/incident.rb
+++ b/app/models/generic_event/incident.rb
@@ -14,6 +14,7 @@ class GenericEvent
 
       child.include LocationValidations
       child.include SupplierPersonnelNumberValidations
+      child.include LocationFeed
 
       child.validates :reported_at, iso_date_time: true
       child.validates :fault_classification, presence: true, inclusion: { in: child.fault_classifications }

--- a/app/models/generic_event/journey_lockout.rb
+++ b/app/models/generic_event/journey_lockout.rb
@@ -6,11 +6,5 @@ class GenericEvent
     eventable_types 'Journey'
 
     include LocationValidations
-
-    def for_feed
-      super.tap do |common_feed_attributes|
-        common_feed_attributes['details'] = from_location.for_feed(prefix: 'from')
-      end
-    end
   end
 end

--- a/app/models/generic_event/journey_lockout.rb
+++ b/app/models/generic_event/journey_lockout.rb
@@ -6,5 +6,6 @@ class GenericEvent
     eventable_types 'Journey'
 
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/journey_lodging.rb
+++ b/app/models/generic_event/journey_lodging.rb
@@ -6,11 +6,6 @@ class GenericEvent
     eventable_types 'Journey'
 
     include LocationValidations
-
-    def for_feed
-      super.tap do |common_feed_attributes|
-        common_feed_attributes['details'] = to_location.for_feed(prefix: 'to')
-      end
-    end
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/move_lockout.rb
+++ b/app/models/generic_event/move_lockout.rb
@@ -4,10 +4,11 @@ class GenericEvent
 
     details_attributes :authorised_at, :authorised_by, :reason
     relationship_attributes from_location_id: :locations
-
     eventable_types 'Move'
+
     include AuthoriserValidations
     include LocationValidations
+    include LocationFeed
 
     enum reason: {
       unachievable_ptr_request: 'unachievable_ptr_request', # (PECS - police only)
@@ -25,17 +26,6 @@ class GenericEvent
 
     def from_location
       Location.find_by(id: from_location_id)
-    end
-
-    def for_feed
-      super.tap do |common_feed_attributes|
-        common_feed_attributes['details'] = from_location.for_feed(prefix: 'from')
-        common_feed_attributes['details'].merge!(
-          'authorised_at' => authorised_at,
-          'authorised_by' => authorised_by,
-          'reason' => reason,
-        )
-      end
     end
   end
 end

--- a/app/models/generic_event/move_lodging_end.rb
+++ b/app/models/generic_event/move_lodging_end.rb
@@ -6,5 +6,6 @@ class GenericEvent
     eventable_types 'Move'
 
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/move_lodging_start.rb
+++ b/app/models/generic_event/move_lodging_start.rb
@@ -7,6 +7,7 @@ class GenericEvent
     eventable_types 'Move'
 
     include LocationValidations
+    include LocationFeed
 
     enum reason: {
       overnight_lodging: 'overnight_lodging',

--- a/app/models/generic_event/move_redirect.rb
+++ b/app/models/generic_event/move_redirect.rb
@@ -16,19 +16,13 @@ class GenericEvent
     }
 
     include LocationValidations
+    include LocationFeed
 
     validates :reason, inclusion: { in: reasons }, if: -> { reason.present? }
 
     def trigger
       eventable.to_location = to_location
       eventable.move_type = move_type if move_type.present?
-    end
-
-    def for_feed
-      super.tap do |common_feed_attributes|
-        common_feed_attributes['details'] = to_location.for_feed(prefix: 'to')
-        common_feed_attributes['details']['move_type'] = move_type if move_type.present?
-      end
     end
   end
 end

--- a/app/models/generic_event/per_court_all_documentation_provided_to_supplier.rb
+++ b/app/models/generic_event/per_court_all_documentation_provided_to_supplier.rb
@@ -7,6 +7,7 @@ class GenericEvent
 
     include PersonEscortRecordEventValidations
     include LocationValidations
+    include LocationFeed
 
     enum subtype: {
       extradition_order: 'extradition_order',

--- a/app/models/generic_event/per_court_cell_share_risk_assessment.rb
+++ b/app/models/generic_event/per_court_cell_share_risk_assessment.rb
@@ -6,5 +6,6 @@ class GenericEvent
 
     include PersonEscortRecordEventValidations
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_court_excessive_delay_not_due_to_supplier.rb
+++ b/app/models/generic_event/per_court_excessive_delay_not_due_to_supplier.rb
@@ -8,6 +8,7 @@ class GenericEvent
     include PersonEscortRecordEventValidations
     include AuthoriserValidations
     include LocationValidations
+    include LocationFeed
 
     enum subtype: {
       making_prisoner_available_for_loading: 'making_prisoner_available_for_loading',

--- a/app/models/generic_event/per_court_hearing.rb
+++ b/app/models/generic_event/per_court_hearing.rb
@@ -3,9 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     details_attributes :is_virtual, :is_trial, :court_listing_at, :started_at, :ended_at, :agreed_at, :court_outcome
-
     relationship_attributes location_id: :locations
-
     eventable_types 'PersonEscortRecord'
 
     validates :is_virtual,       presence: true, inclusion: [true, false]
@@ -17,5 +15,6 @@ class GenericEvent
     validates :court_outcome,    presence: true
 
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_court_pre_release_checks_completed.rb
+++ b/app/models/generic_event/per_court_pre_release_checks_completed.rb
@@ -8,5 +8,6 @@ class GenericEvent
     include PersonEscortRecordEventValidations
     include SupplierPersonnelNumberValidations
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_court_ready_in_custody.rb
+++ b/app/models/generic_event/per_court_ready_in_custody.rb
@@ -6,5 +6,6 @@ class GenericEvent
 
     include PersonEscortRecordEventValidations
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_court_release.rb
+++ b/app/models/generic_event/per_court_release.rb
@@ -8,5 +8,6 @@ class GenericEvent
     include PersonEscortRecordEventValidations
     include SupplierPersonnelNumberValidations
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_court_release_on_bail.rb
+++ b/app/models/generic_event/per_court_release_on_bail.rb
@@ -8,5 +8,6 @@ class GenericEvent
     include PersonEscortRecordEventValidations
     include SupplierPersonnelNumberValidations
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_court_return_to_custody_area_from_dock.rb
+++ b/app/models/generic_event/per_court_return_to_custody_area_from_dock.rb
@@ -7,5 +7,6 @@ class GenericEvent
 
     include PersonEscortRecordEventValidations
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_court_return_to_custody_area_from_visitor_area.rb
+++ b/app/models/generic_event/per_court_return_to_custody_area_from_visitor_area.rb
@@ -7,5 +7,6 @@ class GenericEvent
 
     include PersonEscortRecordEventValidations
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_court_take_from_custody_to_dock.rb
+++ b/app/models/generic_event/per_court_take_from_custody_to_dock.rb
@@ -6,5 +6,6 @@ class GenericEvent
 
     include PersonEscortRecordEventValidations
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_court_take_to_see_visitors.rb
+++ b/app/models/generic_event/per_court_take_to_see_visitors.rb
@@ -6,5 +6,6 @@ class GenericEvent
 
     include PersonEscortRecordEventValidations
     include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_court_task.rb
+++ b/app/models/generic_event/per_court_task.rb
@@ -8,5 +8,6 @@ class GenericEvent
     include PersonEscortRecordEventValidations
     include LocationValidations
     include SupplierPersonnelNumberValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/per_medical_aid.rb
+++ b/app/models/generic_event/per_medical_aid.rb
@@ -9,6 +9,7 @@ class GenericEvent
     include LocationValidations
     include PersonEscortRecordEventValidations
     include SupplierPersonnelNumberValidations
+    include LocationFeed
 
     validates :advised_at, presence: true, iso_date_time: true
     validates :advised_by, presence: true

--- a/app/models/generic_event/per_prisoner_welfare.rb
+++ b/app/models/generic_event/per_prisoner_welfare.rb
@@ -22,6 +22,7 @@ class GenericEvent
     include LocationValidations
     include PersonEscortRecordEventValidations
     include SupplierPersonnelNumberValidations
+    include LocationFeed
 
     validates :given_at, presence: true, iso_date_time: true
 

--- a/app/models/generic_event/person_move_booked_into_receiving_establishment.rb
+++ b/app/models/generic_event/person_move_booked_into_receiving_establishment.rb
@@ -8,5 +8,6 @@ class GenericEvent
 
     include LocationValidations
     include SupplierPersonnelNumberValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/person_move_vehicle_broke_down.rb
+++ b/app/models/generic_event/person_move_vehicle_broke_down.rb
@@ -9,6 +9,7 @@ class GenericEvent
     include LocationValidations
     include SupplierPersonnelNumberValidations
     include VehicleRegValidations
+    include LocationFeed
 
     validates :postcode,    presence: true, postcode: true
     validates :reported_at, presence: true, iso_date_time: true

--- a/app/models/generic_event/person_move_vehicle_systems_failed.rb
+++ b/app/models/generic_event/person_move_vehicle_systems_failed.rb
@@ -9,6 +9,7 @@ class GenericEvent
     include LocationValidations
     include SupplierPersonnelNumberValidations
     include VehicleRegValidations
+    include LocationFeed
 
     validates :postcode, presence: true, postcode: true
     validates :reported_at, iso_date_time: true

--- a/spec/models/generic_event/journey_lockout_spec.rb
+++ b/spec/models/generic_event/journey_lockout_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe GenericEvent::JourneyLockout do
 
   it_behaves_like 'an event with relationships', from_location_id: :locations
   it_behaves_like 'an event requiring a location', :from_location_id
+  it_behaves_like 'an event with a location in the feed', :from_location_id
 
   describe '#from_location' do
     it 'returns a `Location` if from_location_id is in the details' do
@@ -16,34 +17,6 @@ RSpec.describe GenericEvent::JourneyLockout do
     it 'returns nil if from_location_id is nil in the details' do
       generic_event.details['from_location_id'] = nil
       expect(generic_event.from_location).to be_nil
-    end
-  end
-
-  describe '#for_feed' do
-    subject(:generic_event) { create(:event_journey_lockout, details: { from_location_id: from_location.id }) }
-
-    let(:from_location) { create(:location) }
-
-    let(:expected_json) do
-      {
-        'id' => generic_event.id,
-        'type' => 'JourneyLockout',
-        'notes' => 'Flibble',
-        'created_at' => be_a(Time),
-        'updated_at' => be_a(Time),
-        'occurred_at' => be_a(Time),
-        'recorded_at' => be_a(Time),
-        'eventable_id' => generic_event.eventable_id,
-        'eventable_type' => 'Journey',
-        'details' => {
-          'from_location_type' => from_location.location_type,
-          'from_location' => from_location.nomis_agency_id,
-        },
-      }
-    end
-
-    it 'generates a feed document' do
-      expect(generic_event.for_feed).to include_json(expected_json)
     end
   end
 end

--- a/spec/models/generic_event/journey_lodging_spec.rb
+++ b/spec/models/generic_event/journey_lodging_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe GenericEvent::JourneyLodging do
 
   it_behaves_like 'an event with relationships', to_location_id: :locations
   it_behaves_like 'an event requiring a location', :to_location_id
+  it_behaves_like 'an event with a location in the feed', :to_location_id
 
   describe '#to_location' do
     it 'returns a `Location` if to_location_id is in the details' do
@@ -16,34 +17,6 @@ RSpec.describe GenericEvent::JourneyLodging do
     it 'returns nil if to_location_id is nil in the details' do
       generic_event.details['to_location_id'] = nil
       expect(generic_event.to_location).to be_nil
-    end
-  end
-
-  describe '#for_feed' do
-    subject(:generic_event) { create(:event_journey_lodging, details: { to_location_id: to_location.id }) }
-
-    let(:to_location) { create(:location) }
-
-    let(:expected_json) do
-      {
-        'id' => generic_event.id,
-        'type' => 'JourneyLodging',
-        'notes' => 'Flibble',
-        'created_at' => be_a(Time),
-        'updated_at' => be_a(Time),
-        'occurred_at' => be_a(Time),
-        'recorded_at' => be_a(Time),
-        'eventable_id' => generic_event.eventable_id,
-        'eventable_type' => 'Journey',
-        'details' => {
-          'to_location_type' => to_location.location_type,
-          'to_location' => to_location.nomis_agency_id,
-        },
-      }
-    end
-
-    it 'generates a feed document' do
-      expect(generic_event.for_feed).to include_json(expected_json)
     end
   end
 end

--- a/spec/models/generic_event/move_lockout_spec.rb
+++ b/spec/models/generic_event/move_lockout_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe GenericEvent::MoveLockout do
   it_behaves_like 'a move event'
   it_behaves_like 'an authorised event'
   it_behaves_like 'an event requiring a location', :from_location_id
+  it_behaves_like 'an event with a location in the feed', :from_location_id
 
   it { is_expected.to validate_inclusion_of(:reason).in_array(reasons) }
 
@@ -33,37 +34,6 @@ RSpec.describe GenericEvent::MoveLockout do
     it 'returns nil if from_location_id is nil in the details' do
       generic_event.details['from_location_id'] = nil
       expect(generic_event.from_location).to be_nil
-    end
-  end
-
-  describe '#for_feed' do
-    subject(:generic_event) { create(:event_move_lockout, details: { from_location_id: from_location.id, reason: 'no_space', authorised_at: Time.zone.now.iso8601, authorised_by: 'CDM' }) }
-
-    let(:from_location) { create(:location) }
-
-    let(:expected_json) do
-      {
-        'id' => generic_event.id,
-        'type' => 'MoveLockout',
-        'notes' => 'Flibble',
-        'created_at' => be_a(Time),
-        'updated_at' => be_a(Time),
-        'occurred_at' => be_a(Time),
-        'recorded_at' => be_a(Time),
-        'eventable_id' => generic_event.eventable_id,
-        'eventable_type' => 'Move',
-        'details' => {
-          'from_location_type' => from_location.location_type,
-          'from_location' => from_location.nomis_agency_id,
-          'reason' => 'no_space',
-          'authorised_at' => generic_event.authorised_at,
-          'authorised_by' => 'CDM',
-        },
-      }
-    end
-
-    it 'generates a feed document' do
-      expect(generic_event.for_feed).to include_json(expected_json)
     end
   end
 end

--- a/spec/models/generic_event/move_lodging_start_spec.rb
+++ b/spec/models/generic_event/move_lodging_start_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe GenericEvent::MoveLodgingStart do
   it_behaves_like 'an event with details', :reason
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Move]) }
   it { is_expected.to validate_inclusion_of(:reason).in_array(reasons) }

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe GenericEvent::MoveRedirect do
   it_behaves_like 'an event with relationships', to_location_id: :locations
   it_behaves_like 'a move event'
   it_behaves_like 'an event requiring a location', :to_location_id
+  it_behaves_like 'an event with a location in the feed', :to_location_id
 
   it { is_expected.to validate_inclusion_of(:reason).in_array(redirect_reasons) }
 
@@ -68,72 +69,6 @@ RSpec.describe GenericEvent::MoveRedirect do
 
       it 'sets the eventable `move_type' do
         expect { generic_event.trigger }.to change { generic_event.eventable.move_type }.from('prison_transfer').to('court_appearance')
-      end
-    end
-  end
-
-  describe '#for_feed' do
-    subject(:generic_event) { create(:event_move_redirect, details: details) }
-
-    let(:to_location) { create(:location) }
-
-    context 'when the move_type is present' do
-      let(:details) do
-        {
-          to_location_id: to_location.id,
-          move_type: 'court_appearance',
-        }
-      end
-      let(:expected_json) do
-        {
-          'id' => generic_event.id,
-          'type' => 'MoveRedirect',
-          'notes' => 'Flibble',
-          'created_at' => be_a(Time),
-          'updated_at' => be_a(Time),
-          'occurred_at' => be_a(Time),
-          'recorded_at' => be_a(Time),
-          'eventable_id' => generic_event.eventable_id,
-          'eventable_type' => 'Move',
-          'details' => {
-            'to_location_type' => to_location.location_type,
-            'to_location' => to_location.nomis_agency_id,
-            'move_type' => 'court_appearance',
-          },
-        }
-      end
-
-      it 'generates a feed document' do
-        expect(generic_event.for_feed).to include_json(expected_json)
-      end
-    end
-
-    context 'when the move_type is absent' do
-      let(:details) do
-        {
-          to_location_id: to_location.id,
-        }
-      end
-      let(:expected_json) do
-        {
-          'id' => generic_event.id,
-          'type' => 'MoveRedirect',
-          'notes' => 'Flibble',
-          'created_at' => be_a(Time),
-          'updated_at' => be_a(Time),
-          'occurred_at' => be_a(Time),
-          'recorded_at' => be_a(Time),
-          'eventable_id' => generic_event.eventable_id,
-          'eventable_type' => 'Move',
-          'details' => {
-            'to_location_type' => to_location.location_type,
-            'to_location' => to_location.nomis_agency_id,
-          },
-        }
-      end
-
-      it 'generates a feed document' do
-        expect(generic_event.for_feed).to include_json(expected_json)
       end
     end
   end

--- a/spec/models/generic_event/per_court_all_documentation_provided_to_supplier_spec.rb
+++ b/spec/models/generic_event/per_court_all_documentation_provided_to_supplier_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe GenericEvent::PerCourtAllDocumentationProvidedToSupplier do
   it_behaves_like 'an event with details', :subtype
   it_behaves_like 'an event with relationships', court_location_id: :locations
   it_behaves_like 'an event requiring a location', :court_location_id
+  it_behaves_like 'an event with a location in the feed', :court_location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
   it { is_expected.to validate_inclusion_of(:subtype).in_array(subtypes) }

--- a/spec/models/generic_event/per_court_excessive_delay_not_due_to_supplier_spec.rb
+++ b/spec/models/generic_event/per_court_excessive_delay_not_due_to_supplier_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe GenericEvent::PerCourtExcessiveDelayNotDueToSupplier do
   it_behaves_like 'an event with details', :subtype, :vehicle_reg, :ended_at, :authorised_by, :authorised_at
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
   it { is_expected.to validate_inclusion_of(:subtype).in_array(subtypes) }

--- a/spec/models/generic_event/per_court_hearing_spec.rb
+++ b/spec/models/generic_event/per_court_hearing_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe GenericEvent::PerCourtHearing do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event with eventable types', 'PersonEscortRecord'
   it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_presence_of(:is_virtual) }
   it { is_expected.to validate_presence_of(:is_trial) }

--- a/spec/models/generic_event/per_court_pre_release_checks_completed_spec.rb
+++ b/spec/models/generic_event/per_court_pre_release_checks_completed_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe GenericEvent::PerCourtPreReleaseChecksCompleted do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 end

--- a/spec/models/generic_event/per_court_ready_in_custody_spec.rb
+++ b/spec/models/generic_event/per_court_ready_in_custody_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe GenericEvent::PerCourtReadyInCustody do
 
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 end

--- a/spec/models/generic_event/per_court_release_on_bail_spec.rb
+++ b/spec/models/generic_event/per_court_release_on_bail_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe GenericEvent::PerCourtReleaseOnBail do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 end

--- a/spec/models/generic_event/per_court_release_spec.rb
+++ b/spec/models/generic_event/per_court_release_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe GenericEvent::PerCourtRelease do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 end

--- a/spec/models/generic_event/per_court_return_to_custody_area_from_dock_spec.rb
+++ b/spec/models/generic_event/per_court_return_to_custody_area_from_dock_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe GenericEvent::PerCourtReturnToCustodyAreaFromDock do
   it_behaves_like 'an event with details', :court_cell_number
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 end

--- a/spec/models/generic_event/per_court_return_to_custody_area_from_visitor_area_spec.rb
+++ b/spec/models/generic_event/per_court_return_to_custody_area_from_visitor_area_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe GenericEvent::PerCourtReturnToCustodyAreaFromVisitorArea do
   it_behaves_like 'an event with details', :court_cell_number
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 end

--- a/spec/models/generic_event/per_court_take_from_custody_to_dock_spec.rb
+++ b/spec/models/generic_event/per_court_take_from_custody_to_dock_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe GenericEvent::PerCourtTakeFromCustodyToDock do
 
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 end

--- a/spec/models/generic_event/per_court_take_to_see_visitors_spec.rb
+++ b/spec/models/generic_event/per_court_take_to_see_visitors_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe GenericEvent::PerCourtTakeToSeeVisitors do
 
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 end

--- a/spec/models/generic_event/per_court_task_spec.rb
+++ b/spec/models/generic_event/per_court_task_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe GenericEvent::PerCourtTask do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 end

--- a/spec/models/generic_event/per_medical_aid_spec.rb
+++ b/spec/models/generic_event/per_medical_aid_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe GenericEvent::PerMedicalAid do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_presence_of(:advised_at) }
   it { is_expected.to validate_presence_of(:advised_by) }

--- a/spec/models/generic_event/per_prisoner_welfare_spec.rb
+++ b/spec/models/generic_event/per_prisoner_welfare_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe GenericEvent::PerPrisonerWelfare do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_presence_of(:given_at) }
 

--- a/spec/models/generic_event/person_move_booked_into_receiving_establishment_spec.rb
+++ b/spec/models/generic_event/person_move_booked_into_receiving_establishment_spec.rb
@@ -6,4 +6,5 @@ RSpec.describe GenericEvent::PersonMoveBookedIntoReceivingEstablishment do
   it_behaves_like 'an event with eventable types', 'Person', 'Move'
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a supplier personnel number'
+  it_behaves_like 'an event with a location in the feed', :location_id
 end

--- a/spec/models/generic_event/person_move_vehicle_broke_down_spec.rb
+++ b/spec/models/generic_event/person_move_vehicle_broke_down_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe GenericEvent::PersonMoveVehicleBrokeDown do
   it_behaves_like 'an event with eventable types', 'Person', 'Move'
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event that specifies a vehicle registration'
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_presence_of(:supplier_personnel_numbers) }
 

--- a/spec/models/generic_event/person_move_vehicle_systems_failed_spec.rb
+++ b/spec/models/generic_event/person_move_vehicle_systems_failed_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe GenericEvent::PersonMoveVehicleSystemsFailed do
   it_behaves_like 'an event with eventable types', 'Person', 'Move'
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event that specifies a vehicle registration'
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   it { is_expected.to validate_presence_of(:supplier_personnel_numbers) }
 

--- a/spec/support/an_event_about_an_incident.rb
+++ b/spec/support/an_event_about_an_incident.rb
@@ -3,6 +3,7 @@ RSpec.shared_examples 'an event about an incident' do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event with eventable types', 'Person', 'Move'
   it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 
   let(:fault_classifications) do
     %w[

--- a/spec/support/an_event_with_a_location_in_the_feed.rb
+++ b/spec/support/an_event_with_a_location_in_the_feed.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an event with a location in the feed' do |location_id_key|
+  describe '#for_feed' do
+    before do
+      generic_event.details[location_id_key] = location.id
+    end
+
+    let(:location) { create(:location) }
+
+    let(:expected_json) do
+      location_key = location_id_key.to_s.sub('_id', '')
+      location_type_key = "#{location_key}_type"
+
+      {
+        'id' => generic_event.id,
+        'type' => generic_event.type.sub('GenericEvent::', ''),
+        'notes' => 'Flibble',
+        'eventable_id' => generic_event.eventable_id,
+        'eventable_type' => generic_event.eventable_type,
+        'details' => {
+          location_key => location.nomis_agency_id,
+          location_type_key => location.location_type,
+        },
+      }
+    end
+
+    it 'generates a feed document' do
+      expect(generic_event.for_feed).to include_json(expected_json)
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

P4-1981

### What?

Locations have their own way of appearing in the feed via the Location#for_feed method. We need to make sure that all new events that will be getting created by the suppliers are serialised correctly for the hub by using this method. The approach I've taken is to tidy all existing for_feed methods that define a location and consolidate them under a module for this specific purpose. This cleans up quite a bit of code :tada:.

I have added/removed/altered:

- [x] Added module for feeds that serialize locations for the hub and consume it in all GenericEvent classes that have a location relationship

### Why?

These are needed for the hub.