### PR TITLE
Set default callbacks to support new i18n gem version

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,7 +65,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
As seen in: https://github.com/ruby-i18n/i18n/releases/tag/v1.1.0

We need to change the `config.i18n.fallbacks` to `[I18n.default_locale]` instead of true to support newest release of i18n.