### PR TITLE
P4 2616 extra journey events

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -22,6 +22,7 @@ class GenericEvent < ApplicationRecord
     JourneyCreate
     JourneyExitThroughOuterGate
     JourneyHandoverToDestination
+    JourneyHandoverToSupplier
     JourneyLockout
     JourneyLodging
     JourneyPersonBoardsVehicle

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -14,6 +14,7 @@ class GenericEvent < ApplicationRecord
 
   STI_CLASSES = %w[
     JourneyAdmitThroughOuterGate
+    JourneyAdmitToReception
     JourneyArriveAtOuterGate
     JourneyCancel
     JourneyChangeVehicle

--- a/app/models/generic_event/journey_admit_through_outer_gate.rb
+++ b/app/models/generic_event/journey_admit_through_outer_gate.rb
@@ -1,8 +1,13 @@
 class GenericEvent
   class JourneyAdmitThroughOuterGate < GenericEvent
+    LOCATION_ATTRIBUTE_KEY = :location_id
+
+    relationship_attributes location_id: :locations
     details_attributes :vehicle_reg, :supplier_personnel_number
     eventable_types 'Journey'
 
     include VehicleRegValidations
+    include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/journey_admit_to_reception.rb
+++ b/app/models/generic_event/journey_admit_to_reception.rb
@@ -1,0 +1,11 @@
+class GenericEvent
+  class JourneyAdmitToReception < GenericEvent
+    LOCATION_ATTRIBUTE_KEY = :location_id
+
+    relationship_attributes location_id: :locations
+    eventable_types 'Journey'
+
+    include LocationValidations
+    include LocationFeed
+  end
+end

--- a/app/models/generic_event/journey_arrive_at_outer_gate.rb
+++ b/app/models/generic_event/journey_arrive_at_outer_gate.rb
@@ -1,5 +1,11 @@
 class GenericEvent
   class JourneyArriveAtOuterGate < GenericEvent
+    LOCATION_ATTRIBUTE_KEY = :location_id
+
+    relationship_attributes location_id: :locations
     eventable_types 'Journey'
+
+    include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/journey_exit_through_outer_gate.rb
+++ b/app/models/generic_event/journey_exit_through_outer_gate.rb
@@ -1,5 +1,11 @@
 class GenericEvent
   class JourneyExitThroughOuterGate < GenericEvent
+    LOCATION_ATTRIBUTE_KEY = :location_id
+
+    relationship_attributes location_id: :locations
     eventable_types 'Journey'
+
+    include LocationValidations
+    include LocationFeed
   end
 end

--- a/app/models/generic_event/journey_handover_to_supplier.rb
+++ b/app/models/generic_event/journey_handover_to_supplier.rb
@@ -1,0 +1,6 @@
+class GenericEvent
+  class JourneyHandoverToSupplier < GenericEvent
+    details_attributes :supplier_personnel_number
+    eventable_types 'Journey'
+  end
+end

--- a/app/models/generic_event/journey_ready_to_exit.rb
+++ b/app/models/generic_event/journey_ready_to_exit.rb
@@ -1,5 +1,11 @@
 class GenericEvent
   class JourneyReadyToExit < GenericEvent
+    LOCATION_ATTRIBUTE_KEY = :location_id
+
+    relationship_attributes location_id: :locations
     eventable_types 'Journey'
+
+    include LocationValidations
+    include LocationFeed
   end
 end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -252,6 +252,16 @@ FactoryBot.define do
     end
   end
 
+  factory :event_journey_handover_to_supplier, parent: :generic_event, class: 'GenericEvent::JourneyHandoverToSupplier' do
+    eventable { association(:journey) }
+
+    details do
+      {
+        supplier_personnel_number: SecureRandom.uuid,
+      }
+    end
+  end
+
   factory :event_journey_lockout, parent: :generic_event, class: 'GenericEvent::JourneyLockout' do
     eventable { association(:journey) }
     details do

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -201,6 +201,16 @@ FactoryBot.define do
     end
   end
 
+  factory :event_journey_admit_to_reception, parent: :generic_event, class: 'GenericEvent::JourneyAdmitToReception' do
+    eventable { association(:journey) }
+    details do
+      {
+        location_id: create(:location).id,
+      }
+    end
+  end
+
+
   factory :event_journey_arrive_at_outer_gate, parent: :generic_event, class: 'GenericEvent::JourneyArriveAtOuterGate' do
     eventable { association(:journey) }
   end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -197,6 +197,7 @@ FactoryBot.define do
       {
         vehicle_reg: Faker::Vehicle.license_plate,
         supplier_personnel_number: SecureRandom.uuid,
+        location_id: create(:location).id,
       }
     end
   end
@@ -210,9 +211,14 @@ FactoryBot.define do
     end
   end
 
-
   factory :event_journey_arrive_at_outer_gate, parent: :generic_event, class: 'GenericEvent::JourneyArriveAtOuterGate' do
     eventable { association(:journey) }
+
+    details do
+      {
+        location_id: create(:location).id,
+      }
+    end
   end
 
   factory :event_journey_cancel, parent: :generic_event, class: 'GenericEvent::JourneyCancel' do
@@ -240,6 +246,12 @@ FactoryBot.define do
 
   factory :event_journey_exit_through_outer_gate, parent: :generic_event, class: 'GenericEvent::JourneyExitThroughOuterGate' do
     eventable { association(:journey) }
+
+    details do
+      {
+        location_id: create(:location).id,
+      }
+    end
   end
 
   factory :event_journey_handover_to_destination, parent: :generic_event, class: 'GenericEvent::JourneyHandoverToDestination' do
@@ -296,6 +308,12 @@ FactoryBot.define do
 
   factory :event_journey_ready_to_exit, parent: :generic_event, class: 'GenericEvent::JourneyReadyToExit' do
     eventable { association(:journey) }
+
+    details do
+      {
+        location_id: create(:location).id,
+      }
+    end
   end
 
   factory :event_journey_reject, parent: :generic_event, class: 'GenericEvent::JourneyReject' do

--- a/spec/models/generic_event/journey_admit_through_outer_gate_spec.rb
+++ b/spec/models/generic_event/journey_admit_through_outer_gate_spec.rb
@@ -5,4 +5,7 @@ RSpec.describe GenericEvent::JourneyAdmitThroughOuterGate do
 
   it_behaves_like 'an event with details', :vehicle_reg, :supplier_personnel_number
   it_behaves_like 'an event that specifies a vehicle registration'
+  it_behaves_like 'an event with relationships', location_id: :locations
+  it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 end

--- a/spec/models/generic_event/journey_admit_to_reception_spec.rb
+++ b/spec/models/generic_event/journey_admit_to_reception_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe GenericEvent::JourneyAdmitToReception do
+  subject(:generic_event) { build(:event_journey_admit_to_reception) }
+
+  it_behaves_like 'an event with relationships', location_id: :locations
+  it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
+end

--- a/spec/models/generic_event/journey_arrive_at_outer_gate_spec.rb
+++ b/spec/models/generic_event/journey_arrive_at_outer_gate_spec.rb
@@ -1,5 +1,9 @@
 RSpec.describe GenericEvent::JourneyArriveAtOuterGate do
   subject(:generic_event) { build(:event_journey_arrive_at_outer_gate) }
 
+  it_behaves_like 'an event with relationships', location_id: :locations
+  it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
+
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
 end

--- a/spec/models/generic_event/journey_exit_through_outer_gate_spec.rb
+++ b/spec/models/generic_event/journey_exit_through_outer_gate_spec.rb
@@ -1,5 +1,9 @@
 RSpec.describe GenericEvent::JourneyExitThroughOuterGate do
   subject(:generic_event) { build(:event_journey_exit_through_outer_gate) }
 
+  it_behaves_like 'an event with relationships', location_id: :locations
+  it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
+
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
 end

--- a/spec/models/generic_event/journey_handover_to_supplier_spec.rb
+++ b/spec/models/generic_event/journey_handover_to_supplier_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe GenericEvent::JourneyHandoverToSupplier do
+  subject(:generic_event) { build(:event_journey_handover_to_supplier) }
+
+  it_behaves_like 'an event with details', :supplier_personnel_number
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
+end

--- a/spec/models/generic_event/journey_ready_to_exit_spec.rb
+++ b/spec/models/generic_event/journey_ready_to_exit_spec.rb
@@ -1,5 +1,9 @@
 RSpec.describe GenericEvent::JourneyReadyToExit do
   subject(:generic_event) { build(:event_journey_ready_to_exit) }
 
+  it_behaves_like 'an event with relationships', location_id: :locations
+  it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
+
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
 end

--- a/spec/requests/api/generic_events_controller_create_journey_events_spec.rb
+++ b/spec/requests/api/generic_events_controller_create_journey_events_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Api::GenericEventsController do
   let(:eventable_id) { create(:journey).id }
 
   it_behaves_like 'a generic event endpoint', 'JourneyAdmitThroughOuterGate'
+  it_behaves_like 'a generic event endpoint', 'JourneyAdmitToReception'
   it_behaves_like 'a generic event endpoint', 'JourneyArriveAtOuterGate'
   it_behaves_like 'a generic event endpoint', 'JourneyCancel'
   it_behaves_like 'a generic event endpoint', 'JourneyChangeVehicle'

--- a/spec/requests/api/generic_events_controller_create_journey_events_spec.rb
+++ b/spec/requests/api/generic_events_controller_create_journey_events_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::GenericEventsController do
   it_behaves_like 'a generic event endpoint', 'JourneyCreate'
   it_behaves_like 'a generic event endpoint', 'JourneyExitThroughOuterGate'
   it_behaves_like 'a generic event endpoint', 'JourneyHandoverToDestination'
+  it_behaves_like 'a generic event endpoint', 'JourneyHandoverToSupplier'
   it_behaves_like 'a generic event endpoint', 'JourneyLockout'
   it_behaves_like 'a generic event endpoint', 'JourneyLodging'
   it_behaves_like 'a generic event endpoint', 'JourneyPersonBoardsVehicle'

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -52,6 +52,8 @@
       :$ref: "../v1/profile.yaml#/Profile"
     :Move:
       :$ref: "../v2/move.yaml#/Move"
+    :Event:
+      :$ref: "../v2/event.yaml#/EventResponseBody"
 :paths:
   "/people":
     get:

--- a/swagger/v2/event.yaml
+++ b/swagger/v2/event.yaml
@@ -169,7 +169,7 @@ EventRequestPostBody:
             - $ref: "../v1/move_reference.yaml#/MoveReference"
             - $ref: "../v1/journey_reference.yaml#/JourneyReference"
             - $ref: "../v1/person_reference.yaml#/PersonReference"
-            - $ref: "../v1/person_reference.yaml#/PersonEscortRecordReference"
+            - $ref: "../v1/person_escort_record_reference.yaml#/PersonEscortRecordReference"
           description: |
             The subject that the event relates too.
 


### PR DESCRIPTION
### Jira link

P4-2616

### What?

I have added/removed/altered:

- [x] Added JourneyAdmitToReception and JourneyHandoverToSupplier events
- [x] Added location to JourneyAdmitThroughOuterGate, JourneyArriveAtOuterGate, JourneyExitThroughOuterGate, JourneyReadyToExit events
- [x] Fixed swagger doc for events

### Why?

I am doing this because:

- so that suppliers can log location with events relating to pick-up / drop-off (otherwise we won't know what they relate to)


### Have you? (optional)

- [x] Updated API docs if necessary	
- [ ] TODO: update github wiki pages

### Deployment risks (optional)

- small; not used in production yet

