### PR TITLE
Add a rake task which deletes moves and allocations on staging

### DIFF
--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -76,7 +76,7 @@ namespace :data_maintenance do
       moves.destroy_all
       allocations.destroy_all
     else
-      "You are trying to run this on a production-like environment, which is not allowed."
+      puts "You are trying to run this on a production-like environment, which is not allowed."
     end
   end
 end

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -62,4 +62,21 @@ namespace :data_maintenance do
     GenericEvent.where(type: incident_event_types).update_all(classification: 'incident')
     GenericEvent.where(type: notification_event_types).update_all(classification: 'notification')
   end
+
+  desc 'remove moves and allocations on staging'
+  task remove_data_staging: :environment do
+    # NB: this task should never run on production or pre-production
+    is_not_production = Rails.env.development? || ENV.fetch('HOSTNAME', 'UNKNOWN') =~ /(\-(dev|staging|uat)\-)/i
+
+    if is_not_production
+      moves = Move.all
+      puts "Number of moves to be deleted: #{moves.count}"
+      allocations = Allocation.all
+      puts "Number of allocations to be deleted: #{allocations.count}"
+      moves.destroy_all
+      allocations.destroy_all
+    else
+      "You are trying to run this on a production-like environment, which is not allowed."
+    end
+  end
 end

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -76,7 +76,7 @@ namespace :data_maintenance do
       moves.destroy_all
       allocations.destroy_all
     else
-      puts "You are trying to run this on a production-like environment, which is not allowed."
+      puts 'You are trying to run this on a production-like environment, which is not allowed.'
     end
   end
 end


### PR DESCRIPTION
### Jira link

P4-XXXX

### What?

I have added/removed/altered:

- [x] Added a rake task which removes all moves and allocations in the database. This task can only be run on non-production environments.
### Why?

I am doing this because:

- The frontend e2e tests create a lot of data which leads to API timeouts 
