### PR TITLE
P4-2564 Improve serializer performance for assessments

### DIFF
--- a/app/controllers/api/framework_assessments_controller.rb
+++ b/app/controllers/api/framework_assessments_controller.rb
@@ -54,7 +54,9 @@ module Api
     end
 
     def assessment
-      @assessment ||= assessment_class.find(params[:id])
+      @assessment ||= assessment_class
+        .includes(active_record_relationships)
+        .find(params[:id])
     end
 
     def render_assessment(assessment, status)

--- a/app/controllers/api/framework_assessments_controller.rb
+++ b/app/controllers/api/framework_assessments_controller.rb
@@ -16,12 +16,12 @@ module Api
     ].freeze
 
     def create
-      assessment = assessment_class.save_with_responses!(
+      new_assessment = assessment_class.save_with_responses!(
         version: new_assessment_params.dig(:attributes, :version),
         move_id: new_assessment_params.dig(:relationships, :move, :data, :id),
       )
 
-      render_assessment(assessment, :created)
+      render_assessment(assessment(new_assessment.id), :created)
     end
 
     def update
@@ -53,10 +53,10 @@ module Api
       assessment_serializer::SUPPORTED_RELATIONSHIPS
     end
 
-    def assessment
+    def assessment(id = params[:id])
       @assessment ||= assessment_class
         .includes(active_record_relationships)
-        .find(params[:id])
+        .find(id)
     end
 
     def render_assessment(assessment, status)

--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -145,9 +145,7 @@ module Api::V2
     def move
       @move ||= Move
         .accessible_by(current_ability)
-        .includes(
-          :from_location, :to_location, profile: { person: %i[gender ethnicity], person_escort_record: { framework_flags: :framework_question }, youth_risk_assessment: { framework_flags: :framework_question } }
-        )
+        .includes(active_record_relationships)
         .find(params[:id])
     end
 

--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -150,9 +150,9 @@ module FrameworkAssessmentable
 
   def previous_responses
     @previous_responses ||= begin
-      return {} unless previous_assessment
+      return {} unless prefill_source
 
-      previous_assessment.framework_responses.includes(framework_question: :dependents).each_with_object({}) do |response, hash|
+      prefill_source.framework_responses.includes(framework_question: :dependents).each_with_object({}) do |response, hash|
         value = response.prefill_value
         next if value.blank?
 

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -14,6 +14,6 @@ class PersonEscortRecord < VersionedModel
 private
 
   def previous_assessment
-    @previous_assessment ||= profile&.person&.latest_person_escort_record
+    profile&.person&.latest_person_escort_record
   end
 end

--- a/app/models/youth_risk_assessment.rb
+++ b/app/models/youth_risk_assessment.rb
@@ -13,7 +13,7 @@ class YouthRiskAssessment < VersionedModel
 private
 
   def previous_assessment
-    @previous_assessment ||= profile&.person&.latest_youth_risk_assessment
+    profile&.person&.latest_youth_risk_assessment
   end
 
   def move_from_location

--- a/app/serializers/framework_assessment_serializer.rb
+++ b/app/serializers/framework_assessment_serializer.rb
@@ -2,15 +2,12 @@
 
 class FrameworkAssessmentSerializer
   include JSONAPI::Serializer
+  include JSONAPI::ConditionalRelationships
 
   belongs_to :framework
 
-  has_many :responses, serializer: FrameworkResponseSerializer do |object|
-    object.framework_responses.includes(:framework_flags, :framework_nomis_mappings, framework_question: [:framework, dependents: :dependents])
-  end
-  has_many :flags, serializer: FrameworkFlagSerializer do |object|
-    object.framework_flags.includes(framework_question: :dependents)
-  end
+  has_many_if_included :responses, serializer: FrameworkResponseSerializer, &:framework_responses
+  has_many_if_included :flags, serializer: FrameworkFlagSerializer, &:framework_flags
 
   attributes :confirmed_at, :created_at, :nomis_sync_status
 

--- a/app/serializers/framework_flag_serializer.rb
+++ b/app/serializers/framework_flag_serializer.rb
@@ -5,7 +5,7 @@ class FrameworkFlagSerializer
 
   set_type :framework_flags
 
-  belongs_to :question, serializer: FrameworkQuestionSerializer, object_method_name: 'framework_question', id_method_name: 'framework_question_id'
+  belongs_to :question, serializer: FrameworkQuestionSerializer, object_method_name: :framework_question, id_method_name: :framework_question_id
 
   attributes :flag_type, :title, :question_value
 

--- a/app/serializers/framework_flag_serializer.rb
+++ b/app/serializers/framework_flag_serializer.rb
@@ -5,7 +5,7 @@ class FrameworkFlagSerializer
 
   set_type :framework_flags
 
-  belongs_to :question, serializer: FrameworkQuestionSerializer, &:framework_question
+  belongs_to :question, serializer: FrameworkQuestionSerializer, object_method_name: 'framework_question', id_method_name: 'framework_question_id'
 
   attributes :flag_type, :title, :question_value
 

--- a/app/serializers/framework_question_serializer.rb
+++ b/app/serializers/framework_question_serializer.rb
@@ -2,6 +2,7 @@
 
 class FrameworkQuestionSerializer
   include JSONAPI::Serializer
+  include JSONAPI::ConditionalRelationships
 
   set_type :framework_questions
 
@@ -9,7 +10,7 @@ class FrameworkQuestionSerializer
 
   attributes :key, :section, :question_type, :options, :response_type
 
-  has_many :descendants, serializer: FrameworkQuestionSerializer, &:dependents
+  has_many_if_included :descendants, serializer: FrameworkQuestionSerializer, &:dependents
 
   SUPPORTED_RELATIONSHIPS = %w[
     framework

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -7,7 +7,7 @@ class FrameworkResponseSerializer
   set_type :framework_responses
 
   belongs_to :assessment, polymorphic: true, &:assessmentable
-  belongs_to :question, serializer: FrameworkQuestionSerializer, object_method_name: 'framework_question', id_method_name: 'framework_question_id'
+  belongs_to :question, serializer: FrameworkQuestionSerializer, object_method_name: :framework_question, id_method_name: :framework_question_id
   has_many_if_included :flags, serializer: FrameworkFlagSerializer, &:framework_flags
   has_many_if_included :nomis_mappings, serializer: FrameworkNomisMappingSerializer, &:framework_nomis_mappings
 

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -2,13 +2,14 @@
 
 class FrameworkResponseSerializer
   include JSONAPI::Serializer
+  include JSONAPI::ConditionalRelationships
 
   set_type :framework_responses
 
   belongs_to :assessment, polymorphic: true, &:assessmentable
-  belongs_to :question, serializer: FrameworkQuestionSerializer, &:framework_question
-  has_many :flags, serializer: FrameworkFlagSerializer, &:framework_flags
-  has_many :nomis_mappings, serializer: FrameworkNomisMappingSerializer, &:framework_nomis_mappings
+  belongs_to :question, serializer: FrameworkQuestionSerializer, object_method_name: 'framework_question', id_method_name: 'framework_question_id'
+  has_many_if_included :flags, serializer: FrameworkFlagSerializer, &:framework_flags
+  has_many_if_included :nomis_mappings, serializer: FrameworkNomisMappingSerializer, &:framework_nomis_mappings
 
   attributes :value, :responded, :prefilled, :value_type
 

--- a/app/services/include_param_handler.rb
+++ b/app/services/include_param_handler.rb
@@ -41,6 +41,14 @@ private
       :framework_flags
     when 'questions'
       :framework_questions
+    when 'question'
+      :framework_question
+    when 'descendants'
+      :dependents
+    when '**'
+      { dependents: :dependents }
+    when 'nomis_mappings'
+      :framework_nomis_mappings
     when 'responses'
       :framework_responses
     when 'timeline_events'

--- a/app/services/include_param_handler.rb
+++ b/app/services/include_param_handler.rb
@@ -46,6 +46,9 @@ private
     when 'descendants'
       :dependents
     when '**'
+      # This was required for the old JSON serializer, which did not load nested resources.
+      # This can be deprecated after clients move off it, and this nested include can move to
+      # `descendants` instead.
       { dependents: :dependents }
     when 'nomis_mappings'
       :framework_nomis_mappings

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -23,9 +23,10 @@ RSpec.describe Api::FrameworkResponsesController do
         },
       }
     end
+    let(:includes) {}
 
     before do
-      patch "/api/v1/framework_responses/#{framework_response_id}", params: framework_response_params, headers: headers, as: :json
+      patch "/api/v1/framework_responses/#{framework_response_id}?include=#{includes}", params: framework_response_params, headers: headers, as: :json
       framework_response.reload
     end
 
@@ -185,6 +186,8 @@ RSpec.describe Api::FrameworkResponsesController do
       end
 
       context 'with flags' do
+        let(:includes) { 'flags' }
+
         it 'attaches a flag and returns the correct data' do
           expect(response_json).to include_json(data: {
             "id": framework_response_id,

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Api::PersonEscortRecordsController do
             },
           },
         },
+        include: 'responses,flags',
       }
     end
 
@@ -131,6 +132,7 @@ RSpec.describe Api::PersonEscortRecordsController do
               },
             },
           },
+          include: 'responses,flags',
         }
       end
       let(:schema) { load_yaml_schema('post_person_escort_record_responses.yaml') }

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::PersonEscortRecordsController do
     let(:person_escort_record_id) { person_escort_record.id }
 
     before do
-      get "/api/v1/person_escort_records/#{person_escort_record_id}", headers: headers, as: :json
+      get "/api/v1/person_escort_records/#{person_escort_record_id}?include=responses,flags", headers: headers, as: :json
     end
 
     context 'when successful' do

--- a/spec/requests/api/youth_risk_assessments_controller_create_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_create_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
             },
           },
         },
+        include: 'responses,flags',
       }
     end
 
@@ -131,6 +132,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
               },
             },
           },
+          include: 'responses,flags',
         }
       end
       let(:schema) { load_yaml_schema('post_youth_risk_assessment_responses.yaml') }

--- a/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
     let(:youth_risk_assessment_id) { youth_risk_assessment.id }
 
     before do
-      get "/api/youth_risk_assessments/#{youth_risk_assessment_id}", headers: headers, as: :json
+      get "/api/youth_risk_assessments/#{youth_risk_assessment_id}?include=flags,responses", headers: headers, as: :json
     end
 
     context 'when successful' do

--- a/spec/serializers/framework_question_serializer_spec.rb
+++ b/spec/serializers/framework_question_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe FrameworkQuestionSerializer do
-  subject(:serializer) { described_class.new(framework_question, include: includes) }
+  subject(:serializer) { described_class.new(framework_question, includes) }
 
   let(:dependent_question) { create :framework_question }
   let(:framework_question) { create :framework_question, dependents: [dependent_question] }
@@ -45,15 +45,24 @@ RSpec.describe FrameworkQuestionSerializer do
     )
   end
 
-  it 'contains a `descendants` relationship' do
-    expect(result[:data][:relationships][:descendants][:data]).to contain_exactly(
-      id: dependent_question.id,
-      type: 'framework_questions',
-    )
+  context 'with descendants' do
+    let(:includes) { { params: { included: %i[descendants] } } }
+
+    it 'contains a `descendants` relationship' do
+      expect(result[:data][:relationships][:descendants][:data]).to contain_exactly(
+        id: dependent_question.id,
+        type: 'framework_questions',
+      )
+    end
   end
 
   context 'with include options' do
-    let(:includes) { %w[framework descendants] }
+    let(:includes) do
+      {
+        include: %w[framework descendants],
+        params: { included: %i[framework descendants] },
+      }
+    end
 
     let(:expected_json) do
       [


### PR DESCRIPTION
### Jira link

[P4-2564]( https://dsdmoj.atlassian.net/browse/P4-2564)

### What?

- Change eager loading includes on move endpoint
- Add eager loading includes on assessments
- Improve assessment serializers to avoid always eager loading resources
- Improve assessment creation performance

### Why?

To improve the performance of assessments, and to avoid always setting up queries for the worst case scenario, only eager load required and included resources. This means we can cleanup the serializers in question.

Whilst testing there were some n+1 queries occurring on latest assessment, so now that has been cleaned up to look at the pre-fill source.

I avoided fixing up more serializers to avoid too much change in one PR. There is further work to be done on the meta section which is also a big offender, which I will be tackling separately. 

### Deployment risks (optional)

- Changes an api that is used in production

