### PR TITLE
Fix pluralisation of approves move endpoint

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -3,12 +3,13 @@
 # Add new inflection rules using the following format. Inflections
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.singular 'approves', 'approve' # NB prevents "approves".singularize => "approfe"
 #   inflect.plural /^(ox)$/i, '\1en'
 #   inflect.singular /^(ox)en/i, '\1'
 #   inflect.irregular 'person', 'people'
 #   inflect.uncountable %w( fish sheep )
-# end
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/spec/requests/api/move_events_controller_approve_spec.rb
+++ b/spec/requests/api/move_events_controller_approve_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::MoveEventsController do
     let(:approve_params) do
       {
         data: {
-          type: 'approve',
+          type: 'approves',
           attributes: {
             timestamp: '2020-04-23T18:25:43.511Z',
             date: approved_date,


### PR DESCRIPTION
### Jira link

P4-2563

### What?

I have added/removed/altered:

- [x] Added manual inflection of approves => approve (as rails thinks it is 'approfe)'
- [x] Updated test to use approves

### Why?

I am doing this because:

- so the front end can call the approve endpoint easily

### Have you? (optional)

- [x] docs already up-to-date


