### PR TITLE
P4-2537 Add metadata section to moves resource

### DIFF
--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -1,10 +1,9 @@
 module Api::V2
   module MovesActions
     def index_and_render
-      paginate moves,
-               serializer: ::V2::MovesSerializer,
-               include: included_relationships,
-               fields: ::V2::MovesSerializer::INCLUDED_FIELDS
+      paginate moves, serializer: ::V2::MovesSerializer, include: included_relationships, fields: ::V2::MovesSerializer::INCLUDED_FIELDS do |_, options|
+        options[:params] = { vehicle_registration: meta_fields&.include?('vehicle_registration') }
+      end
     end
 
     def show_and_render

--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -2,7 +2,7 @@ module Api::V2
   module MovesActions
     def index_and_render
       paginate moves, serializer: ::V2::MovesSerializer, include: included_relationships, fields: ::V2::MovesSerializer::INCLUDED_FIELDS do |_, options|
-        options[:params] = { vehicle_registration: meta_fields&.include?('vehicle_registration') }
+        options[:params] = { vehicle_registration: meta_fields.include?('vehicle_registration') }
       end
     end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -262,6 +262,10 @@ private
     @included_relationships ||= include_params_handler.included_relationships
   end
 
+  def meta_fields
+    @meta_fields ||= include_params_handler.meta_fields
+  end
+
   def active_record_relationships
     @active_record_relationships ||= include_params_handler.active_record_relationships
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -263,7 +263,7 @@ private
   end
 
   def meta_fields
-    @meta_fields ||= include_params_handler.meta_fields
+    @meta_fields ||= include_params_handler.meta_fields || []
   end
 
   def active_record_relationships

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -216,7 +216,12 @@ class Move < VersionedModel
   end
 
   def vehicle_registration
-    journeys.max_by(&:client_timestamp)&.vehicle&.dig('registration')
+    # Process in memory to avoid n+1 queries in serializers
+    journeys
+      .reject(&:cancelled?)
+      .max_by(&:client_timestamp)
+      &.vehicle
+      &.dig('registration')
   end
 
 private

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -215,6 +215,10 @@ class Move < VersionedModel
     incident_events + (profile&.person_escort_record&.medical_events || [])
   end
 
+  def vehicle_registration
+    journeys.max_by(&:client_timestamp)&.vehicle&.dig('registration')
+  end
+
 private
 
   def date_to_after_date_from

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -24,10 +24,9 @@ module V2
     set_type :moves
 
     meta do |object, params|
-      metadata = {}
-
-      metadata.merge!(vehicle_registration: object.vehicle_registration) if params[:vehicle_registration]
-      metadata
+      {}.tap do |metadata|
+        metadata.merge!(vehicle_registration: object.vehicle_registration) if params[:vehicle_registration]
+      end
     end
 
     INCLUDED_FIELDS = {

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -23,6 +23,13 @@ module V2
 
     set_type :moves
 
+    meta do |object, params|
+      metadata = {}
+
+      metadata.merge!(vehicle_registration: object.vehicle_registration) if params[:vehicle_registration]
+      metadata
+    end
+
     INCLUDED_FIELDS = {
       # TODO: remove these and replace with conditional relationships in relevant serializer
       people: ::V2::PersonSerializer.attributes_to_serialize.keys + %i[gender ethnicity],

--- a/app/services/include_param_handler.rb
+++ b/app/services/include_param_handler.rb
@@ -9,11 +9,19 @@ class IncludeParamHandler
     @params[:include]&.split(SEPARATOR)
   end
 
+  def meta_fields
+    @params[:meta]&.split(SEPARATOR)
+  end
+
   def active_record_relationships
-    @active_record_relationships ||= included_relationships.map { |value| to_active_record_include_hash(value) } if included_relationships.present?
+    @active_record_relationships ||= relationships_and_fields.map { |value| to_active_record_include_hash(value) } if relationships_and_fields.present?
   end
 
 private
+
+  def relationships_and_fields
+    included_relationships.to_a + meta_fields.to_a
+  end
 
   def to_active_record_include_hash(value)
     parts = value.split('.', 2)
@@ -39,6 +47,8 @@ private
       :generic_events
     when 'important_events'
       { incident_events: {}, profile: { person_escort_record: :medical_events } }
+    when 'vehicle_registration'
+      :journeys
     else
       name.to_sym
     end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -798,4 +798,32 @@ RSpec.describe Move do
       end
     end
   end
+
+  describe '#vehicle_registration' do
+    it 'returns nothing if no journeys present' do
+      move = create(:move)
+
+      expect(move.vehicle_registration).to be_nil
+    end
+
+    it 'returns nothing if a journey is present but no vehicle registration available' do
+      move = create(:move, journeys: [create(:journey, vehicle: {})])
+
+      expect(move.vehicle_registration).to be_nil
+    end
+
+    it 'returns the vehicle registration number of a journey' do
+      move = create(:move, :with_journey)
+
+      expect(move.vehicle_registration).to eq('AB12 CDE')
+    end
+
+    it 'returns the latest vehicle registration number if multiple journeys present' do
+      journey1 = create(:journey, client_timestamp: Time.zone.now - 1.day, vehicle: { id: '12345', registration: 'AB12 CDE' })
+      journey2 = create(:journey, client_timestamp: Time.zone.now - 2.days, vehicle: { id: '6789', registration: 'CD12 ABC' })
+      move = create(:move, journeys: [journey1, journey2])
+
+      expect(move.vehicle_registration).to eq('AB12 CDE')
+    end
+  end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -825,5 +825,13 @@ RSpec.describe Move do
 
       expect(move.vehicle_registration).to eq('AB12 CDE')
     end
+
+    it 'returns latest vehicle registration for uncancelled journeys' do
+      journey1 = create(:journey, :cancelled, client_timestamp: Time.zone.now - 1.day, vehicle: { id: '12345', registration: 'AB12 CDE' })
+      journey2 = create(:journey, client_timestamp: Time.zone.now - 2.days, vehicle: { id: '6789', registration: 'CD12 ABC' })
+      move = create(:move, journeys: [journey1, journey2])
+
+      expect(move.vehicle_registration).to eq('CD12 ABC')
+    end
   end
 end

--- a/spec/requests/api/moves_controller_index_v2_spec.rb
+++ b/spec/requests/api/moves_controller_index_v2_spec.rb
@@ -209,6 +209,36 @@ RSpec.describe Api::MovesController do
         end
       end
     end
+
+    describe 'meta fields' do
+      let!(:moves) do
+        create_list(
+          :move,
+          1,
+          :with_journey,
+        )
+      end
+
+      before { do_get(query_params) }
+
+      context 'when not including the meta query param' do
+        let(:query_params) { '' }
+
+        it 'returns an empty meta section' do
+          move = response_json['data'].first
+          expect(move['meta']).to be_empty
+        end
+      end
+
+      context 'when including the meta query param' do
+        let(:query_params) { '?meta=vehicle_registration' }
+
+        it 'includes the requested meta fields in the response' do
+          move = response_json['data'].first
+          expect(move['meta']).to eq('vehicle_registration' => 'AB12 CDE')
+        end
+      end
+    end
   end
 
   def do_get(query_params = nil)

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe V2::MovesSerializer do
 
   let(:move) { create :move, :prison_transfer }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:meta) { result[:data][:meta] }
 
   context 'with no options' do
     let(:options) { {} }
@@ -40,6 +41,7 @@ RSpec.describe V2::MovesSerializer do
             supplier: { data: { id: move.supplier_id, type: 'suppliers' } },
             allocation: { data: nil },
           },
+          meta: {},
         },
       }
     end
@@ -63,6 +65,28 @@ RSpec.describe V2::MovesSerializer do
     it 'contains all included relationships' do
       expect(result[:included].map { |r| r[:type] })
         .to match_array(%w[people ethnicities genders locations locations profiles prison_transfer_reasons suppliers person_escort_records framework_flags])
+    end
+  end
+
+  context 'with vehicle_registrations params set to true' do
+    let(:move) { create :move, :with_journey }
+    let(:options) do
+      { params: { vehicle_registration: true } }
+    end
+
+    it 'contains vehicle_registration meta data' do
+      expect(meta).to eql({ vehicle_registration: 'AB12 CDE' })
+    end
+  end
+
+  context 'with vehicle_registrations params set to false' do
+    let(:move) { create :move, :with_journey }
+    let(:options) do
+      { params: { vehicle_registration: false } }
+    end
+
+    it 'does not contain vehicle_registration meta data' do
+      expect(meta).to be_empty
     end
   end
 end

--- a/spec/services/include_param_handler_spec.rb
+++ b/spec/services/include_param_handler_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe IncludeParamHandler do
   subject(:service) { described_class.new(params) }
 
-  let(:params) { HashWithIndifferentAccess.new(include: include) }
+  let(:params) { HashWithIndifferentAccess.new(include: include, meta: meta) }
+  let(:include) { nil }
+  let(:meta) { nil }
 
   describe 'included_relationships' do
     subject { service.included_relationships }
@@ -27,25 +29,50 @@ RSpec.describe IncludeParamHandler do
     end
   end
 
-  describe 'active_record_relationships' do
-    subject { service.active_record_relationships }
+  describe 'meta_fields' do
+    subject { service.meta_fields }
 
-    context 'when the include param is nil' do
-      let(:include) { nil }
+    context 'when the meta param is nil' do
+      let(:meta) { nil }
 
       it { is_expected.to be_nil }
     end
 
-    context 'when the include param is a splittable string' do
-      let(:include) { 'foo.bar,bla,baz.qux.qax' }
+    context 'when the meta param is a splittable string' do
+      let(:meta) { 'foo,bar,baz' }
 
-      it { is_expected.to eq([{ foo: :bar }, :bla, { baz: { qux: :qax } }]) }
+      it { is_expected.to contain_exactly('foo', 'bar', 'baz') }
     end
 
-    context 'when the include param needs aliasing' do
-      let(:include) { 'foo.flags,bar.bla.questions,responses,timeline_events' }
+    context 'when the meta param is an empty string' do
+      let(:meta) { '' }
 
-      it { is_expected.to eq([{ foo: :framework_flags }, { bar: { bla: :framework_questions } }, :framework_responses, :generic_events]) }
+      it { is_expected.to eq([]) }
+    end
+  end
+
+  describe 'active_record_relationships' do
+    subject { service.active_record_relationships }
+
+    context 'when the include and meta param are nil' do
+      let(:include) { nil }
+      let(:meta) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the meta and include param are both a splittable string' do
+      let(:include) { 'foo.bar,baz.qux.qax' }
+      let(:meta) { 'bla' }
+
+      it { is_expected.to contain_exactly({ foo: :bar }, :bla, { baz: { qux: :qax } }) }
+    end
+
+    context 'when the include and meta param need aliasing' do
+      let(:include) { 'foo.flags,bar.bla.questions,responses,timeline_events' }
+      let(:meta) { 'vehicle_registration' }
+
+      it { is_expected.to contain_exactly({ foo: :framework_flags }, { bar: { bla: :framework_questions } }, :framework_responses, :generic_events, :journeys) }
     end
 
     context 'when the include param needs expanding to include multiple relationships' do
@@ -54,8 +81,20 @@ RSpec.describe IncludeParamHandler do
       it { is_expected.to eq([:foo, { incident_events: {}, profile: { person_escort_record: :medical_events } }]) }
     end
 
+    context 'when the meta param is set without the include param' do
+      let(:meta) { 'foo,vehicle_registration' }
+
+      it { is_expected.to contain_exactly(:foo, :journeys) }
+    end
+
     context 'when the include param is an empty string' do
       let(:include) { '' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the meta param is an empty string' do
+      let(:meta) { '' }
 
       it { is_expected.to be_nil }
     end

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -528,6 +528,15 @@
             enum:
               - asc
               - desc
+        - name: meta
+          description: list of meta section fields to include for specified resource
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            enum:
+              - vehicle_registration
         - "$ref": "../v2/moves_include_parameter.yaml#/MovesIncludeParameter"
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"


### PR DESCRIPTION
### Jira link

[P4-2537](https://dsdmoj.atlassian.net/browse/P4-2537)

### What?

- Add ability to pass in `meta` query param
- Add vehicle registration field in meta section in the move resource for moves index endpoint

### Why?

To surface vehicle registrations for moves, to be used on the FE dashboards, add a meta section to the moves resources only on the moves index endpoint. The vehicle registration is optional and can be included in the new `meta` query string param. If no meta query param is included, we still get a meta section, but it will be empty, as there is no option to make the section itself optional.
 
### Have you? (optional)

- [x] Updated API docs if necessary	


### Deployment risks (optional)

- Changes an api that is used in production

