### PR TITLE
Temporary solution to eager load youth risk assessment in a move

### DIFF
--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -143,7 +143,7 @@ module Api::V2
       @move ||= Move
         .accessible_by(current_ability)
         .includes(
-          :from_location, :to_location, profile: { person: %i[gender ethnicity], person_escort_record: { framework_flags: :framework_question } }
+          :from_location, :to_location, profile: { person: %i[gender ethnicity], person_escort_record: { framework_flags: :framework_question }, youth_risk_assessment: { framework_flags: :framework_question } }
         )
         .find(params[:id])
     end


### PR DESCRIPTION
The assessments eager loading is a can of worms that needs to be addressed properly. I will add a ticket in the backlog but for now this will stave off many many bad queries on a move.

I paired with @smoothcontract around removing this include entirely and fixing the serializers, but it requires quite a bit of work so we will go with this solution for now.