### PR TITLE
Add new handover_occurred_at attribute to PER

### DIFF
--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -6,7 +6,7 @@ module Api
 
     UPDATE_PER_PERMITTED_PARAMS = [
       :type,
-      attributes: [:status, handover_details: {}],
+      attributes: [:status, :handover_occurred_at, handover_details: {}],
     ].freeze
 
   private
@@ -17,7 +17,8 @@ module Api
 
     def confirm_assessment!(assessment)
       handover_details = update_assessment_params.to_h.dig(:attributes, :handover_details)
-      assessment.confirm!(update_assessment_status, handover_details)
+      handover_occurred_at = update_assessment_params.to_h.dig(:attributes, :handover_occurred_at)
+      assessment.confirm!(update_assessment_status, handover_details, handover_occurred_at)
     end
 
     def assessment_class

--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -83,11 +83,12 @@ module FrameworkAssessmentable
     save!
   end
 
-  def confirm!(new_status, handover_details = nil)
+  def confirm!(new_status, handover_details = nil, handover_occurred_at = nil)
     return unless new_status == ASSESSMENT_CONFIRMED
 
     state_machine.confirm!
     self.handover_details = handover_details if handover_details.present? && respond_to?(:handover_details)
+    self.handover_occurred_at = handover_occurred_at if handover_occurred_at.present? && respond_to?(:handover_occurred_at)
     save!
   rescue FiniteMachine::InvalidStateError
     errors.add(:status, :invalid_status, message: "can't update to '#{new_status}' from '#{status}'")

--- a/app/serializers/person_escort_record_serializer.rb
+++ b/app/serializers/person_escort_record_serializer.rb
@@ -10,5 +10,5 @@ class PersonEscortRecordSerializer < FrameworkAssessmentSerializer
 
   belongs_to :prefill_source, serializer: PersonEscortRecordPrefillSourceSerializer
 
-  attributes :amended_at, :handover_details
+  attributes :amended_at, :handover_details, :handover_occurred_at
 end

--- a/app/serializers/person_escort_records_serializer.rb
+++ b/app/serializers/person_escort_records_serializer.rb
@@ -8,7 +8,7 @@ class PersonEscortRecordsSerializer
 
   has_many_if_included :flags, serializer: FrameworkFlagsSerializer, &:framework_flags
 
-  attributes :created_at, :completed_at, :amended_at, :confirmed_at, :nomis_sync_status, :handover_details
+  attributes :created_at, :completed_at, :amended_at, :confirmed_at, :nomis_sync_status, :handover_details, :handover_occurred_at
 
   attribute :status do |object|
     object.status == 'unstarted' ? 'not_started' : object.status

--- a/db/migrate/20210201121439_add_handover_occurred_at_to_person_escort_records.rb
+++ b/db/migrate/20210201121439_add_handover_occurred_at_to_person_escort_records.rb
@@ -1,0 +1,5 @@
+class AddHandoverOccurredAtToPersonEscortRecords < ActiveRecord::Migration[6.0]
+  def change
+    add_column :person_escort_records, :handover_occurred_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_29_120302) do
+ActiveRecord::Schema.define(version: 2021_02_01_121439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -506,6 +506,7 @@ ActiveRecord::Schema.define(version: 2021_01_29_120302) do
     t.jsonb "section_progress", default: [], null: false
     t.datetime "amended_at"
     t.jsonb "handover_details", default: {}, null: false
+    t.datetime "handover_occurred_at"
     t.index ["framework_id"], name: "index_person_escort_records_on_framework_id"
     t.index ["move_id"], name: "index_person_escort_records_on_move_id"
     t.index ["prefill_source_id"], name: "index_person_escort_records_on_prefill_source_id"

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -115,6 +115,28 @@ RSpec.describe PersonEscortRecord do
 
       expect(assessment.handover_details).to be_empty
     end
+
+    it 'stores handover_occurred_at if provided' do
+      timestamp = Time.zone.now
+      assessment = create(:person_escort_record, :completed)
+      assessment.confirm!('confirmed', nil, timestamp.iso8601)
+
+      expect(assessment.handover_occurred_at).to be_within(1.second).of timestamp
+    end
+
+    it 'does not store handover_occurred_at if blank' do
+      assessment = create(:person_escort_record, :completed)
+      assessment.confirm!('confirmed', nil, '')
+
+      expect(assessment.handover_occurred_at).to be_nil
+    end
+
+    it 'does not store handover_occurred_at if nil' do
+      assessment = create(:person_escort_record, :completed)
+      assessment.confirm!('confirmed', nil, nil)
+
+      expect(assessment.handover_occurred_at).to be_nil
+    end
   end
 
   it_behaves_like 'a framework assessment', :person_escort_record, described_class

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Api::PersonEscortRecordsController do
             "attributes": {
               "status": 'confirmed',
               "handover_details": {},
+              "handover_occurred_at": nil,
               "version": person_escort_record.framework.version,
               "confirmed_at": person_escort_record.confirmed_at.iso8601,
             },
@@ -52,6 +53,7 @@ RSpec.describe Api::PersonEscortRecordsController do
       end
 
       context 'when including handover details' do
+        let(:timestamp) { Time.zone.now }
         let(:attributes) do
           {
             'status': status,
@@ -60,6 +62,7 @@ RSpec.describe Api::PersonEscortRecordsController do
               'recipient_id': '12345',
               'recipient_contact_number': '01-811-8055',
             },
+            'handover_occurred_at': timestamp.iso8601,
           }
         end
 
@@ -73,6 +76,7 @@ RSpec.describe Api::PersonEscortRecordsController do
                 'recipient_id': '12345',
                 'recipient_contact_number': '01-811-8055',
               },
+              'handover_occurred_at': timestamp.iso8601,
             },
           })
         end

--- a/spec/serializers/person_escort_record_serializer_spec.rb
+++ b/spec/serializers/person_escort_record_serializer_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe PersonEscortRecordSerializer do
     expect(result[:data][:attributes][:handover_details]).to eq(person_escort_record.handover_details.symbolize_keys)
   end
 
+  it 'contains a `handover_occurred_at` attribute' do
+    person_escort_record.handover_occurred_at = Time.zone.now
+    expect(result[:data][:attributes][:handover_occurred_at]).to eq(person_escort_record.handover_occurred_at.iso8601)
+  end
+
   it 'contains a `profile` relationship' do
     expect(result[:data][:relationships][:profile][:data]).to eq(
       id: person_escort_record.profile.id,

--- a/spec/serializers/person_escort_records_serializer_spec.rb
+++ b/spec/serializers/person_escort_records_serializer_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe PersonEscortRecordsSerializer do
     expect(result[:data][:attributes][:handover_details]).to eq(person_escort_record.handover_details.symbolize_keys)
   end
 
+  it 'contains a `handover_occurred_at` attribute' do
+    person_escort_record.handover_occurred_at = Time.zone.now
+    expect(result[:data][:attributes][:handover_occurred_at]).to eq(person_escort_record.handover_occurred_at.iso8601)
+  end
+
   it 'omits `flags` relationship if not explicitly included' do
     expect(result[:data][:relationships]).not_to include(:flags)
   end

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -65,6 +65,13 @@ PersonEscortRecord:
           - type: 'null'
           - type: object
             description: Optional handover details for the person escort record
+        handover_occurred_at:
+          oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
+            description: Timestamp of when the person escort record handover occurred
+            example: "2020-07-24T17:29:26.338Z"
         created_at:
           example: "2020-07-24T17:29:26.338Z"
           oneOf:


### PR DESCRIPTION
### Jira link

P4-2625

### What?

- [x] Add new `handover_occurred_at` timestamp attribute to person escort records

### Why?

- It's better if this is set explicitly rather than passed as part of the `handover_details` JSON attribute, as this needs to be incorporated into event timestamps in the near future. It's also easier to work with as a strongly typed timestamp rather than having to parse out of the other JSON details.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production; additional attribute is backwards compatible with existing API clients.

