### PR TITLE
Add endpoint to provide pre-populated defaults for new population record

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ Rails.application.routes.draw do
     resources :framework_responses, only: %i[update]
 
     get 'locations_free_spaces', to: 'populations#index'
-    resources :populations, only: %i[show create update]
+    resources :populations, only: %i[new show create update]
 
     namespace :reference do
       resources :allocation_complex_cases, only: :index

--- a/spec/models/population_spec.rb
+++ b/spec/models/population_spec.rb
@@ -151,6 +151,51 @@ RSpec.describe Population do
     end
   end
 
+  describe '.new_with_defaults' do
+    subject(:new_population) { described_class.new_with_defaults(location: location, date: date) }
+
+    let(:location) { create(:location, :prison) }
+    let(:date) { Date.today }
+
+    context 'with a previous population record for same location' do
+      let!(:previous_population) { create(:population, location: location, date: date - 1.day) }
+
+      it 'populates details from previous record' do
+        expect(new_population).to have_attributes({
+          id: nil,
+          location_id: location.id,
+          date: date,
+          operational_capacity: previous_population.operational_capacity,
+          usable_capacity: previous_population.usable_capacity,
+          unlock: previous_population.unlock,
+          bedwatch: previous_population.bedwatch,
+          overnights_in: previous_population.overnights_in,
+          overnights_out: previous_population.overnights_out,
+          out_of_area_courts: previous_population.out_of_area_courts,
+          discharges: previous_population.discharges,
+        })
+      end
+    end
+
+    context 'without a previous population record' do
+      it 'only populates date and location' do
+        expect(new_population).to have_attributes({
+          id: nil,
+          location_id: location.id,
+          date: date,
+          operational_capacity: nil,
+          usable_capacity: nil,
+          unlock: nil,
+          bedwatch: nil,
+          overnights_in: nil,
+          overnights_out: nil,
+          out_of_area_courts: nil,
+          discharges: nil,
+        })
+      end
+    end
+  end
+
   describe '.free_spaces_date_range' do
     let!(:prison1) { create(:location, :prison) }
     let!(:prison2) { create(:location, :prison) }

--- a/spec/models/population_spec.rb
+++ b/spec/models/population_spec.rb
@@ -158,9 +158,10 @@ RSpec.describe Population do
     let(:date) { Date.today }
 
     context 'with a previous population record for same location' do
+      let!(:older_population) { create(:population, location: location, date: date - 2.days) }
       let!(:previous_population) { create(:population, location: location, date: date - 1.day) }
 
-      it 'populates details from previous record' do
+      it 'populates details from most recent previous record' do
         expect(new_population).to have_attributes({
           id: nil,
           location_id: location.id,

--- a/spec/requests/api/populations_controller_new_spec.rb
+++ b/spec/requests/api/populations_controller_new_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::PopulationsController do
+  include_context 'with supplier with spoofed access token'
+
+  subject(:get_new_population) do
+    get '/api/populations/new', params: params, headers: headers
+  end
+
+  let(:response_json) { JSON.parse(response.body) }
+
+  let(:location) { create(:location, :prison) }
+  let(:location_id) { location.id }
+  let(:date) { Date.today.iso8601 }
+  let(:params) { { location_id: location_id, date: date } }
+
+  describe 'GET /populations/new' do
+    context 'when successful' do
+      let(:schema) { load_yaml_schema('get_new_population_responses.yaml') }
+      let(:population) { Population.new(location: location, date: Date.today) }
+      let(:data) { JSON.parse(PopulationSerializer.new(population).serializable_hash.to_json) }
+
+      before { get_new_population }
+
+      it_behaves_like 'an endpoint that responds with success 200'
+
+      it 'returns the correct data' do
+        expect(response_json).to include_json(data)
+      end
+    end
+
+    describe 'included relationships' do
+      context 'when not including the include query param' do
+        before { get_new_population }
+
+        it 'returns the default includes' do
+          returned_types = response_json['included']
+          expect(returned_types).to be_nil
+        end
+      end
+
+      context 'when including the include query param' do
+        let(:params) { { location_id: location_id, date: date, include: 'location' } }
+
+        before { get_new_population }
+
+        it 'includes the requested includes in the response' do
+          returned_types = response_json['included'].map { |r| r['type'] }
+          expect(returned_types).to contain_exactly('locations')
+        end
+      end
+
+      context 'when including an invalid include query param' do
+        let(:params) { { location_id: location_id, date: date, include: 'foo.bar,location' } }
+
+        let(:expected_error) do
+          {
+            'errors' => [
+              {
+                'detail' => match(/foo.bar/),
+                'title' => 'Bad request',
+              },
+            ],
+          }
+        end
+
+        before { get_new_population }
+
+        it 'returns a validation error' do
+          expect(response).to have_http_status(:bad_request)
+          expect(response_json).to include(expected_error)
+        end
+      end
+    end
+
+    context 'when location not found' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+      let(:location_id) { 'foo' }
+      let(:detail_404) { "Couldn't find Location with 'id'=#{location_id}" }
+
+      before { get_new_population }
+
+      it_behaves_like 'an endpoint that responds with error 404'
+    end
+
+    context 'when location is omitted' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+      let(:params) { { date: date } }
+      let(:detail_404) { "Couldn't find Location without an ID" }
+
+      before { get_new_population }
+
+      it_behaves_like 'an endpoint that responds with error 404'
+    end
+
+    context 'when date is invalid' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+      let(:date) { 'foo' }
+      let(:errors_422) { [{ title: 'Invalid date', detail: 'Date is not a valid date' }] }
+
+      before { get_new_population }
+
+      it_behaves_like 'an endpoint that responds with error 422'
+    end
+
+    context 'when date is omitted' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+      let(:params) { { location_id: location.id } }
+      let(:errors_422) { [{ title: 'Invalid date', detail: 'Date is not a valid date' }] }
+
+      before { get_new_population }
+
+      it_behaves_like 'an endpoint that responds with error 422'
+    end
+  end
+end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -2910,6 +2910,40 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v1/post_populations_responses.yaml#/422"
+  "/populations/new":
+    get:
+      summary: Returns prepopulated default population details for a given date and location
+      tags:
+        - Populations
+      parameters:
+        - "$ref": "../v1/content_type_parameter.yaml#/ContentType"
+        - "$ref": "../v2/accept_type_parameter.yaml#/Accept"
+        - "$ref": "../v1/population_include_parameter.yaml#/PopulationIncludeParameter"
+      responses:
+        "200":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/get_new_population_responses.yaml#/200"
+        "401":
+          description: unauthorised
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/401"
+        "404":
+          description: not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/404"
+        "415":
+          description: invalid content type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v1/error_responses.yaml#/415"
   "/populations/{population_id}":
     get:
       summary: Returns population details for a given date and location

--- a/swagger/v1/get_new_population_responses.yaml
+++ b/swagger/v1/get_new_population_responses.yaml
@@ -1,0 +1,13 @@
+'200':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: population.yaml#/NewPopulation
+    included:
+      type: array
+      items:
+        anyOf:
+        - $ref: location.yaml#/Location
+        - $ref: "../v2/move.yaml#/Move"

--- a/swagger/v1/population.yaml
+++ b/swagger/v1/population.yaml
@@ -76,6 +76,7 @@ NewPopulation:
           oneOf:
           - type: string
           - type: 'null'
+          format: date-time
           description: Timestamp of when the population was created
           readOnly: true
     relationships:

--- a/swagger/v1/population.yaml
+++ b/swagger/v1/population.yaml
@@ -1,3 +1,100 @@
+NewPopulation:
+  type: object
+  required:
+  - type
+  - attributes
+  properties:
+    type:
+      type: string
+      example: populations
+      enum:
+      - populations
+      description: The type of this object - always `populations`
+    attributes:
+      type: object
+      required:
+      - date
+      properties:
+        date:
+          type: string
+          format: date
+          example: '2020-05-17'
+          description: Date for which population information applies
+        operational_capacity:
+          oneOf:
+          - type: integer
+          - type: 'null'
+          description: The designed maximum prisoner capacity for this location and date.
+        usable_capacity:
+          oneOf:
+          - type: integer
+          - type: 'null'
+          description: The current maximum prisoner capacity for this location and date.
+        unlock:
+          oneOf:
+          - type: integer
+          - type: 'null'
+          description: The current prisoner occupancy for this location and date (reduces availabilty).
+        bedwatch:
+          oneOf:
+          - type: integer
+          - type: 'null'
+          description: The number of watched beds for this location and date (reduces availabilty).
+        overnights_in:
+          oneOf:
+          - type: integer
+          - type: 'null'
+          description: The number of overnight arrivals for this location and date (reduces availabilty).
+        overnights_out:
+          oneOf:
+          - type: integer
+          - type: 'null'
+          description: The number of overnight departures for this location and date (increases availabilty).
+        out_of_area_courts:
+          oneOf:
+          - type: integer
+          - type: 'null'
+          description: The number of out of area court appearances for this location and date (increases availabilty).
+        discharges:
+          oneOf:
+          - type: integer
+          - type: 'null'
+          description: The of prisoners being discharged (released) for this location and date (increases availabilty).
+        updated_by:
+          oneOf:
+          - type: string
+          - type: 'null'
+          description: Optional name of the person providing population information
+        updated_at:
+          oneOf:
+          - type: string
+          - type: 'null'
+          format: date-time
+          description: Timestamp of when the population was last created or updated
+          readOnly: true
+        created_at:
+          oneOf:
+          - type: string
+          - type: 'null'
+          description: Timestamp of when the population was created
+          readOnly: true
+    relationships:
+      type: object
+      required:
+      - location
+      properties:
+        location:
+          $ref: location_reference.yaml#/LocationReference
+          description: The location (prison) that the population information relates to
+        moves_from:
+          $ref: move_reference.yaml#/MoveReference
+          description: The current scheduled prison transfers out of this location on the specified date
+          readOnly: true
+        moves_to:
+          $ref: move_reference.yaml#/MoveReference
+          description: The current scheduled prison transfers into this location on the specified date
+          readOnly: true
+
 Population:
   type: object
   required:


### PR DESCRIPTION
### Jira link

P4-2576

### What?

- [x] Added a new `GET /populations/new` endpoint

### Why?

- This doesn't create a new record, but returns default values to the front end with selected information copied from the most recent population details for the same location. This then allows the front end to provide a form with pre-populated information for the user to amend as needed and then call the existing `POST /populations` endpoint to actually create the new population record. This saves users time and avoids them having to manually look up and copy/paste previous figures.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- New endpoint so minimal risk
