### PR TITLE
Change the type of a PER confirmed error to return a code in API response

### DIFF
--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -87,8 +87,8 @@ module FrameworkAssessmentable
     state_machine.confirm!
     save!
   rescue FiniteMachine::InvalidStateError
-    errors.add(:status, "can't update to '#{new_status}' from '#{status}'")
-    raise ActiveModel::ValidationError, self
+    errors.add(:status, :invalid_status, message: "can't update to '#{new_status}' from '#{status}'")
+    raise ActiveRecord::RecordInvalid, self
   end
 
   def handle_event_run

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -73,8 +73,14 @@ RSpec.describe Api::PersonEscortRecordsController do
 
         it_behaves_like 'an endpoint that responds with error 422' do
           let(:errors_422) do
-            [{ 'title' => 'Invalid status',
-               'detail' => "Validation failed: Status can't update to 'confirmed' from 'in_progress'" }]
+            [
+              {
+                'title' => 'Unprocessable entity',
+                'detail' => "Status can't update to 'confirmed' from 'in progress'",
+                'source' => { 'pointer' => '/data/attributes/status' },
+                'code' => 'invalid_status',
+              },
+            ]
           end
         end
       end

--- a/spec/requests/api/youth_risk_assessments_controller_update_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_update_spec.rb
@@ -73,8 +73,14 @@ RSpec.describe Api::YouthRiskAssessmentsController do
 
         it_behaves_like 'an endpoint that responds with error 422' do
           let(:errors_422) do
-            [{ 'title' => 'Invalid status',
-               'detail' => "Validation failed: Status can't update to 'confirmed' from 'in_progress'" }]
+            [
+              {
+                'title' => 'Unprocessable entity',
+                'detail' => "Status can't update to 'confirmed' from 'in progress'",
+                'source' => { 'pointer' => '/data/attributes/status' },
+                'code' => 'invalid_status',
+              },
+            ]
           end
         end
       end

--- a/spec/support/a_framework_assessment.rb
+++ b/spec/support/a_framework_assessment.rb
@@ -636,14 +636,14 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
     it 'does not update status if previous status not valid' do
       assessment = create(assessment_type, :in_progress)
 
-      expect { assessment.confirm!('confirmed') }.to raise_error(ActiveModel::ValidationError)
+      expect { assessment.confirm!('confirmed') }.to raise_error(ActiveRecord::RecordInvalid)
       expect(assessment.errors.messages[:status]).to contain_exactly("can't update to 'confirmed' from 'in_progress'")
     end
 
     it 'does not update status if current status the same' do
       assessment = create(assessment_type, :confirmed)
 
-      expect { assessment.confirm!('confirmed') }.to raise_error(ActiveModel::ValidationError)
+      expect { assessment.confirm!('confirmed') }.to raise_error(ActiveRecord::RecordInvalid)
       expect(assessment.errors.messages[:status]).to contain_exactly("can't update to 'confirmed' from 'confirmed'")
     end
   end


### PR DESCRIPTION
To include a code in a PER confirmed error, raise a RecordInvalid error instead,
and set the code to 'invalid_status', to allow clients to look at the code and not the description of the error. This type of error is handled differently in the API controller and adds a code and pointer.

Old error:
```
{
    "errors": [
        {
            "title": "Invalid status",
            "detail": "Validation failed: Status can't update to 'confirmed' from 'confirmed'"
        }
    ]
}
```

New error format:
```
{
    "errors": [
        {
            "title": "Unprocessable entity",
            "detail": "Status can't update to 'confirmed' from 'confirmed'",
            "source": {
                "pointer": "/data/attributes/status"
            },
            "code": "invalid_status"
        }
    ]
}
```


