### PR TITLE
Add new PerHandover event

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -70,6 +70,7 @@ class GenericEvent < ApplicationRecord
     PerCourtTakeToSeeVisitors
     PerCourtTask
     PerGeneric
+    PerHandover
     PerMedicalAid
     PerPrisonerWelfare
     PersonMoveAssault

--- a/app/models/generic_event/per_handover.rb
+++ b/app/models/generic_event/per_handover.rb
@@ -1,0 +1,5 @@
+class GenericEvent
+  class PerHandover < GenericEvent
+    include PersonEscortRecordEventValidations
+  end
+end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -522,6 +522,10 @@ FactoryBot.define do
     end
   end
 
+  factory :event_per_handover, parent: :generic_event, class: 'GenericEvent::PerHandover' do
+    eventable { association(:person_escort_record, :confirmed) }
+  end
+
   factory :event_person_move_assault, parent: :incident, class: 'GenericEvent::PersonMoveAssault' do
   end
 

--- a/spec/models/generic_event/per_handover_spec.rb
+++ b/spec/models/generic_event/per_handover_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe GenericEvent::PerHandover do
+  subject(:generic_event) { build(:event_per_handover) }
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
+end

--- a/spec/requests/api/generic_events_controller_create_person_escort_record_events_spec.rb
+++ b/spec/requests/api/generic_events_controller_create_person_escort_record_events_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Api::GenericEventsController do
   it_behaves_like 'a generic event endpoint', 'PerCourtTakeToSeeVisitors'
   it_behaves_like 'a generic event endpoint', 'PerCourtTask'
   it_behaves_like 'a generic event endpoint', 'PerGeneric'
+  it_behaves_like 'a generic event endpoint', 'PerHandover'
   it_behaves_like 'a generic event endpoint', 'PerMedicalAid'
   it_behaves_like 'a generic event endpoint', 'PerPrisonerWelfare'
 end


### PR DESCRIPTION
### Jira link

P4-2591

### What?

- [x] Create a `PerHandover` event when confirming PER with handover details

### Why?

- This is created instead of the PerConfirmation event when a PER is confirmed with the new `handover_details` and `handover_occurred_at` attributes populated; this will be from the updated frontend including the new PER handover screen. 
- We want to use the new PerHandover event when the handover process is used, but retain the original PerConfirmation event for the legacy PER's. The new PerHandover event includes all of the `handover_details` in the `details` section and the `handover_occurred_at` timestamp in the `occurred_at` attribute.
- The new event looks like this when serialized back to the API client:

```json
{
  "data": {
    "id": "3251297f-ec8d-4d5c-9b59-4391f5fec650",
    "type": "events",
    "attributes": {
      "event_type": "PerHandover",
      "classification": "default",
      "occurred_at": "2021-02-03T17:00:46+00:00",
      "recorded_at": "2021-02-03T17:00:46+00:00",
      "notes": "Automatically generated event",
      "created_by": "Foomanchoo",
      "details": {
        "recipient_id": "12345",
        "recipient_name": "Fulton McKay",
        "recipient_contact_number": "01-811-8055"
      }
    },
    "relationships": {
      "eventable": {
        "data": {
          "id": "fe49dd5e-d783-476e-9e67-51cdb630e948",
          "type": "person_escort_records"
        }
      },
      "supplier": {
        "data": null
      }
    }
  }
}
```

### Deployment risks (optional)

- Changes an api that is used in production; only change is a different event being created when confirming the PER so is backwards compatible. The new event will also be documented in the Wiki.

