### PR TITLE
P4-2537 Surface journeys through moves endpoint

### DIFF
--- a/app/serializers/v2/journeys_serializer.rb
+++ b/app/serializers/v2/journeys_serializer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module V2
+  class JourneysSerializer
+    include JSONAPI::Serializer
+
+    set_type :journeys
+
+    attributes :state, :billable, :vehicle
+    attribute :timestamp, &:client_timestamp
+  end
+end

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -41,6 +41,7 @@ module V2
       prison_transfer_reason
       supplier
       important_events
+      journeys
     ].freeze
 
     belongs_to :from_location, serializer: ::LocationSerializer
@@ -51,5 +52,6 @@ module V2
     belongs_to :allocation, serializer: AllocationSerializer
 
     has_many_if_included :important_events, serializer: ImportantEventsSerializer, &:important_events
+    has_many_if_included :journeys, serializer: V2::JourneysSerializer
   end
 end

--- a/spec/serializers/v2/journeys_serializer_spec.rb
+++ b/spec/serializers/v2/journeys_serializer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V2::JourneysSerializer do
+  subject(:serializer) { described_class.new(journey, adapter_options) }
+
+  let(:journey) { create :journey, client_timestamp: '2020-05-04T08:00:00Z' }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:adapter_options) { {} }
+
+  it 'contains a type property' do
+    expect(result[:data][:type]).to eql 'journeys'
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eql journey.id
+  end
+
+  it 'contains a `billable` attribute' do
+    expect(result[:data][:attributes][:billable]).to be false
+  end
+
+  it 'contains a `state` attribute' do
+    expect(result[:data][:attributes][:state]).to eql 'proposed'
+  end
+
+  it 'contains a `timestamp` attribute' do
+    expect(result[:data][:attributes][:timestamp]).to eql '2020-05-04T09:00:00+01:00'
+  end
+
+  it 'contains vehicle attributes' do
+    expect(result[:data][:attributes][:vehicle]).to eql(id: '12345678ABC', registration: 'AB12 CDE')
+  end
+end

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -52,17 +52,18 @@ RSpec.describe V2::MovesSerializer do
     let(:options) do
       {
         include: described_class::SUPPORTED_RELATIONSHIPS,
-        params: { included: %i[person_escort_record flags] },
+        params: { included: %i[person_escort_record flags journeys] },
       }
     end
 
     let!(:person_escort_record) { create(:person_escort_record, move: move, profile: move.profile) }
     let!(:flag) { create(:framework_flag) }
     let!(:response) { create(:string_response, assessmentable: person_escort_record, framework_flags: [flag]) }
+    let!(:journey) { create(:journey, move: move) }
 
     it 'contains all included relationships' do
       expect(result[:included].map { |r| r[:type] })
-        .to match_array(%w[people ethnicities genders locations locations profiles prison_transfer_reasons suppliers person_escort_records framework_flags])
+        .to match_array(%w[people ethnicities genders locations locations profiles prison_transfer_reasons suppliers person_escort_records framework_flags journeys])
     end
   end
 end

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -146,3 +146,6 @@ Move:
         timeline_events:
           $ref: "../v1/event_reference.yaml#/EventReference"
           description: Aliased events about this record and its nested relationships
+        journeys:
+          $ref: "../v1/journey_reference.yaml#/JourneyReference"
+          description: The journeys associated with this move

--- a/swagger/v2/moves_include_parameter.yaml
+++ b/swagger/v2/moves_include_parameter.yaml
@@ -18,4 +18,5 @@ MovesIncludeParameter:
       - supplier
       - to_location
       - important_events
+      - journeys
   example: from_location


### PR DESCRIPTION
### Jira link

[P4-2537](https://dsdmoj.atlassian.net/browse/P4-2537)

### What?

- Added optional journeys to moves endpoint relationships
- Added lightweight journeys serializer

### Why?

Add an optional journeys relationship to the moves endpoint, which surfaces a journey's attributes including the vehicle registration number which is required for the dashboards on the FE application. Adding a journeys relationship rather than a meta section means we can optionally include this when required, rather than always rendering a meta section, which will always have to load the journeys. However this means that the FE will need to look for the latest journey for a move. 

Only concern is the number of journeys that come back, as that might impact render time due to view serialisation, however the query time is quite fast.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

