### PR TITLE
Add support for medical and critical events

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -85,7 +85,7 @@ class GenericEvent < ApplicationRecord
 
   enum classification: {
     default: 'default',
-    critical: 'critical',
+    incident: 'incident',
     medical: 'medical',
   }
 

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -202,6 +202,6 @@ class GenericEvent < ApplicationRecord
 private
 
   def set_classification
-    self.classification = event_classification if classification.blank?
+    self.classification = event_classification
   end
 end

--- a/app/models/generic_event/incident.rb
+++ b/app/models/generic_event/incident.rb
@@ -2,6 +2,10 @@ class GenericEvent
   class Incident < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
+    def event_classification
+      :critical
+    end
+
     def self.inherited(child)
       child.details_attributes :supplier_personnel_numbers, :vehicle_reg, :reported_at, :fault_classification
       child.relationship_attributes location_id: :locations

--- a/app/models/generic_event/incident.rb
+++ b/app/models/generic_event/incident.rb
@@ -3,7 +3,7 @@ class GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
     def event_classification
-      :critical
+      :incident
     end
 
     def self.inherited(child)

--- a/app/models/generic_event/per_medical_aid.rb
+++ b/app/models/generic_event/per_medical_aid.rb
@@ -15,5 +15,9 @@ class GenericEvent
     validates :advised_by, presence: true
     validates :treated_at, presence: true, iso_date_time: true
     validates :treated_by, presence: true
+
+    def event_classification
+      :medical
+    end
   end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -211,6 +211,10 @@ class Move < VersionedModel
     GenericEvent.where(eventable_type: eventable_types, eventable_id: eventable_ids).applied_order
   end
 
+  def important_events
+    critical_events + (profile&.person_escort_record&.medical_events || [])
+  end
+
 private
 
   def date_to_after_date_from

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -87,7 +87,7 @@ class Move < VersionedModel
   has_many :court_hearings, dependent: :restrict_with_exception
 
   has_many :generic_events, as: :eventable, dependent: :destroy
-  has_many :critical_events, -> { where classification: :critical }, as: :eventable, class_name: 'GenericEvent'
+  has_many :incident_events, -> { where classification: :incident }, as: :eventable, class_name: 'GenericEvent'
 
   validates :from_location, presence: true
   validates :to_location, presence: true, unless: -> { prison_recall? || video_remand? }
@@ -212,7 +212,7 @@ class Move < VersionedModel
   end
 
   def important_events
-    critical_events + (profile&.person_escort_record&.medical_events || [])
+    incident_events + (profile&.person_escort_record&.medical_events || [])
   end
 
 private

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -87,6 +87,7 @@ class Move < VersionedModel
   has_many :court_hearings, dependent: :restrict_with_exception
 
   has_many :generic_events, as: :eventable, dependent: :destroy
+  has_many :critical_events, -> { where classification: :critical }, as: :eventable, class_name: 'GenericEvent'
 
   validates :from_location, presence: true
   validates :to_location, presence: true, unless: -> { prison_recall? || video_remand? }

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -5,6 +5,8 @@ class PersonEscortRecord < VersionedModel
   # To support legacy PERs without a move, allow the association to be optional
   belongs_to :move, optional: true
 
+  has_many :medical_events, -> { where classification: :medical }, as: :eventable, class_name: 'GenericEvent'
+
   def self.framework_name
     'person-escort-record'
   end

--- a/app/serializers/generic_event_serializer.rb
+++ b/app/serializers/generic_event_serializer.rb
@@ -2,15 +2,14 @@
 
 class GenericEventSerializer
   include JSONAPI::Serializer
+  include JSONAPI::ConditionalRelationships
 
   set_type :events
 
-  attributes :event_type, :occurred_at, :recorded_at, :notes
+  attributes :event_type, :classification, :occurred_at, :recorded_at, :notes
 
-  # TODO: should this/these be a belongs_to instead?
-  # TODO consider using has_one_if_included to lazy load these associations
-  has_one :eventable, serializer: ->(record, _params) { SerializerVersionChooser.call(record.class) }
-  has_one :supplier
+  belongs_to :eventable, serializer: ->(record, _params) { SerializerVersionChooser.call(record.class) }
+  belongs_to :supplier
 
   SUPPORTED_RELATIONSHIPS = %w[eventable].freeze
 

--- a/app/serializers/generic_event_serializer.rb
+++ b/app/serializers/generic_event_serializer.rb
@@ -5,16 +5,14 @@ class GenericEventSerializer
 
   set_type :events
 
-  attributes :occurred_at, :recorded_at, :notes
+  attributes :event_type, :occurred_at, :recorded_at, :notes
 
+  # TODO: should this/these be a belongs_to instead?
+  # TODO consider using has_one_if_included to lazy load these associations
   has_one :eventable, serializer: ->(record, _params) { SerializerVersionChooser.call(record.class) }
   has_one :supplier
 
   SUPPORTED_RELATIONSHIPS = %w[eventable].freeze
-
-  attribute :event_type do |object|
-    object.type.try(:gsub, 'GenericEvent::', '')
-  end
 
   attribute :details do |record, _params|
     record.details.deep_dup.tap do |details|

--- a/app/serializers/important_events_serializer.rb
+++ b/app/serializers/important_events_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ImportantEventsSerializer
+  include JSONAPI::Serializer
+
+  set_type :events
+
+  attributes :event_type, :classification
+end

--- a/app/serializers/person_escort_records_serializer.rb
+++ b/app/serializers/person_escort_records_serializer.rb
@@ -7,6 +7,7 @@ class PersonEscortRecordsSerializer
   set_type :person_escort_records
 
   has_many_if_included :flags, serializer: FrameworkFlagsSerializer, &:framework_flags
+  has_many_if_included :medical_events, serializer: ImportantEventsSerializer
 
   attributes :confirmed_at, :created_at, :nomis_sync_status
 end

--- a/app/serializers/person_escort_records_serializer.rb
+++ b/app/serializers/person_escort_records_serializer.rb
@@ -7,7 +7,6 @@ class PersonEscortRecordsSerializer
   set_type :person_escort_records
 
   has_many_if_included :flags, serializer: FrameworkFlagsSerializer, &:framework_flags
-  has_many_if_included :medical_events, serializer: ImportantEventsSerializer
 
   attributes :confirmed_at, :created_at, :nomis_sync_status
 end

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -3,6 +3,7 @@
 module V2
   class MoveSerializer
     include JSONAPI::Serializer
+    include JSONAPI::ConditionalRelationships
 
     set_type :moves
 
@@ -30,7 +31,8 @@ module V2
 
     has_many :court_hearings, serializer: CourtHearingSerializer
 
-    has_many :timeline_events, serializer: ->(record, _params) { record.class.serializer }, &:all_events_for_timeline
+    has_many_if_included :timeline_events, serializer: ->(record, _params) { record.class.serializer }, &:all_events_for_timeline
+    has_many_if_included :important_events, serializer: ImportantEventsSerializer, &:important_events
 
     belongs_to :allocation, serializer: AllocationSerializer
     belongs_to :original_move, serializer: V2::MoveSerializer
@@ -64,6 +66,7 @@ module V2
       allocation
       original_move
       supplier
+      important_events
       timeline_events
       timeline_events.eventable
     ].freeze

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -35,12 +35,11 @@ module V2
       profile.person.gender
       profile.person_escort_record
       profile.person_escort_record.flags
-      profile.person_escort_record.medical_events
       from_location
       to_location
       prison_transfer_reason
       supplier
-      critical_events
+      important_events
     ].freeze
 
     belongs_to :from_location, serializer: ::LocationSerializer
@@ -50,6 +49,6 @@ module V2
     belongs_to :supplier, serializer: SupplierSerializer
     belongs_to :allocation, serializer: AllocationSerializer
 
-    has_many_if_included :critical_events, serializer: ImportantEventsSerializer
+    has_many_if_included :important_events, serializer: ImportantEventsSerializer, &:important_events
   end
 end

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -3,6 +3,7 @@
 module V2
   class MovesSerializer
     include JSONAPI::Serializer
+    include JSONAPI::ConditionalRelationships
 
     attributes  :additional_information,
                 :cancellation_reason,
@@ -34,10 +35,12 @@ module V2
       profile.person.gender
       profile.person_escort_record
       profile.person_escort_record.flags
+      profile.person_escort_record.medical_events
       from_location
       to_location
       prison_transfer_reason
       supplier
+      critical_events
     ].freeze
 
     belongs_to :from_location, serializer: ::LocationSerializer
@@ -46,5 +49,7 @@ module V2
     belongs_to :prison_transfer_reason, serializer: PrisonTransferReasonSerializer
     belongs_to :supplier, serializer: SupplierSerializer
     belongs_to :allocation, serializer: AllocationSerializer
+
+    has_many_if_included :critical_events, serializer: ImportantEventsSerializer
   end
 end

--- a/app/services/include_param_handler.rb
+++ b/app/services/include_param_handler.rb
@@ -38,7 +38,7 @@ private
     when 'timeline_events'
       :generic_events
     when 'important_events'
-      { critical_events: {}, profile: { person_escort_record: :medical_events } }
+      { incident_events: {}, profile: { person_escort_record: :medical_events } }
     else
       name.to_sym
     end

--- a/app/services/include_param_handler.rb
+++ b/app/services/include_param_handler.rb
@@ -36,7 +36,9 @@ private
     when 'responses'
       :framework_responses
     when 'timeline_events'
-      :events
+      :generic_events
+    when 'important_events'
+      { critical_events: {}, profile: { person_escort_record: :medical_events } }
     else
       name.to_sym
     end

--- a/db/migrate/20201130142628_add_classification_to_generic_events.rb
+++ b/db/migrate/20201130142628_add_classification_to_generic_events.rb
@@ -1,0 +1,6 @@
+class AddClassificationToGenericEvents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :generic_events, :classification, :string, default: 'default'
+    add_index :generic_events, [:eventable_id, :eventable_type, :classification], name: 'index_on_generic_event_classification'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_140655) do
+ActiveRecord::Schema.define(version: 2020_11_30_142628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -274,6 +274,8 @@ ActiveRecord::Schema.define(version: 2020_11_30_140655) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "supplier_id"
+    t.string "classification", default: "default"
+    t.index ["eventable_id", "eventable_type", "classification"], name: "index_on_generic_event_classification"
     t.index ["eventable_id", "eventable_type"], name: "index_generic_events_on_eventable_id_and_eventable_type"
     t.index ["occurred_at"], name: "index_generic_events_on_occurred_at"
     t.index ["recorded_at"], name: "index_generic_events_on_recorded_at"

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -36,4 +36,19 @@ namespace :data_maintenance do
     Person.where(criminal_records_office: '').update_all(criminal_records_office: nil)
     Person.where(police_national_computer: '').update_all(police_national_computer: nil)
   end
+
+  desc 'fix generic event classification for existing data'
+  task fix_generic_event_classifications: :environment do
+    GenericEvent.where(eventable_type: 'GenericEvent::PerMedicalAid').update_all(classification: 'medical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveAssault').update_all(classification: 'critical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveDeathInCustody').update_all(classification: 'critical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveMajorIncidentOther').update_all(classification: 'critical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveMinorIncidentOther').update_all(classification: 'critical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMovePersonEscapedKpi').update_all(classification: 'critical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMovePersonEscaped').update_all(classification: 'critical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveReleasedError').update_all(classification: 'critical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveRoadTrafficAccident').update_all(classification: 'critical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveSeriousInjury').update_all(classification: 'critical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveUsedForce').update_all(classification: 'critical')
+  end
 end

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -40,15 +40,15 @@ namespace :data_maintenance do
   desc 'fix generic event classification for existing data'
   task fix_generic_event_classifications: :environment do
     GenericEvent.where(eventable_type: 'GenericEvent::PerMedicalAid').update_all(classification: 'medical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveAssault').update_all(classification: 'critical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveDeathInCustody').update_all(classification: 'critical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveMajorIncidentOther').update_all(classification: 'critical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveMinorIncidentOther').update_all(classification: 'critical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMovePersonEscapedKpi').update_all(classification: 'critical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMovePersonEscaped').update_all(classification: 'critical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveReleasedError').update_all(classification: 'critical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveRoadTrafficAccident').update_all(classification: 'critical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveSeriousInjury').update_all(classification: 'critical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveUsedForce').update_all(classification: 'critical')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveAssault').update_all(classification: 'incident')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveDeathInCustody').update_all(classification: 'incident')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveMajorIncidentOther').update_all(classification: 'incident')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveMinorIncidentOther').update_all(classification: 'incident')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMovePersonEscapedKpi').update_all(classification: 'incident')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMovePersonEscaped').update_all(classification: 'incident')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveReleasedError').update_all(classification: 'incident')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveRoadTrafficAccident').update_all(classification: 'incident')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveSeriousInjury').update_all(classification: 'incident')
+    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveUsedForce').update_all(classification: 'incident')
   end
 end

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -39,16 +39,21 @@ namespace :data_maintenance do
 
   desc 'fix generic event classification for existing data'
   task fix_generic_event_classifications: :environment do
-    GenericEvent.where(eventable_type: 'GenericEvent::PerMedicalAid').update_all(classification: 'medical')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveAssault').update_all(classification: 'incident')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveDeathInCustody').update_all(classification: 'incident')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveMajorIncidentOther').update_all(classification: 'incident')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveMinorIncidentOther').update_all(classification: 'incident')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMovePersonEscapedKpi').update_all(classification: 'incident')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMovePersonEscaped').update_all(classification: 'incident')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveReleasedError').update_all(classification: 'incident')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveRoadTrafficAccident').update_all(classification: 'incident')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveSeriousInjury').update_all(classification: 'incident')
-    GenericEvent.where(eventable_type: 'GenericEvent::PersonMoveUsedForce').update_all(classification: 'incident')
+    medical_event_type = 'GenericEvent::PerMedicalAid'
+    incident_event_types = [
+      'GenericEvent::PersonMoveRoadTrafficAccident',
+      'GenericEvent::PersonMovePersonEscaped',
+      'GenericEvent::PersonMoveUsedForce',
+      'GenericEvent::PersonMoveMajorIncidentOther',
+      'GenericEvent::PersonMoveSeriousInjury',
+      'GenericEvent::PersonMoveMinorIncidentOther',
+      'GenericEvent::PersonMoveDeathInCustody',
+      'GenericEvent::PersonMoveAssault',
+      'GenericEvent::PersonMovePersonEscapedKpi',
+      'GenericEvent::PersonMoveReleasedError',
+    ]
+
+    GenericEvent.where(eventable_type: medical_event_type).update_all(classification: 'medical')
+    GenericEvent.where(eventable_type: incident_event_types).update_all(classification: 'incident')
   end
 end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
   end
 
   factory :incident, parent: :generic_event do
-    classification { 'critical' }
+    classification { 'incident' }
     details do
       {
         location_id: create(:location).id,

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
   end
 
   factory :incident, parent: :generic_event do
+    classification { 'critical' }
     details do
       {
         location_id: create(:location).id,
@@ -445,6 +446,7 @@ FactoryBot.define do
 
   factory :event_per_medical_aid, parent: :generic_event, class: 'GenericEvent::PerMedicalAid' do
     eventable { association(:person_escort_record) }
+    classification { 'medical' }
     details do
       {
         advised_by: Faker::Name.name,

--- a/spec/models/generic_event/incident_spec.rb
+++ b/spec/models/generic_event/incident_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::Incident, type: :model do
+  describe '#event_type' do
+    it 'removes GenericEvent namespace when type is present' do
+      event = described_class.new
+
+      expect(event.event_type).to eq 'Incident'
+    end
+  end
+
+  describe '#event_classification' do
+    it 'returns :incident' do
+      event = described_class.new
+
+      expect(event.event_classification).to eq :incident
+    end
+
+    it 'is automatically assigned on creation' do
+      event = create(:event_person_move_assault, classification: nil)
+
+      expect(event.classification).to eq 'incident'
+    end
+  end
+end

--- a/spec/models/generic_event/per_medical_aid_spec.rb
+++ b/spec/models/generic_event/per_medical_aid_spec.rb
@@ -33,4 +33,18 @@ RSpec.describe GenericEvent::PerMedicalAid do
 
     it { is_expected.not_to be_valid }
   end
+
+  describe '#event_classification' do
+    it 'returns :medical' do
+      event = described_class.new
+
+      expect(event.event_classification).to eq :medical
+    end
+
+    it 'is automatically assigned on creation' do
+      event = create(:event_per_medical_aid, classification: nil)
+
+      expect(event.classification).to eq 'medical'
+    end
+  end
 end

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -36,6 +36,28 @@ RSpec.describe GenericEvent, type: :model do
     expect(described_class::STI_CLASSES).to match_array(expected_sti_classes)
   end
 
+  describe '#event_type' do
+    it 'returns nil when type is missing' do
+      event = described_class.new
+
+      expect(event.event_type).to be_nil
+    end
+  end
+
+  describe '#event_classification' do
+    it 'returns :default' do
+      event = described_class.new
+
+      expect(event.event_classification).to eq :default
+    end
+
+    it 'is automatically assigned on creation' do
+      event = create(:event_move_cancel, classification: nil)
+
+      expect(event.classification).to eq 'default'
+    end
+  end
+
   describe '#trigger' do
     subject(:generic_event) { create(:event_move_cancel) }
 

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe PersonEscortRecord do
   end
 
   it { is_expected.to belong_to(:move).optional }
+  it { is_expected.to have_many(:medical_events) }
 
   it 'creates NOMIS mappings for framework responses' do
     move = create(:move, from_location: from_location)

--- a/spec/serializers/generic_event_serializer_spec.rb
+++ b/spec/serializers/generic_event_serializer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe GenericEventSerializer do
         id: event.id,
         type: 'events',
         attributes: {
+          classification: 'default',
           occurred_at: event.occurred_at.iso8601,
           recorded_at: event.recorded_at.iso8601,
           notes: 'Flibble',
@@ -73,6 +74,7 @@ RSpec.describe GenericEventSerializer do
           id: event.id,
           type: 'events',
           attributes: {
+            classification: 'default',
             occurred_at: event.occurred_at.iso8601,
             recorded_at: event.recorded_at.iso8601,
             notes: 'Flibble',

--- a/spec/serializers/important_events_serializer_spec.rb
+++ b/spec/serializers/important_events_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ImportantEventsSerializer do
   subject(:serializer) { described_class.new(event) }
 
-  let(:event) { create(:event_move_approve) }
+  let(:event) { create(:event_person_move_assault) }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
   let(:result_data) { result[:data] }
   let(:attributes) { result_data[:attributes] }
@@ -19,10 +19,10 @@ RSpec.describe ImportantEventsSerializer do
   end
 
   it 'contains an event_type attribute' do
-    expect(attributes[:event_type]).to eql 'MoveApprove'
+    expect(attributes[:event_type]).to eql 'PersonMoveAssault'
   end
 
   it 'contains a classification attribute' do
-    expect(attributes[:classification]).to eql 'default'
+    expect(attributes[:classification]).to eql 'incident'
   end
 end

--- a/spec/serializers/important_events_serializer_spec.rb
+++ b/spec/serializers/important_events_serializer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImportantEventsSerializer do
+  subject(:serializer) { described_class.new(event) }
+
+  let(:event) { create(:event_move_approve) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:result_data) { result[:data] }
+  let(:attributes) { result_data[:attributes] }
+
+  it 'contains a type property' do
+    expect(result_data[:type]).to eql 'events'
+  end
+
+  it 'contains an id property' do
+    expect(result_data[:id]).to eql event.id
+  end
+
+  it 'contains an event_type attribute' do
+    expect(attributes[:event_type]).to eql 'MoveApprove'
+  end
+
+  it 'contains a classification attribute' do
+    expect(attributes[:classification]).to eql 'default'
+  end
+end

--- a/spec/services/include_param_handler_spec.rb
+++ b/spec/services/include_param_handler_spec.rb
@@ -45,7 +45,13 @@ RSpec.describe IncludeParamHandler do
     context 'when the include param needs aliasing' do
       let(:include) { 'foo.flags,bar.bla.questions,responses,timeline_events' }
 
-      it { is_expected.to eq([{ foo: :framework_flags }, { bar: { bla: :framework_questions } }, :framework_responses, :events]) }
+      it { is_expected.to eq([{ foo: :framework_flags }, { bar: { bla: :framework_questions } }, :framework_responses, :generic_events]) }
+    end
+
+    context 'when the include param needs expanding to include multiple relationships' do
+      let(:include) { 'foo,important_events' }
+
+      it { is_expected.to eq([:foo, { incident_events: {}, profile: { person_escort_record: :medical_events } }]) }
     end
 
     context 'when the include param is an empty string' do

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -140,6 +140,9 @@ Move:
         prison_transfer_reason:
           $ref: "../v1/prison_transfer_reason_reference.yaml#/PrisonTransferReasonReference"
           description: The reason for this prison transfer
+        important_events:
+          $ref: "../v1/event_reference.yaml#/EventReference"
+          description: Brief details of incident and medical events related to this move
         timeline_events:
           $ref: "../v1/event_reference.yaml#/EventReference"
           description: Aliased events about this record and its nested relationships

--- a/swagger/v2/move_include_parameter.yaml
+++ b/swagger/v2/move_include_parameter.yaml
@@ -1,6 +1,6 @@
 MoveIncludeParameter:
   name: include
-  description: Returns a specific list of related resources to the move
+  description: Returns a specific list of related resources to the move. Note that timeline_events and important_events are mutually exclusive and may not be included together.
   in: query
   style: form
   explode: false
@@ -34,4 +34,7 @@ MoveIncludeParameter:
       - profile.youth_risk_assessment.responses.nomis_mappings
       - profile.youth_risk_assessment.responses.question
       - profile.youth_risk_assessment.responses.question.descendants.\*\*
+      - important_events
+      - timeline_events
+      - timeline_events.eventable
   example: from_location

--- a/swagger/v2/moves_include_parameter.yaml
+++ b/swagger/v2/moves_include_parameter.yaml
@@ -16,4 +16,5 @@ MovesIncludeParameter:
       - profile.person_escort_record.flags
       - supplier
       - to_location
+      - important_events
   example: from_location


### PR DESCRIPTION
### Jira link

P4-2425

### What?

- [x] Added new `classification` attribute to `GenericEvent` model (populated automatically when creating events)
- [x] Added rake task to back fill `classification` for all existing events
- [x] Added support for new `incident_events` includes on `GET /moves` and `GET /moves/:id` endpoints

### Why?

- Medical events occur against a PER, and incident events (aka red flag events) occur against a move. These need to be exposed efficiently in the API to allow relevant flags to be shown in the front end when listing moves. This means minimising SQL queries and the rows retrieved to keep the endpoint performant.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Extends includes for existing API, but is backwards compatible