### PR TITLE
Add fake data rake tasks to create move incidents and PER medical events

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -2,6 +2,8 @@
 
 require_relative 'fake_data/journeys'
 require_relative 'fake_data/gps'
+require_relative 'fake_data/incident_events'
+require_relative 'fake_data/medical_events'
 
 namespace :fake_data do
   desc 'create fake people'
@@ -168,6 +170,31 @@ namespace :fake_data do
         complete_in_full: Faker::Boolean.boolean,
         complex_cases: fake_complex_case_answers,
       )
+    end
+  end
+
+  desc 'create fake incident events'
+  task create_incident_events: :environment do
+    puts 'create_incident_events...'
+    Move
+        .where(status: %w[completed booked requested])
+        .where.not(to_location_id: nil)
+        .order(Arel.sql('RANDOM()'))
+        .limit(1000)
+        .find_each do |move|
+      Tasks::FakeData::IncidentEvents.new(move).call
+    end
+  end
+
+  desc 'create fake medical events'
+  task create_medical_events: :environment do
+    puts 'create_medical_events...'
+    PersonEscortRecord
+        .where.not(move_id: nil)
+        .order(Arel.sql('RANDOM()'))
+        .limit(100)
+        .find_each do |per|
+      Tasks::FakeData::MedicalEvents.new(per).call
     end
   end
 

--- a/lib/tasks/fake_data/incident_events.rb
+++ b/lib/tasks/fake_data/incident_events.rb
@@ -1,0 +1,59 @@
+module Tasks
+  module FakeData
+    class IncidentEvents
+      attr_reader :move
+
+      def initialize(move)
+        @move = move
+      end
+
+      def call
+        event_count = rand(1..5)
+        event_count.times do
+          random_event.create!(
+            eventable: move,
+            occurred_at: Time.zone.now,
+            recorded_at: Time.zone.now,
+            details: {
+              reported_at: Time.zone.now,
+              location_id: move.to_location_id,
+              supplier_personnel_numbers: [12_345, 54_321],
+              vehicle_reg: 'C63 AMG',
+              fault_classification: 'investigation',
+              fake: true,
+            },
+            supplier: random_supplier,
+            notes: 'Created from fake data',
+          )
+        end
+
+        puts "Added #{event_count} incident events to Move #{move.id}"
+      end
+
+    private
+
+      def suppliers
+        @suppliers ||= Supplier.all.to_a
+      end
+
+      def random_supplier
+        suppliers.sample
+      end
+
+      def random_event
+        [
+          GenericEvent::PersonMoveRoadTrafficAccident,
+          GenericEvent::PersonMovePersonEscaped,
+          GenericEvent::PersonMoveUsedForce,
+          GenericEvent::PersonMoveMajorIncidentOther,
+          GenericEvent::PersonMoveSeriousInjury,
+          GenericEvent::PersonMoveMinorIncidentOther,
+          GenericEvent::PersonMoveDeathInCustody,
+          GenericEvent::PersonMoveAssault,
+          GenericEvent::PersonMovePersonEscapedKpi,
+          GenericEvent::PersonMoveReleasedError,
+        ].sample
+      end
+    end
+  end
+end

--- a/lib/tasks/fake_data/medical_events.rb
+++ b/lib/tasks/fake_data/medical_events.rb
@@ -1,0 +1,43 @@
+module Tasks
+  module FakeData
+    class MedicalEvents
+      attr_reader :per, :move
+
+      def initialize(per)
+        @per = per
+        @move = per.move
+      end
+
+      def call
+        GenericEvent::PerMedicalAid.create!(
+          eventable: per,
+          occurred_at: Time.zone.now,
+          recorded_at: Time.zone.now,
+          details: {
+            advised_at: Time.zone.now,
+            advised_by: 'Dr. Bunsen',
+            treated_at: Time.zone.now,
+            treated_by: 'Beaker',
+            location_id: move.from_location_id,
+            supplier_personnel_number: 12_345,
+            fake: true,
+          },
+          supplier: random_supplier,
+          notes: 'Created from fake data',
+        )
+
+        puts "Added a medical event to Person Escort Record #{per.id}, part of Move #{per.move_id}"
+      end
+
+    private
+
+      def suppliers
+        @suppliers ||= Supplier.all.to_a
+      end
+
+      def random_supplier
+        suppliers.sample
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

P4-2425

### What?

- [x] Add new `fake_data:create_incident_events` and `fake_data:create_medical_events` tasks

### Why?

- Suppliers will eventually create these events via the API, but in the meantime we need some sample data for testing. As this will run on production mode environments the factory fixtures unfortunately can't be used as none of the required test group gems are bundled.