### PR TITLE
Add support for new handover_details JSONB attribute when confirming PER

### DIFF
--- a/app/controllers/api/framework_assessments_controller.rb
+++ b/app/controllers/api/framework_assessments_controller.rb
@@ -4,13 +4,13 @@ module Api
   class FrameworkAssessmentsController < ApiController
     after_action :send_notification, only: :update
 
-    NEW_PERMITTED_PER_PARAMS = [
+    NEW_ASSESSMENT_PERMITTED_PARAMS = [
       :type,
       attributes: [:version],
       relationships: [move: {}],
     ].freeze
 
-    UPDATE_PERMITTED_PER_PARAMS = [
+    UPDATE_ASSESSMENT_PERMITTED_PARAMS = [
       :type,
       attributes: [:status],
     ].freeze
@@ -26,7 +26,7 @@ module Api
 
     def update
       FrameworkAssessments::ParamsValidator.new(update_assessment_status).validate!
-      assessment.confirm!(update_assessment_status)
+      assessment.confirm!(update_assessment_status, handover_details)
 
       render_assessment(assessment, :ok)
     end
@@ -38,15 +38,19 @@ module Api
   private
 
     def new_assessment_params
-      params.require(:data).permit(NEW_PERMITTED_PER_PARAMS).to_h
+      params.require(:data).permit(NEW_ASSESSMENT_PERMITTED_PARAMS).to_h
     end
 
     def update_assessment_params
-      params.require(:data).permit(UPDATE_PERMITTED_PER_PARAMS)
+      params.require(:data).permit(UPDATE_ASSESSMENT_PERMITTED_PARAMS)
     end
 
     def update_assessment_status
       update_assessment_params.to_h.dig(:attributes, :status)
+    end
+
+    def handover_details
+      update_assessment_params.to_h.dig(:attributes, :handover_details)
     end
 
     def supported_relationships

--- a/app/controllers/api/framework_assessments_controller.rb
+++ b/app/controllers/api/framework_assessments_controller.rb
@@ -26,7 +26,7 @@ module Api
 
     def update
       FrameworkAssessments::ParamsValidator.new(update_assessment_status).validate!
-      assessment.confirm!(update_assessment_status, handover_details)
+      confirm_assessment!(assessment)
 
       render_assessment(assessment, :ok)
     end
@@ -49,10 +49,6 @@ module Api
       update_assessment_params.to_h.dig(:attributes, :status)
     end
 
-    def handover_details
-      update_assessment_params.to_h.dig(:attributes, :handover_details)
-    end
-
     def supported_relationships
       assessment_serializer::SUPPORTED_RELATIONSHIPS
     end
@@ -61,6 +57,10 @@ module Api
       @assessment ||= assessment_class
         .includes(active_record_relationships)
         .find(id)
+    end
+
+    def confirm_assessment!(assessment)
+      assessment.confirm!(update_assessment_status)
     end
 
     def render_assessment(assessment, status)

--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -15,6 +15,11 @@ module Api
       params.require(:data).permit(UPDATE_PER_PERMITTED_PARAMS)
     end
 
+    def confirm_assessment!(assessment)
+      handover_details = update_assessment_params.to_h.dig(:attributes, :handover_details)
+      assessment.confirm!(update_assessment_status, handover_details)
+    end
+
     def assessment_class
       PersonEscortRecord
     end

--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -4,7 +4,16 @@ module Api
   class PersonEscortRecordsController < FrameworkAssessmentsController
     after_action :create_confirmation_event, only: :update # rubocop:disable LexicallyScopedActionFilter
 
+    UPDATE_PER_PERMITTED_PARAMS = [
+      :type,
+      attributes: [:status, handover_details: {}],
+    ].freeze
+
   private
+
+    def update_assessment_params
+      params.require(:data).permit(UPDATE_PER_PERMITTED_PARAMS)
+    end
 
     def assessment_class
       PersonEscortRecord

--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -83,10 +83,11 @@ module FrameworkAssessmentable
     save!
   end
 
-  def confirm!(new_status)
+  def confirm!(new_status, handover_details = nil)
     return unless new_status == ASSESSMENT_CONFIRMED
 
     state_machine.confirm!
+    self.handover_details = handover_details if handover_details.present? && respond_to?(:handover_details)
     save!
   rescue FiniteMachine::InvalidStateError
     errors.add(:status, :invalid_status, message: "can't update to '#{new_status}' from '#{status}'")

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -10,5 +10,5 @@ class PersonEscortRecordSerializer < FrameworkAssessmentSerializer
 
   belongs_to :prefill_source, serializer: PersonEscortRecordPrefillSourceSerializer
 
-  attribute :amended_at
+  attributes :amended_at, :handover_details
 end

--- a/app/serializers/person_escort_records_serializer.rb
+++ b/app/serializers/person_escort_records_serializer.rb
@@ -8,7 +8,7 @@ class PersonEscortRecordsSerializer
 
   has_many_if_included :flags, serializer: FrameworkFlagsSerializer, &:framework_flags
 
-  attributes :created_at, :completed_at, :amended_at, :confirmed_at, :nomis_sync_status
+  attributes :created_at, :completed_at, :amended_at, :confirmed_at, :nomis_sync_status, :handover_details
 
   attribute :status do |object|
     object.status == 'unstarted' ? 'not_started' : object.status

--- a/db/migrate/20210129120302_add_handover_details_to_person_escort_records.rb
+++ b/db/migrate/20210129120302_add_handover_details_to_person_escort_records.rb
@@ -1,0 +1,5 @@
+class AddHandoverDetailsToPersonEscortRecords < ActiveRecord::Migration[6.0]
+  def change
+    add_column :person_escort_records, :handover_details, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_22_172150) do
+ActiveRecord::Schema.define(version: 2021_01_29_120302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -505,6 +505,7 @@ ActiveRecord::Schema.define(version: 2021_01_22_172150) do
     t.datetime "completed_at"
     t.jsonb "section_progress", default: [], null: false
     t.datetime "amended_at"
+    t.jsonb "handover_details", default: {}, null: false
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
     t.index ["move_id"], name: "index_person_escort_records_on_move_id"
     t.index ["prefill_source_id"], name: "index_person_escort_records_on_prefill_source_id"

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -94,5 +94,28 @@ RSpec.describe PersonEscortRecord do
     end
   end
 
+  describe '#confirm!' do
+    it 'stores handover_details if provided' do
+      assessment = create(:person_escort_record, :completed)
+      assessment.confirm!('confirmed', { foo: 'bar' })
+
+      expect(assessment.handover_details).to eq({ 'foo' => 'bar' })
+    end
+
+    it 'does not store handover_details if blank' do
+      assessment = create(:person_escort_record, :completed)
+      assessment.confirm!('confirmed', {})
+
+      expect(assessment.handover_details).to be_empty
+    end
+
+    it 'does not store handover_details if nil' do
+      assessment = create(:person_escort_record, :completed)
+      assessment.confirm!('confirmed', nil)
+
+      expect(assessment.handover_details).to be_empty
+    end
+  end
+
   it_behaves_like 'a framework assessment', :person_escort_record, described_class
 end

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -17,13 +17,16 @@ RSpec.describe Api::PersonEscortRecordsController do
     let(:person_escort_record) { create(:person_escort_record, :with_responses, :completed) }
     let(:person_escort_record_id) { person_escort_record.id }
     let(:status) { 'confirmed' }
+    let(:attributes) do
+      {
+        'status': status,
+      }
+    end
     let(:person_escort_record_params) do
       {
         data: {
-          "type": 'person_escort_records',
-          "attributes": {
-            "status": status,
-          },
+          'type': 'person_escort_records',
+          'attributes': attributes,
         },
       }
     end
@@ -40,8 +43,36 @@ RSpec.describe Api::PersonEscortRecordsController do
             "type": 'person_escort_records',
             "attributes": {
               "status": 'confirmed',
+              "handover_details": {},
               "version": person_escort_record.framework.version,
               "confirmed_at": person_escort_record.confirmed_at.iso8601,
+            },
+          })
+        end
+      end
+
+      context 'when including handover details' do
+        let(:attributes) do
+          {
+            'status': status,
+            'handover_details': {
+              'recipient_name': 'Fulton McKay',
+              'recipient_id': '12345',
+              'recipient_contact_number': '01-811-8055',
+            },
+          }
+        end
+
+        it_behaves_like 'an endpoint that responds with success 200'
+
+        it 'returns the correct handover details' do
+          expect(response_json).to include_json(data: {
+            'attributes': {
+              'handover_details': {
+                'recipient_name': 'Fulton McKay',
+                'recipient_id': '12345',
+                'recipient_contact_number': '01-811-8055',
+              },
             },
           })
         end

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe PersonEscortRecordSerializer do
     expect(result[:data][:attributes][:amended_at]).to eq(person_escort_record.amended_at.iso8601)
   end
 
+  it 'contains a `handover_details` attribute' do
+    person_escort_record.handover_details = { foo: 'bar' }
+    expect(result[:data][:attributes][:handover_details]).to eq(person_escort_record.handover_details.symbolize_keys)
+  end
+
   it 'contains a `profile` relationship' do
     expect(result[:data][:relationships][:profile][:data]).to eq(
       id: person_escort_record.profile.id,

--- a/spec/serializers/person_escort_records_serializer_spec.rb
+++ b/spec/serializers/person_escort_records_serializer_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe PersonEscortRecordsSerializer do
     expect(result[:data][:attributes][:nomis_sync_status]).to eq(person_escort_record.nomis_sync_status)
   end
 
+  it 'contains a `handover_details` attribute' do
+    person_escort_record.handover_details = { foo: 'bar' }
+    expect(result[:data][:attributes][:handover_details]).to eq(person_escort_record.handover_details.symbolize_keys)
+  end
+
   it 'omits `flags` relationship if not explicitly included' do
     expect(result[:data][:relationships]).not_to include(:flags)
   end

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -60,6 +60,11 @@ PersonEscortRecord:
                 type: string
           readOnly: true
           description: A list of all NOMIS resources imported when creating the person escort record, and the status of the import, either successful or failed. The timestamp and error message are also included.
+        handover_details:
+          oneOf:
+          - type: 'null'
+          - type: object
+            description: Optional handover details for the person escort record
         created_at:
           example: "2020-07-24T17:29:26.338Z"
           oneOf:


### PR DESCRIPTION
### Jira link

P4-2625

### What?

- [x] Add new `handover_details` attribute to PER
- [x] Support new attribute for `PATCH /person_escort_records/:id` endpoint
- [x] Include new attribute in PER serializers (defaults to an empty hash)

### Why?

- The initial spike for this work proposed defining explicit attributes for each of the various handover attributes e.g. `handover_recipient` but already we have seen some churn in the requirements and expect this to continue. To provide future flexibility this instead supports a single `handover_details` attribute which will persist any key/value hash the front end wishes to use.

- Currently we only require handover details for PER's so this includes some refactoring to support the diverging parameter support when patching the PER.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production: new attribute is optional when updating a PER so is backwards compatible, but we should probably let suppliers know about it.

