### PR TITLE
Update metadata for location free spaces endpoint

### DIFF
--- a/app/models/population.rb
+++ b/app/models/population.rb
@@ -35,9 +35,14 @@ class Population < ApplicationRecord
     {}.tap do |locations_hash|
       date_range.each do |date|
         free_spaces_for_date(locations, date).each do |row|
-          location_id, population_id, free_spaces = *row
+          location_id, population_id, transfers_in, transfers_out, free_spaces_excluding_transfers = *row
 
-          free_space_details = { id: population_id, free_spaces: free_spaces } if population_id.present?
+          free_space_details = {
+            id: population_id,
+            free_spaces: (free_spaces_excluding_transfers - transfers_in + transfers_out if population_id.present?),
+            transfers_in: transfers_in,
+            transfers_out: transfers_out,
+          }
 
           locations_hash[location_id] = [] unless locations_hash.key?(location_id)
           locations_hash[location_id] << free_space_details
@@ -50,14 +55,12 @@ class Population < ApplicationRecord
     locations
       # Join with matching populations for location and given date (if any). Can't use a where clause as there may not be a population record
       .joins(sanitize_sql(['LEFT OUTER JOIN populations p ON p.location_id = locations.id AND p.date = :date', date: date]))
-      # Join with matching (non cancelled) prison transfers to the location on the given date (if any) so we can count them
-      .joins("LEFT OUTER JOIN moves moves_in ON moves_in.to_location_id = locations.id AND moves_in.move_type = 'prison_transfer' AND moves_in.status <> 'cancelled' AND moves_in.date = p.date")
-      # Join with matching (non cancelled) prison transfers from the location on the given date (if any) so we can count them
-      .joins("LEFT OUTER JOIN moves moves_out ON moves_out.from_location_id = locations.id AND moves_out.move_type = 'prison_transfer' AND moves_out.status <> 'cancelled' AND moves_out.date = p.date")
+      # Join with matching (non cancelled) prison transfers on the given date (if any) so we can count them
+      .joins(sanitize_sql(["LEFT OUTER JOIN moves m ON m.move_type = 'prison_transfer' AND m.status <> 'cancelled' AND m.date = :date", date: date]))
       # Group by columns used in the free space calculation
-      .group(:id, :'p.id', :usable_capacity, :unlock, :bedwatch, :overnights_in, :overnights_out, :out_of_area_courts, :discharges)
+      .group(:id, :'p.id')
       # Need to wrap derived columns in pointless Arel.sql call to resolve annoying deprecation warning, even though this is safe :(
-      .pluck(Arel.sql('locations.id, p.id, usable_capacity - unlock - bedwatch - overnights_in - count(moves_in) + overnights_out + out_of_area_courts + discharges + count(moves_out) as free_space'))
+      .pluck(Arel.sql('locations.id, p.id, COUNT(m.id) FILTER (WHERE m.to_location_id = locations.id) AS transfers_in, COUNT(m.id) FILTER (WHERE m.from_location_id = locations.id) AS transfers_out, usable_capacity - unlock - bedwatch - overnights_in + overnights_out + out_of_area_courts + discharges AS free_space_excluding_transfers'))
   end
 
   private_class_method :free_spaces_for_date

--- a/spec/models/population_spec.rb
+++ b/spec/models/population_spec.rb
@@ -154,9 +154,12 @@ RSpec.describe Population do
   describe '.free_spaces_date_range' do
     let!(:prison1) { create(:location, :prison) }
     let!(:prison2) { create(:location, :prison) }
-    let!(:move1) { create(:move, :prison_transfer, from_location: prison1, date: Date.today) }
-    let!(:move2) { create(:move, :prison_transfer, to_location: prison2, date: Date.today) }
-    let!(:move3) { create(:move, :prison_transfer, from_location: prison1, date: Date.tomorrow) }
+    let!(:move1) { create(:move, :prison_transfer, from_location: prison1, date: Date.yesterday) }
+    let!(:move2) { create(:move, :prison_transfer, from_location: prison1, date: Date.yesterday) }
+    let!(:move3) { create(:move, :prison_transfer, to_location: prison1, date: Date.yesterday) }
+    let!(:move4) { create(:move, :prison_transfer, from_location: prison1, date: Date.today) }
+    let!(:move5) { create(:move, :prison_transfer, to_location: prison2, date: Date.today) }
+    let!(:move6) { create(:move, :prison_transfer, from_location: prison1, date: Date.tomorrow) }
     let!(:population1) { create(:population, location: prison1, date: Date.today) } # Included
     let!(:population2) { create(:population, location: prison2, date: Date.today) } # Included
     let!(:population3) { create(:population, location: prison1, date: Date.tomorrow) } # Included
@@ -168,25 +171,45 @@ RSpec.describe Population do
     let(:expected_hash) do
       {
         prison1.id => [
-          nil, # No population data for yesterday
+          {
+            # No population data for yesterday
+            free_spaces: nil,
+            id: nil,
+            transfers_in: 1,
+            transfers_out: 2,
+          },
           {
             free_spaces: population1.free_spaces,
             id: population1.id,
+            transfers_in: 0,
+            transfers_out: 1,
           },
           {
             free_spaces: population3.free_spaces,
             id: population3.id,
+            transfers_in: 0,
+            transfers_out: 1,
           },
         ],
         prison2.id => [
-          nil, # No population data for yesterday
+          {
+            # No population data for yesterday
+            free_spaces: nil,
+            id: nil,
+            transfers_in: 0,
+            transfers_out: 0,
+          },
           {
             free_spaces: population2.free_spaces,
             id: population2.id,
+            transfers_in: 1,
+            transfers_out: 0,
           },
           {
             free_spaces: population4.free_spaces,
             id: population4.id,
+            transfers_in: 0,
+            transfers_out: 0,
           },
         ],
       }

--- a/spec/requests/api/populations_controller_index_spec.rb
+++ b/spec/requests/api/populations_controller_index_spec.rb
@@ -40,8 +40,15 @@ RSpec.describe Api::PopulationsController do
                   {
                     "id": population.id,
                     "free_spaces": population.free_spaces,
+                    "transfers_in": 0,
+                    "transfers_out": 0,
                   },
-                  nil,
+                  {
+                    "id": nil,
+                    "free_spaces": nil,
+                    "transfers_in": 0,
+                    "transfers_out": 0,
+                  },
                 ],
               },
             },


### PR DESCRIPTION
### Jira link

P4-2566

### What?

- [x] Revised `Population` metadata generation to return location free spaces to separately include transfer in and out counts

### Why?

- This now includes a count of transfers (moves) in and out as distinct keys in the metadata, so this necessitated a slight change in the behaviour. Previously if a population model was not present for a given date and location then the corresponding hash value was `nil`. With this change the hash is always generated so that `transfers_in` and `transfers_out` can be populated, but `id` and `free_spaces` keys will be `nil`.

- This allows the PMU dashboard to be updated in the front end so that transfer counts can be shown even if there is not yet a corresponding population record. As the behaviour of the generated metadata is amended this is a breaking change so will need to be released in coordination with the front end, however this is not yet a production feature.

### Have you? (optional)

- [ ] Updated API docs if necessary - This endpoint is intentionally undocumented as it's intended for front end use only

### Deployment risks (optional)

- Changes an api that is used in production (but currently sits behind a feature flag in the front end). No impact on suppliers.

