### PR TITLE
P4-2538 Surface ETA and collection time in moves meta data

### DIFF
--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -2,7 +2,11 @@ module Api::V2
   module MovesActions
     def index_and_render
       paginate moves, serializer: ::V2::MovesSerializer, include: included_relationships, fields: ::V2::MovesSerializer::INCLUDED_FIELDS do |_, options|
-        options[:params] = { vehicle_registration: meta_fields.include?('vehicle_registration') }
+        options[:params] = {
+          vehicle_registration: meta_fields.include?('vehicle_registration'),
+          expected_time_of_arrival: meta_fields.include?('expected_time_of_arrival'),
+          expected_collection_time: meta_fields.include?('expected_collection_time'),
+        }
       end
     end
 

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -88,6 +88,7 @@ class GenericEvent < ApplicationRecord
     default: 'default',
     incident: 'incident',
     medical: 'medical',
+    notification: 'notification',
   }
 
   belongs_to :eventable, polymorphic: true, touch: true

--- a/app/models/generic_event/move_notify_premises_of_arrival_in_30_mins.rb
+++ b/app/models/generic_event/move_notify_premises_of_arrival_in_30_mins.rb
@@ -1,9 +1,5 @@
 class GenericEvent
-  class MoveNotifyPremisesOfArrivalIn30Mins < GenericEvent
+  class MoveNotifyPremisesOfArrivalIn30Mins < Notification
     eventable_types 'Move'
-
-    def event_classification
-      :notification
-    end
   end
 end

--- a/app/models/generic_event/move_notify_premises_of_arrival_in_30_mins.rb
+++ b/app/models/generic_event/move_notify_premises_of_arrival_in_30_mins.rb
@@ -1,5 +1,9 @@
 class GenericEvent
   class MoveNotifyPremisesOfArrivalIn30Mins < GenericEvent
     eventable_types 'Move'
+
+    def event_classification
+      :notification
+    end
   end
 end

--- a/app/models/generic_event/move_notify_premises_of_eta.rb
+++ b/app/models/generic_event/move_notify_premises_of_eta.rb
@@ -1,14 +1,10 @@
 class GenericEvent
-  class MoveNotifyPremisesOfEta < GenericEvent
+  class MoveNotifyPremisesOfEta < Notification
     details_attributes :expected_at
     eventable_types 'Move'
 
     validates :expected_at, presence: true
 
     validates :expected_at, iso_date_time: true
-
-    def event_classification
-      :notification
-    end
   end
 end

--- a/app/models/generic_event/move_notify_premises_of_eta.rb
+++ b/app/models/generic_event/move_notify_premises_of_eta.rb
@@ -6,5 +6,9 @@ class GenericEvent
     validates :expected_at, presence: true
 
     validates :expected_at, iso_date_time: true
+
+    def event_classification
+      :notification
+    end
   end
 end

--- a/app/models/generic_event/move_notify_premises_of_expected_collection_time.rb
+++ b/app/models/generic_event/move_notify_premises_of_expected_collection_time.rb
@@ -7,5 +7,9 @@ class GenericEvent
     validates :expected_at, presence: true
 
     validates :expected_at, iso_date_time: true
+
+    def event_classification
+      :notification
+    end
   end
 end

--- a/app/models/generic_event/move_notify_premises_of_expected_collection_time.rb
+++ b/app/models/generic_event/move_notify_premises_of_expected_collection_time.rb
@@ -1,5 +1,5 @@
 class GenericEvent
-  class MoveNotifyPremisesOfExpectedCollectionTime < GenericEvent
+  class MoveNotifyPremisesOfExpectedCollectionTime < Notification
     details_attributes :expected_at
 
     eventable_types 'Move'
@@ -7,9 +7,5 @@ class GenericEvent
     validates :expected_at, presence: true
 
     validates :expected_at, iso_date_time: true
-
-    def event_classification
-      :notification
-    end
   end
 end

--- a/app/models/generic_event/notification.rb
+++ b/app/models/generic_event/notification.rb
@@ -1,0 +1,7 @@
+class GenericEvent
+  class Notification < GenericEvent
+    def event_classification
+      :notification
+    end
+  end
+end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -225,6 +225,14 @@ class Move < VersionedModel
       &.dig('registration')
   end
 
+  def expected_time_of_arrival
+    notification_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfEta' }.max_by(&:occurred_at)&.expected_at
+  end
+
+  def expected_collection_time
+    notification_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime' }.max_by(&:occurred_at)&.expected_at
+  end
+
 private
 
   def date_to_after_date_from

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -226,10 +226,12 @@ class Move < VersionedModel
   end
 
   def expected_time_of_arrival
+    # Process in memory to avoid n+1 queries in serializers
     notification_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfEta' }.max_by(&:occurred_at)&.expected_at
   end
 
   def expected_collection_time
+    # Process in memory to avoid n+1 queries in serializers
     notification_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime' }.max_by(&:occurred_at)&.expected_at
   end
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -88,6 +88,7 @@ class Move < VersionedModel
 
   has_many :generic_events, as: :eventable, dependent: :destroy
   has_many :incident_events, -> { where classification: :incident }, as: :eventable, class_name: 'GenericEvent'
+  has_many :notification_events, -> { where classification: :notification }, as: :eventable, class_name: 'GenericEvent'
 
   validates :from_location, presence: true
   validates :to_location, presence: true, unless: -> { prison_recall? || video_remand? }

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -26,6 +26,8 @@ module V2
     meta do |object, params|
       {}.tap do |metadata|
         metadata.merge!(vehicle_registration: object.vehicle_registration) if params[:vehicle_registration]
+        metadata.merge!(expected_time_of_arrival: object.expected_time_of_arrival) if params[:expected_time_of_arrival]
+        metadata.merge!(expected_collection_time: object.expected_collection_time) if params[:expected_collection_time]
       end
     end
 

--- a/app/services/include_param_handler.rb
+++ b/app/services/include_param_handler.rb
@@ -47,6 +47,8 @@ private
       :generic_events
     when 'important_events'
       { incident_events: {}, profile: { person_escort_record: :medical_events } }
+    when 'expected_time_of_arrival', 'expected_collection_time'
+      :notification_events
     when 'vehicle_registration'
       :journeys
     else

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -52,8 +52,14 @@ namespace :data_maintenance do
       'GenericEvent::PersonMovePersonEscapedKpi',
       'GenericEvent::PersonMoveReleasedError',
     ]
+    notification_event_types = [
+      'GenericEvent::MoveNotifyPremisesOfArrivalIn30Mins',
+      'GenericEvent::MoveNotifyPremisesOfEta',
+      'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime',
+    ]
 
-    GenericEvent.where(eventable_type: medical_event_type).update_all(classification: 'medical')
-    GenericEvent.where(eventable_type: incident_event_types).update_all(classification: 'incident')
+    GenericEvent.where(type: medical_event_type).update_all(classification: 'medical')
+    GenericEvent.where(type: incident_event_types).update_all(classification: 'incident')
+    GenericEvent.where(type: notification_event_types).update_all(classification: 'notification')
   end
 end

--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -4,6 +4,7 @@ require_relative 'fake_data/journeys'
 require_relative 'fake_data/gps'
 require_relative 'fake_data/incident_events'
 require_relative 'fake_data/medical_events'
+require_relative 'fake_data/notification_events'
 
 namespace :fake_data do
   desc 'create fake people'
@@ -195,6 +196,19 @@ namespace :fake_data do
         .limit(100)
         .find_each do |per|
       Tasks::FakeData::MedicalEvents.new(per).call
+    end
+  end
+
+  desc 'create fake notification events'
+  task create_notification_events: :environment do
+    puts 'create_notification_events...'
+    Move
+        .where(status: %w[booked requested in_transit completed])
+        .where.not(to_location_id: nil)
+        .order(Arel.sql('RANDOM()'))
+        .limit(1000)
+        .find_each do |move|
+      Tasks::FakeData::NotificationEvents.new(move).call
     end
   end
 

--- a/lib/tasks/fake_data/notification_events.rb
+++ b/lib/tasks/fake_data/notification_events.rb
@@ -1,0 +1,44 @@
+module Tasks
+  module FakeData
+    class NotificationEvents
+      attr_reader :move
+
+      def initialize(move)
+        @move = move
+      end
+
+      def call
+        random_event.create!(
+          eventable: move,
+          occurred_at: Time.zone.now,
+          created_by: 'TEST_USER',
+          recorded_at: Time.zone.now,
+          details: {
+            expected_at: Time.zone.now + 2.hours,
+          },
+          supplier: random_supplier,
+          notes: 'Created from fake data',
+        )
+
+        puts "Added #{random_event} notification event to Move #{move.id}"
+      end
+
+    private
+
+      def suppliers
+        @suppliers ||= Supplier.all.to_a
+      end
+
+      def random_supplier
+        suppliers.sample
+      end
+
+      def random_event
+        [
+          GenericEvent::MoveNotifyPremisesOfEta,
+          GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime,
+        ].sample
+      end
+    end
+  end
+end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -124,7 +124,7 @@ FactoryBot.define do
     end
   end
 
-  factory :event_move_notify_premises_of_expected_collection_time, parent: :generic_event, class: 'GenericEvent::MoveNotifyPremisesOfEta' do
+  factory :event_move_notify_premises_of_expected_collection_time, parent: :generic_event, class: 'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime' do
     eventable { association(:move) }
     details do
       {

--- a/spec/models/generic_event/move_notify_premises_of_arrival_in30_mins_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_arrival_in30_mins_spec.rb
@@ -3,17 +3,5 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfArrivalIn30Mins do
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Move]) }
 
-  describe '#event_classification' do
-    it 'returns :notification' do
-      event = described_class.new
-
-      expect(event.event_classification).to eq :notification
-    end
-
-    it 'is automatically assigned on creation' do
-      event = create(:event_move_notify_premises_of_arrival_in30_mins, classification: nil)
-
-      expect(event.classification).to eq 'notification'
-    end
-  end
+  it_behaves_like 'an event about a notification', :event_move_notify_premises_of_arrival_in30_mins
 end

--- a/spec/models/generic_event/move_notify_premises_of_arrival_in30_mins_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_arrival_in30_mins_spec.rb
@@ -2,4 +2,18 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfArrivalIn30Mins do
   subject(:generic_event) { build(:event_move_notify_premises_of_arrival_in30_mins) }
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Move]) }
+
+  describe '#event_classification' do
+    it 'returns :notification' do
+      event = described_class.new
+
+      expect(event.event_classification).to eq :notification
+    end
+
+    it 'is automatically assigned on creation' do
+      event = create(:event_move_notify_premises_of_arrival_in30_mins, classification: nil)
+
+      expect(event.classification).to eq 'notification'
+    end
+  end
 end

--- a/spec/models/generic_event/move_notify_premises_of_eta_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_eta_spec.rb
@@ -16,17 +16,5 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfEta do
     expect(generic_event).not_to be_valid
   end
 
-  describe '#event_classification' do
-    it 'returns :notification' do
-      event = described_class.new
-
-      expect(event.event_classification).to eq :notification
-    end
-
-    it 'is automatically assigned on creation' do
-      event = create(:event_move_notify_premises_of_eta, classification: nil)
-
-      expect(event.classification).to eq 'notification'
-    end
-  end
+  it_behaves_like 'an event about a notification', :event_move_notify_premises_of_eta
 end

--- a/spec/models/generic_event/move_notify_premises_of_eta_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_eta_spec.rb
@@ -15,4 +15,18 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfEta do
     generic_event.expected_at = '16-06-2020 10:20:30+01:00'
     expect(generic_event).not_to be_valid
   end
+
+  describe '#event_classification' do
+    it 'returns :notification' do
+      event = described_class.new
+
+      expect(event.event_classification).to eq :notification
+    end
+
+    it 'is automatically assigned on creation' do
+      event = create(:event_move_notify_premises_of_eta, classification: nil)
+
+      expect(event.classification).to eq 'notification'
+    end
+  end
 end

--- a/spec/models/generic_event/move_notify_premises_of_expected_collection_time_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_expected_collection_time_spec.rb
@@ -16,17 +16,5 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime do
     expect(generic_event).not_to be_valid
   end
 
-  describe '#event_classification' do
-    it 'returns :notification' do
-      event = described_class.new
-
-      expect(event.event_classification).to eq :notification
-    end
-
-    it 'is automatically assigned on creation' do
-      event = create(:event_move_notify_premises_of_expected_collection_time, classification: nil)
-
-      expect(event.classification).to eq 'notification'
-    end
-  end
+  it_behaves_like 'an event about a notification', :event_move_notify_premises_of_expected_collection_time
 end

--- a/spec/models/generic_event/move_notify_premises_of_expected_collection_time_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_expected_collection_time_spec.rb
@@ -15,4 +15,18 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime do
     generic_event.expected_at = '16-06-2020 10:20:30+01:00'
     expect(generic_event).not_to be_valid
   end
+
+  describe '#event_classification' do
+    it 'returns :notification' do
+      event = described_class.new
+
+      expect(event.event_classification).to eq :notification
+    end
+
+    it 'is automatically assigned on creation' do
+      event = create(:event_move_notify_premises_of_expected_collection_time, classification: nil)
+
+      expect(event.classification).to eq 'notification'
+    end
+  end
 end

--- a/spec/models/generic_event/notification_spec.rb
+++ b/spec/models/generic_event/notification_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::Notification, type: :model do
+  describe '#event_type' do
+    it 'removes GenericEvent namespace when type is present' do
+      event = described_class.new
+
+      expect(event.event_type).to eq 'Notification'
+    end
+  end
+
+  describe '#event_classification' do
+    it 'returns :notification' do
+      event = described_class.new
+
+      expect(event.event_classification).to eq :notification
+    end
+
+    it 'is automatically assigned on creation' do
+      event = create(:event_move_notify_premises_of_arrival_in30_mins, classification: nil)
+
+      expect(event.classification).to eq 'notification'
+    end
+  end
+end

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe GenericEvent, type: :model do
         .sub('app/models/generic_event/', '')
         .sub('.rb', '')
         .camelcase
-    } - %w[Incident]
+    } - %w[Incident Notification]
 
     expect(described_class::STI_CLASSES).to match_array(expected_sti_classes)
   end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -835,4 +835,78 @@ RSpec.describe Move do
       expect(move.vehicle_registration).to eq('CD12 ABC')
     end
   end
+
+  describe '#expected_time_of_arrival' do
+    it 'returns nothing if no events present' do
+      move = create(:move)
+
+      expect(move.expected_time_of_arrival).to be_nil
+    end
+
+    it 'returns nothing if a different notification event is present' do
+      move = create(:move, notification_events: [create(:event_move_notify_premises_of_arrival_in30_mins)])
+
+      expect(move.expected_time_of_arrival).to be_nil
+    end
+
+    it 'returns the expected time of arrival for a vehicle' do
+      event = create(:event_move_notify_premises_of_eta, expected_at: '2019-06-16T10:20:30+01:00')
+      move = create(:move, notification_events: [event])
+
+      expect(move.expected_time_of_arrival).to eq('2019-06-16T10:20:30+01:00')
+    end
+
+    it 'returns the expected time of arrival for a vehicle if multiple different notification events exist' do
+      event1 = create(:event_move_notify_premises_of_eta, expected_at: '2019-06-16T10:20:30+01:00', occurred_at: 2.minutes.ago)
+      event2 = create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-17T10:20:30+01:00', occurred_at: 1.minute.ago)
+      move = create(:move, notification_events: [event2, event1])
+
+      expect(move.expected_time_of_arrival).to eq('2019-06-16T10:20:30+01:00')
+    end
+
+    it 'returns the latest expected time of arrival for a vehicle if multiple events present' do
+      event1 = create(:event_move_notify_premises_of_eta, expected_at: '2019-06-16T10:20:30+01:00', occurred_at: 2.minutes.ago)
+      event2 = create(:event_move_notify_premises_of_eta, expected_at: '2019-06-17T10:20:30+01:00', occurred_at: 1.minute.ago)
+      move = create(:move, notification_events: [event2, event1])
+
+      expect(move.expected_time_of_arrival).to eq('2019-06-17T10:20:30+01:00')
+    end
+  end
+
+  describe '#expected_collection_time' do
+    it 'returns nothing if no events present' do
+      move = create(:move)
+
+      expect(move.expected_collection_time).to be_nil
+    end
+
+    it 'returns nothing if a different notification event is present' do
+      move = create(:move, notification_events: [create(:event_move_notify_premises_of_arrival_in30_mins)])
+
+      expect(move.expected_collection_time).to be_nil
+    end
+
+    it 'returns the expected collection time for a vehicle' do
+      event = create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-16T10:20:30+01:00')
+      move = create(:move, notification_events: [event])
+
+      expect(move.expected_collection_time).to eq('2019-06-16T10:20:30+01:00')
+    end
+
+    it 'returns the expected collection time for a vehicle if multiple different notification events exist' do
+      event1 = create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-16T10:20:30+01:00', occurred_at: 2.minutes.ago)
+      event2 = create(:event_move_notify_premises_of_eta, expected_at: '2019-06-17T10:20:30+01:00', occurred_at: 1.minute.ago)
+      move = create(:move, notification_events: [event2, event1])
+
+      expect(move.expected_collection_time).to eq('2019-06-16T10:20:30+01:00')
+    end
+
+    it 'returns the latest expected collection time for a vehicle if multiple events present' do
+      event1 = create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-16T10:20:30+01:00', occurred_at: 2.minutes.ago)
+      event2 = create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-17T10:20:30+01:00', occurred_at: 1.minute.ago)
+      move = create(:move, notification_events: [event2, event1])
+
+      expect(move.expected_collection_time).to eq('2019-06-17T10:20:30+01:00')
+    end
+  end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Move do
   it { is_expected.to have_many(:journeys) }
   it { is_expected.to have_many(:generic_events) }
   it { is_expected.to have_many(:incident_events) }
+  it { is_expected.to have_many(:notification_events) }
   it { is_expected.to have_one(:person_escort_record) }
   it { is_expected.to have_one(:youth_risk_assessment) }
 

--- a/spec/requests/api/moves_controller_index_v2_spec.rb
+++ b/spec/requests/api/moves_controller_index_v2_spec.rb
@@ -211,11 +211,18 @@ RSpec.describe Api::MovesController do
     end
 
     describe 'meta fields' do
+      let(:notification_events) do
+        [
+          create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-17T10:20:30+01:00'),
+          create(:event_move_notify_premises_of_eta, expected_at: '2019-06-19T10:20:30+01:00'),
+        ]
+      end
       let!(:moves) do
         create_list(
           :move,
           1,
           :with_journey,
+          notification_events: notification_events,
         )
       end
 
@@ -231,11 +238,15 @@ RSpec.describe Api::MovesController do
       end
 
       context 'when including the meta query param' do
-        let(:query_params) { '?meta=vehicle_registration' }
+        let(:query_params) { '?meta=vehicle_registration,expected_time_of_arrival,expected_collection_time' }
 
         it 'includes the requested meta fields in the response' do
           move = response_json['data'].first
-          expect(move['meta']).to eq('vehicle_registration' => 'AB12 CDE')
+          expect(move['meta']).to eq(
+            'vehicle_registration' => 'AB12 CDE',
+            'expected_time_of_arrival' => '2019-06-19T10:20:30+01:00',
+            'expected_collection_time' => '2019-06-17T10:20:30+01:00',
+          )
         end
       end
     end

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe V2::MovesSerializer do
     end
   end
 
-  context 'with vehicle_registrations params set to true' do
+  context 'with vehicle_registration params set to true' do
     let(:move) { create :move, :with_journey }
     let(:options) do
       { params: { vehicle_registration: true } }
@@ -79,13 +79,61 @@ RSpec.describe V2::MovesSerializer do
     end
   end
 
-  context 'with vehicle_registrations params set to false' do
+  context 'with vehicle_registration params set to false' do
     let(:move) { create :move, :with_journey }
     let(:options) do
       { params: { vehicle_registration: false } }
     end
 
     it 'does not contain vehicle_registration meta data' do
+      expect(meta).to be_empty
+    end
+  end
+
+  context 'with expected_time_of_arrival params set to true' do
+    let(:event) { create(:event_move_notify_premises_of_eta, expected_at: '2019-06-16T10:20:30+01:00') }
+    let(:move) { create :move, notification_events: [event] }
+    let(:options) do
+      { params: { expected_time_of_arrival: true } }
+    end
+
+    it 'contains expected_time_of_arrival meta data' do
+      expect(meta).to eq({ expected_time_of_arrival: '2019-06-16T10:20:30+01:00' })
+    end
+  end
+
+  context 'with expected_time_of_arrival params set to false' do
+    let(:event) { create(:event_move_notify_premises_of_eta, expected_at: '2019-06-16T10:20:30+01:00') }
+    let(:move) { create :move, notification_events: [event] }
+    let(:options) do
+      { params: { expected_time_of_arrival: false } }
+    end
+
+    it 'does not contain expected_time_of_arrival meta data' do
+      expect(meta).to be_empty
+    end
+  end
+
+  context 'with expected_collection_time params set to true' do
+    let(:event) { create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-16T10:20:30+01:00') }
+    let(:move) { create :move, notification_events: [event] }
+    let(:options) do
+      { params: { expected_collection_time: true } }
+    end
+
+    it 'contains expected_collection_time meta data' do
+      expect(meta).to eq({ expected_collection_time: '2019-06-16T10:20:30+01:00' })
+    end
+  end
+
+  context 'with expected_collection_time params set to false' do
+    let(:event) { create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-16T10:20:30+01:00') }
+    let(:move) { create :move, notification_events: [event] }
+    let(:options) do
+      { params: { expected_collection_time: false } }
+    end
+
+    it 'does not contain expected_collection_time meta data' do
       expect(meta).to be_empty
     end
   end

--- a/spec/support/an_event_about_a_notification.rb
+++ b/spec/support/an_event_about_a_notification.rb
@@ -1,0 +1,15 @@
+RSpec.shared_examples 'an event about a notification' do |event_type|
+  describe '#event_classification' do
+    it 'returns :notification' do
+      event = described_class.new
+
+      expect(event.event_classification).to eq :notification
+    end
+
+    it 'is automatically assigned on creation' do
+      event = create(event_type, classification: nil)
+
+      expect(event.classification).to eq 'notification'
+    end
+  end
+end

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -529,7 +529,7 @@
               - asc
               - desc
         - name: meta
-          description: list of meta section fields to include for specified resource
+          description: list of meta data fields to include for specified resource
           in: query
           style: form
           explode: false
@@ -537,6 +537,8 @@
             type: string
             enum:
               - vehicle_registration
+              - expected_time_of_arrival
+              - expected_collection_time
         - "$ref": "../v2/moves_include_parameter.yaml#/MovesIncludeParameter"
         - "$ref": "../v1/pagination_parameters.yaml#/Page"
         - "$ref": "../v1/pagination_parameters.yaml#/PerPage"


### PR DESCRIPTION
### Jira link

[P4-2538](https://dsdmoj.atlassian.net/browse/P4-2538)
[P4-2539](https://dsdmoj.atlassian.net/browse/P4-2539)

### What?

- Add new type of event classification: notifications
-  Add task to backfill all notification events with correct classification type
- Surface ETA and collection times in meta data for moves on index moves endpoint
- Add task to generate fake data for notification events

### Why?

To allow the FE to build dashboards and group by vehicles expected collection time for outgoing moves, and ETA for incoming moves, surface those values from the relevant events that are attached to those moves in the metadata. The event corresponding to expected collection time is `MoveNotifyPremisesOfExpectedCollectionTime`, which contain an `expected_at` timestamp. The event corresponding to ETA is `MoveNotifyPremisesOfEta`, which also contains an `expected_at` timestamp as well.

To avoid eager loading all events on the index moves endpoint, add a new classification: notification events, which includes all events that a supplier sends to inform of expected times. To help with testing on staging, add a fake data generator for notification events.

### Have you? (optional)

- [x] Updated API docs if necessary	


### Deployment risks (optional)

- Changes an api that is used in production

