### PR TITLE
Remove support for including allocation on v1/v2 GET /moves and v1 GET /move

### DIFF
--- a/app/controllers/api/v1/moves_actions.rb
+++ b/app/controllers/api/v1/moves_actions.rb
@@ -3,8 +3,7 @@ module Api::V1
     def index_and_render
       paginate moves,
                serializer: MoveSerializer,
-               include: included_relationships - %w[court_hearings],
-               fields: MoveSerializer::INCLUDED_FIELDS
+               include: included_relationships - %w[court_hearings]
     end
 
     def show_and_render
@@ -102,7 +101,7 @@ module Api::V1
     end
 
     def render_move(move, status)
-      render_json move, serializer: MoveSerializer, include: included_relationships, fields: MoveSerializer::INCLUDED_FIELDS, status: status
+      render_json move, serializer: MoveSerializer, include: included_relationships, status: status
     end
 
     def move

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -33,7 +33,6 @@ class MoveSerializer
   end
   has_many :court_hearings
 
-  belongs_to :allocation
   belongs_to :original_move, serializer: MoveSerializer
 
   SUPPORTED_RELATIONSHIPS = %w[
@@ -57,11 +56,6 @@ class MoveSerializer
     documents
     prison_transfer_reason
     court_hearings
-    allocation
     original_move
   ].freeze
-
-  INCLUDED_FIELDS = {
-    allocations: %i[to_location from_location moves_count created_at],
-  }.freeze
 end

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -33,6 +33,7 @@ class MoveSerializer
   end
   has_many :court_hearings
 
+  belongs_to :allocation
   belongs_to :original_move, serializer: MoveSerializer
 
   SUPPORTED_RELATIONSHIPS = %w[

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -26,7 +26,6 @@ module V2
       # TODO: remove these and replace with conditional relationships in relevant serializer
       people: ::V2::PersonSerializer.attributes_to_serialize.keys + %i[gender ethnicity],
       locations: ::LocationSerializer.attributes_to_serialize.keys,
-      allocations: ::AllocationSerializer.attributes_to_serialize.keys,
     }.freeze
 
     SUPPORTED_RELATIONSHIPS = %w[
@@ -39,7 +38,6 @@ module V2
       to_location
       prison_transfer_reason
       supplier
-      allocation
     ].freeze
 
     belongs_to :from_location, serializer: ::LocationSerializer
@@ -47,6 +45,5 @@ module V2
     belongs_to :profile, serializer: V2::ProfilesSerializer
     belongs_to :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
     belongs_to :supplier, serializer: SupplierSerializer
-    belongs_to :allocation, serializer: AllocationSerializer
   end
 end

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -45,5 +45,6 @@ module V2
     belongs_to :profile, serializer: V2::ProfilesSerializer
     belongs_to :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
     belongs_to :supplier, serializer: SupplierSerializer
+    belongs_to :allocation, serializer: AllocationSerializer
   end
 end

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -150,6 +150,17 @@ RSpec.describe MoveSerializer do
     end
   end
 
+  describe 'allocation' do
+    context 'with an allocation' do
+      let(:adapter_options) { {} }
+      let(:move) { create(:move, :with_allocation) }
+
+      it 'contains an allocation relationship' do
+        expect(result_data[:relationships][:allocation]).to eq(data: { id: move.allocation.id, type: 'allocations' })
+      end
+    end
+  end
+
   describe 'original_move' do
     let(:adapter_options) { { include: MoveSerializer::SUPPORTED_RELATIONSHIPS } }
 

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -150,68 +150,6 @@ RSpec.describe MoveSerializer do
     end
   end
 
-  describe 'allocation' do
-    context 'with an allocation' do
-      let(:adapter_options) do
-        { include: %i[allocation], fields: MoveSerializer::INCLUDED_FIELDS }
-      end
-      let(:move) { create(:move, :with_allocation) }
-      let(:expected_json) do
-        [
-          {
-            id: move.allocation.id,
-            type: 'allocations',
-            attributes: {
-              moves_count: move.allocation.moves_count,
-              created_at: move.allocation.created_at.iso8601,
-            },
-            meta: {
-              moves: {
-                total: 1,
-                filled: 1,
-                unfilled: 0,
-              },
-            },
-            relationships: {
-              from_location: {
-                data: {
-                  id: move.from_location.id,
-                  type: 'locations',
-                },
-              },
-              to_location: {
-                data: {
-                  id: move.to_location.id,
-                  type: 'locations',
-                },
-              },
-            },
-          },
-        ]
-      end
-
-      it 'contains an allocation relationship' do
-        expect(result_data[:relationships][:allocation]).to eq(data: { id: move.allocation.id, type: 'allocations' })
-      end
-
-      it 'contains an included allocation' do
-        expect(result[:included]).to eq(expected_json)
-      end
-    end
-
-    context 'without an allocation' do
-      let(:adapter_options) { { include: MoveSerializer::SUPPORTED_RELATIONSHIPS } }
-
-      it 'contains an empty allocation' do
-        expect(result_data[:relationships][:allocation]).to eq(data: nil)
-      end
-
-      it 'does not contain an included move' do
-        expect(result[:included].map { |r| r[:type] }).to match_array(%w[locations locations ethnicities genders people profiles])
-      end
-    end
-  end
-
   describe 'original_move' do
     let(:adapter_options) { { include: MoveSerializer::SUPPORTED_RELATIONSHIPS } }
 
@@ -230,7 +168,7 @@ RSpec.describe MoveSerializer do
 
     context 'without an original_move' do
       it 'contains an empty original_move' do
-        expect(result_data[:relationships][:allocation]).to eq(data: nil)
+        expect(result_data[:relationships][:original_move]).to eq(data: nil)
       end
 
       it 'does not contain an included move' do

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe V2::MovesSerializer do
             to_location: { data: { id: move.to_location_id, type: 'locations' } },
             prison_transfer_reason: { data: { id: move.prison_transfer_reason_id, type: 'prison_transfer_reasons' } },
             supplier: { data: { id: move.supplier_id, type: 'suppliers' } },
-            allocation: { data: nil },
           },
         },
       }
@@ -59,11 +58,10 @@ RSpec.describe V2::MovesSerializer do
     let!(:person_escort_record) { create(:person_escort_record, move: move, profile: move.profile) }
     let!(:flag) { create(:framework_flag) }
     let!(:response) { create(:string_response, assessmentable: person_escort_record, framework_flags: [flag]) }
-    let!(:allocation) { create(:allocation, moves: [move]) }
 
     it 'contains all included relationships' do
       expect(result[:included].map { |r| r[:type] })
-        .to match_array(%w[people ethnicities genders locations locations profiles prison_transfer_reasons suppliers person_escort_records framework_flags allocations])
+        .to match_array(%w[people ethnicities genders locations locations profiles prison_transfer_reasons suppliers person_escort_records framework_flags])
     end
   end
 end

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe V2::MovesSerializer do
             to_location: { data: { id: move.to_location_id, type: 'locations' } },
             prison_transfer_reason: { data: { id: move.prison_transfer_reason_id, type: 'prison_transfer_reasons' } },
             supplier: { data: { id: move.supplier_id, type: 'suppliers' } },
+            allocation: { data: nil },
           },
         },
       }

--- a/swagger/v1/move_include_parameter.yaml
+++ b/swagger/v1/move_include_parameter.yaml
@@ -7,7 +7,6 @@ MoveIncludeParameter:
   schema:
     type: string
     enum:
-      - allocation
       - court_hearings
       - documents
       - from_location

--- a/swagger/v2/moves_include_parameter.yaml
+++ b/swagger/v2/moves_include_parameter.yaml
@@ -7,7 +7,6 @@ MovesIncludeParameter:
   schema:
     type: string
     enum:
-      - allocation
       - from_location
       - prison_transfer_reason
       - profile.person


### PR DESCRIPTION
### Jira link

P4-2476

### What?

- [x] Cleaned up unused `allocation` includes for v1 GET /moves/:id endpoint
- [x] Cleaned up unused `allocation` includes for v1 GET /moves endpoint
- [x] Cleaned up unused `allocation` includes for v2 GET /moves endpoint

### Why?

- Suppliers have no need to see allocation details as part of a move so removing support completely under v1 API should not impact them. The v2 API still retains support for including an allocation when retrieving one move, but not multiple moves.
Including allocation details with a list of moves is extremely slow so has been replaced with custom metadata for moves counts under v2 GET /moves.

- We don't want API clients to inadvertently make use of this include so it's good to remove support and cleanup associated code.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Should be no risk if suppliers and front end are not using this include. Flagging as a breaking change however to remind us to test this assumption!