### PR TITLE
Surface the status on the PER serializer

### DIFF
--- a/app/serializers/person_escort_records_serializer.rb
+++ b/app/serializers/person_escort_records_serializer.rb
@@ -9,4 +9,8 @@ class PersonEscortRecordsSerializer
   has_many_if_included :flags, serializer: FrameworkFlagsSerializer, &:framework_flags
 
   attributes :confirmed_at, :created_at, :nomis_sync_status
+
+  attribute :status do |object|
+    object.status == 'unstarted' ? 'not_started' : object.status
+  end
 end

--- a/spec/serializers/person_escort_records_serializer_spec.rb
+++ b/spec/serializers/person_escort_records_serializer_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe PersonEscortRecordsSerializer do
     expect(result[:data][:id]).to eq(person_escort_record.id)
   end
 
+  it 'contains a `status` attribute' do
+    expect(result[:data][:attributes][:status]).to eq('not_started')
+  end
+
   it 'contains a `confirmed_at` attribute' do
     expect(result[:data][:attributes][:confirmed_at]).to eq(person_escort_record.confirmed_at)
   end


### PR DESCRIPTION
Add the status to the PER seriazlier on the moves endpoint, as this is needed to show when the PER is completed to show flags under a person's name.
