### PR TITLE
P4-2588 Add `section`, `responded_by`, and `responded_at` to framework responses

### DIFF
--- a/app/controllers/api/framework_responses_controller.rb
+++ b/app/controllers/api/framework_responses_controller.rb
@@ -19,13 +19,22 @@ module Api
     rescue_from FrameworkResponses::BulkUpdateError, with: :render_bulk_update_error
 
     def update
-      framework_response.update_with_flags!(update_framework_response_attributes)
+      framework_response.update_with_flags!(
+        new_value: update_framework_response_attributes,
+        responded_by: created_by,
+        responded_at: Time.zone.now.iso8601,
+      )
 
       render_json framework_response, serializer: FrameworkResponseSerializer, include: included_relationships, status: :ok
     end
 
     def bulk_update
-      FrameworkResponses::BulkUpdater.new(assessment, bulk_update_framework_response_values).call
+      FrameworkResponses::BulkUpdater.new(
+        assessment: assessment,
+        response_values_hash: bulk_update_framework_response_values,
+        responded_by: created_by,
+        responded_at: Time.zone.now.iso8601,
+      ).call
 
       render status: :no_content
     end

--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -50,7 +50,7 @@ module FrameworkAssessmentable
         next unless question.parent_id.nil?
 
         response = question.build_responses(assessmentable: self, questions: questions, previous_responses: previous_responses)
-        framework_responses.build(response.slice(:type, :framework_question, :dependents, :value, :prefilled, :value_type, :assessmentable))
+        framework_responses.build(response.slice(:type, :framework_question, :dependents, :value, :prefilled, :value_type, :section, :assessmentable))
       end
 
       self.class.import([self], validate: false, recursive: true, all_or_none: true, validate_uniqueness: true, on_duplicate_key_update: { conflict_target: [:id] })

--- a/app/models/framework_question.rb
+++ b/app/models/framework_question.rb
@@ -29,7 +29,7 @@ class FrameworkQuestion < VersionedModel
     question.dependents.each do |dependent_question|
       # NB: to avoid extra queries use original set of questions
       dependent_response = build_responses(question: questions[dependent_question.id], assessmentable: assessmentable, questions: questions, previous_responses: previous_responses)
-      dependent_response_values = dependent_response.slice(:type, :framework_question, :dependents, :assessmentable, :value, :prefilled, :value_type)
+      dependent_response_values = dependent_response.slice(:type, :framework_question, :dependents, :assessmentable, :value, :prefilled, :value_type, :section)
       response.dependents.build(dependent_response_values)
     end
 
@@ -62,8 +62,8 @@ class FrameworkQuestion < VersionedModel
         FrameworkResponse::String
       end
 
-    klass.new(framework_question: question, assessmentable: assessmentable, value_type: question.response_type, value: previous_response, prefilled: previous_response.present?)
+    klass.new(framework_question: question, assessmentable: assessmentable, value_type: question.response_type, value: previous_response, section: question.section, prefilled: previous_response.present?)
   rescue FrameworkResponse::ValueTypeError
-    klass.new(framework_question: question, assessmentable: assessmentable, value_type: question.response_type)
+    klass.new(framework_question: question, assessmentable: assessmentable, value_type: question.response_type, section: question.section)
   end
 end

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -24,7 +24,7 @@ class FrameworkResponse < VersionedModel
   def update_with_flags!(new_value:, responded_by: nil, responded_at: nil)
     return unless value != new_value
 
-    ApplicationRecord.retriable_transaction { update_response_transaction(new_value, responded_by, responded_at) }
+    ApplicationRecord.retriable_transaction { update_response_transaction(new_value: new_value, responded_by: responded_by, responded_at: responded_at) }
   rescue FiniteMachine::InvalidStateError
     raise ActiveRecord::ReadOnlyRecord, "Can't update framework_responses because assessment is #{assessmentable.status}"
   end
@@ -111,7 +111,7 @@ private
     self.responded = true
   end
 
-  def update_response_transaction(new_value, responded_by, responded_at)
+  def update_response_transaction(new_value:, responded_by:, responded_at:)
     update!(value: new_value, responded_by: responded_by, responded_at: responded_at)
     rebuild_flags!
     FrameworkResponse.clear_dependent_values_and_flags!([self])

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -21,10 +21,10 @@ class FrameworkResponse < VersionedModel
 
   after_validation :set_responded_value, on: :update
 
-  def update_with_flags!(new_value)
+  def update_with_flags!(new_value:, responded_by: nil, responded_at: nil)
     return unless value != new_value
 
-    ApplicationRecord.retriable_transaction { update_response_transaction(new_value) }
+    ApplicationRecord.retriable_transaction { update_response_transaction(new_value, responded_by, responded_at) }
   rescue FiniteMachine::InvalidStateError
     raise ActiveRecord::ReadOnlyRecord, "Can't update framework_responses because assessment is #{assessmentable.status}"
   end
@@ -111,8 +111,8 @@ private
     self.responded = true
   end
 
-  def update_response_transaction(new_value)
-    update!(value: new_value)
+  def update_response_transaction(new_value, responded_by, responded_at)
+    update!(value: new_value, responded_by: responded_by, responded_at: responded_at)
     rebuild_flags!
     FrameworkResponse.clear_dependent_values_and_flags!([self])
 

--- a/app/services/framework_responses/bulk_updater.rb
+++ b/app/services/framework_responses/bulk_updater.rb
@@ -2,11 +2,14 @@
 
 module FrameworkResponses
   class BulkUpdater
-    attr_accessor :assessment, :response_values_hash, :errors
+    attr_accessor :assessment, :response_values_hash, :responded_by, :responded_at, :errors
 
-    def initialize(assessment, response_values_hash)
+    def initialize(assessment:, response_values_hash:, responded_by: nil, responded_at: nil)
       self.assessment = assessment
       self.response_values_hash = response_values_hash
+      self.responded_by = responded_by
+      self.responded_at = responded_at
+
       self.errors = {}
     end
 
@@ -35,6 +38,8 @@ module FrameworkResponses
           next if response.value == new_value && response.responded == true
 
           response.value = new_value
+          response.responded_by = responded_by
+          response.responded_at = responded_at
           if validator.valid_model?(response)
             updated_responses << response
           else
@@ -48,7 +53,7 @@ module FrameworkResponses
 
     def apply_bulk_response_changes(updated_responses)
       # Bulk update all modified response values
-      FrameworkResponse.import(updated_responses, validate: false, on_duplicate_key_update: { conflict_target: [:id], columns: %i[value_text value_json responded] })
+      FrameworkResponse.import(updated_responses, validate: false, on_duplicate_key_update: { conflict_target: [:id], columns: %i[value_text value_json responded responded_by responded_at] })
 
       # Update associated flags for all modified response values
       updated_responses.each(&:rebuild_flags!)

--- a/db/migrate/20210118124654_add_section_and_responded_by_to_framework_responses.rb
+++ b/db/migrate/20210118124654_add_section_and_responded_by_to_framework_responses.rb
@@ -1,0 +1,7 @@
+class AddSectionAndRespondedByToFrameworkResponses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :framework_responses, :section, :string
+    add_column :framework_responses, :responded_by, :string
+    add_column :framework_responses, :responded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_13_092719) do
+ActiveRecord::Schema.define(version: 2021_01_18_124654) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -239,6 +239,9 @@ ActiveRecord::Schema.define(version: 2021_01_13_092719) do
     t.uuid "assessmentable_id"
     t.string "assessmentable_type"
     t.string "value_type"
+    t.string "section"
+    t.string "responded_by"
+    t.datetime "responded_at"
     t.index ["assessmentable_type", "assessmentable_id"], name: "index_responses_on_assessmentable_type_and_assessmentable_id"
     t.index ["framework_question_id"], name: "index_framework_responses_on_framework_question_id"
     t.index ["parent_id"], name: "index_framework_responses_on_parent_id"

--- a/lib/tasks/refresh_framework_responses.rake
+++ b/lib/tasks/refresh_framework_responses.rake
@@ -12,4 +12,13 @@ namespace :framework_responses do
       FrameworkResponse.import(response_batch.to_a, validate: false, timestamps: false, all_or_none: true, on_duplicate_key_update: %i[value_type])
     end
   end
+
+  desc 'Populate section on framework_responses'
+  task populate_section: :environment do
+    # Updates the response section in batches of 1000
+    FrameworkResponse.where(section: nil).includes(:framework_question).in_batches.each do |response_batch|
+      response_batch.each { |response| response.section = response.framework_question.section }
+      FrameworkResponse.import(response_batch.to_a, validate: false, timestamps: false, all_or_none: true, on_duplicate_key_update: %i[section])
+    end
+  end
 end

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     association(:framework_question)
     association(:assessmentable, factory: :person_escort_record)
     value_type { framework_question.response_type }
+    section { framework_question.section }
   end
 
   factory :object_response, parent: :framework_response, class: 'FrameworkResponse::Object' do

--- a/spec/models/framework_question_spec.rb
+++ b/spec/models/framework_question_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe FrameworkQuestion do
       expect(response.value_type).to eq('string')
     end
 
+    it 'builds response with correct section' do
+      question = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_responses(
+        assessmentable: person_escort_record,
+        questions: questions,
+      )
+
+      expect(response.section).to eq(question.section)
+    end
+
     it 'builds response dependents if question is dependent' do
       person_escort_record = create(:person_escort_record)
       question = create(:framework_question)
@@ -214,6 +225,23 @@ RSpec.describe FrameworkQuestion do
         expect(response.dependents.first.value_type).to eq('array')
       end
 
+      it 'sets section on dependents' do
+        person_escort_record = create(:person_escort_record)
+        question = create(:framework_question)
+        dependent_question = create(:framework_question, :checkbox, parent: question)
+        previous_responses = {
+          question.key => 'Yes',
+          dependent_question.key => ['Level 1'],
+        }
+        response = question.build_responses(
+          assessmentable: person_escort_record,
+          questions: questions,
+          previous_responses: previous_responses,
+        )
+
+        expect(response.dependents.first.section).to eq(dependent_question.section)
+      end
+
       it 'builds response for multiple item question with correct value' do
         person_escort_record = create(:person_escort_record)
         question = create(:framework_question, :add_multiple_items)
@@ -332,6 +360,17 @@ RSpec.describe FrameworkQuestion do
       expect(response.value_type).to eq('string')
     end
 
+    it 'sets the section from the question' do
+      question = create(:framework_question)
+      person_escort_record = create(:person_escort_record)
+      response = question.build_response(
+        question,
+        person_escort_record,
+      )
+
+      expect(response.section).to eq(question.section)
+    end
+
     context 'with previous response value' do
       it 'builds a response with the value set' do
         question = create(:framework_question)
@@ -403,6 +442,18 @@ RSpec.describe FrameworkQuestion do
         )
 
         expect(response.value_type).to eq('string')
+      end
+
+      it 'sets the section from the question if different question value type supplied' do
+        question = create(:framework_question)
+        person_escort_record = create(:person_escort_record)
+        response = question.build_response(
+          question,
+          person_escort_record,
+          %w[Yes],
+        )
+
+        expect(response.section).to eq(question.section)
       end
     end
   end

--- a/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Api::FrameworkResponsesController do
     include_context 'with supplier with spoofed access token'
 
     subject(:bulk_update_framework_responses) do
-      Timecop.freeze(recorded_timestamp)
-      patch "/api/person_escort_records/#{per_id}/framework_responses", params: bulk_per_params, headers: headers, as: :json
-      Timecop.return
+      Timecop.freeze(recorded_timestamp) do
+        patch "/api/person_escort_records/#{per_id}/framework_responses", params: bulk_per_params, headers: headers, as: :json
+      end
     end
 
     let(:schema) { load_yaml_schema('patch_framework_response_responses.yaml') }

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -24,9 +24,13 @@ RSpec.describe Api::FrameworkResponsesController do
       }
     end
     let(:includes) {}
+    let(:recorded_timestamp) { Time.zone.parse('2020-10-07 01:02:03').iso8601 }
 
     before do
+      Timecop.freeze(recorded_timestamp)
       patch "/api/v1/framework_responses/#{framework_response_id}?include=#{includes}", params: framework_response_params, headers: headers, as: :json
+      Timecop.return
+
       framework_response.reload
     end
 
@@ -124,6 +128,16 @@ RSpec.describe Api::FrameworkResponsesController do
               "responded": true,
             },
           })
+        end
+      end
+
+      context 'when setting user responded data' do
+        it 'returns the responded by value' do
+          expect(framework_response.responded_by).to eq('TEST_USER')
+        end
+
+        it 'returns the responded at timestamp' do
+          expect(framework_response.responded_at).to eq(recorded_timestamp)
         end
       end
 

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe Api::FrameworkResponsesController do
     let(:recorded_timestamp) { Time.zone.parse('2020-10-07 01:02:03').iso8601 }
 
     before do
-      Timecop.freeze(recorded_timestamp)
-      patch "/api/v1/framework_responses/#{framework_response_id}?include=#{includes}", params: framework_response_params, headers: headers, as: :json
-      Timecop.return
+      Timecop.freeze(recorded_timestamp) do
+        patch "/api/v1/framework_responses/#{framework_response_id}?include=#{includes}", params: framework_response_params, headers: headers, as: :json
+      end
 
       framework_response.reload
     end

--- a/spec/support/a_framework_assessment.rb
+++ b/spec/support/a_framework_assessment.rb
@@ -259,6 +259,7 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
         assessmentable_id: assessment.id,
         type: 'FrameworkResponse::String',
         value_type: 'string',
+        section: radio_question.section,
       )
     end
 
@@ -292,6 +293,7 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
         assessmentable_id: assessment.id,
         type: 'FrameworkResponse::Array',
         value_type: 'array',
+        section: child_question.section,
       )
     end
 


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2588

This is part of multiple PRs to help with performance and capturing of user data.

To help simplify the assessment section completion calculation, add a new field `section` to framework responses, which although causes denormalisation in the data, will help with this calculation and will avoid reaching into framework questions.
The section will be added once on response creation and does not need to be edited after. Also add a backfill task to fill in all older section values on legacy responses. This value does not need to be surfaced through the serializer as its only for internal calculation.

I've also added the `responded_by` and `responded_at` values to responses, to start recording who responds to questions and when. This will help with future work with surfacing who has completed different sections. I'm not going to surface those values either yet.