### PR TITLE
DRY up various implementations of automatic event creation

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -2,6 +2,8 @@
 
 module Api
   class MovesController < ApiController
+    include Eventable
+
     before_action :validate_filter_params, only: %i[index filtered]
 
     CSV_INCLUDES = [:from_location, :to_location, { profile: :documents }, person: %i[gender ethnicity]].freeze

--- a/app/controllers/api/v1/moves_actions.rb
+++ b/app/controllers/api/v1/moves_actions.rb
@@ -26,7 +26,7 @@ module Api::V1
     def update_and_render
       updater.call
 
-      create_auto_event(updater.move, GenericEvent::MoveDateChanged, date: updater.move.date.iso8601) if updater.date_changed
+      create_automatic_event!(eventable: updater.move, event_class: GenericEvent::MoveDateChanged, details: { date: updater.move.date.iso8601 }) if updater.date_changed
 
       Notifier.prepare_notifications(topic: updater.move, action_name: updater.status_changed ? 'update_status' : 'update')
       render_move(updater.move, :ok)
@@ -140,20 +140,6 @@ module Api::V1
 
     def supported_relationships
       MoveSerializer::SUPPORTED_RELATIONSHIPS
-    end
-
-    def create_auto_event(move, event_class, details = {})
-      now = Time.zone.now.iso8601
-
-      event_class.create!(
-        eventable: move,
-        occurred_at: now,
-        recorded_at: now,
-        notes: 'Automatically generated event',
-        details: details,
-        supplier_id: doorkeeper_application_owner&.id,
-        created_by: created_by,
-      )
     end
   end
 end


### PR DESCRIPTION
### Jira link

P4-2591

### What?

- [x] Add new `create_automatic_event!` method and use in various controllers to create associated events

### Why?

- This happens in a few controllers now, so it's good to standardise the implementation of this with a single method with sufficient flexibility to work for all current use cases. Event creation already has good existing coverage to ensure the correct attributes are populated so we can be confident this is working as expected.