### PR TITLE
P4-2588 Use section progress in serializer

### DIFF
--- a/app/models/framework_response.rb
+++ b/app/models/framework_response.rb
@@ -3,7 +3,7 @@
 class FrameworkResponse < VersionedModel
   ValueTypeError = Class.new(StandardError)
 
-  validates :type, presence: true
+  validates :type, :value_type, :section, presence: true
   validates :responded, inclusion: { in: [true, false] }
   validates_each :value, on: :update do |record, _attr, value|
     record.errors.add(:value, :blank) if requires_value?(value, record)

--- a/app/serializers/framework_assessment_serializer.rb
+++ b/app/serializers/framework_assessment_serializer.rb
@@ -24,7 +24,7 @@ class FrameworkAssessmentSerializer
   attribute :editable, &:editable?
 
   meta do |object|
-    { section_progress: object.calculate_section_progress }
+    { section_progress: object.section_progress }
   end
 
   SUPPORTED_RELATIONSHIPS = %w[

--- a/app/serializers/person_escort_records_serializer.rb
+++ b/app/serializers/person_escort_records_serializer.rb
@@ -13,4 +13,8 @@ class PersonEscortRecordsSerializer
   attribute :status do |object|
     object.status == 'unstarted' ? 'not_started' : object.status
   end
+
+  meta do |object|
+    { section_progress: object.section_progress }
+  end
 end

--- a/db/migrate/20210120101859_add_null_fields_to_framework_responses.rb
+++ b/db/migrate/20210120101859_add_null_fields_to_framework_responses.rb
@@ -1,0 +1,6 @@
+class AddNullFieldsToFrameworkResponses < ActiveRecord::Migration[6.0]
+  def change
+    change_column :framework_responses, :section, :string, null: false
+    change_column :framework_responses, :value_type, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_18_152930) do
+ActiveRecord::Schema.define(version: 2021_01_20_101859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -238,8 +238,8 @@ ActiveRecord::Schema.define(version: 2021_01_18_152930) do
     t.boolean "prefilled", default: false, null: false
     t.uuid "assessmentable_id"
     t.string "assessmentable_type"
-    t.string "value_type"
-    t.string "section"
+    t.string "value_type", null: false
+    t.string "section", null: false
     t.string "responded_by"
     t.datetime "responded_at"
     t.index ["assessmentable_type", "assessmentable_id"], name: "index_responses_on_assessmentable_type_and_assessmentable_id"

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe FrameworkResponse do
   it { is_expected.to have_and_belong_to_many(:framework_flags) }
   it { is_expected.to have_and_belong_to_many(:framework_nomis_mappings) }
   it { is_expected.to validate_presence_of(:type) }
+  it { is_expected.to validate_presence_of(:value_type) }
+  it { is_expected.to validate_presence_of(:section) }
 
   context 'with validations' do
     it 'validates string dependent responses' do

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Api::PersonEscortRecordsController do
     let(:person_escort_record_id) { person_escort_record.id }
 
     before do
+      person_escort_record.update_status_and_progress!
       get "/api/v1/person_escort_records/#{person_escort_record_id}?include=responses,flags", headers: headers, as: :json
     end
 
@@ -30,7 +31,7 @@ RSpec.describe Api::PersonEscortRecordsController do
           "type": 'person_escort_records',
           "attributes": {
             "version": person_escort_record.framework.version,
-            "status": 'not_started',
+            "status": 'completed',
           },
           "meta": {
             'section_progress' => [

--- a/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
     let(:youth_risk_assessment_id) { youth_risk_assessment.id }
 
     before do
+      youth_risk_assessment.update_status_and_progress!
       get "/api/youth_risk_assessments/#{youth_risk_assessment_id}?include=flags,responses", headers: headers, as: :json
     end
 
@@ -30,7 +31,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
           "type": 'youth_risk_assessments',
           "attributes": {
             "version": youth_risk_assessment.framework.version,
-            "status": 'not_started',
+            "status": 'completed',
           },
           "meta": {
             'section_progress' => [

--- a/spec/serializers/framework_assessment_serializer_spec.rb
+++ b/spec/serializers/framework_assessment_serializer_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe FrameworkAssessmentSerializer do
     it 'includes section progress' do
       question = create(:framework_question, framework: assessment.framework, section: 'risk-information')
       create(:string_response, value: nil, framework_question: question, assessmentable: assessment)
+      assessment.update_status_and_progress!
 
       expect(result[:data][:meta][:section_progress]).to contain_exactly(
         key: 'risk-information',

--- a/spec/serializers/person_escort_records_serializer_spec.rb
+++ b/spec/serializers/person_escort_records_serializer_spec.rb
@@ -37,6 +37,25 @@ RSpec.describe PersonEscortRecordsSerializer do
     expect(result[:data][:relationships]).not_to include(:flags)
   end
 
+  describe 'meta' do
+    it 'includes section progress' do
+      question = create(:framework_question, framework: person_escort_record.framework, section: 'risk-information')
+      create(:string_response, value: nil, framework_question: question, assessmentable: person_escort_record)
+      person_escort_record.update_status_and_progress!
+
+      expect(result[:data][:meta][:section_progress]).to contain_exactly(
+        key: 'risk-information',
+        status: 'not_started',
+      )
+    end
+
+    context 'with no questions' do
+      it 'does not include includes section progress' do
+        expect(result[:data][:meta][:section_progress]).to be_empty
+      end
+    end
+  end
+
   context 'with included flags' do
     let(:options) { { params: { included: %i[flags] } } }
 


### PR DESCRIPTION
jira-ticket: https://dsdmoj.atlassian.net/browse/P4-2588

This is the third PR for improving performance.
After all section progress columns are backfilled, use the section progress column instead in assessment serializer and multiple moves PER serializer, to allow section progress to be viewed on FE dashboards. Since responses are created after assessments, explicitly call section calculation in GET specs.

Also add null restrictions and validations to framework response database columns now we ensure they are always populated.