### PR TITLE
Fix filters bug

### DIFF
--- a/app/services/allocations/finder.rb
+++ b/app/services/allocations/finder.rb
@@ -73,7 +73,9 @@ module Allocations
     end
 
     def split_params(name)
-      filter_params[name]&.split(',')
+      return if filter_params[name].blank?
+
+      filter_params[name].split(',')
     end
 
     def apply_location_filters(scope)

--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -40,7 +40,9 @@ module Locations
     end
 
     def split_params(name)
-      filter_params[name]&.split(',')
+      return if filter_params[name].blank?
+
+      filter_params[name].split(',')
     end
 
     def apply_supplier_filters(scope)

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -59,7 +59,9 @@ module Moves
     end
 
     def split_params(name)
-      filter_params[name]&.split(',')
+      return if filter_params[name].blank?
+
+      filter_params[name].split(',')
     end
 
     def apply_filter(scope, param_name)

--- a/app/services/v2/people/finder.rb
+++ b/app/services/v2/people/finder.rb
@@ -16,7 +16,9 @@ module V2
     private
 
       def split_params(name)
-        filter_params[name]&.split(',')
+        return if filter_params[name].blank?
+
+        filter_params[name].split(',')
       end
 
       def apply_filters(scope)

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -341,9 +341,10 @@ RSpec.describe Moves::Finder do
 
       context 'with empty cancellation reason' do
         let(:filter_params) { { cancellation_reason: '' } }
+        let!(:prison_recall_move) { create :move, :prison_recall }
 
         it 'returns only moves without a cancellation reason' do
-          expect(results).to be_empty
+          expect(results).to contain_exactly(prison_recall_move)
         end
       end
 
@@ -386,9 +387,10 @@ RSpec.describe Moves::Finder do
 
       context 'with empty rejection reason' do
         let(:filter_params) { { rejection_reason: '' } }
+        let!(:prison_recall_move) { create :move, :prison_recall }
 
         it 'returns only moves without a rejection reason' do
-          expect(results).to be_empty
+          expect(results).to contain_exactly(prison_recall_move)
         end
       end
 

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -113,6 +113,15 @@ RSpec.describe Moves::Finder do
         end
       end
 
+      context 'with empty location filter' do
+        let!(:second_move) { create(:move, :video_remand) }
+        let(:filter_params) { { to_location_id: [] } }
+
+        it 'returns moves matching empty location' do
+          expect(results).to contain_exactly(second_move)
+        end
+      end
+
       context 'with mis-matching location filter' do
         let(:filter_params) { { to_location_id: Random.uuid } }
 

--- a/spec/services/people/finder_spec.rb
+++ b/spec/services/people/finder_spec.rb
@@ -16,11 +16,29 @@ RSpec.describe People::Finder do
       end
     end
 
+    context 'when filtering by empty police_national_computer' do
+      let(:filter_params) { { police_national_computer: nil } }
+      let!(:other_person) { create(:person, police_national_computer: nil, prison_number: 'GFEDCBA') }
+
+      it 'returns people matching the police_national_computer' do
+        expect(people_finder.call).to eq [other_person]
+      end
+    end
+
     context 'when filtering by prison_number' do
       let(:filter_params) { { prison_number: 'GFEDCBA' } }
 
       it 'returns people matching the prison_number' do
         expect(people_finder.call).to eq [person]
+      end
+    end
+
+    context 'when filtering by empty prison_number' do
+      let(:filter_params) { { prison_number: nil } }
+      let!(:other_person) { create(:person, prison_number: nil) }
+
+      it 'returns people matching the prison_number' do
+        expect(people_finder.call).to eq [other_person]
       end
     end
   end


### PR DESCRIPTION
If a filter is present but empty in a query parameter, it is interpreted as an empty string. When splitting an empty string the result is an empty array. This means that we query an empty array instead of nil for filters which does not return the intended results. Instead we should return nil when the string is empty to query any filter and expect values that are nil to be returned.

```
[3] pry(main)> ''.split(',')
=> []
[4] pry(main)> Move.where(to_location_id: nil).count
   (8.9ms)  SELECT COUNT(*) FROM "moves" WHERE "moves"."to_location_id" IS NULL
=> 3320
[5] pry(main)> Move.where(to_location_id: []).count
   (0.6ms)  SELECT COUNT(*) FROM "moves" WHERE 1=0
=> 0
[6] pry(main)> Move.where(cancellation_reason: []).count
   (0.6ms)  SELECT COUNT(*) FROM "moves" WHERE 1=0
=> 0
[7] pry(main)> Move.where(cancellation_reason: nil).count
   (14.6ms)  SELECT COUNT(*) FROM "moves" WHERE "moves"."cancellation_reason" IS NULL
=> 28222
[8] pry(main)> Move.where(rejection_reason: []).count
   (0.5ms)  SELECT COUNT(*) FROM "moves" WHERE 1=0
=> 0
[9] pry(main)> Move.where(rejection_reason: nil).count
   (16.7ms)  SELECT COUNT(*) FROM "moves" WHERE "moves"."rejection_reason" IS NULL
=> 43062
```