### PR TITLE
Update location categories

### DIFF
--- a/lib/tasks/data/categories.yml
+++ b/lib/tasks/data/categories.yml
@@ -18,13 +18,17 @@
     - SLI
     - WDI
     - WRI
-    - MRI
-    - WHI
   BTH:
     title: Category B Therapeutic
     move_supported: true
     locations:
     - GNI
+  BTRN:
+    title: Category B Training
+    move_supported: true
+    locations:
+    - MRI
+    - WHI
   C:
     title: Category C
     move_supported: true
@@ -33,10 +37,8 @@
     - MSI
     - CWI
     - BXI
-    - BRI
     - HPI
     - ISI
-    - LTI
     - MTI
     - WII
     - WLI
@@ -47,7 +49,6 @@
     - OWI
     - ONI
     - RNI
-    - SFI
     - SKI
     - SNI
     - WEI
@@ -65,10 +66,13 @@
     title: Category C VPU
     move_supported: true
     locations:
-    - WTI
     - ASI
-    - VEI
+    - BRI
+    - LTI
+    - SFI
     - UKI
+    - VEI
+    - WTI
   CYOI:
     title: Category C / YOI
     move_supported: true


### PR DESCRIPTION
### Jira link

P4-2583

### What?

- [x] Just some tweaks to location/category mapping

### Why?

- Stafford (SFI), Littlehey (LTI) and Bure (BRI) move from "Category C" to "Category C VPU". Manchester (MRI) and Woodhill (WHI) move from "Category B" to a new "Category B Training" category. This presumably better fits with how PMU manage the prison estate.