### PR TITLE
P4-2461 adding category to profile serializer

### DIFF
--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -39,6 +39,7 @@ module V2
 
     SUPPORTED_RELATIONSHIPS = %w[
       profile.documents
+      profile.category
       profile.person.ethnicity
       profile.person.gender
       profile.person_escort_record

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -30,6 +30,7 @@ module V2
     }.freeze
 
     SUPPORTED_RELATIONSHIPS = %w[
+      profile.category
       profile.person
       profile.person.ethnicity
       profile.person.gender

--- a/app/serializers/v2/profile_serializer.rb
+++ b/app/serializers/v2/profile_serializer.rb
@@ -8,9 +8,10 @@ class V2::ProfileSerializer
   attributes :requires_youth_risk_assessment, :assessment_answers
 
   belongs_to :person, serializer: ::V2::PersonSerializer
+  belongs_to :category, serializer: CategorySerializer
   has_many :documents, serializer: DocumentSerializer
   has_one :person_escort_record, serializer: PersonEscortRecordSerializer
   has_one :youth_risk_assessment, serializer: YouthRiskAssessmentSerializer
 
-  SUPPORTED_RELATIONSHIPS = %w[documents person person_escort_record youth_risk_assessment].freeze
+  SUPPORTED_RELATIONSHIPS = %w[documents category person person_escort_record youth_risk_assessment].freeze
 end

--- a/app/serializers/v2/profiles_serializer.rb
+++ b/app/serializers/v2/profiles_serializer.rb
@@ -8,6 +8,7 @@ class V2::ProfilesSerializer
 
   attributes :assessment_answers
 
+  belongs_to :category, serializer: CategorySerializer
   belongs_to :person, serializer: ::V2::PersonSerializer
 
   has_one_if_included :person_escort_record, serializer: PersonEscortRecordsSerializer

--- a/spec/serializers/v2/profiles_serializer_spec.rb
+++ b/spec/serializers/v2/profiles_serializer_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe V2::ProfilesSerializer do
           person: {
             data: { id: profile.person.id, type: 'people' },
           },
+          category: {
+            data: nil,
+          },
         },
       },
     }
@@ -58,7 +61,9 @@ RSpec.describe V2::ProfilesSerializer do
   end
 
   context 'with included person escort record' do
-    let(:options) { { params: { included: %i[person_escort_record] } } }
+    let(:options) { { params: { included: %i[person_escort_record category] } } }
+    let(:category) { create(:category) }
+    let(:profile) { create(:profile, category: category) }
 
     it 'contains a nil `person_escort_record` relationship if no person escort record present' do
       expect(result[:data][:relationships][:person_escort_record][:data]).to be_nil
@@ -70,6 +75,13 @@ RSpec.describe V2::ProfilesSerializer do
       expect(result[:data][:relationships][:person_escort_record][:data]).to eq({
         id: person_escort_record.id,
         type: 'person_escort_records',
+      })
+    end
+
+    it 'contains a`category` relationship with category record' do
+      expect(result[:data][:relationships][:category][:data]).to eq({
+        id: category.id,
+        type: 'categories',
       })
     end
   end

--- a/swagger/v1/profile.yaml
+++ b/swagger/v1/profile.yaml
@@ -43,3 +43,6 @@ Profile:
         youth_risk_assessment:
           $ref: youth_risk_assessment_reference.yaml#/YouthRiskAssessmentReference
           description: The youth_risk_assessment associated with this Move
+        category:
+          $ref: ../v2/category_reference.yaml#/CategoryReference
+          description: The recorded prisoner category associated with this Move

--- a/swagger/v1/profile_include_parameter.yaml
+++ b/swagger/v1/profile_include_parameter.yaml
@@ -9,4 +9,5 @@ ProfileIncludeParameter:
     enum:
       - documents
       - person
+      - category
   example: documents

--- a/swagger/v2/category_reference.yaml
+++ b/swagger/v2/category_reference.yaml
@@ -1,0 +1,27 @@
+CategoryReference:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      oneOf:
+        - type: object
+        - type: array
+        - type: "null"
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          example: categories
+          enum:
+            - categories
+          description: The type of this object - always `categories`
+        id:
+          type: string
+          format: uuid
+          example: c8415c5a-1e16-4fbd-9b03-54b27089bb1a
+          description:
+            The unique identifier (UUID) of the object that this reference
+            points to

--- a/swagger/v2/move_include_parameter.yaml
+++ b/swagger/v2/move_include_parameter.yaml
@@ -15,6 +15,7 @@ MoveIncludeParameter:
       - to_location
       - supplier
       - profile.documents
+      - profile.category
       - profile.person
       - profile.person.gender
       - profile.person.ethnicity

--- a/swagger/v2/moves_include_parameter.yaml
+++ b/swagger/v2/moves_include_parameter.yaml
@@ -9,6 +9,7 @@ MovesIncludeParameter:
     enum:
       - from_location
       - prison_transfer_reason
+      - profile.category
       - profile.person
       - profile.person.ethnicity
       - profile.person.gender


### PR DESCRIPTION
### Jira link

P4-<2461>

### What?

I have added/removed/altered:

- [x] Added category to profile serializer and profiles serializer
- [x] Updated swagger docs

### Why?

I am doing this because:

- in order to present a prisoner's category when viewing a move's details


### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- minimal

cc @solidgoldpig 
