### PR TITLE
Add validation to Person#date_of_birth

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -35,6 +35,7 @@ class Person < VersionedModel
 
   validates :last_name, presence: true
   validates :first_names, presence: true
+  validate :validate_age
 
   auto_strip_attributes :nomis_prison_number, :prison_number, :criminal_records_office, :police_national_computer
 
@@ -79,5 +80,13 @@ class Person < VersionedModel
 
   def category
     @category ||= Categories::FindByNomisBookingId.new(latest_nomis_booking_id).call
+  end
+
+private
+
+  def validate_age
+    if date_of_birth.present? && date_of_birth.year < 1900
+      errors.add(:birth_date, 'must be after 1900-01-01.')
+    end
   end
 end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -22,6 +22,10 @@ FactoryBot.define do
         "T#{number}T#{letter}"
       end
     end
+
+    trait :pre1900 do
+      date_of_birth { Date.new(1899, 1, 1) }
+    end
   end
 
   factory :person_without_profiles, class: 'Person' do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -159,4 +159,10 @@ RSpec.describe Person do
       expect(person.latest_youth_risk_assessment).to eq(newest_youth_risk_assessment)
     end
   end
+
+  context 'when the date of birth is before 1900-01-01' do
+    it 'fails with an error' do
+      expect { create(:person, :pre1900) }.to raise_exception(ActiveRecord::RecordInvalid, 'Validation failed: Birth date must be after 1900-01-01.')
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

P4-2442

### What?

I have added/removed/altered:

- [ ] Added validation to Person#date_of_birth

### Why?

I am doing this because:

- A move recently failed when a person's date of birth was given as `0919-03-01`.