### PR TITLE
Add rack:timeout gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'paper_trail'
 gem 'pg', '~> 1'
 gem 'prometheus_exporter'
 gem 'puma', '~> 5'
+gem 'rack-timeout', '~> 0.6.0', require: false
 gem 'rails', '~> 6.0.3'
 gem 'redis', '~> 4.2', '>= 4.2.1'
 gem 'routing-filter', '~> 0.6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,6 +259,7 @@ GEM
       rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack-timeout (0.6.0)
     rails (6.0.3.4)
       actioncable (= 6.0.3.4)
       actionmailbox (= 6.0.3.4)
@@ -457,6 +458,7 @@ DEPENDENCIES
   puma (~> 5)
   rack-cors
   rack-test (~> 1.1.0)
+  rack-timeout (~> 0.6.0)
   rails (~> 6.0.3)
   rails-erd
   redis (~> 4.2, >= 4.2.1)

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,8 @@
+# NB: this middleware should never be mounted on production or pre-production
+if Rails.env.development? || ENV.fetch('HOSTNAME', 'UNKNOWN') =~ /(\-(dev|staging|uat)\-)/i
+  require 'rack/timeout/base'
+
+  # Insert timeout middleware with a short timeout to catch downstream timeouts; this can be increased
+  # at a later date once we get a better idea of which requests are problematic.
+  Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 9
+end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

- [x] Add rack timeout gem and enable for non production environments

### Why?

- This is a temporary measure to gather improved diagnostics on dev and staging environments; we've been seeing an increase in timeouts recently but it's not obvious where those timeouts are happening or which requests are causing them. Adding this gem with a short timeout (9 seconds for now) should mean that this timeout fires first and gives decent exception details via Sentry so we have a clearer picture of what's happening rather than relying on just logs.

- As we build a single docker image for distribution on all environments, the gem is enabled for all environment, but to prevent this from affecting production or pre-production sites the timeout middleware is only loaded for specific environments. I've tested this locally and can confirm that the timeout logging statements are only seen when the middleware is explicitly loaded:

```
source=rack-timeout id=1f97b308-f8d5-4847-93f7-7c4d1fd8a604 timeout=9000ms state=ready
source=rack-timeout id=1f97b308-f8d5-4847-93f7-7c4d1fd8a604 timeout=9000ms service=1ms state=active
Started GET "/api-docs/index.html" for ::1 at 2021-01-26 16:50:21 +0000
   (0.6ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
source=rack-timeout id=1f97b308-f8d5-4847-93f7-7c4d1fd8a604 timeout=9000ms service=269ms state=completed
```

### Deployment risks (optional)

- This could lead to inconsistent data either in external systems or the Postgres database, so the relevant middleware is only loaded for non production environments.