### PR TITLE
Remove superfluous relationships and attributes from GET /moves endpoint

### DIFF
--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -8,7 +8,7 @@ module Api
       allocations_params = Allocations::ParamsValidator.new(filter_params, sort_params)
       if allocations_params.valid?
         paginate allocations, serializer: AllocationsSerializer, include: included_relationships, fields: AllocationsSerializer::INCLUDED_FIELDS do |paginated_allocations, options|
-          options[:params] = paginated_allocations.move_totals
+          options[:params] = { totals: paginated_allocations.move_totals }
         end
       else
         render json: { error: allocations_params.errors }, status: :bad_request

--- a/app/controllers/api/populations_controller.rb
+++ b/app/controllers/api/populations_controller.rb
@@ -6,7 +6,7 @@ module Api
 
     def index
       paginate locations, serializer: LocationFreeSpacesSerializer, include: included_relationships do |paginated_locations, options|
-        options[:params] = Population.free_spaces_date_range(paginated_locations, (date_from..date_to))
+        options[:params] = { spaces: Population.free_spaces_date_range(paginated_locations, (date_from..date_to)) }
       end
     end
 

--- a/app/controllers/concerns/serializable.rb
+++ b/app/controllers/concerns/serializable.rb
@@ -34,12 +34,14 @@ private
     serializer_class = options.delete(:serializer)
     raise ArgumentError, 'serializer option must be specified' unless serializer_class
 
-    options[:params] = included_params(options)
+    options[:params] = merge_included_params(options)
 
     serializer_class.new(serializable, options.slice(:include, :fields, :meta, :links, :params))
   end
 
-  def included_params(options)
+  def merge_included_params(options)
+    # This converts a string or array of includes to a unique list of individual symbols for each level
+    # e.g. "profile.person,profile.person_escort_record" => [:profile, :person, :person_escort_record]
     includes_list = [options[:include]].flatten.compact
     unique_resources = includes_list.map { |i| i.split('.') }.flatten.uniq.map(&:to_sym)
 

--- a/app/controllers/concerns/serializable.rb
+++ b/app/controllers/concerns/serializable.rb
@@ -10,8 +10,8 @@ module Serializable
 
     yield(paginated_collection, options) if block_given?
 
-    options[:meta] = meta(paginated_collection, options)
-    options[:links] = links(paginated_collection, options)
+    options[:meta] = pagination_meta(paginated_collection, options)
+    options[:links] = pagination_links(paginated_collection, options)
     options[:json] = build_serializer(paginated_collection, options)
 
     render options.slice(:json, :status)
@@ -34,7 +34,18 @@ private
     serializer_class = options.delete(:serializer)
     raise ArgumentError, 'serializer option must be specified' unless serializer_class
 
+    options[:params] = included_params(options)
+
     serializer_class.new(serializable, options.slice(:include, :fields, :meta, :links, :params))
+  end
+
+  def included_params(options)
+    includes_list = [options[:include]].flatten.compact
+    unique_resources = includes_list.map { |i| i.split('.') }.flatten.uniq.map(&:to_sym)
+
+    options.fetch(:params, {}).merge(
+      included: unique_resources,
+    )
   end
 
   def paginate_collection(collection, options)
@@ -44,7 +55,7 @@ private
     collection.page(options[:page]).per(options[:per_page])
   end
 
-  def meta(collection, options)
+  def pagination_meta(collection, options)
     options.fetch(:meta, {}).merge(
       pagination:
       {
@@ -56,7 +67,7 @@ private
   end
 
   # Based on https://github.com/rails-api/active_model_serializers
-  def links(collection, options)
+  def pagination_links(collection, options)
     no_pages = collection.total_pages.zero?
 
     options.fetch(:links, {}).merge(

--- a/app/lib/JSONAPI/conditional_relationships.rb
+++ b/app/lib/JSONAPI/conditional_relationships.rb
@@ -1,0 +1,23 @@
+module JSONAPI
+  module ConditionalRelationships
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def has_one_if_included(relationship_name, options = {}, &block)
+        options[:if] = proc do |_record, params|
+          params[:included]&.include?(relationship_name)
+        end
+
+        has_one relationship_name, options, &block
+      end
+
+      def has_many_if_included(relationship_name, options = {}, &block)
+        options[:if] = proc do |_record, params|
+          params[:included]&.include?(relationship_name)
+        end
+
+        has_many relationship_name, options, &block
+      end
+    end
+  end
+end

--- a/app/serializers/allocations_serializer.rb
+++ b/app/serializers/allocations_serializer.rb
@@ -3,7 +3,7 @@
 class AllocationsSerializer < AllocationSerializer
   meta do |object, params|
     {
-      moves: params[object.id],
+      moves: params.dig(:totals, object.id),
     }
   end
 

--- a/app/serializers/framework_flags_serializer.rb
+++ b/app/serializers/framework_flags_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class FrameworkFlagsSerializer
+  include JSONAPI::Serializer
+
+  set_type :framework_flags
+
+  attributes :flag_type, :title, :question_value
+end

--- a/app/serializers/location_free_spaces_serializer.rb
+++ b/app/serializers/location_free_spaces_serializer.rb
@@ -11,7 +11,7 @@ class LocationFreeSpacesSerializer
 
   meta do |object, params|
     {
-      populations: params[object.id],
+      populations: params.dig(:spaces, object.id),
     }
   end
 

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -22,7 +22,7 @@ class MoveSerializer
              :date_from,
              :date_to
 
-  belongs_to :person
+  has_one :person
   belongs_to :profile
   belongs_to :from_location, serializer: LocationSerializer
   belongs_to :to_location, serializer: LocationSerializer

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -22,16 +22,17 @@ class MoveSerializer
              :date_from,
              :date_to
 
-  has_one :person
-  has_one :profile
+  belongs_to :person
+  belongs_to :profile
+  belongs_to :from_location, serializer: LocationSerializer
+  belongs_to :to_location, serializer: LocationSerializer
+  belongs_to :prison_transfer_reason
 
-  has_one :from_location, serializer: LocationSerializer
-  has_one :to_location, serializer: LocationSerializer
-  has_one :prison_transfer_reason
   has_many :documents do |object|
     object.profile&.documents
   end
   has_many :court_hearings
+
   belongs_to :allocation
   belongs_to :original_move, serializer: MoveSerializer
 

--- a/app/serializers/person_escort_records_serializer.rb
+++ b/app/serializers/person_escort_records_serializer.rb
@@ -2,15 +2,11 @@
 
 class PersonEscortRecordsSerializer
   include JSONAPI::Serializer
+  include JSONAPI::ConditionalRelationships
 
   set_type :person_escort_records
 
-  # TODO: confirm whether this includes is really necessary - it seems to cause N+1 issues
-  # has_many :flags, serializer: FrameworkFlagSerializer do |object|
-  #   object.framework_flags.includes(framework_question: :dependents)
-  # end
-
-  has_many :flags, serializer: FrameworkFlagsSerializer, &:framework_flags
+  has_many_if_included :flags, serializer: FrameworkFlagsSerializer, &:framework_flags
 
   attributes :confirmed_at, :created_at, :nomis_sync_status
 end

--- a/app/serializers/person_escort_records_serializer.rb
+++ b/app/serializers/person_escort_records_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class PersonEscortRecordsSerializer
+  include JSONAPI::Serializer
+
+  set_type :person_escort_records
+
+  # TODO: confirm whether this includes is really necessary - it seems to cause N+1 issues
+  # has_many :flags, serializer: FrameworkFlagSerializer do |object|
+  #   object.framework_flags.includes(framework_question: :dependents)
+  # end
+
+  has_many :flags, serializer: FrameworkFlagsSerializer, &:framework_flags
+
+  attributes :confirmed_at, :created_at, :nomis_sync_status
+end

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -22,11 +22,11 @@ module V2
                :time_due,
                :updated_at
 
-    has_one :from_location,          serializer: LocationSerializer
-    has_one :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
-    has_one :profile,                serializer: V2::ProfileSerializer
-    has_one :supplier,               serializer: SupplierSerializer
-    has_one :to_location,            serializer: LocationSerializer
+    belongs_to :from_location,          serializer: LocationSerializer
+    belongs_to :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
+    belongs_to :profile,                serializer: V2::ProfileSerializer
+    belongs_to :supplier,               serializer: SupplierSerializer
+    belongs_to :to_location,            serializer: LocationSerializer
 
     has_many :court_hearings, serializer: CourtHearingSerializer
 

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -3,7 +3,6 @@
 module V2
   class MovesSerializer
     include JSONAPI::Serializer
-    include JSONAPI::ConditionalRelationships
 
     attributes  :additional_information,
                 :cancellation_reason,
@@ -27,6 +26,7 @@ module V2
       # TODO: remove these and replace with conditional relationships in relevant serializer
       people: ::V2::PersonSerializer.attributes_to_serialize.keys + %i[gender ethnicity],
       locations: ::LocationSerializer.attributes_to_serialize.keys,
+      allocations: ::AllocationSerializer.attributes_to_serialize.keys,
     }.freeze
 
     SUPPORTED_RELATIONSHIPS = %w[
@@ -38,11 +38,15 @@ module V2
       from_location
       to_location
       prison_transfer_reason
+      supplier
+      allocation
     ].freeze
 
-    has_one_if_included :profile, serializer: V2::ProfilesSerializer
-    has_one_if_included :from_location, serializer: ::LocationSerializer
-    has_one_if_included :to_location, serializer: ::LocationSerializer
-    has_one_if_included :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
+    belongs_to :from_location, serializer: ::LocationSerializer
+    belongs_to :to_location, serializer: ::LocationSerializer
+    belongs_to :profile, serializer: V2::ProfilesSerializer
+    belongs_to :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
+    belongs_to :supplier, serializer: SupplierSerializer
+    belongs_to :allocation, serializer: AllocationSerializer
   end
 end

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -24,13 +24,10 @@ module V2
 
     INCLUDED_FIELDS = {
       moves: attributes_to_serialize.keys +
-        %i[profile from_location to_location prison_transfer_reason supplier],
-      profiles: ::V2::ProfileSerializer.attributes_to_serialize.keys + %i[person person_escort_record],
+        %i[profile from_location to_location prison_transfer_reason],
       people: ::V2::PersonSerializer.attributes_to_serialize.keys + %i[gender ethnicity],
       locations: ::LocationSerializer.attributes_to_serialize.keys,
       prison_transfer_reasons: ::PrisonTransferReasonSerializer.attributes_to_serialize.keys,
-      suppliers: ::SupplierSerializer.attributes_to_serialize.keys,
-      allocations: ::AllocationSerializer.attributes_to_serialize.keys,
     }.freeze
 
     SUPPORTED_RELATIONSHIPS = %w[
@@ -39,20 +36,14 @@ module V2
       profile.person.gender
       profile.person_escort_record
       profile.person_escort_record.flags
-      profile.person_escort_record.framework
-      profile.person_escort_record.responses
       from_location
       to_location
       prison_transfer_reason
-      supplier
-      allocation
     ].freeze
 
-    has_one :profile, serializer: V2::ProfileSerializer
+    has_one :profile, serializer: V2::ProfilesSerializer
     has_one :from_location, serializer: ::LocationSerializer
     has_one :to_location, serializer: ::LocationSerializer
     has_one :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
-    has_one :supplier, serializer: SupplierSerializer
-    has_one :allocation, serializer: AllocationSerializer
   end
 end

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -3,6 +3,7 @@
 module V2
   class MovesSerializer
     include JSONAPI::Serializer
+    include JSONAPI::ConditionalRelationships
 
     attributes  :additional_information,
                 :cancellation_reason,
@@ -23,11 +24,9 @@ module V2
     set_type :moves
 
     INCLUDED_FIELDS = {
-      moves: attributes_to_serialize.keys +
-        %i[profile from_location to_location prison_transfer_reason],
+      # TODO: remove these and replace with conditional relationships in relevant serializer
       people: ::V2::PersonSerializer.attributes_to_serialize.keys + %i[gender ethnicity],
       locations: ::LocationSerializer.attributes_to_serialize.keys,
-      prison_transfer_reasons: ::PrisonTransferReasonSerializer.attributes_to_serialize.keys,
     }.freeze
 
     SUPPORTED_RELATIONSHIPS = %w[
@@ -41,9 +40,9 @@ module V2
       prison_transfer_reason
     ].freeze
 
-    has_one :profile, serializer: V2::ProfilesSerializer
-    has_one :from_location, serializer: ::LocationSerializer
-    has_one :to_location, serializer: ::LocationSerializer
-    has_one :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
+    has_one_if_included :profile, serializer: V2::ProfilesSerializer
+    has_one_if_included :from_location, serializer: ::LocationSerializer
+    has_one_if_included :to_location, serializer: ::LocationSerializer
+    has_one_if_included :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
   end
 end

--- a/app/serializers/v2/person_serializer.rb
+++ b/app/serializers/v2/person_serializer.rb
@@ -19,6 +19,7 @@ module V2
     has_one :ethnicity, serializer: EthnicitySerializer
     has_one :gender, serializer: GenderSerializer
 
+    # TODO: replace this with has_many_if_included - lazy loading is buggy for nested resources
     # NB without lazy_load_data: true this relationship will trigger an N+1 database query,
     # unless it is included in the includes list
     has_many :profiles, serializer: ProfileSerializer, lazy_load_data: true

--- a/app/serializers/v2/profiles_serializer.rb
+++ b/app/serializers/v2/profiles_serializer.rb
@@ -2,11 +2,13 @@
 
 class V2::ProfilesSerializer
   include JSONAPI::Serializer
+  include JSONAPI::ConditionalRelationships
 
   set_type :profiles
 
   attributes :assessment_answers
 
   belongs_to :person, serializer: ::V2::PersonSerializer
-  has_one :person_escort_record, serializer: PersonEscortRecordsSerializer
+
+  has_one_if_included :person_escort_record, serializer: PersonEscortRecordsSerializer
 end

--- a/app/serializers/v2/profiles_serializer.rb
+++ b/app/serializers/v2/profiles_serializer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class V2::ProfilesSerializer
+  include JSONAPI::Serializer
+
+  set_type :profiles
+
+  attributes :assessment_answers
+
+  belongs_to :person, serializer: ::V2::PersonSerializer
+  has_one :person_escort_record, serializer: PersonEscortRecordsSerializer
+end

--- a/spec/requests/api/moves_controller_index_v2_spec.rb
+++ b/spec/requests/api/moves_controller_index_v2_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::MovesController do
     let!(:moves) { create_list :move, 2 }
 
     it_behaves_like 'an endpoint that responds with success 200' do
-      before { do_get }
+      before { do_get('?include=from_location') }
     end
 
     describe 'filtering results' do
@@ -169,9 +169,7 @@ RSpec.describe Api::MovesController do
       let(:to_location) { create(:location, suppliers: [supplier]) }
       let(:from_location) { create(:location, suppliers: [supplier]) }
 
-      before do
-        get "/api/moves#{query_params}", params: params, headers: headers
-      end
+      before { do_get(query_params) }
 
       context 'when not including the include query param' do
         let(:query_params) { '' }
@@ -213,7 +211,7 @@ RSpec.describe Api::MovesController do
     end
   end
 
-  def do_get
-    get '/api/moves', params: params, headers: headers
+  def do_get(query_params = nil)
+    get "/api/moves#{query_params}", params: params, headers: headers
   end
 end

--- a/spec/requests/api/moves_controller_index_v2_spec.rb
+++ b/spec/requests/api/moves_controller_index_v2_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::MovesController do
     let!(:moves) { create_list :move, 2 }
 
     it_behaves_like 'an endpoint that responds with success 200' do
-      before { do_get('?include=from_location') }
+      before { do_get }
     end
 
     describe 'filtering results' do

--- a/spec/serializers/allocations_serializer_spec.rb
+++ b/spec/serializers/allocations_serializer_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe AllocationsSerializer do
   context 'with custom params' do
     let(:adapter_options) do
       { params: {
-        allocation.id => { foo: 'bar' },
+        totals: {
+          allocation.id => { foo: 'bar' },
+        },
       } }
     end
 

--- a/spec/serializers/framework_flags_serializer_spec.rb
+++ b/spec/serializers/framework_flags_serializer_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkFlagsSerializer do
+  subject(:serializer) { described_class.new(framework_flag) }
+
+  let(:framework_flag) { create(:framework_flag) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('framework_flags')
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eq(framework_flag.id)
+  end
+
+  it 'contains a `title` attribute' do
+    expect(result[:data][:attributes][:title]).to eq(framework_flag.title)
+  end
+
+  it 'contains a `flag_type` attribute' do
+    expect(result[:data][:attributes][:flag_type]).to eq(framework_flag.flag_type)
+  end
+
+  it 'contains a `question_value` attribute' do
+    expect(result[:data][:attributes][:question_value]).to eq(framework_flag.question_value)
+  end
+end

--- a/spec/serializers/location_free_spaces_serializer_spec.rb
+++ b/spec/serializers/location_free_spaces_serializer_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe LocationFreeSpacesSerializer do
   context 'with custom params' do
     let(:adapter_options) do
       { params: {
-        location.id => { foo: 'bar' },
+        spaces: {
+          location.id => { foo: 'bar' },
+        },
       } }
     end
 

--- a/spec/serializers/person_escort_records_serializer_spec.rb
+++ b/spec/serializers/person_escort_records_serializer_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonEscortRecordsSerializer do
+  subject(:serializer) { described_class.new(person_escort_record, options) }
+
+  let(:person_escort_record) { create(:person_escort_record) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:options) { {} }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('person_escort_records')
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eq(person_escort_record.id)
+  end
+
+  it 'contains a `confirmed_at` attribute' do
+    expect(result[:data][:attributes][:confirmed_at]).to eq(person_escort_record.confirmed_at)
+  end
+
+  it 'contains a `created_at` attribute' do
+    expect(result[:data][:attributes][:created_at]).to eq(person_escort_record.created_at.iso8601)
+  end
+
+  it 'contains a `nomis_sync_status` attribute' do
+    expect(result[:data][:attributes][:nomis_sync_status]).to eq(person_escort_record.nomis_sync_status)
+  end
+
+  it 'omits `flags` relationship if not explicitly included' do
+    expect(result[:data][:relationships]).not_to include(:flags)
+  end
+
+  context 'with included flags' do
+    let(:options) { { params: { included: %i[flags] } } }
+
+    it 'contains an empty `flags` relationship if no flags present' do
+      expect(result[:data][:relationships][:flags][:data]).to be_empty
+    end
+
+    it 'contains a`flags` relationship with framework response flags' do
+      flag = create(:framework_flag)
+      create(:string_response, assessmentable: person_escort_record, framework_flags: [flag])
+
+      expect(result[:data][:relationships][:flags][:data]).to contain_exactly(
+        id: flag.id,
+        type: 'framework_flags',
+      )
+    end
+  end
+end

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V2::MovesSerializer do
+  subject(:serializer) { described_class.new(move, options) }
+
+  let(:move) { create :move, :prison_transfer }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+
+  context 'with no options' do
+    let(:options) { {} }
+    let(:expected_json) do
+      {
+        data: {
+          id: move.id,
+          type: 'moves',
+          attributes: {
+            additional_information: 'some more info about the move that the supplier might need to know',
+            cancellation_reason: nil,
+            cancellation_reason_comment: nil,
+            created_at: move.created_at.iso8601,
+            date: move.date.iso8601,
+            date_from: move.date_from.iso8601,
+            date_to: nil,
+            move_agreed: nil,
+            move_agreed_by: nil,
+            move_type: 'prison_transfer',
+            reference: move.reference,
+            rejection_reason: nil,
+            status: 'requested',
+            time_due: move.time_due.iso8601,
+            updated_at: move.updated_at.iso8601,
+          },
+          relationships: {
+          },
+        },
+      }
+    end
+
+    it { expect(result).to include_json(expected_json) }
+    it { expect(result[:included]).to be_nil }
+  end
+
+  context 'with included profile' do
+    let(:options) { { params: { included: %i[profile] } } }
+
+    it 'contains a `profile` relationship with profile' do
+      expect(result[:data][:relationships][:profile][:data]).to eq({
+        id: move.profile.id,
+        type: 'profiles',
+      })
+    end
+  end
+
+  context 'with included from location' do
+    let(:options) { { params: { included: %i[from_location] } } }
+
+    it 'contains a `from_location` relationship with location' do
+      expect(result[:data][:relationships][:from_location][:data]).to eq({
+        id: move.from_location.id,
+        type: 'locations',
+      })
+    end
+  end
+
+  context 'with included to location' do
+    let(:options) { { params: { included: %i[to_location] } } }
+
+    it 'contains a `to_location` relationship with location' do
+      expect(result[:data][:relationships][:to_location][:data]).to eq({
+        id: move.to_location.id,
+        type: 'locations',
+      })
+    end
+  end
+
+  context 'with included prison transfer reason' do
+    let(:options) { { params: { included: %i[prison_transfer_reason] } } }
+
+    it 'contains a `prison_transfer_reason` relationship with prison transfer reason' do
+      expect(result[:data][:relationships][:prison_transfer_reason][:data]).to eq({
+        id: move.prison_transfer_reason.id,
+        type: 'prison_transfer_reasons',
+      })
+    end
+  end
+end

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe V2::MovesSerializer do
             updated_at: move.updated_at.iso8601,
           },
           relationships: {
+            profile: { data: { id: move.profile_id, type: 'profiles' } },
+            from_location: { data: { id: move.from_location_id, type: 'locations' } },
+            to_location: { data: { id: move.to_location_id, type: 'locations' } },
+            prison_transfer_reason: { data: { id: move.prison_transfer_reason_id, type: 'prison_transfer_reasons' } },
+            supplier: { data: { id: move.supplier_id, type: 'suppliers' } },
           },
         },
       }
@@ -42,47 +47,12 @@ RSpec.describe V2::MovesSerializer do
     it { expect(result[:included]).to be_nil }
   end
 
-  context 'with included profile' do
-    let(:options) { { params: { included: %i[profile] } } }
+  context 'with all supported includes' do
+    let(:options) { { include: described_class::SUPPORTED_RELATIONSHIPS } }
 
-    it 'contains a `profile` relationship with profile' do
-      expect(result[:data][:relationships][:profile][:data]).to eq({
-        id: move.profile.id,
-        type: 'profiles',
-      })
-    end
-  end
-
-  context 'with included from location' do
-    let(:options) { { params: { included: %i[from_location] } } }
-
-    it 'contains a `from_location` relationship with location' do
-      expect(result[:data][:relationships][:from_location][:data]).to eq({
-        id: move.from_location.id,
-        type: 'locations',
-      })
-    end
-  end
-
-  context 'with included to location' do
-    let(:options) { { params: { included: %i[to_location] } } }
-
-    it 'contains a `to_location` relationship with location' do
-      expect(result[:data][:relationships][:to_location][:data]).to eq({
-        id: move.to_location.id,
-        type: 'locations',
-      })
-    end
-  end
-
-  context 'with included prison transfer reason' do
-    let(:options) { { params: { included: %i[prison_transfer_reason] } } }
-
-    it 'contains a `prison_transfer_reason` relationship with prison transfer reason' do
-      expect(result[:data][:relationships][:prison_transfer_reason][:data]).to eq({
-        id: move.prison_transfer_reason.id,
-        type: 'prison_transfer_reasons',
-      })
+    it 'contains all included relationships' do
+      expect(result[:included].map { |r| r[:type] })
+        .to match_array(%w[people ethnicities genders locations locations profiles prison_transfer_reasons suppliers])
     end
   end
 end

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe V2::MovesSerializer do
             to_location: { data: { id: move.to_location_id, type: 'locations' } },
             prison_transfer_reason: { data: { id: move.prison_transfer_reason_id, type: 'prison_transfer_reasons' } },
             supplier: { data: { id: move.supplier_id, type: 'suppliers' } },
+            allocation: { data: nil },
           },
         },
       }
@@ -48,11 +49,21 @@ RSpec.describe V2::MovesSerializer do
   end
 
   context 'with all supported includes' do
-    let(:options) { { include: described_class::SUPPORTED_RELATIONSHIPS } }
+    let(:options) do
+      {
+        include: described_class::SUPPORTED_RELATIONSHIPS,
+        params: { included: %i[person_escort_record flags] },
+      }
+    end
+
+    let!(:person_escort_record) { create(:person_escort_record, move: move, profile: move.profile) }
+    let!(:flag) { create(:framework_flag) }
+    let!(:response) { create(:string_response, assessmentable: person_escort_record, framework_flags: [flag]) }
+    let!(:allocation) { create(:allocation, moves: [move]) }
 
     it 'contains all included relationships' do
       expect(result[:included].map { |r| r[:type] })
-        .to match_array(%w[people ethnicities genders locations locations profiles prison_transfer_reasons suppliers])
+        .to match_array(%w[people ethnicities genders locations locations profiles prison_transfer_reasons suppliers person_escort_records framework_flags allocations])
     end
   end
 end

--- a/spec/serializers/v2/profiles_serializer_spec.rb
+++ b/spec/serializers/v2/profiles_serializer_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V2::ProfilesSerializer do
+  subject(:serializer) { described_class.new(profile, options) }
+
+  let(:profile) { create(:profile) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:options) { {} }
+
+  let(:expected_document) do
+    {
+      data: {
+        id: profile.id,
+        type: 'profiles',
+        attributes: { assessment_answers: [] },
+        relationships: {
+          person: {
+            data: { id: profile.person.id, type: 'people' },
+          },
+        },
+      },
+    }
+  end
+
+  it 'returns the expected serialized `Profile`' do
+    expect(result).to eq(expected_document)
+  end
+
+  context 'with assessment_answers' do
+    let(:risk_alert_type) { create :assessment_question, :risk }
+    let(:health_alert_type) { create :assessment_question, :health }
+
+    let(:risk_alert) do
+      {
+        title: risk_alert_type.title,
+        comments: 'Former miner',
+        assessment_question_id: risk_alert_type.id,
+      }
+    end
+
+    let(:health_alert) do
+      {
+        title: health_alert_type.title,
+        comments: 'Needs something for a headache',
+        assessment_question_id: health_alert_type.id,
+      }
+    end
+
+    let(:profile) { create(:profile, assessment_answers: [risk_alert, health_alert]) }
+
+    it 'contains an `assessment_answers` nested collection' do
+      assessment_answers = result[:data][:attributes][:assessment_answers].map { |alert| alert[:title] }
+
+      expect(assessment_answers).to match_array [risk_alert_type.title, health_alert_type.title]
+    end
+  end
+
+  context 'with included person escort record' do
+    let(:options) { { params: { included: %i[person_escort_record] } } }
+
+    it 'contains a nil `person_escort_record` relationship if no person escort record present' do
+      expect(result[:data][:relationships][:person_escort_record][:data]).to be_nil
+    end
+
+    it 'contains a`person_escort_record` relationship with person escort record' do
+      person_escort_record = create(:person_escort_record, profile: profile)
+
+      expect(result[:data][:relationships][:person_escort_record][:data]).to eq({
+        id: person_escort_record.id,
+        type: 'person_escort_records',
+      })
+    end
+  end
+end

--- a/swagger/v2/moves_include_parameter.yaml
+++ b/swagger/v2/moves_include_parameter.yaml
@@ -15,9 +15,6 @@ MovesIncludeParameter:
       - profile.person.gender
       - profile.person_escort_record
       - profile.person_escort_record.flags
-      - profile.person_escort_record.framework
-      - profile.person_escort_record.responses
       - supplier
       - to_location
-
   example: from_location


### PR DESCRIPTION
### Jira link

P4-2467

### What?

- [x] Added new `ConditionalRelationships` module to support conditional `has_many` and `has_one` methods
- [x] Refactored existing `MovesSerializer` and selected child serializers to leverage the new conditional resources approach
- [x] Updated/added coverage for new serializers
- [x] Dropped support for `profile.person_escort_record.framework` and `profile.person_escort_record.responses` includes within `GET /moves` endpoint.

### Why?

- We have been trying a number of techniques to improve API performance when serialising a graph of resources. The aim is to support a reasonable set of includes for each endpoint and to ensure that the associated resources are retrieved efficiently without superfluous or N+1 queries. There are known performance issues when including `profile.person_escort_record.flags` as part of a `GET /moves` request that need to be addressed.

- Previous approaches have used a hard coded list of relationships to render in the `MovesSerializer` - this works to a point if all of those relationships are passed in the `include` query string. If those are omitted then for a `has_one` or `has_many` relationship we see N+1 SQL queries as the id's for those resources cannot be retrieved directly from the parent record (move). If a `belongs_to` relationship is omitted from the `include` query string there is no additional SQL query as the child record id is present on the move record.

- This PR introduces conditional relationships, namely `has_one_if_included` and `has_many_if_included`. These relationships are only rendered in the JSONAPI output if they are explicitly requested in the `include` query string parameter. Some careful plumbing is needed to make the serializer aware of the original query string; this is added via the `paginate` and `render_json` methods from the `Serializable` concern; the `include` query string is parsed and added as a custom `included` param in the serializer constructor. These params are then available when rendering child serializers which allows us to check whether the relationship should be rendered.

- Effectively this gives the same net result as using `lazy_load_data: true` option for `has_many` and `has_one` relationships. Unfortunately the implementation of this is broken within the jsonapi-serializer gem and we see orphaned resources without the correct relationships defined. This produces broken JSONAPI output that cannot be correctly deserialized so we (for now at least) need to avoid using that approach.

- As the serializer `params` are now used to support `included`, some existing serializers for location free spaces and allocations needed a slight change to their use of `params`. These have now been namespaced rather than including parameter data at the root level. This allows simultaneous use of the conditional relationships and custom parameters.

- The change has only been applied to the `v2` `GET /moves` endpoint but this PR lays the groundwork for rolling the approach out across other endpoints over time. Client behaviour should be unaffected as the same response is returned if the correct `include` query string is passed, however this will need to be extensively tested.


### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

