### PR TITLE
Make sure tests use timezones in time specific tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,7 +68,6 @@ Rails/Date:
 # The anonymiser isn't production code, and is going away soon
 Rails/TimeZone:
   Exclude:
-    - "spec/**/**/*"
     - "app/services/moves/anonymiser.rb"
 
 Lint/AmbiguousBlockAssociation:

--- a/spec/factories/journeys.rb
+++ b/spec/factories/journeys.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     association(:supplier)
     association(:from_location, factory: :location)
     association(:to_location, :court, factory: :location)
-    client_timestamp { Time.now.utc + rand(-60..60).seconds } # NB: the client_timestamp will never be perfectly in sync with system clock
+    client_timestamp { Time.zone.now.utc + rand(-60..60).seconds } # NB: the client_timestamp will never be perfectly in sync with system clock
     vehicle { { id: '12345678ABC', registration: 'AB12 CDE' } }
 
     # NB we need to initialize_state because FactoryBot fires the after_initialize callback before the attributes are initialised!

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -6,10 +6,10 @@ FactoryBot.define do
     association(:from_location, factory: :location)
     association(:to_location, :court, factory: :location)
     sequence(:date) { |n| Date.today + n.days }
-    time_due { Time.now }
+    time_due { Time.zone.now }
     status { 'requested' }
     additional_information { 'some more info about the move that the supplier might need to know' }
-    sequence(:created_at) { |n| Time.now - n.minutes }
+    sequence(:created_at) { |n| Time.zone.now - n.minutes }
     sequence(:date_from) { |n| Date.today - n.days }
 
     association(:supplier)
@@ -185,7 +185,7 @@ FactoryBot.define do
     association(:supplier)
 
     date { Date.today }
-    time_due { Time.now }
+    time_due { Time.zone.now }
     status { 'requested' }
     additional_information { 'some more info about the move that the supplier might need to know' }
     move_type { 'court_appearance' }

--- a/spec/lib/cloud_data_feed_spec.rb
+++ b/spec/lib/cloud_data_feed_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CloudDataFeed do
   before do
     Aws.config.update(stub_responses: true)
-    Timecop.freeze(Time.local(2020, 1, 30))
+    Timecop.freeze(Time.zone.local(2020, 1, 30))
   end
 
   after do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Activity do
     let(:expected_attributes) do
       {
         id: nomis_scheduled_event['eventId'],
-        start_time: Time.parse(nomis_scheduled_event['startTime']),
+        start_time: Time.parse(nomis_scheduled_event['startTime']), # rubocop:disable Rails/TimeZone
         type: 'Prison Activities',
         reason: nomis_scheduled_event['eventTypeDesc'],
         agency_id: nomis_scheduled_event['locationCode'],

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -579,12 +579,12 @@ RSpec.describe Move do
 
     it 'does not create a profile version record if only changing move updated_at timestamp' do
       expect {
-        move.update(updated_at: Time.now)
+        move.update(updated_at: Time.zone.now)
       }.not_to change(move.profile.versions, :count)
     end
 
     it 'does not create a move version record if only changing move updated_at timestamp' do
-      move.update(updated_at: Time.now)
+      move.update(updated_at: Time.zone.now)
       expect(move.versions.count).to eq 1
     end
 

--- a/spec/models/nomis_court_hearing_spec.rb
+++ b/spec/models/nomis_court_hearing_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe NomisCourtHearing do
     let(:expected_attributes) do
       {
         id: nomis_court_hearing['id'],
-        start_time: Time.parse(nomis_court_hearing['dateTime']),
+        start_time: Time.zone.parse(nomis_court_hearing['dateTime']),
         type: 'Court',
         reason: 'Court appearance',
         agency_id: nomis_court_hearing['location']['agencyId'],

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Notification, type: :model do
     subject(:notification) { build(:notification, :webhook, subscription: subscription, discarded_at: discarded_at) }
 
     context 'when parent subscription is discarded' do
-      let(:subscription) { create(:subscription, discarded_at: Time.now) }
+      let(:subscription) { create(:subscription, discarded_at: Time.zone.now) }
 
       context 'when notification is discarded' do
-        let(:discarded_at) { Time.now }
+        let(:discarded_at) { Time.zone.now }
 
         it { expect(notification.kept?).to be false }
       end
@@ -31,7 +31,7 @@ RSpec.describe Notification, type: :model do
       let(:subscription) { build(:subscription, discarded_at: nil) }
 
       context 'when notification is discarded' do
-        let(:discarded_at) { Time.now }
+        let(:discarded_at) { Time.zone.now }
 
         it { expect(notification.kept?).to be false }
       end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Subscription do
     subject(:subscription) { build(:subscription, discarded_at: discarded_at) }
 
     context 'when subscription is discarded' do
-      let(:discarded_at) { Time.now }
+      let(:discarded_at) { Time.zone.now }
 
       it { expect(subscription.kept?).to be false }
     end

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::MovesController do
 
     let(:move_attributes) do
       { date: Date.today,
-        time_due: Time.now,
+        time_due: Time.zone.now,
         status: 'requested',
         additional_information: 'some more info',
         move_type: 'court_appearance' }
@@ -222,7 +222,7 @@ RSpec.describe Api::MovesController do
             type: 'moves',
             attributes: {
               date: Date.today,
-              time_due: Time.now,
+              time_due: Time.zone.now,
               status: 'requested',
               additional_information: 'some more info',
               move_type: nil,

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::MovesController do
     let(:move_attributes) do
       {
         date: Date.today,
-        time_due: Time.now,
+        time_due: Time.zone.now,
         status: status,
         additional_information: 'some more info',
         move_type: 'court_appearance',
@@ -274,7 +274,7 @@ RSpec.describe Api::MovesController do
           type: 'moves',
           attributes: {
             date: Date.today,
-            time_due: Time.now,
+            time_due: Time.zone.now,
             status: 'requested',
             additional_information: 'some more info',
             move_type: 'court_appearance',

--- a/spec/serializers/assessment_question_serializer_spec.rb
+++ b/spec/serializers/assessment_question_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AssessmentQuestionSerializer do
   subject(:serializer) { described_class.new(assessment_question) }
 
-  let(:disabled_at) { Time.new(2019, 1, 1) }
+  let(:disabled_at) { Time.zone.local(2019, 1, 1) }
   let(:assessment_question) { create :assessment_question, disabled_at: disabled_at }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
 

--- a/spec/serializers/ethnicity_serializer_spec.rb
+++ b/spec/serializers/ethnicity_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe EthnicitySerializer do
   subject(:serializer) { described_class.new(ethnicity) }
 
-  let(:disabled_at) { Time.new(2019, 1, 1) }
+  let(:disabled_at) { Time.zone.local(2019, 1, 1) }
   let(:ethnicity) { create :ethnicity, disabled_at: disabled_at }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
 

--- a/spec/serializers/gender_serializer_spec.rb
+++ b/spec/serializers/gender_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe GenderSerializer do
   subject(:serializer) { described_class.new(gender) }
 
-  let(:disabled_at) { Time.new(2019, 1, 1) }
+  let(:disabled_at) { Time.zone.local(2019, 1, 1) }
   let(:gender) { create :gender, disabled_at: disabled_at }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
 

--- a/spec/serializers/identifier_type_serializer_spec.rb
+++ b/spec/serializers/identifier_type_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe IdentifierTypeSerializer do
   subject(:serializer) { described_class.new(identifier_type) }
 
-  let(:disabled_at) { Time.new(2019, 1, 1) }
+  let(:disabled_at) { Time.zone.local(2019, 1, 1) }
   let(:identifier_type) { create :identifier_type, disabled_at: disabled_at }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
 

--- a/spec/serializers/location_serializer_spec.rb
+++ b/spec/serializers/location_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe LocationSerializer do
   subject(:serializer) { described_class.new(location, include: %i[suppliers]) }
 
-  let(:disabled_at) { Time.new(2019, 1, 1) }
+  let(:disabled_at) { Time.zone.local(2019, 1, 1) }
   let(:supplier) { create(:supplier) }
   let(:location) { create :location, disabled_at: disabled_at, suppliers: [supplier] }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }

--- a/spec/serializers/prison_transfer_reason_serializer_spec.rb
+++ b/spec/serializers/prison_transfer_reason_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe PrisonTransferReasonSerializer do
   subject(:serializer) { described_class.new(reason) }
 
-  let(:disabled_at) { Time.new(2019, 1, 1) }
+  let(:disabled_at) { Time.zone.local(2019, 1, 1) }
   let(:reason) { create :prison_transfer_reason, disabled_at: disabled_at }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
 

--- a/spec/services/court_hearings/create_in_nomis_spec.rb
+++ b/spec/services/court_hearings/create_in_nomis_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CourtHearings::CreateInNomis do
     let(:nomis_case_id) { 1_111_111 }
     let(:from_nomis_agency_id) { 'LEI' }
     let(:to_nomis_agency_id) { 'LEEDCC' }
-    let(:hearing_date_time) { Time.parse('2020-04-15T17:36:02+01:00') }
+    let(:hearing_date_time) { Time.zone.parse('2020-04-15T17:36:02+01:00') }
     let(:comments) { 'Restricted access to parking level.' }
     let(:booking_id) { 123 }
 


### PR DESCRIPTION
Allow tests to utilise timezones, as running tests from a different timezone is causing issues if these aren't set.