### PR TITLE
P4-2589 Add new column value_type to responses

### DIFF
--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -62,8 +62,8 @@ class FrameworkQuestion < VersionedModel
         FrameworkResponse::String
       end
 
-    klass.new(framework_question: question, assessmentable: assessmentable, value: previous_response, prefilled: previous_response.present?)
+    klass.new(framework_question: question, assessmentable: assessmentable, value_type: question.response_type, value: previous_response, prefilled: previous_response.present?)
   rescue FrameworkResponse::ValueTypeError
-    klass.new(framework_question: question, assessmentable: assessmentable)
+    klass.new(framework_question: question, assessmentable: assessmentable, value_type: question.response_type)
   end
 end

--- a/db/migrate/20210107140348_add_value_type_to_framework_responses.rb
+++ b/db/migrate/20210107140348_add_value_type_to_framework_responses.rb
@@ -1,0 +1,5 @@
+class AddValueTypeToFrameworkResponses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :framework_responses, :value_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_10_180043) do
+ActiveRecord::Schema.define(version: 2021_01_07_140348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -238,6 +238,7 @@ ActiveRecord::Schema.define(version: 2020_12_10_180043) do
     t.boolean "prefilled", default: false, null: false
     t.uuid "assessmentable_id"
     t.string "assessmentable_type"
+    t.string "value_type"
     t.index ["assessmentable_type", "assessmentable_id"], name: "index_responses_on_assessmentable_type_and_assessmentable_id"
     t.index ["framework_question_id"], name: "index_framework_responses_on_framework_question_id"
     t.index ["parent_id"], name: "index_framework_responses_on_parent_id"

--- a/lib/tasks/refresh_framework_responses.rake
+++ b/lib/tasks/refresh_framework_responses.rake
@@ -3,4 +3,13 @@ namespace :framework_responses do
   task refresh_data: :environment do
     FrameworkResponse.update_all("assessmentable_type = 'PersonEscortRecord', assessmentable_id = person_escort_record_id")
   end
+
+  desc 'Populate value_type on framework_responses'
+  task populate_value_type: :environment do
+    # Updates the response value type in batches of 1000
+    FrameworkResponse.where(value_type: nil).includes(:framework_question).in_batches.each do |response_batch|
+      response_batch.each { |response| response.value_type = response.framework_question.response_type }
+      FrameworkResponse.import(response_batch.to_a, validate: false, timestamps: false, all_or_none: true, on_duplicate_key_update: %i[value_type])
+    end
+  end
 end

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -293,6 +293,17 @@ RSpec.describe FrameworkQuestion do
       expect(response).not_to be_prefilled
     end
 
+    it 'sets the value type from the question' do
+      question = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_response(
+        question,
+        person_escort_record,
+      )
+
+      expect(response.value_type).to eq('string')
+    end
+
     context 'with previous response value' do
       it 'builds a response with the value set' do
         question = create(:framework_question)
@@ -328,6 +339,42 @@ RSpec.describe FrameworkQuestion do
         )
 
         expect(response).not_to be_prefilled
+      end
+
+      it 'sets prefilled value to false if different question value type supplied' do
+        question = create(:framework_question)
+        person_escort_record = create(:person_escort_record)
+        response = question.build_response(
+          question,
+          person_escort_record,
+          %w[Yes],
+        )
+
+        expect(response).not_to be_prefilled
+      end
+
+      it 'sets value to empty if different question value type supplied' do
+        question = create(:framework_question)
+        person_escort_record = create(:person_escort_record)
+        response = question.build_response(
+          question,
+          person_escort_record,
+          %w[Yes],
+        )
+
+        expect(response.value).to be_nil
+      end
+
+      it 'sets the value type from the question if different question value type supplied' do
+        question = create(:framework_question)
+        person_escort_record = create(:person_escort_record)
+        response = question.build_response(
+          question,
+          person_escort_record,
+          %w[Yes],
+        )
+
+        expect(response.value_type).to eq('string')
       end
     end
   end


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2589

We currently calculate the value type on responses on the fly using the framework questions in framework response serializers. This was previously ok as we were hard coding an eager load list when rendering the framework response serializer. Since we are moving away from this, and only eager loading including resources, reaching into questions for each response will cause n+1 queries. Instead persist the value_type on response creation. 

This is part of a phased deploy, this PR introduces the column and starts populating it going forward. Also add a rake task which backfills all value types in batches, the next pr will start using this value.
