### PR TITLE
Add new `yoi` attribute to locations

### DIFF
--- a/app/controllers/api/reference/locations_controller.rb
+++ b/app/controllers/api/reference/locations_controller.rb
@@ -23,7 +23,7 @@ module Api
         render_json location, serializer: LocationSerializer, include: included_relationships, status: status
       end
 
-      PERMITTED_FILTER_PARAMS = %i[location_type nomis_agency_id supplier_id location_id region_id].freeze
+      PERMITTED_FILTER_PARAMS = %i[location_type nomis_agency_id supplier_id location_id region_id yoi].freeze
 
       def filter_params
         params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h

--- a/app/controllers/api/reference/locations_controller.rb
+++ b/app/controllers/api/reference/locations_controller.rb
@@ -23,7 +23,7 @@ module Api
         render_json location, serializer: LocationSerializer, include: included_relationships, status: status
       end
 
-      PERMITTED_FILTER_PARAMS = %i[location_type nomis_agency_id supplier_id location_id region_id yoi].freeze
+      PERMITTED_FILTER_PARAMS = %i[location_type nomis_agency_id supplier_id location_id region_id young_offender_institution].freeze
 
       def filter_params
         params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h

--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -10,7 +10,7 @@ class LocationSerializer
              :location_type,
              :nomis_agency_id,
              :can_upload_documents,
-             :yoi,
+             :young_offender_institution,
              :disabled_at
 
   has_many :suppliers

--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -10,6 +10,7 @@ class LocationSerializer
              :location_type,
              :nomis_agency_id,
              :can_upload_documents,
+             :yoi,
              :disabled_at
 
   has_many :suppliers

--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -35,7 +35,7 @@ module Locations
       scope = apply_supplier_filters(scope)
       scope = apply_location_filters(scope)
       scope = apply_region_filters(scope)
-      scope = apply_yoi_filters(scope)
+      scope = apply_young_offender_institution_filters(scope)
       scope
     end
 
@@ -60,9 +60,9 @@ module Locations
       scope
     end
 
-    def apply_yoi_filters(scope)
-      scope = scope.where(yoi: true) if filter_params[:yoi].to_s == 'true'
-      scope = scope.where(yoi: false) if filter_params[:yoi].to_s == 'false'
+    def apply_young_offender_institution_filters(scope)
+      scope = scope.where(young_offender_institution: true) if filter_params[:young_offender_institution].to_s == 'true'
+      scope = scope.where(young_offender_institution: false) if filter_params[:young_offender_institution].to_s == 'false'
       scope
     end
   end

--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -35,6 +35,7 @@ module Locations
       scope = apply_supplier_filters(scope)
       scope = apply_location_filters(scope)
       scope = apply_region_filters(scope)
+      scope = apply_yoi_filters(scope)
       scope
     end
 
@@ -56,6 +57,12 @@ module Locations
 
     def apply_region_filters(scope)
       scope = scope.joins(:regions).where(regions: { id: split_params(:region_id) }) if filter_params.key?(:region_id)
+      scope
+    end
+
+    def apply_yoi_filters(scope)
+      scope = scope.where(yoi: true) if filter_params[:yoi].to_s == 'true'
+      scope = scope.where(yoi: false) if filter_params[:yoi].to_s == 'false'
       scope
     end
   end

--- a/app/services/locations/updater.rb
+++ b/app/services/locations/updater.rb
@@ -5,8 +5,10 @@ module Locations
     YOI_NOMIS_AGENCIES = %w[WYI WNI CKI PRI FMI].freeze
 
     def self.call
-      Location.update_all(young_offender_institution: false)
-      Location.where(nomis_agency_id: YOI_NOMIS_AGENCIES).update_all(young_offender_institution: true)
+      Location.transaction do
+        Location.update_all(young_offender_institution: false)
+        Location.where(nomis_agency_id: YOI_NOMIS_AGENCIES).update_all(young_offender_institution: true)
+      end
     end
   end
 end

--- a/app/services/locations/updater.rb
+++ b/app/services/locations/updater.rb
@@ -5,8 +5,8 @@ module Locations
     YOI_NOMIS_AGENCIES = %w[WYI WNI CKI PRI FMI].freeze
 
     def self.call
-      Location.update_all(yoi: false)
-      Location.where(nomis_agency_id: YOI_NOMIS_AGENCIES).update_all(yoi: true)
+      Location.update_all(young_offender_institution: false)
+      Location.where(nomis_agency_id: YOI_NOMIS_AGENCIES).update_all(young_offender_institution: true)
     end
   end
 end

--- a/app/services/locations/updater.rb
+++ b/app/services/locations/updater.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Locations
+  class Updater
+    YOI_NOMIS_AGENCIES = %w[WYI WNI CKI PRI FMI].freeze
+
+    def self.call
+      Location.update_all(yoi: false)
+      Location.where(nomis_agency_id: YOI_NOMIS_AGENCIES).update_all(yoi: true)
+    end
+  end
+end

--- a/db/migrate/20201210180043_add_yoi_to_locations.rb
+++ b/db/migrate/20201210180043_add_yoi_to_locations.rb
@@ -1,0 +1,6 @@
+class AddYoiToLocations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :locations, :yoi, :boolean, default: false
+    add_index :locations, :yoi
+  end
+end

--- a/db/migrate/20201210180043_add_yoi_to_locations.rb
+++ b/db/migrate/20201210180043_add_yoi_to_locations.rb
@@ -1,6 +1,6 @@
 class AddYoiToLocations < ActiveRecord::Migration[6.0]
   def change
-    add_column :locations, :yoi, :boolean, default: false
-    add_index :locations, :yoi
+    add_column :locations, :young_offender_institution, :boolean, default: false
+    add_index :locations, :young_offender_institution
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -322,9 +322,9 @@ ActiveRecord::Schema.define(version: 2020_12_10_180043) do
     t.datetime "disabled_at"
     t.boolean "can_upload_documents", default: false, null: false
     t.uuid "category_id"
-    t.boolean "yoi", default: false
+    t.boolean "young_offender_institution", default: false
     t.index ["category_id"], name: "index_locations_on_category_id"
-    t.index ["yoi"], name: "index_locations_on_yoi"
+    t.index ["young_offender_institution"], name: "index_locations_on_young_offender_institution"
   end
 
   create_table "locations_regions", id: false, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_10_135224) do
+ActiveRecord::Schema.define(version: 2020_12_10_180043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -322,7 +322,9 @@ ActiveRecord::Schema.define(version: 2020_12_10_135224) do
     t.datetime "disabled_at"
     t.boolean "can_upload_documents", default: false, null: false
     t.uuid "category_id"
+    t.boolean "yoi", default: false
     t.index ["category_id"], name: "index_locations_on_category_id"
+    t.index ["yoi"], name: "index_locations_on_yoi"
   end
 
   create_table "locations_regions", id: false, force: :cascade do |t|

--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -17,6 +17,9 @@ namespace :reference_data do
 
     puts "DISABLED LOCATIONS (#{importer.disabled_locations.length}):"
     puts importer.disabled_locations.sort.join(', ')
+
+    puts 'Updating locations...'
+    Locations::Updater.call
   end
 
   desc 'update locations'

--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -19,6 +19,12 @@ namespace :reference_data do
     puts importer.disabled_locations.sort.join(', ')
   end
 
+  desc 'update locations'
+  task update_locations: :environment do
+    puts 'Updating locations...'
+    Locations::Updater.call
+  end
+
   desc 'create ethnicities'
   task create_ethnicities: :environment do
     Ethnicities::Importer.new(NomisClient::Ethnicities.get).call

--- a/spec/requests/api/reference/locations_controller_spec.rb
+++ b/spec/requests/api/reference/locations_controller_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Api::Reference::LocationsController do
     describe 'filters' do
       let!(:supplier) { create :supplier }
       let!(:location) { create :location, suppliers: [supplier] }
-      let(:filters) { { location_type: 'prison', nomis_agency_id: 'PEI', supplier_id: supplier.id, yoi: nil } }
+      let(:filters) { { location_type: 'prison', nomis_agency_id: 'PEI', supplier_id: supplier.id, young_offender_institution: nil } }
       let(:params) { { filter: filters } }
 
       before do
@@ -177,7 +177,7 @@ RSpec.describe Api::Reference::LocationsController do
             location_type: location.location_type,
             nomis_agency_id: location.nomis_agency_id,
             supplier_id: supplier.id,
-            yoi: nil,
+            young_offender_institution: nil,
           },
           active_record_relationships: nil,
         )
@@ -200,7 +200,7 @@ RSpec.describe Api::Reference::LocationsController do
           title: 'HMP Pentonville',
           location_type: 'prison',
           nomis_agency_id: 'PEI',
-          yoi: false,
+          young_offender_institution: false,
         },
       }
     end

--- a/spec/requests/api/reference/locations_controller_spec.rb
+++ b/spec/requests/api/reference/locations_controller_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Api::Reference::LocationsController do
     describe 'filters' do
       let!(:supplier) { create :supplier }
       let!(:location) { create :location, suppliers: [supplier] }
-      let(:filters) { { location_type: 'prison', nomis_agency_id: 'PEI', supplier_id: supplier.id } }
+      let(:filters) { { location_type: 'prison', nomis_agency_id: 'PEI', supplier_id: supplier.id, yoi: nil } }
       let(:params) { { filter: filters } }
 
       before do
@@ -177,6 +177,7 @@ RSpec.describe Api::Reference::LocationsController do
             location_type: location.location_type,
             nomis_agency_id: location.nomis_agency_id,
             supplier_id: supplier.id,
+            yoi: nil,
           },
           active_record_relationships: nil,
         )
@@ -199,6 +200,7 @@ RSpec.describe Api::Reference::LocationsController do
           title: 'HMP Pentonville',
           location_type: 'prison',
           nomis_agency_id: 'PEI',
+          yoi: false,
         },
       }
     end

--- a/spec/serializers/location_serializer_spec.rb
+++ b/spec/serializers/location_serializer_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe LocationSerializer do
     expect(attributes[:nomis_agency_id]).to eql 'PEI'
   end
 
+  it 'contains a yoi attribute' do
+    expect(attributes[:yoi]).to eql location.yoi
+  end
+
   it 'contains a disabled_at attribute' do
     expect(attributes[:disabled_at]).to eql disabled_at.iso8601
   end

--- a/spec/serializers/location_serializer_spec.rb
+++ b/spec/serializers/location_serializer_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe LocationSerializer do
     expect(attributes[:nomis_agency_id]).to eql 'PEI'
   end
 
-  it 'contains a yoi attribute' do
-    expect(attributes[:yoi]).to eql location.yoi
+  it 'contains a young_offender_institution attribute' do
+    expect(attributes[:young_offender_institution]).to eql location.young_offender_institution
   end
 
   it 'contains a disabled_at attribute' do

--- a/spec/services/locations/finder_spec.rb
+++ b/spec/services/locations/finder_spec.rb
@@ -57,6 +57,32 @@ RSpec.describe Locations::Finder do
         expect(location_finder.call.pluck(:id)).to contain_exactly(location1.id)
       end
     end
+
+    context 'with yoi true' do
+      let(:filter_params) { { yoi: true } }
+
+      before do
+        create(:location, yoi: true, title: 'YOI Location')
+        create(:location, yoi: false, title: 'Non YOI')
+      end
+
+      it 'returns YOI only locations' do
+        expect(location_finder.call.pluck(:title)).to contain_exactly('YOI Location')
+      end
+    end
+
+    context 'with yoi false' do
+      let(:filter_params) { { yoi: false } }
+
+      before do
+        create(:location, yoi: true, title: 'YOI Location')
+        create(:location, yoi: false, title: 'Non YOI')
+      end
+
+      it 'returns YOI only locations' do
+        expect(location_finder.call.pluck(:title)).to contain_exactly('Non YOI')
+      end
+    end
   end
 
   describe 'sorting' do

--- a/spec/services/locations/finder_spec.rb
+++ b/spec/services/locations/finder_spec.rb
@@ -58,12 +58,12 @@ RSpec.describe Locations::Finder do
       end
     end
 
-    context 'with yoi true' do
-      let(:filter_params) { { yoi: true } }
+    context 'with young_offender_institution true' do
+      let(:filter_params) { { young_offender_institution: true } }
 
       before do
-        create(:location, yoi: true, title: 'YOI Location')
-        create(:location, yoi: false, title: 'Non YOI')
+        create(:location, young_offender_institution: true, title: 'YOI Location')
+        create(:location, young_offender_institution: false, title: 'Non YOI')
       end
 
       it 'returns YOI only locations' do
@@ -71,12 +71,12 @@ RSpec.describe Locations::Finder do
       end
     end
 
-    context 'with yoi false' do
-      let(:filter_params) { { yoi: false } }
+    context 'with young_offender_institution false' do
+      let(:filter_params) { { young_offender_institution: false } }
 
       before do
-        create(:location, yoi: true, title: 'YOI Location')
-        create(:location, yoi: false, title: 'Non YOI')
+        create(:location, young_offender_institution: true, title: 'YOI Location')
+        create(:location, young_offender_institution: false, title: 'Non YOI')
       end
 
       it 'returns YOI only locations' do

--- a/spec/services/locations/updater_spec.rb
+++ b/spec/services/locations/updater_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Locations::Updater do
+  subject(:updater) { described_class.call }
+
+  context 'with yoi locations' do
+    it 'leaves existing YOI locations unchanged' do
+      existing_yoi = create(:location, yoi: true, nomis_agency_id: 'WYI')
+      updater
+      expect(existing_yoi.reload.yoi).to eq true
+    end
+
+    it 'clears flag on retired YOI locations' do
+      retired_yoi = create(:location, yoi: true, nomis_agency_id: 'FOO')
+      updater
+      expect(retired_yoi.reload.yoi).to eq false
+    end
+
+    it 'sets flag on new retired YOI locations' do
+      new_yoi = create(:location, yoi: false, nomis_agency_id: 'WNI')
+      updater
+      expect(new_yoi.reload.yoi).to eq true
+    end
+
+    it 'leaves existing non YOI locations unchanged' do
+      non_yoi = create(:location, yoi: false, nomis_agency_id: 'BAR')
+      updater
+      expect(non_yoi.reload.yoi).to eq false
+    end
+  end
+end

--- a/spec/services/locations/updater_spec.rb
+++ b/spec/services/locations/updater_spec.rb
@@ -5,29 +5,29 @@ require 'rails_helper'
 RSpec.describe Locations::Updater do
   subject(:updater) { described_class.call }
 
-  context 'with yoi locations' do
+  context 'with young_offender_institution locations' do
     it 'leaves existing YOI locations unchanged' do
-      existing_yoi = create(:location, yoi: true, nomis_agency_id: 'WYI')
+      existing_young_offender_institution = create(:location, young_offender_institution: true, nomis_agency_id: 'WYI')
       updater
-      expect(existing_yoi.reload.yoi).to eq true
+      expect(existing_young_offender_institution.reload.young_offender_institution).to eq true
     end
 
     it 'clears flag on retired YOI locations' do
-      retired_yoi = create(:location, yoi: true, nomis_agency_id: 'FOO')
+      retired_young_offender_institution = create(:location, young_offender_institution: true, nomis_agency_id: 'FOO')
       updater
-      expect(retired_yoi.reload.yoi).to eq false
+      expect(retired_young_offender_institution.reload.young_offender_institution).to eq false
     end
 
     it 'sets flag on new retired YOI locations' do
-      new_yoi = create(:location, yoi: false, nomis_agency_id: 'WNI')
+      new_young_offender_institution = create(:location, young_offender_institution: false, nomis_agency_id: 'WNI')
       updater
-      expect(new_yoi.reload.yoi).to eq true
+      expect(new_young_offender_institution.reload.young_offender_institution).to eq true
     end
 
     it 'leaves existing non YOI locations unchanged' do
-      non_yoi = create(:location, yoi: false, nomis_agency_id: 'BAR')
+      non_young_offender_institution = create(:location, young_offender_institution: false, nomis_agency_id: 'BAR')
       updater
-      expect(non_yoi.reload.yoi).to eq false
+      expect(non_young_offender_institution.reload.young_offender_institution).to eq false
     end
   end
 end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -3366,7 +3366,7 @@
             type: string
           format: uuid
           example: 950ef512-a25f-46d7-8ced-7ad09510659b
-        - name: filter[yoi]
+        - name: filter[young_offender_institution]
           in: query
           explode: false
           description: Filters results to only include (when true) or exclude (when false) Youth Offender Institutions

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -3366,6 +3366,13 @@
             type: string
           format: uuid
           example: 950ef512-a25f-46d7-8ced-7ad09510659b
+        - name: filter[yoi]
+          in: query
+          explode: false
+          description: Filters results to only include (when true) or exclude (when false) Youth Offender Institutions
+          schema:
+            type: boolean
+            example: false
         - "$ref": "../v1/location_include_parameter.yaml#/LocationIncludeParameter"
       responses:
         "200":

--- a/swagger/v1/location.yaml
+++ b/swagger/v1/location.yaml
@@ -51,6 +51,10 @@ Location:
           type: string
           example: BAI
           description: The NOMIS `agency_id`, for prisons this is a 3-letter code
+        yoi:
+          type: boolean
+          example: false
+          description: Indicates that the location is a Youth Offenders Institute (note that some locations may have mixed populations so have a differing location type).
         disabled_at:
           oneOf:
           - type: string

--- a/swagger/v1/location.yaml
+++ b/swagger/v1/location.yaml
@@ -51,7 +51,7 @@ Location:
           type: string
           example: BAI
           description: The NOMIS `agency_id`, for prisons this is a 3-letter code
-        yoi:
+        young_offender_institution:
           type: boolean
           example: false
           description: Indicates that the location is a Youth Offenders Institute (note that some locations may have mixed populations so have a differing location type).


### PR DESCRIPTION
### Jira link

P4-2374

### What?

- [x] Add new boolean `yoi` flag to `Location` model
- [x] Include new attribute in serialized locations
- [x] Support `filter[yoi]=false` and `filter[yoi]=true` when fetching a list of locations
- [x] Add new rake task `reference_data:update_locations` to correctly set new flag values

### Why?

- Some institutions have YOI as well as adult populations. Within Nomis these are generally held with the prison location type, which means we can't perform YOI specific logic. In an effort to avoid these data issues from Nomis, the new attribute of YOI can be applied independently of the location type and is used to identify the 5 current YOI locations. The rake task and update service sets the correct YOI value for these known locations. `Locations::Finder service` has been extended to support filtering with/without this attribute to allow the front end to get a list of relevant YOI locations from the reference data end point. Finally the `LocationSerializer` now includes the new attribute.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Introduces a new attribute in the serialized locations, so has a knock on effect to various endpoints but will be backwards compatible as it's a new attribute. Suppliers will need to be informed of this addition.
