### PR TITLE
P4-2058 Add PER confirmation event

### DIFF
--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -2,6 +2,8 @@
 
 module Api
   class PersonEscortRecordsController < FrameworkAssessmentsController
+    after_action :create_confirmation_event, only: :update # rubocop:disable LexicallyScopedActionFilter
+
   private
 
     def assessment_class
@@ -10,6 +12,23 @@ module Api
 
     def assessment_serializer
       PersonEscortRecordSerializer
+    end
+
+    def create_confirmation_event
+      now = Time.zone.now.iso8601
+
+      event_attributes = {
+        eventable: assessment,
+        occurred_at: now,
+        recorded_at: now,
+        notes: 'Automatically generated event',
+        details: {
+          confirmed_at: assessment.confirmed_at.iso8601,
+        },
+        created_by: created_by,
+      }
+
+      GenericEvent::PerConfirmation.create!(event_attributes)
     end
   end
 end

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -52,6 +52,7 @@ class GenericEvent < ApplicationRecord
     MoveReject
     MoveRequested
     MoveStart
+    PerConfirmation
     PerCourtAllDocumentationProvidedToSupplier
     PerCourtAssignCellInCustody
     PerCourtCellShareRiskAssessment

--- a/app/models/generic_event/per_confirmation.rb
+++ b/app/models/generic_event/per_confirmation.rb
@@ -1,0 +1,8 @@
+class GenericEvent
+  class PerConfirmation < GenericEvent
+    details_attributes :confirmed_at
+    include PersonEscortRecordEventValidations
+
+    validates :confirmed_at, presence: true
+  end
+end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -475,6 +475,15 @@ FactoryBot.define do
     end
   end
 
+  factory :event_per_confirmation, parent: :generic_event, class: 'GenericEvent::PerConfirmation' do
+    eventable { association(:person_escort_record, :confirmed, confirmed_at: '2021-01-01') }
+    details do
+      {
+        confirmed_at: '2021-01-01',
+      }
+    end
+  end
+
   factory :event_person_move_assault, parent: :incident, class: 'GenericEvent::PersonMoveAssault' do
   end
 

--- a/spec/models/generic_event/per_confirmation_spec.rb
+++ b/spec/models/generic_event/per_confirmation_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe GenericEvent::PerConfirmation do
+  subject(:generic_event) { build(:event_per_confirmation) }
+
+  it_behaves_like 'an event with details', :confirmed_at
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
+  it { is_expected.to validate_presence_of(:confirmed_at) }
+end

--- a/spec/requests/api/generic_events_controller_create_person_escort_record_events_spec.rb
+++ b/spec/requests/api/generic_events_controller_create_person_escort_record_events_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Api::GenericEventsController do
   let(:eventable_type) { 'person_escort_records' }
   let(:eventable_id) { create(:person_escort_record).id }
 
+  it_behaves_like 'a generic event endpoint', 'PerConfirmation'
   it_behaves_like 'a generic event endpoint', 'PerCourtAllDocumentationProvidedToSupplier'
   it_behaves_like 'a generic event endpoint', 'PerCourtAssignCellInCustody'
   it_behaves_like 'a generic event endpoint', 'PerCourtCellShareRiskAssessment'

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -156,5 +156,44 @@ RSpec.describe Api::PersonEscortRecordsController do
         end
       end
     end
+
+    context 'with confirmation event' do
+      it 'creates a per confirmation event' do
+        expect { patch_person_escort_record }.to change(GenericEvent, :count).by(1)
+      end
+
+      it 'persists correct attributes to a per confirmation event' do
+        recorded_timestamp = Time.zone.parse('2020-10-07 01:02:03')
+        Timecop.freeze(recorded_timestamp)
+        patch_person_escort_record
+        Timecop.return
+
+        event = GenericEvent.find_by(eventable: person_escort_record, type: 'GenericEvent::PerConfirmation')
+
+        expect(event).to have_attributes(
+          created_by: 'TEST_USER',
+          occurred_at: recorded_timestamp,
+          recorded_at: recorded_timestamp,
+          details: { 'confirmed_at' => person_escort_record.confirmed_at },
+          notes: 'Automatically generated event',
+        )
+      end
+
+      context 'when request is unsuccessful' do
+        let(:status) { 'foo-bar' }
+
+        it 'does not create confirmation event' do
+          expect { patch_person_escort_record }.not_to change(GenericEvent, :count)
+        end
+      end
+
+      context 'when Person Escort Record is already confirmed' do
+        it 'does not create confirmation event' do
+          patch_person_escort_record
+
+          expect { patch_person_escort_record }.not_to change(GenericEvent, :count)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[P4-2058](https://dsdmoj.atlassian.net/browse/P4-2058)

### What?

I have added/removed/altered:

- [x] Add a new PER confirmation event
- [x] Add a callback on confirming a PER to create a new confirmation event

### Why?

To surface who and when a PER is confirmed on a move's timeline, add a PER confirmation event which captures who confirms a PER and when as a callback on a successful confirmation of the PER, through the PATCH endpoint.

This event will appear when including a move's timeline events.

### Have you? (optional)

- [] Updated API docs if necessary: I'll update https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki/Event-Documentation once this is merged


### Deployment risks (optional)

- Changes an api that is used in production

