### PR TITLE
Reduce spam logging of Papertrail versions

### DIFF
--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FrameworkResponse < VersionedModel
+class FrameworkResponse < ApplicationRecord
   ValueTypeError = Class.new(StandardError)
 
   validates :type, presence: true

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -9,6 +9,7 @@ class Profile < VersionedModel
     assessment_answers
   ].freeze
 
+  # TODO: drop these columns from existing databases
   self.ignored_columns = %w[
     last_name
     first_names

--- a/app/models/versioned_model.rb
+++ b/app/models/versioned_model.rb
@@ -3,5 +3,5 @@
 class VersionedModel < ApplicationRecord
   self.abstract_class = true
 
-  has_paper_trail
+  has_paper_trail ignore: [:updated_at]
 end

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,15 @@
+# Ensure that touching a model does not create a papertrail version when `updated_at` column is ignored
+# See: https://github.com/paper-trail-gem/paper_trail/issues/1161#issuecomment-636619530
+
+module RecordTrailTouchExtension
+  def record_update(force:, in_after_callback:, is_touch:)
+    return if is_touch
+    super
+  end
+end
+
+module PaperTrail
+  class RecordTrail
+    prepend RecordTrailTouchExtension
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Person do
   it { is_expected.to validate_presence_of(:first_names) }
 
   it 'has an audit' do
+    expect(person.versions.map(&:event)).to eq(%w[create])
+    person.update(first_names: 'Finbarr', last_name: 'Saunders')
     expect(person.versions.map(&:event)).to eq(%w[create update])
   end
 

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -109,10 +109,8 @@ RSpec.describe Api::MovesController do
       it 'audits the supplier' do
         do_post
 
-        # NB: Creation of the move and the associated event for the timeline generates multiple
-        # entries in the versions table.
-        expect(move.versions.map(&:whodunnit)).to eq([nil, nil])
-        expect(move.versions.map(&:supplier_id)).to eq([supplier.id, supplier.id])
+        expect(move.versions.map(&:whodunnit)).to eq([nil])
+        expect(move.versions.map(&:supplier_id)).to eq([supplier.id])
       end
 
       it 'sets the application owner as the supplier on the move' do


### PR DESCRIPTION
### Jira link

P4-2516

### What?

- [x] Stop versioning `FrameworkResponse` model
- [x] Don't version changes to `updated_at` column

### Why?

- There's no need to version FrameworkResponses - we don't care about those while the PER is in draft status and once completed the PER becomes read only so those rows are essentially immutable.
For other versioned resources there's no need to record a new version if only a timestamp is modified; this can happen when the `updated_at` attribute is updated in isolation, or if the model is touched.
This change now means that updating resources won't trigger a cascade of associated versions via the "touch model". In production this should speed up endpoints that modify data as we won't need as many writes to the 7 million row versions table.

### Deployment risks (optional)

- Minimal risk, but should improve performance