### PR TITLE
Set value type when creating framework responses

### DIFF
--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -50,7 +50,7 @@ module FrameworkAssessmentable
         next unless question.parent_id.nil?
 
         response = question.build_responses(assessmentable: self, questions: questions, previous_responses: previous_responses)
-        framework_responses.build(response.slice(:type, :framework_question, :dependents, :value, :prefilled, :assessmentable))
+        framework_responses.build(response.slice(:type, :framework_question, :dependents, :value, :prefilled, :value_type, :assessmentable))
       end
 
       self.class.import([self], validate: false, recursive: true, all_or_none: true, validate_uniqueness: true, on_duplicate_key_update: { conflict_target: [:id] })

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -29,7 +29,7 @@ class FrameworkQuestion < VersionedModel
     question.dependents.each do |dependent_question|
       # NB: to avoid extra queries use original set of questions
       dependent_response = build_responses(question: questions[dependent_question.id], assessmentable: assessmentable, questions: questions, previous_responses: previous_responses)
-      dependent_response_values = dependent_response.slice(:type, :framework_question, :dependents, :assessmentable, :value, :prefilled)
+      dependent_response_values = dependent_response.slice(:type, :framework_question, :dependents, :assessmentable, :value, :prefilled, :value_type)
       response.dependents.build(dependent_response_values)
     end
 

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe FrameworkQuestion do
       expect(response.framework_question).to eq(question)
     end
 
+    it 'builds response with correct value type' do
+      question = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_responses(
+        assessmentable: person_escort_record,
+        questions: questions,
+      )
+
+      expect(response.value_type).to eq('string')
+    end
+
     it 'builds response dependents if question is dependent' do
       person_escort_record = create(:person_escort_record)
       question = create(:framework_question)
@@ -184,6 +195,23 @@ RSpec.describe FrameworkQuestion do
         )
 
         expect(response.dependents.first).to be_prefilled
+      end
+
+      it 'sets value_type on dependents' do
+        person_escort_record = create(:person_escort_record)
+        question = create(:framework_question)
+        dependent_question = create(:framework_question, :checkbox, parent: question)
+        previous_responses = {
+          question.key => 'Yes',
+          dependent_question.key => ['Level 1'],
+        }
+        response = question.build_responses(
+          assessmentable: person_escort_record,
+          questions: questions,
+          previous_responses: previous_responses,
+        )
+
+        expect(response.dependents.first.value_type).to eq('array')
       end
 
       it 'builds response for multiple item question with correct value' do

--- a/spec/support/a_framework_assessment.rb
+++ b/spec/support/a_framework_assessment.rb
@@ -258,6 +258,7 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
         framework_question_id: radio_question.id,
         assessmentable_id: assessment.id,
         type: 'FrameworkResponse::String',
+        value_type: 'string',
       )
     end
 
@@ -290,6 +291,7 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
         framework_question_id: child_question.id,
         assessmentable_id: assessment.id,
         type: 'FrameworkResponse::Array',
+        value_type: 'array',
       )
     end
 


### PR DESCRIPTION
We currently slice response and dependent response values before setting them in bulk when creating an assessment. Make sure `value_type` is in the selected fields to be set on responses as well as dependent responses