### PR TITLE
Validate Youth Risk Assessment move `from_location` on creation

### DIFF
--- a/app/models/youth_risk_assessment.rb
+++ b/app/models/youth_risk_assessment.rb
@@ -4,6 +4,8 @@ class YouthRiskAssessment < VersionedModel
   belongs_to :prefill_source, class_name: 'YouthRiskAssessment', optional: true
   belongs_to :move
 
+  validate :move_from_location
+
   def self.framework_name
     'youth-risk-assessment'
   end
@@ -12,5 +14,9 @@ private
 
   def previous_assessment
     @previous_assessment ||= profile&.person&.latest_youth_risk_assessment
+  end
+
+  def move_from_location
+    errors.add(:move, "'from_location' must be from either a secure training centre or a secure children's home") unless move&.from_location&.secure_training_centre? || move&.from_location&.secure_childrens_home?
   end
 end

--- a/spec/factories/framework_assessment.rb
+++ b/spec/factories/framework_assessment.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
   end
 
   factory :youth_risk_assessment, class: 'YouthRiskAssessment', parent: :framework_assessmentable do
-    association(:move)
+    association(:move, :from_stc_to_court, factory: :move)
     association(:framework, :youth_risk_assessment)
 
     after(:build) do |youth_risk_assessment|

--- a/spec/factories/framework_assessment.rb
+++ b/spec/factories/framework_assessment.rb
@@ -46,7 +46,7 @@ FactoryBot.define do
     association(:framework, :youth_risk_assessment)
 
     after(:build) do |youth_risk_assessment|
-      youth_risk_assessment.profile = youth_risk_assessment.move.profile if youth_risk_assessment.profile.blank?
+      youth_risk_assessment.profile = youth_risk_assessment.move&.profile if youth_risk_assessment.profile.blank?
     end
 
     trait :prefilled do

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -169,6 +169,13 @@ FactoryBot.define do
         create_list(:court_hearing, 1, move: move)
       end
     end
+
+    trait :from_stc_to_court do
+      association(:from_location, :stc, factory: :location)
+      association(:to_location, :court, factory: :location)
+
+      move_type { 'court_appearance' }
+    end
   end
 
   factory :from_prison_to_court, class: 'Move' do

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -3,7 +3,48 @@
 require 'rails_helper'
 
 RSpec.describe PersonEscortRecord do
+  let(:from_location) { create(:location, :prison) }
+  let(:nomis_alert) do
+    {
+      alert_id: 2,
+      alert_code: 'VI',
+      alert_code_description: 'Hold separately',
+      comment: 'Some comment',
+      created_at: '2013-03-29',
+      expires_at: '2100-06-08',
+      expired: false,
+      active: true,
+      offender_no: 'A9127EK',
+    }
+  end
+
   it { is_expected.to belong_to(:move).optional }
+
+  it 'creates NOMIS mappings for framework responses' do
+    move = create(:move, from_location: from_location)
+    framework = create(:framework)
+    alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
+    create(:framework_question, framework: framework, framework_nomis_codes: [alert_code])
+    allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert])
+    person_escort_record = described_class.save_with_responses!(move_id: move.id, version: framework.version)
+
+    expect(person_escort_record.framework_responses.first.framework_nomis_mappings.count).to eq(1)
+  end
+
+  it 'updates nomis sync status if successful' do
+    move = create(:move, from_location: from_location)
+    framework = create(:framework)
+    alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
+    create(:framework_question, framework: framework, framework_nomis_codes: [alert_code])
+    allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert])
+    person_escort_record = described_class.save_with_responses!(move_id: move.id, version: framework.version)
+
+    expect(person_escort_record.nomis_sync_status).to include_json(
+      [
+        { 'resource_type' => 'alerts', 'status' => 'success' },
+      ],
+    )
+  end
 
   # To support legacy PERs without a move
   context 'when no move associated' do
@@ -32,6 +73,23 @@ RSpec.describe PersonEscortRecord do
 
         expect { person_escort_record.import_nomis_mappings! }.not_to change(FrameworkNomisMapping, :count)
       end
+    end
+  end
+
+  describe '#import_nomis_mappings!' do
+    before do
+      allow(NomisClient::Alerts).to receive(:get).and_return([nomis_alert])
+    end
+
+    it 'imports nomis mappings if move is a prison' do
+      framework = create(:framework)
+      move = create(:move, from_location: from_location)
+      alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
+      question = create(:framework_question, framework: framework, framework_nomis_codes: [alert_code])
+      response = create(:string_response, framework_question: question)
+      person_escort_record = create(:person_escort_record, framework: framework, move: move, framework_responses: [response])
+
+      expect { person_escort_record.import_nomis_mappings! }.to change(FrameworkNomisMapping, :count).by(1)
     end
   end
 

--- a/spec/models/youth_risk_assessment_spec.rb
+++ b/spec/models/youth_risk_assessment_spec.rb
@@ -5,5 +5,32 @@ require 'rails_helper'
 RSpec.describe YouthRiskAssessment do
   it { is_expected.to belong_to(:move) }
 
+  context 'with validations' do
+    it 'is valid if the move from location is from an stc' do
+      location = create(:location, :stc)
+      move = create(:move, from_location: location)
+      youth_risk_assessment = build(:youth_risk_assessment, move: move)
+
+      expect(youth_risk_assessment).to be_valid
+    end
+
+    it 'is valid if the move from location is from an sch' do
+      location = create(:location, :sch)
+      move = create(:move, from_location: location)
+      youth_risk_assessment = build(:youth_risk_assessment, move: move)
+
+      expect(youth_risk_assessment).to be_valid
+    end
+
+    it 'is invalid if the move from location is not from an sch or stc' do
+      location = create(:location, :prison)
+      move = create(:move, from_location: location)
+      youth_risk_assessment = build(:youth_risk_assessment, move: move)
+
+      expect(youth_risk_assessment).not_to be_valid
+      expect(youth_risk_assessment.errors.messages[:move]).to eq(["'from_location' must be from either a secure training centre or a secure children's home"])
+    end
+  end
+
   it_behaves_like 'a framework assessment', :youth_risk_assessment, described_class
 end

--- a/spec/models/youth_risk_assessment_spec.rb
+++ b/spec/models/youth_risk_assessment_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe YouthRiskAssessment do
       expect(youth_risk_assessment).not_to be_valid
       expect(youth_risk_assessment.errors.messages[:move]).to eq(["'from_location' must be from either a secure training centre or a secure children's home"])
     end
+
+    it 'is invalid if there is no move attached to a youth risk assessment' do
+      youth_risk_assessment = build(:youth_risk_assessment, move: nil)
+
+      expect(youth_risk_assessment).not_to be_valid
+      expect(youth_risk_assessment.errors.messages[:move]).to eq(['must exist', "'from_location' must be from either a secure training centre or a secure children's home"])
+    end
   end
 
   it_behaves_like 'a framework assessment', :youth_risk_assessment, described_class

--- a/spec/models/youth_risk_assessment_spec.rb
+++ b/spec/models/youth_risk_assessment_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe YouthRiskAssessment do
+  let(:from_location) { create(:location, :stc) }
+
   it { is_expected.to belong_to(:move) }
 
   context 'with validations' do

--- a/spec/requests/api/youth_risk_assessments_controller_create_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_create_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
     let(:person) { create(:person) }
     let(:profile) { create(:profile, person: person) }
     let(:profile_id) { profile.id }
-    let(:move) { create(:move, profile: profile) }
+    let(:move) { create(:move, :from_stc_to_court, profile: profile) }
     let(:move_id) { move.id }
     let(:framework) { create(:framework, :youth_risk_assessment, framework_questions: [build(:framework_question, section: 'risk-information', prefill: true)]) }
     let(:framework_version) { framework.version }
@@ -214,6 +214,21 @@ RSpec.describe Api::YouthRiskAssessmentsController do
         let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
 
         it_behaves_like 'an endpoint that responds with error 404'
+      end
+
+      context 'when move location is not from sch or stc' do
+        let(:move) { create(:move, profile: profile) }
+        let(:errors_422) do
+          [
+            {
+              'title' => 'Unprocessable entity',
+              'detail' => "Move 'from location' must be from either a secure training centre or a secure children's home",
+              'source' => { 'pointer' => '/data/attributes/move' },
+            },
+          ]
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422'
       end
 
       context 'when a youth risk assessment already exists on a profile' do

--- a/spec/requests/api/youth_risk_assessments_controller_update_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_update_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
       let!(:subscription) { create(:subscription, supplier: supplier) }
       let!(:notification_type_email) { create(:notification_type, :email) }
       let!(:notification_type_webhook) { create(:notification_type, :webhook) }
-      let(:from_location) { create(:location, suppliers: [supplier]) }
+      let(:from_location) { create(:location, :stc, suppliers: [supplier]) }
       let(:move) { create(:move, from_location: from_location, supplier: supplier) }
       let(:youth_risk_assessment) { create(:youth_risk_assessment, :with_responses, :completed, move: move) }
 


### PR DESCRIPTION
Add validation on the youth risk assessment to only being created if a move `from_location` is either a secure training centre (STC) or a secure children's home (SCH).

This requires some changes to the shared tests, where now we allow passing in a `from_location` to the respective assessment specs.
This also means we will never import NOMIS mappings on the youth risk assessment, as for NOMIS mappings to be imported, the from location should be a prison. I have moved out the specific tests to the PER now instead.