### PR TITLE
Enforce a move on a PER

### DIFF
--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -28,6 +28,7 @@ module FrameworkAssessmentable
     has_many :framework_questions, through: :framework
     has_many :framework_flags, through: :framework_responses
     belongs_to :profile
+    belongs_to :move
 
     has_state_machine FrameworkAssessmentStateMachine, on: :status
 
@@ -61,7 +62,7 @@ module FrameworkAssessmentable
   end
 
   def import_nomis_mappings!
-    return unless move&.from_location&.prison?
+    return unless move.from_location.prison?
 
     FrameworkNomisMappings::Importer.new(assessmentable: self).call
   end
@@ -104,7 +105,7 @@ module FrameworkAssessmentable
   end
 
   class_methods do
-    def save_with_responses!(version: nil, move_id: nil)
+    def save_with_responses!(version:, move_id:)
       move = Move.find(move_id)
       profile = move.profile
 
@@ -160,8 +161,6 @@ module FrameworkAssessmentable
   end
 
   def move_status_editable?
-    return true if move.blank?
-
     move.requested? || move.booked?
   end
 end

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -2,8 +2,6 @@ class PersonEscortRecord < VersionedModel
   include FrameworkAssessmentable
 
   belongs_to :prefill_source, class_name: 'PersonEscortRecord', optional: true
-  # To support legacy PERs without a move, allow the association to be optional
-  belongs_to :move, optional: true
 
   has_many :medical_events, -> { where classification: :medical }, as: :eventable, class_name: 'GenericEvent'
 

--- a/app/models/youth_risk_assessment.rb
+++ b/app/models/youth_risk_assessment.rb
@@ -2,7 +2,6 @@ class YouthRiskAssessment < VersionedModel
   include FrameworkAssessmentable
 
   belongs_to :prefill_source, class_name: 'YouthRiskAssessment', optional: true
-  belongs_to :move
 
   validate :move_from_location
 

--- a/db/migrate/20210128153802_add_null_fields_to_person_escort_records.rb
+++ b/db/migrate/20210128153802_add_null_fields_to_person_escort_records.rb
@@ -1,0 +1,5 @@
+class AddNullFieldsToPersonEscortRecords < ActiveRecord::Migration[6.0]
+  def change
+    change_column :person_escort_records, :move_id, :uuid, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_22_172150) do
+ActiveRecord::Schema.define(version: 2021_01_28_153802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -499,7 +499,7 @@ ActiveRecord::Schema.define(version: 2021_01_22_172150) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "confirmed_at"
-    t.uuid "move_id"
+    t.uuid "move_id", null: false
     t.jsonb "nomis_sync_status", default: [], null: false
     t.uuid "prefill_source_id"
     t.datetime "completed_at"

--- a/spec/factories/framework_assessment.rb
+++ b/spec/factories/framework_assessment.rb
@@ -34,6 +34,7 @@ FactoryBot.define do
 
   factory :person_escort_record, class: 'PersonEscortRecord', parent: :framework_assessmentable do
     association(:profile)
+    association(:move)
     association(:framework)
 
     trait :prefilled do

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -149,6 +149,7 @@ FactoryBot.define do
         create(
           :person_escort_record,
           profile: move.profile,
+          move: move,
           status: evaluator.person_escort_record_status,
           confirmed_at: evaluator.person_escort_record_status == 'confirmed' ? Time.zone.now : nil,
           completed_at: evaluator.person_escort_record_status == 'completed' ? Time.zone.now : nil,

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe PersonEscortRecord do
     }
   end
 
-  it { is_expected.to belong_to(:move).optional }
   it { is_expected.to have_many(:medical_events) }
 
   it 'creates NOMIS mappings for framework responses' do
@@ -45,36 +44,6 @@ RSpec.describe PersonEscortRecord do
         { 'resource_type' => 'alerts', 'status' => 'success' },
       ],
     )
-  end
-
-  # To support legacy PERs without a move
-  context 'when no move associated' do
-    describe '#editable?' do
-      it 'is editable if a PER is not confirmed' do
-        person_escort_record = create(:person_escort_record, :with_responses, move: nil)
-
-        expect(person_escort_record).to be_editable
-      end
-
-      it 'is not editable if a PER is confirmed' do
-        person_escort_record = create(:person_escort_record, :confirmed, :with_responses, move: nil)
-
-        expect(person_escort_record).not_to be_editable
-      end
-    end
-
-    describe '#import_nomis_mappings!' do
-      it 'does nothing if no move associated to person escort record' do
-        framework = create(:framework)
-        profile = create(:profile)
-        alert_code = create(:framework_nomis_code, code: 'VI', code_type: 'alert')
-        question = create(:framework_question, framework: framework, framework_nomis_codes: [alert_code])
-        response = create(:string_response, framework_question: question)
-        person_escort_record = create(:person_escort_record, framework: framework, profile: profile, framework_responses: [response])
-
-        expect { person_escort_record.import_nomis_mappings! }.not_to change(FrameworkNomisMapping, :count)
-      end
-    end
   end
 
   describe '#import_nomis_mappings!' do

--- a/spec/models/youth_risk_assessment_spec.rb
+++ b/spec/models/youth_risk_assessment_spec.rb
@@ -5,8 +5,6 @@ require 'rails_helper'
 RSpec.describe YouthRiskAssessment do
   let(:from_location) { create(:location, :stc) }
 
-  it { is_expected.to belong_to(:move) }
-
   context 'with validations' do
     it 'is valid if the move from location is from an stc' do
       location = create(:location, :stc)

--- a/spec/support/a_framework_assessment.rb
+++ b/spec/support/a_framework_assessment.rb
@@ -23,6 +23,7 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
   it { is_expected.to have_many(:generic_events) }
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:profile) }
+  it { is_expected.to belong_to(:move) }
   it { is_expected.to belong_to(:prefill_source).optional }
 
   it 'validates uniqueness of profile' do
@@ -72,7 +73,7 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
     it 'returns error if no framework version passed' do
       create(:framework, name: assessment_type.to_s.dasherize, version: '1.0.0')
       move = create(:move, from_location: from_location)
-      expect { assessment_class.save_with_responses!(move_id: move.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { assessment_class.save_with_responses!(version: nil, move_id: move.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'returns error if nil framework version passed' do


### PR DESCRIPTION
After backfilling all legacy PERs to have moves, enforce a move relationship on a PER. Remove legacy logic which used to support a move existing and not existing.