### PR TITLE
Add amended_at timestamp for subsequent updates of a completed PER

### DIFF
--- a/app/serializers/framework_assessment_serializer.rb
+++ b/app/serializers/framework_assessment_serializer.rb
@@ -9,7 +9,9 @@ class FrameworkAssessmentSerializer
   has_many_if_included :responses, serializer: FrameworkResponseSerializer, &:framework_responses
   has_many_if_included :flags, serializer: FrameworkFlagSerializer, &:framework_flags
 
-  attributes :confirmed_at, :created_at, :nomis_sync_status
+  attributes :completed_at, :confirmed_at, :created_at, :nomis_sync_status
+
+  attribute :amended_at, if: proc { |object| object.respond_to?(:amended_at) }
 
   attribute :version do |object|
     object.framework.version

--- a/app/serializers/framework_assessment_serializer.rb
+++ b/app/serializers/framework_assessment_serializer.rb
@@ -11,8 +11,6 @@ class FrameworkAssessmentSerializer
 
   attributes :completed_at, :confirmed_at, :created_at, :nomis_sync_status
 
-  attribute :amended_at, if: proc { |object| object.respond_to?(:amended_at) }
-
   attribute :version do |object|
     object.framework.version
   end

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -9,4 +9,6 @@ class PersonEscortRecordSerializer < FrameworkAssessmentSerializer
   set_type :person_escort_records
 
   belongs_to :prefill_source, serializer: PersonEscortRecordPrefillSourceSerializer
+
+  attribute :amended_at
 end

--- a/app/serializers/person_escort_records_serializer.rb
+++ b/app/serializers/person_escort_records_serializer.rb
@@ -8,7 +8,7 @@ class PersonEscortRecordsSerializer
 
   has_many_if_included :flags, serializer: FrameworkFlagsSerializer, &:framework_flags
 
-  attributes :confirmed_at, :created_at, :nomis_sync_status
+  attributes :created_at, :completed_at, :amended_at, :confirmed_at, :nomis_sync_status
 
   attribute :status do |object|
     object.status == 'unstarted' ? 'not_started' : object.status

--- a/app/state_machines/framework_assessment_state_machine.rb
+++ b/app/state_machines/framework_assessment_state_machine.rb
@@ -12,7 +12,10 @@ class FrameworkAssessmentStateMachine < FiniteMachine::Definition
   end
 
   on_after :calculate do
-    target.completed_at = Time.zone.now if completed? && target.completed_at.nil?
+    if completed?
+      target.amended_at = Time.zone.now if target.respond_to?(:amended_at) && target.completed_at.present?
+      target.completed_at = Time.zone.now if target.completed_at.nil?
+    end
   end
 
   on_after :confirm do

--- a/db/migrate/20210122172150_add_amended_at_to_person_escort_records.rb
+++ b/db/migrate/20210122172150_add_amended_at_to_person_escort_records.rb
@@ -1,0 +1,5 @@
+class AddAmendedAtToPersonEscortRecords < ActiveRecord::Migration[6.0]
+  def change
+    add_column :person_escort_records, :amended_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_20_101859) do
+ActiveRecord::Schema.define(version: 2021_01_22_172150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -504,6 +504,7 @@ ActiveRecord::Schema.define(version: 2021_01_20_101859) do
     t.uuid "prefill_source_id"
     t.datetime "completed_at"
     t.jsonb "section_progress", default: [], null: false
+    t.datetime "amended_at"
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
     t.index ["move_id"], name: "index_person_escort_records_on_move_id"
     t.index ["prefill_source_id"], name: "index_person_escort_records_on_prefill_source_id"

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe Api::PersonEscortRecordsController do
           "type": 'person_escort_records',
           "attributes": {
             "version": person_escort_record.framework.version,
+            "completed_at": person_escort_record.completed_at.iso8601,
+            "amended_at": nil,
             "status": 'completed',
           },
           "meta": {

--- a/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
           "type": 'youth_risk_assessments',
           "attributes": {
             "version": youth_risk_assessment.framework.version,
+            "completed_at": youth_risk_assessment.completed_at.iso8601,
             "status": 'completed',
           },
           "meta": {

--- a/spec/serializers/framework_assessment_serializer_spec.rb
+++ b/spec/serializers/framework_assessment_serializer_spec.rb
@@ -28,29 +28,13 @@ RSpec.describe FrameworkAssessmentSerializer do
   end
 
   it 'contains a `completed_at` attribute' do
-    expect(result[:data][:attributes][:completed_at]).to eq(assessment.completed_at)
-  end
-
-  describe '#amended_at attribute' do
-    context 'with a person_escort_record' do
-      it 'is included' do
-        assessment.amended_at = Time.zone.now
-        expect(result[:data][:attributes][:amended_at]).to eq(assessment.amended_at.iso8601)
-      end
-    end
-
-    context 'with a youth risk assessment' do
-      let(:location) { create(:location, :secure_childrens_home) }
-      let(:assessment) { create(:youth_risk_assessment, move: move, profile: move.profile) }
-
-      it 'is not included' do
-        expect(result[:data][:attributes]).not_to have_key(:amended_at)
-      end
-    end
+    assessment.completed_at = Time.zone.now
+    expect(result[:data][:attributes][:completed_at]).to eq(assessment.completed_at.iso8601)
   end
 
   it 'contains a `confirmed_at` attribute' do
-    expect(result[:data][:attributes][:confirmed_at]).to eq(assessment.confirmed_at)
+    assessment.confirmed_at = Time.zone.now
+    expect(result[:data][:attributes][:confirmed_at]).to eq(assessment.confirmed_at.iso8601)
   end
 
   it 'contains a `created_at` attribute' do

--- a/spec/serializers/framework_assessment_serializer_spec.rb
+++ b/spec/serializers/framework_assessment_serializer_spec.rb
@@ -5,8 +5,7 @@ require 'rails_helper'
 RSpec.describe FrameworkAssessmentSerializer do
   subject(:serializer) { described_class.new(assessment, includes) }
 
-  let(:location) { create(:location) }
-  let(:move) { create(:move, from_location: location) }
+  let(:move) { create(:move) }
   let(:assessment) { create(:person_escort_record, move: move, profile: move.profile) }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
   let(:includes) { {} }

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe PersonEscortRecordSerializer do
     expect(result[:data][:type]).to eq('person_escort_records')
   end
 
+  it 'contains an `amended_at` attribute' do
+    person_escort_record.amended_at = Time.zone.now
+    expect(result[:data][:attributes][:amended_at]).to eq(person_escort_record.amended_at.iso8601)
+  end
+
   it 'contains a `profile` relationship' do
     expect(result[:data][:relationships][:profile][:data]).to eq(
       id: person_escort_record.profile.id,

--- a/spec/serializers/person_escort_records_serializer_spec.rb
+++ b/spec/serializers/person_escort_records_serializer_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe PersonEscortRecordsSerializer do
     expect(result[:data][:attributes][:status]).to eq('not_started')
   end
 
+  it 'contains a `completed_at` attribute' do
+    person_escort_record.completed_at = Time.zone.now
+    expect(result[:data][:attributes][:completed_at]).to eq(person_escort_record.completed_at.iso8601)
+  end
+
+  it 'contains an `amended_at` attribute' do
+    person_escort_record.amended_at = Time.zone.now
+    expect(result[:data][:attributes][:amended_at]).to eq(person_escort_record.amended_at.iso8601)
+  end
+
   it 'contains a `confirmed_at` attribute' do
     expect(result[:data][:attributes][:confirmed_at]).to eq(person_escort_record.confirmed_at)
   end

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -60,14 +60,6 @@ PersonEscortRecord:
                 type: string
           readOnly: true
           description: A list of all NOMIS resources imported when creating the person escort record, and the status of the import, either successful or failed. The timestamp and error message are also included.
-        confirmed_at:
-          example: "2020-07-24T17:29:26.338Z"
-          oneOf:
-          - type: 'null'
-          - type: string
-            format: date-time
-            description: Timestamp of when the person_escort_record was confirmed
-            readOnly: true
         created_at:
           example: "2020-07-24T17:29:26.338Z"
           oneOf:
@@ -75,6 +67,30 @@ PersonEscortRecord:
           - type: string
             format: date-time
             description: Timestamp of when the person_escort_record was created
+            readOnly: true
+        completed_at:
+          example: "2020-07-24T17:29:26.338Z"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of when the person_escort_record was first completed
+            readOnly: true
+        amended_at:
+          example: "2020-07-24T17:29:26.338Z"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of subsequent amendments to person_escort_record after completion
+            readOnly: true
+        confirmed_at:
+          example: "2020-07-24T17:29:26.338Z"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of when the person_escort_record was confirmed
             readOnly: true
     meta:
       readOnly: true

--- a/swagger/v1/youth_risk_assessment.yaml
+++ b/swagger/v1/youth_risk_assessment.yaml
@@ -60,14 +60,6 @@ YouthRiskAssessment:
                 type: string
           readOnly: true
           description: A list of all NOMIS resources imported when creating the youth risk assessment, and the status of the import, either successful or failed. The timestamp and error message are also included.
-        confirmed_at:
-          example: "2020-07-24T17:29:26.338Z"
-          oneOf:
-          - type: 'null'
-          - type: string
-            format: date-time
-            description: Timestamp of when the youth_risk_assessment was confirmed
-            readOnly: true
         created_at:
           example: "2020-07-24T17:29:26.338Z"
           oneOf:
@@ -75,6 +67,22 @@ YouthRiskAssessment:
           - type: string
             format: date-time
             description: Timestamp of when the youth_risk_assessment was created
+            readOnly: true
+        completed_at:
+          example: "2020-07-24T17:29:26.338Z"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of when the youth_risk_assessment was first completed
+            readOnly: true
+        confirmed_at:
+          example: "2020-07-24T17:29:26.338Z"
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of when the youth_risk_assessment was confirmed
             readOnly: true
     meta:
       readOnly: true


### PR DESCRIPTION
### Jira link

P4-2607

### What?

- [x] Added `amended_at` timestamp for person escort records
- [x] Include new `amended_at` attribute for serialized person escort records
- [x] Include existing `completed_at` attribute for serialized person escort records and youth risk assessments

### Why?

- This attribute is initially `nil` when the PER is first completed. If the PER is updated and completed again the current time is stored. This allows the front end to distinguish between initial completion and subsequent amendments.

- For now `amended_at` is not implemented for youth risk assessments, so the shared state machine checks whether the relevant model supports `amended_at` - if not then it's ignored.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Adds new attributes to existing API endpoints so should be backwards compatible