### PR TITLE
P4-2589 Use value_type column value in response serializer

### DIFF
--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -10,11 +10,7 @@ class FrameworkResponseSerializer
   has_many :flags, serializer: FrameworkFlagSerializer, &:framework_flags
   has_many :nomis_mappings, serializer: FrameworkNomisMappingSerializer, &:framework_nomis_mappings
 
-  attributes :value, :responded, :prefilled
-
-  attribute :value_type do |object|
-    object.framework_question.response_type
-  end
+  attributes :value, :responded, :prefilled, :value_type
 
   SUPPORTED_RELATIONSHIPS = %w[
     assessment

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :framework_response do
     association(:framework_question)
     association(:assessmentable, factory: :person_escort_record)
+    value_type { framework_question.response_type }
   end
 
   factory :object_response, parent: :framework_response, class: 'FrameworkResponse::Object' do


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2589

Switch to using persisted value type on responses, to avoid having to reach into framework questions. This is the second part of a phased deploy, after all value types have been backfilled on all ENVs
