### PR TITLE
P4-2521 Switch to using generic assessment job on assessment confirm action

### DIFF
--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -11,8 +11,8 @@ class Notifier
       PreparePersonNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
     when Profile
       PrepareProfileNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
-    when PersonEscortRecord
-      PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, queue_as: :notifications_medium)
+    when PersonEscortRecord, YouthRiskAssessment
+      PrepareAssessmentNotificationsJob.perform_later(topic_id: topic.id, topic_class: topic.class.name, queue_as: :notifications_medium)
     end
   end
 end

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Api::PersonEscortRecordsController do
       before do
         allow(Faraday).to receive(:new).and_return(faraday_client)
         allow(MoveMailer).to receive(:notify).and_return(notify_response)
-        perform_enqueued_jobs(only: [PreparePersonEscortRecordNotificationsJob, NotifyWebhookJob, NotifyEmailJob]) do
+        perform_enqueued_jobs(only: [PrepareAssessmentNotificationsJob, NotifyWebhookJob, NotifyEmailJob]) do
           patch_person_escort_record
         end
       end

--- a/spec/requests/api/youth_risk_assessments_controller_update_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_update_spec.rb
@@ -117,12 +117,12 @@ RSpec.describe Api::YouthRiskAssessmentsController do
       before do
         allow(Faraday).to receive(:new).and_return(faraday_client)
         allow(MoveMailer).to receive(:notify).and_return(notify_response)
-        perform_enqueued_jobs(only: [PreparePersonEscortRecordNotificationsJob, NotifyWebhookJob, NotifyEmailJob]) do
+        perform_enqueued_jobs(only: [PrepareAssessmentNotificationsJob, NotifyWebhookJob, NotifyEmailJob]) do
           patch_youth_risk_assessment
         end
       end
 
-      xit 'creates a webhook notification' do
+      it 'creates a webhook notification' do
         notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
 
         expect(notification).to have_attributes(
@@ -132,7 +132,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
         )
       end
 
-      xit 'creates an email notification' do
+      it 'creates an email notification' do
         notification = subscription.notifications.find_by(notification_type: notification_type_email)
 
         expect(notification).to have_attributes(

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -61,7 +61,15 @@ RSpec.describe Notifier do
     let(:topic) { create(:person_escort_record) }
 
     it 'queues a job' do
-      expect(PreparePersonEscortRecordNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, queue_as: :notifications_medium)
+      expect(PrepareAssessmentNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, topic_class: 'PersonEscortRecord', queue_as: :notifications_medium)
+    end
+  end
+
+  context 'when scheduled with a youth_risk_assessment' do
+    let(:topic) { create(:youth_risk_assessment) }
+
+    it 'queues a job' do
+      expect(PrepareAssessmentNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, topic_class: 'YouthRiskAssessment', queue_as: :notifications_medium)
     end
   end
 


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2451

Switch both youth risk assessment and PER to use generic assessment job notifier
