### PR TITLE
P4-2378 Add `requires_youth_risk_assessment` attribute to profiles

### DIFF
--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -26,6 +26,7 @@ module Api
     PROFILE_ATTRIBUTES = [
       :type,
       attributes: [
+        :requires_youth_risk_assessment,
         assessment_answers: [
           %i[
             key

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -5,7 +5,7 @@ class ProfileSerializer
 
   set_type :profiles
 
-  attributes :assessment_answers
+  attributes :requires_youth_risk_assessment, :assessment_answers
 
   belongs_to :person
   has_many :documents

--- a/app/serializers/v2/profile_serializer.rb
+++ b/app/serializers/v2/profile_serializer.rb
@@ -5,7 +5,7 @@ class V2::ProfileSerializer
 
   set_type :profiles
 
-  attributes :assessment_answers
+  attributes :requires_youth_risk_assessment, :assessment_answers
 
   belongs_to :person, serializer: ::V2::PersonSerializer
   has_many :documents, serializer: DocumentSerializer

--- a/db/migrate/20201210135224_add_requires_youth_risk_assessment_to_profiles.rb
+++ b/db/migrate/20201210135224_add_requires_youth_risk_assessment_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddRequiresYouthRiskAssessmentToProfiles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :profiles, :requires_youth_risk_assessment, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_142628) do
+ActiveRecord::Schema.define(version: 2020_12_10_135224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -547,6 +547,7 @@ ActiveRecord::Schema.define(version: 2020_11_30_142628) do
     t.string "category"
     t.string "category_code"
     t.uuid "category_id"
+    t.boolean "requires_youth_risk_assessment"
     t.index ["category_code"], name: "index_profiles_on_category_code"
     t.index ["category_id"], name: "index_profiles_on_category_id"
     t.index ["updated_at"], name: "index_profiles_on_updated_at"

--- a/spec/serializers/profile_serializer_spec.rb
+++ b/spec/serializers/profile_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProfileSerializer do
       data: {
         id: profile.id,
         type: 'profiles',
-        attributes: { assessment_answers: [] },
+        attributes: { assessment_answers: [], requires_youth_risk_assessment: nil },
         relationships: {
           person: {
             data: { id: profile.person.id, type: 'people' },

--- a/spec/serializers/v2/profile_serializer_spec.rb
+++ b/spec/serializers/v2/profile_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe V2::ProfileSerializer do
       data: {
         id: profile.id,
         type: 'profiles',
-        attributes: { assessment_answers: [] },
+        attributes: { assessment_answers: [], requires_youth_risk_assessment: nil },
         relationships: {
           person: {
             data: { id: profile.person.id, type: 'people' },

--- a/swagger/v1/profile.yaml
+++ b/swagger/v1/profile.yaml
@@ -18,6 +18,12 @@ Profile:
     attributes:
       type: object
       properties:
+        requires_youth_risk_assessment:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+          example: 'true'
+          description: Indicates if the person requires a youth risk assessment or not
         assessment_answers:
           type: array
           items:


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2378

If a person is moving from a YOI, the client is required to ask the user if the person needs a youth risk assessment if their age is between 18 and 19. The answer can be stored on the profile as a new attribute which is a boolean representing if the user selects true or false. The attribute remains nil if the question is not answered.

The logic around when to ask this question will be with the client, which will be looking at the move from location, and at the age of the person, being between 18 - 19.