### PR TITLE
P4-2415 fix duplicate move validation

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -152,12 +152,23 @@ class Move < VersionedModel
     cancellation_reason == CANCELLATION_REASON_REJECTED
   end
 
-  def existing
-    self.class.not_cancelled.find_by(date: date, profile_id: profile_id, from_location_id: from_location_id, to_location_id: to_location_id)
+  def existing_moves
+    Move
+        .joins(:profile)
+        .where('profiles.person_id = ?', profile.person_id)
+        .not_cancelled
+        .not_proposed
+        .where(
+          from_location_id: from_location_id,
+          to_location_id: to_location_id,
+          date: date,
+        )
+        .where.not(profile: nil)
+        .where.not(id: id) # When updating an existing move, don't consider self a duplicate
   end
 
   def existing_id
-    existing&.id
+    existing_moves&.first&.id
   end
 
   def current?
@@ -242,16 +253,6 @@ private
   end
 
   def validate_move_uniqueness
-    existing_moves = Move.joins(:profile)
-      .where('profiles.person_id = ?', profile.person_id)
-      .where(
-        status: status,
-        from_location_id: from_location_id,
-        to_location_id: to_location_id,
-        date: date,
-      )
-      .where.not(id: id) # When updating an existing move, don't consider self a duplicate
-
     errors.add(:date, :taken) if existing_moves.any?
   end
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -153,7 +153,7 @@ class Move < VersionedModel
   end
 
   def existing_moves
-    Move
+    @existing_moves ||= Move
         .joins(:profile)
         .where('profiles.person_id = ?', profile.person_id)
         .not_cancelled

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -153,7 +153,7 @@ class Move < VersionedModel
   end
 
   def existing_moves
-    @existing_moves ||= Move
+    Move
         .joins(:profile)
         .where('profiles.person_id = ?', profile.person_id)
         .not_cancelled


### PR DESCRIPTION
### Jira link

P4-2415

### What?

I have added/removed/altered:

- [x] Ensure duplicate moves are identified by matching people rather than by matching profiles
- [x] Exempt cancelled, proposed and nil profiles from duplicate checks

### Why?

I am doing this because:

- to ensure duplicate moves are correctly identified and reported to the frontend
- reduce the number of errors raised which are actually about duplicate moves


### Have you? (optional)

- [ ] TODO: run front end end-to-end tests


### Deployment risks (optional)

- Changes an api that is used in production

