### PR TITLE
Enable youth risk assessments for Feltham A location

### DIFF
--- a/app/services/locations/updater.rb
+++ b/app/services/locations/updater.rb
@@ -2,7 +2,7 @@
 
 module Locations
   class Updater
-    YOI_NOMIS_AGENCIES = %w[WYI WNI CKI PRI FMI].freeze
+    YOI_NOMIS_AGENCIES = %w[WYI WNI CKI PRI FMI FYI].freeze
 
     def self.call
       Location.transaction do


### PR DESCRIPTION
### Jira link

P4-2622

### What?

- [x] Added `FYI` to list of prisons for youth risk assessments.

### Why?

- Looks like this one was missed previously as annoyingly, this location is only present in production environments as it comes from Nomis live, and isn't in Nomis dev.