### PR TITLE
Add rake task to backfill moves on legacy PERs

### DIFF
--- a/lib/tasks/refresh_assessments.rake
+++ b/lib/tasks/refresh_assessments.rake
@@ -9,6 +9,22 @@ namespace :assessments do
       update_section_progress(batch, YouthRiskAssessment)
     end
   end
+
+  desc 'Populate moves on assessments'
+  task populate_moves: :environment do
+    PersonEscortRecord.where(move: nil).in_batches(of: 10).each do |batch|
+      updated_batch = batch.includes(profile: :moves).each do |assessment|
+        moves = assessment.profile.moves
+        if moves.size > 1
+          print "PersonEscortRecord with id: #{assessment.id} has multiple moves\n"
+        else
+          assessment.move_id = moves.first&.id
+        end
+      end
+
+      PersonEscortRecord.import(updated_batch, validate: false, timestamps: false, all_or_none: true, on_duplicate_key_update: %i[move_id])
+    end
+  end
 end
 
 def update_section_progress(batch, klass_name)


### PR DESCRIPTION
Before attaching a move to a PER, we previously used to attach a profile, which can be linked to multiple moves. Backfill legacy PERs with moves if possible, if there are multiple moves ignore those as they will be attached manually.