### PR TITLE
P4-2451 Add Youth Risk Assessment routes and controllers

### DIFF
--- a/app/controllers/api/youth_risk_assessments_controller.rb
+++ b/app/controllers/api/youth_risk_assessments_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Api
+  class YouthRiskAssessmentsController < FrameworkAssessmentsController
+  private
+
+    def assessment_class
+      YouthRiskAssessment
+    end
+
+    def assessment_serializer
+      YouthRiskAssessmentSerializer
+    end
+  end
+end

--- a/app/serializers/framework_assessment_serializer.rb
+++ b/app/serializers/framework_assessment_serializer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class FrameworkAssessmentSerializer
+  include JSONAPI::Serializer
+
+  belongs_to :profile, serializer: V2::ProfileSerializer
+  belongs_to :move, serializer: V2::MoveSerializer
+  belongs_to :framework
+
+  has_many :responses, serializer: FrameworkResponseSerializer do |object|
+    object.framework_responses.includes(:framework_flags, :framework_nomis_mappings, framework_question: [:framework, dependents: :dependents])
+  end
+  has_many :flags, serializer: FrameworkFlagSerializer do |object|
+    object.framework_flags.includes(framework_question: :dependents)
+  end
+
+  attributes :confirmed_at, :created_at, :nomis_sync_status
+
+  attribute :version do |object|
+    object.framework.version
+  end
+
+  attribute :status do |object|
+    object.status == 'unstarted' ? 'not_started' : object.status
+  end
+
+  attribute :editable, &:editable?
+
+  meta do |object|
+    { section_progress: object.section_progress }
+  end
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    move
+    framework
+    profile.person
+    responses.question
+    responses.nomis_mappings
+    responses.question.descendants.**
+    flags
+    prefill_source
+  ].freeze
+end

--- a/app/serializers/framework_assessment_serializer.rb
+++ b/app/serializers/framework_assessment_serializer.rb
@@ -3,8 +3,6 @@
 class FrameworkAssessmentSerializer
   include JSONAPI::Serializer
 
-  belongs_to :profile, serializer: V2::ProfileSerializer
-  belongs_to :move, serializer: V2::MoveSerializer
   belongs_to :framework
 
   has_many :responses, serializer: FrameworkResponseSerializer do |object|

--- a/app/serializers/framework_assessment_serializer.rb
+++ b/app/serializers/framework_assessment_serializer.rb
@@ -18,6 +18,8 @@ class FrameworkAssessmentSerializer
     object.framework.version
   end
 
+  # "not_started" cannot be used as the name of the enum due to warnings in the model
+  # that it starts with a "not_", however we surface this as "not_started" for readability.
   attribute :status do |object|
     object.status == 'unstarted' ? 'not_started' : object.status
   end

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -50,6 +50,14 @@ class MoveSerializer
     profile.person_escort_record.responses.nomis_mappings
     profile.person_escort_record.responses.question
     profile.person_escort_record.responses.question.descendants.**
+    profile.youth_risk_assessment
+    profile.youth_risk_assessment.flags
+    profile.youth_risk_assessment.framework
+    profile.youth_risk_assessment.prefill_source
+    profile.youth_risk_assessment.responses
+    profile.youth_risk_assessment.responses.nomis_mappings
+    profile.youth_risk_assessment.responses.question
+    profile.youth_risk_assessment.responses.question.descendants.**
     from_location
     from_location.suppliers
     to_location

--- a/app/serializers/person_escort_record_prefill_source_serializer.rb
+++ b/app/serializers/person_escort_record_prefill_source_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class PersonEscortRecordPrefillSourceSerializer < PrefillSourceSerializer
+  set_type :person_escort_records
+end

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class PersonEscortRecordSerializer < FrameworkAssessmentSerializer
+  belongs_to :profile, serializer: V2::ProfileSerializer
+  belongs_to :move, serializer: V2::MoveSerializer
+
   set_type :person_escort_records
 
   belongs_to :prefill_source, serializer: PersonEscortRecordPrefillSourceSerializer

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PersonEscortRecordSerializer < FrameworkAssessmentSerializer
+  # Due to autoloading issues, have mirrored relationships in children classes
+  # TODO: when moving off versions, move this back into framework assessment serializer
   belongs_to :profile, serializer: V2::ProfileSerializer
   belongs_to :move, serializer: V2::MoveSerializer
 

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -1,46 +1,7 @@
 # frozen_string_literal: true
 
-class PersonEscortRecordSerializer
-  include JSONAPI::Serializer
-
+class PersonEscortRecordSerializer < FrameworkAssessmentSerializer
   set_type :person_escort_records
 
-  belongs_to :profile, serializer: V2::ProfileSerializer
-  belongs_to :move, serializer: V2::MoveSerializer
-  belongs_to :framework
-  belongs_to :prefill_source, serializer: PrefillSourceSerializer
-
-  has_many :responses, serializer: FrameworkResponseSerializer do |object|
-    object.framework_responses.includes(:framework_flags, :framework_nomis_mappings, framework_question: [:framework, dependents: :dependents])
-  end
-  has_many :flags, serializer: FrameworkFlagSerializer do |object|
-    object.framework_flags.includes(framework_question: :dependents)
-  end
-
-  attributes :confirmed_at, :created_at, :nomis_sync_status
-
-  attribute :version do |object|
-    object.framework.version
-  end
-
-  attribute :status do |object|
-    object.status == 'unstarted' ? 'not_started' : object.status
-  end
-
-  attribute :editable, &:editable?
-
-  meta do |object|
-    { section_progress: object.section_progress }
-  end
-
-  SUPPORTED_RELATIONSHIPS = %w[
-    move
-    framework
-    profile.person
-    responses.question
-    responses.nomis_mappings
-    responses.question.descendants.**
-    flags
-    prefill_source
-  ].freeze
+  belongs_to :prefill_source, serializer: PersonEscortRecordPrefillSourceSerializer
 end

--- a/app/serializers/prefill_source_serializer.rb
+++ b/app/serializers/prefill_source_serializer.rb
@@ -3,8 +3,6 @@
 class PrefillSourceSerializer
   include JSONAPI::Serializer
 
-  set_type :person_escort_records
-
   attributes :confirmed_at, :created_at, :nomis_sync_status
 
   attribute :status do |object|

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -10,6 +10,7 @@ class ProfileSerializer
   belongs_to :person
   has_many :documents
   has_one :person_escort_record
+  has_one :youth_risk_assessment
 
   SUPPORTED_RELATIONSHIPS = %w[documents person].freeze
 end

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -47,6 +47,14 @@ module V2
       profile.person_escort_record.responses.nomis_mappings
       profile.person_escort_record.responses.question
       profile.person_escort_record.responses.question.descendants.**
+      profile.youth_risk_assessment
+      profile.youth_risk_assessment.flags
+      profile.youth_risk_assessment.framework
+      profile.youth_risk_assessment.responses
+      profile.youth_risk_assessment.prefill_source
+      profile.youth_risk_assessment.responses.nomis_mappings
+      profile.youth_risk_assessment.responses.question
+      profile.youth_risk_assessment.responses.question.descendants.**
       from_location
       from_location.suppliers
       to_location

--- a/app/serializers/v2/profile_serializer.rb
+++ b/app/serializers/v2/profile_serializer.rb
@@ -10,6 +10,7 @@ class V2::ProfileSerializer
   belongs_to :person, serializer: ::V2::PersonSerializer
   has_many :documents, serializer: DocumentSerializer
   has_one :person_escort_record, serializer: PersonEscortRecordSerializer
+  has_one :youth_risk_assessment, serializer: YouthRiskAssessmentSerializer
 
-  SUPPORTED_RELATIONSHIPS = %w[documents person person_escort_record].freeze
+  SUPPORTED_RELATIONSHIPS = %w[documents person person_escort_record youth_risk_assessment].freeze
 end

--- a/app/serializers/youth_risk_assessment_prefill_source_serializer.rb
+++ b/app/serializers/youth_risk_assessment_prefill_source_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class YouthRiskAssessmentPrefillSourceSerializer < PrefillSourceSerializer
+  set_type :youth_risk_assessments
+end

--- a/app/serializers/youth_risk_assessment_serializer.rb
+++ b/app/serializers/youth_risk_assessment_serializer.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class YouthRiskAssessmentSerializer < FrameworkAssessmentSerializer
+  belongs_to :profile, serializer: V2::ProfileSerializer
+  belongs_to :move, serializer: V2::MoveSerializer
+
   set_type :youth_risk_assessments
 
   belongs_to :prefill_source, serializer: YouthRiskAssessmentPrefillSourceSerializer

--- a/app/serializers/youth_risk_assessment_serializer.rb
+++ b/app/serializers/youth_risk_assessment_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class YouthRiskAssessmentSerializer < FrameworkAssessmentSerializer
+  set_type :youth_risk_assessments
+
+  belongs_to :prefill_source, serializer: YouthRiskAssessmentPrefillSourceSerializer
+end

--- a/app/serializers/youth_risk_assessment_serializer.rb
+++ b/app/serializers/youth_risk_assessment_serializer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class YouthRiskAssessmentSerializer < FrameworkAssessmentSerializer
+  # Due to autoloading issues, have mirrored relationships in children classes
+  # TODO: when moving off versions, move this back into framework assessment serializer
   belongs_to :profile, serializer: V2::ProfileSerializer
   belongs_to :move, serializer: V2::MoveSerializer
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,13 @@ Rails.application.routes.draw do
         patch 'framework_responses', to: 'framework_responses#bulk_update', assessment_class: PersonEscortRecord
       end
     end
+
+    resources :youth_risk_assessments, only: %i[create show update] do
+      member do
+        patch 'framework_responses', to: 'framework_responses#bulk_update', assessment_class: YouthRiskAssessment
+      end
+    end
+
     resources :framework_responses, only: %i[update]
 
     get 'locations_free_spaces', to: 'populations#index'

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -284,8 +284,8 @@ RSpec.describe Api::FrameworkResponsesController do
       end
 
       context 'when assessment confirmed' do
-        let(:person_escort_record) { create(:person_escort_record, :confirmed) }
-        let(:framework_response) { create(:string_response, assessmentable: person_escort_record) }
+        let(:assessment) { create(:person_escort_record, :confirmed) }
+        let(:framework_response) { create(:string_response, assessmentable: assessment) }
         let(:detail_403) do
           "Can't update framework_responses because assessment is confirmed"
         end

--- a/spec/requests/api/youth_risk_assessments_controller_create_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_create_spec.rb
@@ -1,0 +1,291 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::YouthRiskAssessmentsController do
+  describe 'POST /youth_risk_assessments' do
+    include_context 'with supplier with spoofed access token'
+
+    subject(:post_youth_risk_assessment) do
+      post '/api/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
+    end
+
+    let(:response_json) { JSON.parse(response.body) }
+    let(:person) { create(:person) }
+    let(:profile) { create(:profile, person: person) }
+    let(:profile_id) { profile.id }
+    let(:move) { create(:move, profile: profile) }
+    let(:move_id) { move.id }
+    let(:framework) { create(:framework, :youth_risk_assessment, framework_questions: [build(:framework_question, section: 'risk-information', prefill: true)]) }
+    let(:framework_version) { framework.version }
+
+    let(:youth_risk_assessment_params) do
+      {
+        data: {
+          "type": 'youth_risk_assessments',
+          "attributes": {
+            "version": framework_version,
+          },
+          "relationships": {
+            "move": {
+              "data": {
+                "id": move_id,
+                "type": 'moves',
+              },
+            },
+          },
+        },
+      }
+    end
+
+    before { post_youth_risk_assessment }
+
+    context 'when successful' do
+      let(:schema) { load_yaml_schema('post_youth_risk_assessment_responses.yaml') }
+      let(:data) do
+        {
+          "id": YouthRiskAssessment.last.id,
+          "type": 'youth_risk_assessments',
+          "attributes": {
+            "version": framework_version,
+            "status": 'not_started',
+            "confirmed_at": nil,
+            "nomis_sync_status": [],
+          },
+          "meta": {
+            'section_progress' => [
+              {
+                "key": 'risk-information',
+                "status": 'not_started',
+              },
+            ],
+          },
+          "relationships": {
+            "profile": {
+              "data": {
+                "id": profile_id,
+                "type": 'profiles',
+              },
+            },
+            "move": {
+              "data": {
+                "id": move_id,
+                "type": 'moves',
+              },
+            },
+            "framework": {
+              "data": {
+                "id": framework.id,
+                "type": 'frameworks',
+              },
+            },
+            "responses": {
+              "data": [
+                {
+                  "id": FrameworkResponse.last.id,
+                  "type": 'framework_responses',
+                },
+              ],
+            },
+            "flags": {
+              "data": [],
+            },
+            "prefill_source": {
+              "data": nil,
+            },
+          },
+        }
+      end
+
+      it_behaves_like 'an endpoint that responds with success 201'
+
+      it 'returns the correct data' do
+        expect(response_json).to include_json(data: data)
+      end
+    end
+
+    context 'when prefilling from previous youth risk assessment' do
+      subject(:post_youth_risk_assessment) do
+        previous_pesron_escort_record
+
+        post '/api/v1/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
+      end
+
+      let(:previous_profile) { create(:profile, person: person) }
+      let(:previous_pesron_escort_record) do
+        create(:youth_risk_assessment, :confirmed, profile: previous_profile, framework_responses: [create(:string_response, framework_question: framework.framework_questions.first)])
+      end
+      let(:youth_risk_assessment_params) do
+        {
+          data: {
+            "type": 'youth_risk_assessments',
+            "attributes": {
+              "version": framework_version,
+            },
+            "relationships": {
+              "move": {
+                "data": {
+                  "id": move_id,
+                  "type": 'moves',
+                },
+              },
+            },
+          },
+        }
+      end
+      let(:schema) { load_yaml_schema('post_youth_risk_assessment_responses.yaml') }
+      let(:new_youth_risk_assessment) { YouthRiskAssessment.order(created_at: :desc).first }
+      let(:data) do
+        {
+          "id": new_youth_risk_assessment.id,
+          "type": 'youth_risk_assessments',
+          "attributes": {
+            "version": framework_version,
+            "status": 'not_started',
+            "confirmed_at": nil,
+            "nomis_sync_status": [],
+          },
+          "meta": {
+            'section_progress' => [
+              {
+                "key": 'risk-information',
+                "status": 'not_started',
+              },
+            ],
+          },
+          "relationships": {
+            "profile": {
+              "data": {
+                "id": profile_id,
+                "type": 'profiles',
+              },
+            },
+            "move": {
+              "data": {
+                "id": move_id,
+                "type": 'moves',
+              },
+            },
+            "framework": {
+              "data": {
+                "id": framework.id,
+                "type": 'frameworks',
+              },
+            },
+            "responses": {
+              "data": [
+                {
+                  "id": new_youth_risk_assessment.reload.framework_responses.last.id,
+                  "type": 'framework_responses',
+                },
+              ],
+            },
+            "flags": {
+              "data": [],
+            },
+            "prefill_source": {
+              "data": {
+                "id": previous_pesron_escort_record.id,
+                "type": 'youth_risk_assessments',
+              },
+            },
+          },
+        }
+      end
+
+      it_behaves_like 'an endpoint that responds with success 201'
+
+      it 'returns the correct data' do
+        expect(response_json).to include_json(data: data)
+      end
+    end
+
+    context 'when unsuccessful' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+
+      context 'with a bad request' do
+        let(:youth_risk_assessment_params) { nil }
+
+        it_behaves_like 'an endpoint that responds with error 400'
+      end
+
+      context 'when the move is not found' do
+        let(:move_id) { 'foo-bar' }
+        let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+
+      context 'when a youth risk assessment already exists on a profile' do
+        let(:errors_422) do
+          [
+            {
+              'title' => 'Unprocessable entity',
+              'detail' => 'Profile has already been taken',
+              'source' => { 'pointer' => '/data/attributes/profile' },
+              'code' => 'taken',
+            },
+          ]
+        end
+
+        before do
+          post '/api/v1/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
+          post '/api/v1/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422'
+      end
+
+      context 'when a youth risk assessment already exists on a profile and unique index error thrown' do
+        let(:errors_422) do
+          [
+            {
+              'title' => 'Unprocessable entity',
+              'detail' => 'Profile has already been taken',
+              'source' => { 'pointer' => '/data/attributes/profile' },
+              'code' => 'taken',
+            },
+          ]
+        end
+
+        before do
+          youth_risk_assessment = YouthRiskAssessment.new
+          allow(YouthRiskAssessment).to receive(:new).and_return(youth_risk_assessment)
+          allow(youth_risk_assessment).to receive(:build_responses!).and_raise(PG::UniqueViolation, 'duplicate key value violates unique constraint')
+
+          post '/api/v1/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422'
+      end
+
+      context 'with a reference to a missing framework' do
+        let(:framework_version) { '0.2.1' }
+        let(:detail_404) { "Couldn't find Framework" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+
+      context 'with no framework' do
+        let(:youth_risk_assessment_params) do
+          {
+            data: {
+              "type": 'youth_risk_assessments',
+              "relationships": {
+                "move": {
+                  "data": {
+                    "id": move_id,
+                    "type": 'moves',
+                  },
+                },
+              },
+            },
+          }
+        end
+        let(:detail_404) { "Couldn't find Framework" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+    end
+  end
+end

--- a/spec/requests/api/youth_risk_assessments_controller_create_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_create_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
       subject(:post_youth_risk_assessment) do
         previous_pesron_escort_record
 
-        post '/api/v1/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
+        post '/api/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
       end
 
       let(:previous_profile) { create(:profile, person: person) }
@@ -229,8 +229,8 @@ RSpec.describe Api::YouthRiskAssessmentsController do
         end
 
         before do
-          post '/api/v1/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
-          post '/api/v1/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
+          post '/api/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
+          post '/api/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
         end
 
         it_behaves_like 'an endpoint that responds with error 422'
@@ -253,7 +253,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
           allow(YouthRiskAssessment).to receive(:new).and_return(youth_risk_assessment)
           allow(youth_risk_assessment).to receive(:build_responses!).and_raise(PG::UniqueViolation, 'duplicate key value violates unique constraint')
 
-          post '/api/v1/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
+          post '/api/youth_risk_assessments', params: youth_risk_assessment_params, headers: headers, as: :json
         end
 
         it_behaves_like 'an endpoint that responds with error 422'

--- a/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
     let(:youth_risk_assessment_id) { youth_risk_assessment.id }
 
     before do
-      get "/api/v1/youth_risk_assessments/#{youth_risk_assessment_id}", headers: headers, as: :json
+      get "/api/youth_risk_assessments/#{youth_risk_assessment_id}", headers: headers, as: :json
     end
 
     context 'when successful' do

--- a/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::YouthRiskAssessmentsController do
+  describe 'GET /youth_risk_assessments/:youth_risk_assessment_id' do
+    include_context 'with supplier with spoofed access token'
+
+    let(:response_json) { JSON.parse(response.body) }
+    let(:framework_question) { build(:framework_question, section: 'risk-information') }
+    let(:flag) { build(:framework_flag, framework_question: framework_question) }
+    let(:framework) { create(:framework, framework_questions: [framework_question]) }
+    let(:youth_risk_assessment) do
+      youth_risk_assessment = create(:youth_risk_assessment)
+      create(:string_response, framework_question: framework_question, responded: true, framework_flags: [flag], assessmentable: youth_risk_assessment)
+
+      youth_risk_assessment
+    end
+    let(:youth_risk_assessment_id) { youth_risk_assessment.id }
+
+    before do
+      get "/api/v1/youth_risk_assessments/#{youth_risk_assessment_id}", headers: headers, as: :json
+    end
+
+    context 'when successful' do
+      let(:schema) { load_yaml_schema('get_youth_risk_assessment_responses.yaml') }
+      let(:data) do
+        {
+          "id": youth_risk_assessment.id,
+          "type": 'youth_risk_assessments',
+          "attributes": {
+            "version": youth_risk_assessment.framework.version,
+            "status": 'not_started',
+          },
+          "meta": {
+            'section_progress' => [
+              {
+                "key": 'risk-information',
+                "status": 'completed',
+              },
+            ],
+          },
+          "relationships": {
+            "profile": {
+              "data": {
+                "id": youth_risk_assessment.profile.id,
+                "type": 'profiles',
+              },
+            },
+            "framework": {
+              "data": {
+                "id": youth_risk_assessment.framework.id,
+                "type": 'frameworks',
+              },
+            },
+            "responses": {
+              "data": [
+                {
+                  "id": youth_risk_assessment.framework_responses.first.id,
+                  "type": 'framework_responses',
+                },
+              ],
+            },
+            "flags": {
+              "data": [
+                {
+                  "id": flag.id,
+                  "type": 'framework_flags',
+                },
+              ],
+            },
+          },
+        }
+      end
+
+      it_behaves_like 'an endpoint that responds with success 200'
+
+      it 'returns the correct data' do
+        expect(response_json).to include_json(data: data)
+      end
+    end
+
+    context 'when unsuccessful' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+
+      context 'when attempting to access an unknown youth risk assessment' do
+        let(:youth_risk_assessment_id) { SecureRandom.uuid }
+        let(:detail_404) { "Couldn't find YouthRiskAssessment with 'id'=#{youth_risk_assessment_id}" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+    end
+  end
+end

--- a/spec/requests/api/youth_risk_assessments_controller_update_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_update_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::YouthRiskAssessmentsController do
+  describe 'PATCH /youth_risk_assessments/:youth_risk_assessment_id' do
+    include_context 'with supplier with spoofed access token'
+
+    subject(:patch_youth_risk_assessment) do
+      patch "/api/youth_risk_assessments/#{youth_risk_assessment_id}", params: youth_risk_assessment_params, headers: headers, as: :json
+
+      youth_risk_assessment.reload
+    end
+
+    let(:schema) { load_yaml_schema('patch_youth_risk_assessment_responses.yaml') }
+    let(:response_json) { JSON.parse(response.body) }
+    let(:youth_risk_assessment) { create(:youth_risk_assessment, :with_responses, :completed) }
+    let(:youth_risk_assessment_id) { youth_risk_assessment.id }
+    let(:status) { 'confirmed' }
+    let(:youth_risk_assessment_params) do
+      {
+        data: {
+          "type": 'youth_risk_assessments',
+          "attributes": {
+            "status": status,
+          },
+        },
+      }
+    end
+
+    context 'when successful' do
+      before { patch_youth_risk_assessment }
+
+      context 'when status is confirmed' do
+        it_behaves_like 'an endpoint that responds with success 200'
+
+        it 'returns the correct data' do
+          expect(response_json).to include_json(data: {
+            "id": youth_risk_assessment_id,
+            "type": 'youth_risk_assessments',
+            "attributes": {
+              "status": 'confirmed',
+              "version": youth_risk_assessment.framework.version,
+              "confirmed_at": youth_risk_assessment.confirmed_at.iso8601,
+            },
+          })
+        end
+      end
+    end
+
+    context 'when unsuccessful' do
+      before { patch_youth_risk_assessment }
+
+      context 'with a bad request' do
+        let(:youth_risk_assessment_params) { nil }
+
+        it_behaves_like 'an endpoint that responds with error 400'
+      end
+
+      context 'with an invalid status' do
+        let(:status) { 'foo-bar' }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [{ 'title' => 'Invalid status',
+               'detail' => 'Validation failed: Status is not included in the list' }]
+          end
+        end
+      end
+
+      context 'when youth_risk_assessment is wrong starting status' do
+        let(:youth_risk_assessment) { create(:youth_risk_assessment, :with_responses, :in_progress) }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [{ 'title' => 'Invalid status',
+               'detail' => "Validation failed: Status can't update to 'confirmed' from 'in_progress'" }]
+          end
+        end
+      end
+
+      context 'when the youth_risk_assessment_id is not found' do
+        let(:youth_risk_assessment_id) { 'foo-bar' }
+        let(:detail_404) { "Couldn't find YouthRiskAssessment with 'id'=foo-bar" }
+
+        it_behaves_like 'an endpoint that responds with error 404'
+      end
+    end
+
+    context 'with subscriptions' do
+      let!(:subscription) { create(:subscription, supplier: supplier) }
+      let!(:notification_type_email) { create(:notification_type, :email) }
+      let!(:notification_type_webhook) { create(:notification_type, :webhook) }
+      let(:from_location) { create(:location, suppliers: [supplier]) }
+      let(:move) { create(:move, from_location: from_location, supplier: supplier) }
+      let(:youth_risk_assessment) { create(:youth_risk_assessment, :with_responses, :completed, move: move) }
+
+      let(:faraday_client) do
+        class_double(
+          Faraday,
+          headers: {},
+          post: instance_double(Faraday::Response, success?: true, status: 202),
+        )
+      end
+      let(:notify_response) do
+        instance_double(
+          ActionMailer::MessageDelivery,
+          deliver_now!:
+          instance_double(
+            Mail::Message,
+            govuk_notify_response:
+            instance_double(Notifications::Client::ResponseNotification, id: SecureRandom.uuid),
+          ),
+        )
+      end
+
+      before do
+        allow(Faraday).to receive(:new).and_return(faraday_client)
+        allow(MoveMailer).to receive(:notify).and_return(notify_response)
+        perform_enqueued_jobs(only: [PreparePersonEscortRecordNotificationsJob, NotifyWebhookJob, NotifyEmailJob]) do
+          patch_youth_risk_assessment
+        end
+      end
+
+      xit 'creates a webhook notification' do
+        notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
+
+        expect(notification).to have_attributes(
+          topic: youth_risk_assessment.move,
+          notification_type: notification_type_webhook,
+          event_type: 'confirm_youth_risk_assessment',
+        )
+      end
+
+      xit 'creates an email notification' do
+        notification = subscription.notifications.find_by(notification_type: notification_type_email)
+
+        expect(notification).to have_attributes(
+          topic: youth_risk_assessment.move,
+          notification_type: notification_type_email,
+          event_type: 'confirm_youth_risk_assessment',
+        )
+      end
+
+      context 'when request is unsuccessful' do
+        let(:status) { 'foo-bar' }
+
+        it 'does not create notifications' do
+          expect(subscription.notifications).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/framework_assessment_serializer_spec.rb
+++ b/spec/serializers/framework_assessment_serializer_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FrameworkAssessmentSerializer do
+  subject(:serializer) { described_class.new(assessment, include: includes) }
+
+  let(:move) { create(:move) }
+  let(:assessment) { create(:person_escort_record, move: move, profile: move.profile) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:includes) { {} }
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eq(assessment.id)
+  end
+
+  it 'contains a `status` attribute' do
+    expect(result[:data][:attributes][:status]).to eq('not_started')
+  end
+
+  it 'contains a `version` attribute' do
+    expect(result[:data][:attributes][:version]).to eq(assessment.framework.version)
+  end
+
+  it 'contains a `editable` attribute' do
+    expect(result[:data][:attributes][:editable]).to eq(assessment.editable?)
+  end
+
+  it 'contains a `confirmed_at` attribute' do
+    expect(result[:data][:attributes][:confirmed_at]).to eq(assessment.confirmed_at)
+  end
+
+  it 'contains a `created_at` attribute' do
+    expect(result[:data][:attributes][:created_at]).to eq(assessment.created_at.iso8601)
+  end
+
+  it 'contains a `nomis_sync_status` attribute' do
+    expect(result[:data][:attributes][:nomis_sync_status]).to eq(assessment.nomis_sync_status)
+  end
+
+  it 'contains a `profile` relationship' do
+    expect(result[:data][:relationships][:profile][:data]).to eq(
+      id: assessment.profile.id,
+      type: 'profiles',
+    )
+  end
+
+  it 'contains a `move` relationship' do
+    expect(result[:data][:relationships][:move][:data]).to eq(
+      id: assessment.move.id,
+      type: 'moves',
+    )
+  end
+
+  it 'contains a `framework` relationship' do
+    expect(result[:data][:relationships][:framework][:data]).to eq(
+      id: assessment.framework.id,
+      type: 'frameworks',
+    )
+  end
+
+  it 'contains an empty `responses` relationship if no responses present' do
+    expect(result[:data][:relationships][:responses][:data]).to be_empty
+  end
+
+  it 'contains a`responses` relationship with framework responses' do
+    response = create(:string_response, assessmentable: assessment)
+
+    expect(result[:data][:relationships][:responses][:data]).to contain_exactly(
+      id: response.id,
+      type: 'framework_responses',
+    )
+  end
+
+  it 'contains an empty `flags` relationship if no flags present' do
+    expect(result[:data][:relationships][:flags][:data]).to be_empty
+  end
+
+  it 'contains a`flags` relationship with framework response flags' do
+    flag = create(:framework_flag)
+    create(:string_response, assessmentable: assessment, framework_flags: [flag])
+
+    expect(result[:data][:relationships][:flags][:data]).to contain_exactly(
+      id: flag.id,
+      type: 'framework_flags',
+    )
+  end
+
+  describe 'meta' do
+    it 'includes section progress' do
+      question = create(:framework_question, framework: assessment.framework, section: 'risk-information')
+      create(:string_response, value: nil, framework_question: question, assessmentable: assessment)
+
+      expect(result[:data][:meta][:section_progress]).to contain_exactly(
+        key: 'risk-information',
+        status: 'not_started',
+      )
+    end
+
+    context 'with no questions' do
+      it 'does not include includes section progress' do
+        expect(result[:data][:meta][:section_progress]).to be_empty
+      end
+    end
+  end
+
+  context 'with include options' do
+    let(:includes) { ['responses', 'responses.question', 'responses.nomis_mappings'] }
+    let(:framework_nomis_mapping) { create(:framework_nomis_mapping) }
+    let(:assessment) do
+      assessment = create(:person_escort_record)
+      create(:object_response, framework_nomis_mappings: [framework_nomis_mapping], assessmentable: assessment)
+      assessment
+    end
+    let(:framework_response) { assessment.framework_responses.first }
+
+    let(:expected_json) do
+      UnorderedArray(
+        {
+          id: framework_response.id,
+          type: 'framework_responses',
+          attributes: { value: framework_response.value },
+        },
+        {
+          id: framework_response.framework_question.id,
+          type: 'framework_questions',
+          attributes: { key: framework_response.framework_question.key },
+        },
+        {
+          id: framework_nomis_mapping.id,
+          type: 'framework_nomis_mappings',
+          attributes: { code: framework_nomis_mapping.code },
+        },
+      )
+    end
+
+    it 'contains an included responses and question' do
+      expect(result[:included]).to include_json(expected_json)
+    end
+  end
+end

--- a/spec/serializers/framework_assessment_serializer_spec.rb
+++ b/spec/serializers/framework_assessment_serializer_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe FrameworkAssessmentSerializer do
     expect(result[:data][:relationships][:flags][:data]).to be_empty
   end
 
-  it 'contains a`flags` relationship with framework response flags' do
+  it 'contains a `flags` relationship with framework response flags' do
     flag = create(:framework_flag)
     create(:string_response, assessmentable: assessment, framework_flags: [flag])
 

--- a/spec/serializers/framework_assessment_serializer_spec.rb
+++ b/spec/serializers/framework_assessment_serializer_spec.rb
@@ -38,20 +38,6 @@ RSpec.describe FrameworkAssessmentSerializer do
     expect(result[:data][:attributes][:nomis_sync_status]).to eq(assessment.nomis_sync_status)
   end
 
-  it 'contains a `profile` relationship' do
-    expect(result[:data][:relationships][:profile][:data]).to eq(
-      id: assessment.profile.id,
-      type: 'profiles',
-    )
-  end
-
-  it 'contains a `move` relationship' do
-    expect(result[:data][:relationships][:move][:data]).to eq(
-      id: assessment.move.id,
-      type: 'moves',
-    )
-  end
-
   it 'contains a `framework` relationship' do
     expect(result[:data][:relationships][:framework][:data]).to eq(
       id: assessment.framework.id,

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe FrameworkResponseSerializer do
     expect(result[:data][:relationships][:flags][:data]).to be_empty
   end
 
-  it 'contains a`flags` relationship when flags present' do
+  it 'contains a `flags` relationship when flags present' do
     flag = create(:framework_flag)
     framework_response.update(framework_flags: [flag])
 

--- a/spec/serializers/person_escort_record_prefill_source_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_prefill_source_serializer_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersonEscortRecordPrefillSourceSerializer do
+  subject(:serializer) { described_class.new(person_escort_record) }
+
+  let(:person_escort_record) { create(:person_escort_record) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('person_escort_records')
+  end
+end

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -5,12 +5,27 @@ require 'rails_helper'
 RSpec.describe PersonEscortRecordSerializer do
   subject(:serializer) { described_class.new(person_escort_record, include: includes) }
 
-  let(:person_escort_record) { create(:person_escort_record) }
+  let(:move) { create(:move) }
+  let(:person_escort_record) { create(:person_escort_record, move: move, profile: move.profile) }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
   let(:includes) { {} }
 
   it 'contains a `type` property' do
     expect(result[:data][:type]).to eq('person_escort_records')
+  end
+
+  it 'contains a `profile` relationship' do
+    expect(result[:data][:relationships][:profile][:data]).to eq(
+      id: person_escort_record.profile.id,
+      type: 'profiles',
+    )
+  end
+
+  it 'contains a `move` relationship' do
+    expect(result[:data][:relationships][:move][:data]).to eq(
+      id: person_escort_record.move.id,
+      type: 'moves',
+    )
   end
 
   it 'contains a nil `prefill_source` relationship if no prefill_source present' do

--- a/spec/serializers/person_escort_records_serializer_spec.rb
+++ b/spec/serializers/person_escort_records_serializer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe PersonEscortRecordsSerializer do
       expect(result[:data][:relationships][:flags][:data]).to be_empty
     end
 
-    it 'contains a`flags` relationship with framework response flags' do
+    it 'contains a `flags` relationship with framework response flags' do
       flag = create(:framework_flag)
       create(:string_response, assessmentable: person_escort_record, framework_flags: [flag])
 

--- a/spec/serializers/prefill_source_serializer_spec.rb
+++ b/spec/serializers/prefill_source_serializer_spec.rb
@@ -3,18 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe PrefillSourceSerializer do
-  subject(:serializer) { described_class.new(person_escort_record) }
+  subject(:serializer) { described_class.new(assessment) }
 
-  let(:move) { create(:move) }
-  let(:person_escort_record) { create(:person_escort_record, move: move, profile: move.profile) }
+  let(:assessment) { create(:person_escort_record) }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
 
-  it 'contains a `type` property' do
-    expect(result[:data][:type]).to eq('person_escort_records')
-  end
-
   it 'contains an `id` property' do
-    expect(result[:data][:id]).to eq(person_escort_record.id)
+    expect(result[:data][:id]).to eq(assessment.id)
   end
 
   it 'contains a `status` attribute' do
@@ -22,14 +17,14 @@ RSpec.describe PrefillSourceSerializer do
   end
 
   it 'contains a `confirmed_at` attribute' do
-    expect(result[:data][:attributes][:confirmed_at]).to eq(person_escort_record.confirmed_at)
+    expect(result[:data][:attributes][:confirmed_at]).to eq(assessment.confirmed_at)
   end
 
   it 'contains a `created_at` attribute' do
-    expect(result[:data][:attributes][:created_at]).to eq(person_escort_record.created_at.iso8601)
+    expect(result[:data][:attributes][:created_at]).to eq(assessment.created_at.iso8601)
   end
 
   it 'contains a `nomis_sync_status` attribute' do
-    expect(result[:data][:attributes][:nomis_sync_status]).to eq(person_escort_record.nomis_sync_status)
+    expect(result[:data][:attributes][:nomis_sync_status]).to eq(assessment.nomis_sync_status)
   end
 end

--- a/spec/serializers/profile_serializer_spec.rb
+++ b/spec/serializers/profile_serializer_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe ProfileSerializer do
           person_escort_record: {
             data: nil,
           },
+          youth_risk_assessment: {
+            data: nil,
+          },
         },
       },
     }

--- a/spec/serializers/v2/profile_serializer_spec.rb
+++ b/spec/serializers/v2/profile_serializer_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe V2::ProfileSerializer do
           person_escort_record: {
             data: nil,
           },
+          youth_risk_assessment: {
+            data: nil,
+          },
         },
       },
     }

--- a/spec/serializers/youth_risk_assessment_prefill_source_serializer_spec.rb
+++ b/spec/serializers/youth_risk_assessment_prefill_source_serializer_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe YouthRiskAssessmentPrefillSourceSerializer do
+  subject(:serializer) { described_class.new(youth_risk_assessment) }
+
+  let(:youth_risk_assessment) { create(:youth_risk_assessment) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+
+  it 'contains a `type` property' do
+    expect(result[:data][:type]).to eq('youth_risk_assessments')
+  end
+end

--- a/spec/serializers/youth_risk_assessment_serializer_spec.rb
+++ b/spec/serializers/youth_risk_assessment_serializer_spec.rb
@@ -2,15 +2,15 @@
 
 require 'rails_helper'
 
-RSpec.describe PersonEscortRecordSerializer do
-  subject(:serializer) { described_class.new(person_escort_record, include: includes) }
+RSpec.describe YouthRiskAssessmentSerializer do
+  subject(:serializer) { described_class.new(youth_risk_assessment, include: includes) }
 
-  let(:person_escort_record) { create(:person_escort_record) }
+  let(:youth_risk_assessment) { create(:youth_risk_assessment) }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
   let(:includes) { {} }
 
   it 'contains a `type` property' do
-    expect(result[:data][:type]).to eq('person_escort_records')
+    expect(result[:data][:type]).to eq('youth_risk_assessments')
   end
 
   it 'contains a nil `prefill_source` relationship if no prefill_source present' do
@@ -18,28 +18,28 @@ RSpec.describe PersonEscortRecordSerializer do
   end
 
   context 'with a prefill source' do
-    let(:person_escort_record) { create(:person_escort_record, :prefilled) }
+    let(:youth_risk_assessment) { create(:youth_risk_assessment, :prefilled) }
 
     it 'contains a`prefill_source` relationship ' do
       expect(result[:data][:relationships][:prefill_source][:data]).to eq(
-        id: person_escort_record.prefill_source.id,
-        type: 'person_escort_records',
+        id: youth_risk_assessment.prefill_source.id,
+        type: 'youth_risk_assessments',
       )
     end
   end
 
   context 'with include options' do
     let(:includes) { %w[prefill_source] }
-    let(:person_escort_record) do
-      create(:person_escort_record, :prefilled)
+    let(:youth_risk_assessment) do
+      create(:youth_risk_assessment, :prefilled)
     end
 
     let(:expected_json) do
       UnorderedArray(
         {
-          id: person_escort_record.prefill_source.id,
-          type: 'person_escort_records',
-          attributes: { created_at: person_escort_record.prefill_source.created_at.iso8601 },
+          id: youth_risk_assessment.prefill_source.id,
+          type: 'youth_risk_assessments',
+          attributes: { created_at: youth_risk_assessment.prefill_source.created_at.iso8601 },
         },
       )
     end

--- a/spec/serializers/youth_risk_assessment_serializer_spec.rb
+++ b/spec/serializers/youth_risk_assessment_serializer_spec.rb
@@ -13,6 +13,20 @@ RSpec.describe YouthRiskAssessmentSerializer do
     expect(result[:data][:type]).to eq('youth_risk_assessments')
   end
 
+  it 'contains a `profile` relationship' do
+    expect(result[:data][:relationships][:profile][:data]).to eq(
+      id: youth_risk_assessment.profile.id,
+      type: 'profiles',
+    )
+  end
+
+  it 'contains a `move` relationship' do
+    expect(result[:data][:relationships][:move][:data]).to eq(
+      id: youth_risk_assessment.move.id,
+      type: 'moves',
+    )
+  end
+
   it 'contains a nil `prefill_source` relationship if no prefill_source present' do
     expect(result[:data][:relationships][:prefill_source][:data]).to be_nil
   end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -98,6 +98,8 @@
       :$ref: "../v1/supplier.yaml#/Supplier"
     :TimetableEntry:
       :$ref: "../v1/timetable_entry.yaml#/TimetableEntry"
+    :YouthRiskAssessment:
+      :$ref: "../v1/youth_risk_assessment.yaml#/YouthRiskAssessment"
 :paths:
   "/allocations":
     get:
@@ -2995,6 +2997,208 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/patch_population_responses.yaml#/422"
+  "/youth_risk_assessments":
+    post:
+      summary: Creates a new youth risk assessment
+      tags:
+      - Youth risk assessments
+      consumes:
+      - application/vnd.api+json
+      parameters:
+      - "$ref": "../v1/youth_risk_assessment_include_parameter.yaml#/YouthRiskAssessmentIncludeParameter"
+      - name: body
+        in: body
+        required: true
+        description: The `youth_risk_assessment` object to be created. Requires the `version` of the framework of questions, as well as the `move` already associated to a `profile` for a person.
+        schema:
+          "$ref": "../v1/post_youth_risk_assessment.yaml#/PostYouthRiskAssessment"
+      responses:
+        '201':
+          description: created
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_youth_risk_assessment_responses.yaml#/201"
+        '400':
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_youth_risk_assessment_responses.yaml#/400"
+        '401':
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_youth_risk_assessment_responses.yaml#/401"
+        '404':
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_youth_risk_assessment_responses.yaml#/404"
+        '415':
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_youth_risk_assessment_responses.yaml#/415"
+        '422':
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/post_youth_risk_assessment_responses.yaml#/422"
+  "/youth_risk_assessments/{youth_risk_assessment_id}":
+    get:
+      summary: Gets a youth_risk_assessment
+      description:
+        "This method gets the specified youth_risk_assessment"
+      tags:
+        - Youth risk assessments
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - "$ref": "../v1/youth_risk_assessment_id_parameter.yaml#/YouthRiskAssessmentId"
+        - "$ref": "../v1/youth_risk_assessment_include_parameter.yaml#/YouthRiskAssessmentIncludeParameter"
+      responses:
+        "200":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_youth_risk_assessment_responses.yaml#/200"
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/400"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/401"
+        "404":
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/404"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/415"
+    patch:
+      summary: Updates a youth_risk_assessment's status
+      tags:
+      - Youth risk assessments
+      consumes:
+      - application/vnd.api+json
+      parameters:
+      - "$ref": "../v1/youth_risk_assessment_id_parameter.yaml#/YouthRiskAssessmentId"
+      - "$ref": "../v1/youth_risk_assessment_include_parameter.yaml#/YouthRiskAssessmentIncludeParameter"
+      - name: body
+        in: body
+        required: true
+        description: The `youth_risk_assessment` object to be modified. Sets the current status of the `youth_risk_assessment` as `confirmed` after a `youth_risk_assessment` is `completed`.
+        schema:
+          "$ref": "../v1/patch_youth_risk_assessment.yaml#/PatchYouthRiskAssessment"
+      responses:
+        '200':
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_youth_risk_assessment_responses.yaml#/200"
+        '400':
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_youth_risk_assessment_responses.yaml#/400"
+        '401':
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_youth_risk_assessment_responses.yaml#/401"
+        '404':
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_youth_risk_assessment_responses.yaml#/404"
+        '415':
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_youth_risk_assessment_responses.yaml#/415"
+        '422':
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/patch_youth_risk_assessment_responses.yaml#/422"
+  "/youth_risk_assessments/{youth_risk_assessment_id}/framework_responses":
+    patch:
+      summary: Bulk updates multiple framework response values for a youth_risk_assessment
+      description:
+        "This method updates multiple framework response values for the specified youth_risk_assessment"
+      tags:
+        - Framework Responses
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - "$ref": "../v1/youth_risk_assessment_id_parameter.yaml#/YouthRiskAssessmentId"
+        - name: body
+          in: body
+          required: true
+          description: __Array__ of framework_response objects to be modified
+          schema:
+            type: array
+            items:
+              "$ref": "../v1/patch_framework_response.yaml#/PatchFrameworkResponse"
+      responses:
+        "204":
+          description: no content
+          content:
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/400"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/401"
+        "404":
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/404"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/415"
+        "422":
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/422"
   "/reference/allocation_complex_cases":
     get:
       summary: Returns a list of allocation complex cases

--- a/swagger/v1/assessment_reference.yaml
+++ b/swagger/v1/assessment_reference.yaml
@@ -1,0 +1,27 @@
+AssessmentReference:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      oneOf:
+      - type: object
+      - type: 'null'
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          example: person_escort_records
+          enum:
+            - person_escort_records
+            - youth_risk_assessments
+          description: The type of this assessment object - either `person_escort_records` or `youth_risk_assessments`
+        id:
+          type: string
+          format: uuid
+          example: ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154
+          description:
+            The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v1/framework_response.yaml
+++ b/swagger/v1/framework_response.yaml
@@ -23,7 +23,7 @@ FrameworkResponse:
       properties:
         value:
           example: 'yes'
-          description: the answer value to the person_escort_record question
+          description: the answer value to the assessment question
           oneOf:
           - type: string
             example: 'Yes'
@@ -78,8 +78,8 @@ FrameworkResponse:
       - assessment
       properties:
         assessment:
-          $ref: person_escort_record_reference.yaml#/PersonEscortRecordReference
-          description: The assessment the responses refer to, current assessments supported include the Person Escort Record
+          $ref: assessment_reference.yaml#/AssessmentReference
+          description: The assessment the responses refer to, current assessments supported include the Person Escort Record and Youth risk assessment
         question:
           $ref: framework_question_reference.yaml#/FrameworkQuestionReference
           description: The question this response is for

--- a/swagger/v1/get_youth_risk_assessment_responses.yaml
+++ b/swagger/v1/get_youth_risk_assessment_responses.yaml
@@ -1,0 +1,7 @@
+'200':
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      $ref: youth_risk_assessment.yaml#/YouthRiskAssessment

--- a/swagger/v1/move_include_parameter.yaml
+++ b/swagger/v1/move_include_parameter.yaml
@@ -31,4 +31,12 @@ MoveIncludeParameter:
       - profile.person_escort_record.responses.nomis_mappings
       - profile.person_escort_record.responses.question
       - profile.person_escort_record.responses.question.descendants.**
+      - profile.youth_risk_assessment
+      - profile.youth_risk_assessment.flags
+      - profile.youth_risk_assessment.framework
+      - profile.youth_risk_assessment.prefill_source
+      - profile.youth_risk_assessment.responses
+      - profile.youth_risk_assessment.responses.nomis_mappings
+      - profile.youth_risk_assessment.responses.question
+      - profile.youth_risk_assessment.responses.question.descendants.**
   example: from_location

--- a/swagger/v1/move_include_parameter.yaml
+++ b/swagger/v1/move_include_parameter.yaml
@@ -30,7 +30,7 @@ MoveIncludeParameter:
       - profile.person_escort_record.responses
       - profile.person_escort_record.responses.nomis_mappings
       - profile.person_escort_record.responses.question
-      - profile.person_escort_record.responses.question.descendants.**
+      - profile.person_escort_record.responses.question.descendants.\*\*
       - profile.youth_risk_assessment
       - profile.youth_risk_assessment.flags
       - profile.youth_risk_assessment.framework
@@ -38,5 +38,5 @@ MoveIncludeParameter:
       - profile.youth_risk_assessment.responses
       - profile.youth_risk_assessment.responses.nomis_mappings
       - profile.youth_risk_assessment.responses.question
-      - profile.youth_risk_assessment.responses.question.descendants.**
+      - profile.youth_risk_assessment.responses.question.descendants.\*\*
   example: from_location

--- a/swagger/v1/patch_framework_response.yaml
+++ b/swagger/v1/patch_framework_response.yaml
@@ -22,7 +22,7 @@ PatchFrameworkResponse:
       - value
       properties:
         value:
-          description: the answer value to the person_escort_record question
+          description: the answer value to the assessment question
           example: 'Yes'
           oneOf:
           - type: string

--- a/swagger/v1/patch_youth_risk_assessment.yaml
+++ b/swagger/v1/patch_youth_risk_assessment.yaml
@@ -1,0 +1,29 @@
+PatchYouthRiskAssessment:
+  type: object
+  required:
+    - id
+    - type
+    - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: youth_risk_assessments
+      enum:
+      - youth_risk_assessments
+      description: The type of this object - always `youth_risk_assessments`
+    attributes:
+      type: object
+      required:
+      - status
+      properties:
+        status:
+          example: confirmed
+          type: string
+          enum:
+            - confirmed
+          description: Sets the current status of the `youth_risk_assessment`

--- a/swagger/v1/patch_youth_risk_assessment_responses.yaml
+++ b/swagger/v1/patch_youth_risk_assessment_responses.yaml
@@ -1,0 +1,52 @@
+'200':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: youth_risk_assessment.yaml#/YouthRiskAssessment
+'400':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError
+'404':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/ResourceNotFound
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnsupportedMediaType
+'422':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnprocessableEntity

--- a/swagger/v1/post_youth_risk_assessment.yaml
+++ b/swagger/v1/post_youth_risk_assessment.yaml
@@ -1,0 +1,35 @@
+PostYouthRiskAssessment:
+  type: object
+  required:
+    - id
+    - type
+    - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: youth_risk_assessments
+      enum:
+      - youth_risk_assessments
+      description: The type of this object - always `youth_risk_assessments`
+    attributes:
+      type: object
+      required:
+      - version
+      properties:
+        version:
+          type: string
+          example: '1.0.1'
+          description: Determines the version of framework questions of the `youth_risk_assessment`
+    relationships:
+      type: object
+      required:
+        - move
+      properties:
+        move:
+          $ref: move_reference.yaml#/MoveReference
+          description: The move of the person being moved, already associated to the profile.

--- a/swagger/v1/post_youth_risk_assessment_responses.yaml
+++ b/swagger/v1/post_youth_risk_assessment_responses.yaml
@@ -1,0 +1,52 @@
+'201':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: youth_risk_assessment.yaml#/YouthRiskAssessment
+'400':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/BadRequest
+'401':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/NotAuthorisedError
+'404':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/ResourceNotFound
+'415':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnsupportedMediaType
+'422':
+  type: object
+  required:
+  - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: errors.yaml#/UnprocessableEntity

--- a/swagger/v1/profile.yaml
+++ b/swagger/v1/profile.yaml
@@ -34,3 +34,6 @@ Profile:
         person_escort_record:
           $ref: person_escort_record_reference.yaml#/PersonEscortRecordReference
           description: The person_escort_record associated with this Move
+        youth_risk_assessment:
+          $ref: youth_risk_assessment_reference.yaml#/YouthRiskAssessmentReference
+          description: The youth_risk_assessment associated with this Move

--- a/swagger/v1/youth_risk_assessment.yaml
+++ b/swagger/v1/youth_risk_assessment.yaml
@@ -1,0 +1,127 @@
+YouthRiskAssessment:
+  type: object
+  required:
+    - id
+    - type
+    - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: f0a91e16-1b0e-4e1f-93fe-319dda9933e6
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: youth_risk_assessments
+      enum:
+      - youth_risk_assessments
+      description: The type of this object - always `youth_risk_assessments`
+    attributes:
+      type: object
+      required:
+      - version
+      properties:
+        status:
+          type: string
+          enum:
+            - not_started
+            - in_progress
+            - completed
+            - confirmed
+          description: Determines the current status of the `youth_risk_assessment`
+        version:
+          type: string
+          example: '1.0.1'
+          description: Determines the version of framework questions of the `youth_risk_assessment`
+        editable:
+          type: boolean
+          example: true
+          description: Determines if a youth risk assessment's responses can be amended. A youth risk assessment is editable if the associated move's status is `requested` or `booked`, and the status of the youth risk assessment is not `confirmed`
+        nomis_sync_status:
+          type: array
+          items:
+            type: object
+            properties:
+              resource_type:
+                type: string
+                enum:
+                  - alerts
+                  - personal_care_needs
+                  - reasonable_adjustments
+              status:
+                type: string
+                enum:
+                  - success
+                  - failed
+              synced_at:
+                type: string
+                format: date-time
+              message:
+                type: string
+          readOnly: true
+          description: A list of all NOMIS resources imported when creating the youth risk assessment, and the status of the import, either successful or failed. The timestamp and error message are also included.
+        confirmed_at:
+          example: "2020-07-24T17:29:26.338Z"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of when the youth_risk_assessment was confirmed
+            readOnly: true
+        created_at:
+          example: "2020-07-24T17:29:26.338Z"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of when the youth_risk_assessment was created
+            readOnly: true
+    meta:
+      readOnly: true
+      type: object
+      properties:
+        section_progress:
+          type: array
+          description: Determines the current progress of all responses in each `section` in the youth_risk_assessment
+          items:
+            type: object
+            required:
+              - key
+              - status
+            properties:
+              key:
+                type: string
+                example: risk-information
+                description: identifier of section
+              status:
+                type: string
+                example: not_started
+                enum:
+                  - not_started
+                  - in_progress
+                  - completed
+                description: status of progress of a section
+    relationships:
+      type: object
+      required:
+        - move
+        - framework
+      properties:
+        profile:
+          $ref: profile_reference.yaml#/ProfileReference
+          description: The profile of the person being moved
+        move:
+          $ref: move_reference.yaml#/MoveReference
+          description: The move of the person being moved
+        framework:
+          $ref: framework_reference.yaml#/FrameworkReference
+          description: The framework associated with this youth_risk_assessment
+        prefill_source:
+          $ref: youth_risk_assessment_reference.yaml#/YouthRiskAssessmentReference
+          description: The youth_risk_assessment the current youth_risk_assessment has been prefilled from
+        responses:
+          $ref: framework_response_reference.yaml#/FrameworkResponseReference
+          description: The framework response associated with this youth_risk_assessment
+        flags:
+          $ref: framework_flag_reference.yaml#/FrameworkFlagReference
+          description: The framework flags associated with this youth_risk_assessment

--- a/swagger/v1/youth_risk_assessment_id_parameter.yaml
+++ b/swagger/v1/youth_risk_assessment_id_parameter.yaml
@@ -1,0 +1,9 @@
+YouthRiskAssessmentId:
+  name: youth_risk_assessment_id
+  in: path
+  required: true
+  description: The ID of the youth_risk_assessment
+  schema:
+    type: string
+    format: uuid
+  example: 5b61f755-0fd7-4a91-b7a3-a33d751f985f

--- a/swagger/v1/youth_risk_assessment_include_parameter.yaml
+++ b/swagger/v1/youth_risk_assessment_include_parameter.yaml
@@ -1,0 +1,20 @@
+YouthRiskAssessmentIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the youth_risk_assessment
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - framework
+      - profile
+      - profile.person
+      - responses
+      - responses.question
+      - responses.nomis_mappings
+      - responses.question.descendants.**
+      - flags
+      - move
+      - prefill_source
+  example: framework

--- a/swagger/v1/youth_risk_assessment_reference.yaml
+++ b/swagger/v1/youth_risk_assessment_reference.yaml
@@ -1,0 +1,26 @@
+YouthRiskAssessmentReference:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      oneOf:
+      - type: object
+      - type: 'null'
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          example: youth_risk_assessments
+          enum:
+            - youth_risk_assessments
+          description: The type of this object - always `youth_risk_assessments`
+        id:
+          type: string
+          format: uuid
+          example: ea5ace8e-e9ad-4ca3-9977-9bf69e3b6154
+          description:
+            The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v2/move_include_parameter.yaml
+++ b/swagger/v2/move_include_parameter.yaml
@@ -25,7 +25,7 @@ MoveIncludeParameter:
       - profile.person_escort_record.responses
       - profile.person_escort_record.responses.nomis_mappings
       - profile.person_escort_record.responses.question
-      - profile.person_escort_record.responses.question.descendants.**
+      - profile.person_escort_record.responses.question.descendants.\*\*
       - profile.youth_risk_assessment
       - profile.youth_risk_assessment.flags
       - profile.youth_risk_assessment.framework
@@ -33,5 +33,5 @@ MoveIncludeParameter:
       - profile.youth_risk_assessment.responses
       - profile.youth_risk_assessment.responses.nomis_mappings
       - profile.youth_risk_assessment.responses.question
-      - profile.youth_risk_assessment.responses.question.descendants.**
+      - profile.youth_risk_assessment.responses.question.descendants.\*\*
   example: from_location

--- a/swagger/v2/move_include_parameter.yaml
+++ b/swagger/v2/move_include_parameter.yaml
@@ -26,4 +26,12 @@ MoveIncludeParameter:
       - profile.person_escort_record.responses.nomis_mappings
       - profile.person_escort_record.responses.question
       - profile.person_escort_record.responses.question.descendants.**
+      - profile.youth_risk_assessment
+      - profile.youth_risk_assessment.flags
+      - profile.youth_risk_assessment.framework
+      - profile.youth_risk_assessment.prefill_source
+      - profile.youth_risk_assessment.responses
+      - profile.youth_risk_assessment.responses.nomis_mappings
+      - profile.youth_risk_assessment.responses.question
+      - profile.youth_risk_assessment.responses.question.descendants.**
   example: from_location


### PR DESCRIPTION
### Jira link

[P4-2451](https://dsdmoj.atlassian.net/browse/P4-2451)

### What?

- Added new routes for Youth risk assessment
- Added new controller for Youth risk assessment
- Updated assessment serializers to inherit from parent assessment serializer class
- Added new Youth risk assessment serializer
- Added includes of Youth risk assessment to moves and profiles

### Why?

Surface new routes for Youth risk assessment, by adding new controller which inherits from framework assessments. The serializers will inherit from a parent framework assessment serializer, only for single assessments, as there is no requirement to expose youth risk assessment on the get multiple moves endpoint.

Prefilling unfortunately needs to follow a similar pattern as we cannot pass in a block for the type of serializer. 
Notifications for youth risk assessments will be picked up in a different PR, so tests have been marked for now as pending.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

