### PR TITLE
Add framework responses back to the version model

### DIFF
--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FrameworkResponse < ApplicationRecord
+class FrameworkResponse < VersionedModel
   ValueTypeError = Class.new(StandardError)
 
   validates :type, presence: true


### PR DESCRIPTION
We would like to track who answers/edits responses which helps us calculate the people responsible for completing sections in the PER for auditing purposes. Add back the version model to responses for now to have this information available and tracked, so we can parse it later.