### PR TITLE
Add a unique index to the profile id on youth risk assessments

### DIFF
--- a/db/migrate/20210113092719_add_unique_index_on_youth_risk_assessment.rb
+++ b/db/migrate/20210113092719_add_unique_index_on_youth_risk_assessment.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexOnYouthRiskAssessment < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :youth_risk_assessments, :profile_id
+    add_index :youth_risk_assessments, :profile_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_140348) do
+ActiveRecord::Schema.define(version: 2021_01_13_092719) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -626,7 +626,7 @@ ActiveRecord::Schema.define(version: 2021_01_07_140348) do
     t.index ["framework_id"], name: "index_youth_risk_assessments_on_framework_id"
     t.index ["move_id"], name: "index_youth_risk_assessments_on_move_id"
     t.index ["prefill_source_id"], name: "index_youth_risk_assessments_on_prefill_source_id"
-    t.index ["profile_id"], name: "index_youth_risk_assessments_on_profile_id"
+    t.index ["profile_id"], name: "index_youth_risk_assessments_on_profile_id", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
Alls well that ends well

To prevent two youth risk assessments being created for the same profile add db level unique index.