### PR TITLE
P4-2588 Add `section_progress` to assessments

### DIFF
--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -44,6 +44,7 @@ module FrameworkAssessmentable
     ApplicationRecord.retriable_transaction do
       self.prefill_source = previous_assessment
       save!
+
       questions = framework_questions.includes(:dependents).index_by(&:id)
       questions.values.each do |question|
         next unless question.parent_id.nil?

--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -118,7 +118,7 @@ private
 
     # lock the status update to avoid race condition on multiple response patches
     assessmentable.with_lock do
-      assessmentable.update_status!
+      assessmentable.update_status_and_progress!
     end
   end
 end

--- a/app/serializers/framework_assessment_serializer.rb
+++ b/app/serializers/framework_assessment_serializer.rb
@@ -24,7 +24,7 @@ class FrameworkAssessmentSerializer
   attribute :editable, &:editable?
 
   meta do |object|
-    { section_progress: object.section_progress }
+    { section_progress: object.calculate_section_progress }
   end
 
   SUPPORTED_RELATIONSHIPS = %w[

--- a/app/services/framework_responses/bulk_updater.rb
+++ b/app/services/framework_responses/bulk_updater.rb
@@ -64,7 +64,7 @@ module FrameworkResponses
 
     def apply_assessment_changes
       # Update PER progress with revised responses
-      assessment.update_status!
+      assessment.update_status_and_progress!
     rescue FiniteMachine::InvalidStateError
       raise ActiveRecord::ReadOnlyRecord, "Can't update framework_responses because assessment is #{assessment.status}"
     end

--- a/db/migrate/20210118152930_add_section_progress_to_assessments.rb
+++ b/db/migrate/20210118152930_add_section_progress_to_assessments.rb
@@ -1,0 +1,6 @@
+class AddSectionProgressToAssessments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :person_escort_records, :section_progress, :jsonb, default: [], null: false
+    add_column :youth_risk_assessments, :section_progress, :jsonb, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_18_124654) do
+ActiveRecord::Schema.define(version: 2021_01_18_152930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -503,6 +503,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_124654) do
     t.jsonb "nomis_sync_status", default: [], null: false
     t.uuid "prefill_source_id"
     t.datetime "completed_at"
+    t.jsonb "section_progress", default: [], null: false
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
     t.index ["move_id"], name: "index_person_escort_records_on_move_id"
     t.index ["prefill_source_id"], name: "index_person_escort_records_on_prefill_source_id"
@@ -626,6 +627,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_124654) do
     t.datetime "completed_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.jsonb "section_progress", default: [], null: false
     t.index ["framework_id"], name: "index_youth_risk_assessments_on_framework_id"
     t.index ["move_id"], name: "index_youth_risk_assessments_on_move_id"
     t.index ["prefill_source_id"], name: "index_youth_risk_assessments_on_prefill_source_id"

--- a/lib/tasks/refresh_assessments.rake
+++ b/lib/tasks/refresh_assessments.rake
@@ -1,0 +1,17 @@
+namespace :assessments do
+  desc 'Populate section_progress on assessments'
+  task populate_section_progress: :environment do
+    PersonEscortRecord.where("section_progress = '[]'").in_batches.each do |batch|
+      update_section_progress(batch, PersonEscortRecord)
+    end
+
+    YouthRiskAssessment.where("section_progress = '[]'").in_batches.each do |batch|
+      update_section_progress(batch, YouthRiskAssessment)
+    end
+  end
+end
+
+def update_section_progress(batch, klass_name)
+  batch.each { |assessment| assessment.section_progress = assessment.calculate_section_progress }
+  klass_name.import(batch.to_a, validate: false, timestamps: false, all_or_none: true, on_duplicate_key_update: %i[section_progress])
+end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe FrameworkResponse do
         response = create(:string_response, value: nil, framework_question: question)
         response.update_with_flags!(new_value: 'Yes')
 
-        expect(response.assessmentable.section_progress).to contain_exactly(
+        expect(response.reload.assessmentable.section_progress).to contain_exactly(
           { 'key' => 'risk-information', 'status' => 'completed' },
         )
       end

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -411,6 +411,16 @@ RSpec.describe FrameworkResponse do
         expect(response1.assessmentable).to be_in_progress
       end
 
+      it 'updates person escort record progress' do
+        question = create(:framework_question, section: 'risk-information')
+        response = create(:string_response, value: nil, framework_question: question)
+        response.update_with_flags!(new_value: 'Yes')
+
+        expect(response.assessmentable.section_progress).to contain_exactly(
+          { 'key' => 'risk-information', 'status' => 'completed' },
+        )
+      end
+
       it 'does not allow updating responses if person_escort_record status is confirmed' do
         person_escort_record = create(:person_escort_record, :confirmed, :with_responses)
         response = person_escort_record.framework_responses.first


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2588

This is the second PR to improve performance. This comes after https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1277 has moved section to framework responses, and all sections have been backfilled.

Add a new column `section_progress` to both assessment tables, to avoid having to do this calculation each time we invoke the PER serialiser. 

First we add the column, and on creation calculate the section progress, then on recalculate on each PATCH either bulk or single. I have tested all PER endpoints and this does not make the calls any worse, as we are making use of already loaded responses on creation, and on PATCH updates we already call the relevant records to calculate the status, so it won't make things worse.

Also add a backfill task to add sections to all existing assessments. After all this is deployed we can move off calculation in the serialiser and just checking the column value instead.