### PR TITLE
Add webhook and email notifications for PER amendments

### DIFF
--- a/app/controllers/api/framework_responses_controller.rb
+++ b/app/controllers/api/framework_responses_controller.rb
@@ -108,7 +108,7 @@ module Api
 
     def send_notification
       if assessment.respond_to?(:amended_at) && assessment.amended_at.present?
-        Notifier.prepare_notifications(topic: assessment, action_name: 'amend')
+        Notifier.prepare_notifications(topic: assessment, action_name: 'amend_person_escort_record')
       end
     end
   end

--- a/app/controllers/api/framework_responses_controller.rb
+++ b/app/controllers/api/framework_responses_controller.rb
@@ -2,6 +2,8 @@
 
 module Api
   class FrameworkResponsesController < ApiController
+    after_action :send_notification, only: %i[update bulk_update]
+
     # NB: permit multiple types of value attributes: array, array of objects,
     # object with option details fields, and string
     PERMITTED_PARAMS = [
@@ -68,7 +70,13 @@ module Api
     end
 
     def assessment
-      @assessment ||= params['assessment_class'].find(params[:id])
+      @assessment ||= begin
+        if action_name == 'bulk_update'
+          params['assessment_class'].find(params[:id])
+        else
+          framework_response.assessmentable
+        end
+      end
     end
 
     def render_value_type_error(exception)
@@ -96,6 +104,12 @@ module Api
         json: { errors: errors },
         status: :unprocessable_entity,
       )
+    end
+
+    def send_notification
+      if assessment.respond_to?(:amended_at) && assessment.amended_at.present?
+        Notifier.prepare_notifications(topic: assessment, action_name: 'amend')
+      end
     end
   end
 end

--- a/app/jobs/notify_email_job.rb
+++ b/app/jobs/notify_email_job.rb
@@ -14,7 +14,7 @@ class NotifyEmailJob < ApplicationJob
 
     begin
       # NB: deliver_now! will raise an exception unless the email is delivered to gov.uk Notify
-      response = MoveMailer.notify(notification).deliver_now!
+      response = notification.mailer.notify(notification).deliver_now!
       raise('govuk_notify_response is missing') if response.govuk_notify_response.blank?
 
       notification.update(

--- a/app/jobs/prepare_base_notifications_job.rb
+++ b/app/jobs/prepare_base_notifications_job.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# This job is responsible for preparing a set of notify jobs to run
+class PrepareBaseNotificationsJob < ApplicationJob
+  include QueueDeterminer
+
+  def perform(topic_id:, action_name:, queue_as:, send_webhooks: true, send_emails: true, only_supplier_id: nil)
+    topic = find_topic(topic_id)
+    move = associated_move(topic)
+
+    # if the move has a specified supplier, use it; otherwise use the move.suppliers delegate based on from_location
+    [move.supplier || move.suppliers].flatten.each do |supplier|
+      next unless only_supplier_id.nil? || only_supplier_id == supplier.id
+
+      supplier.subscriptions.kept.each do |subscription|
+        next unless subscription.enabled?
+
+        # NB: always notify the webhook (if defined) on any change, even for back-dated historic moves
+        if send_webhooks && subscription.callback_url.present?
+          NotifyWebhookJob.perform_later(
+            notification_id: build_notification(subscription, NotificationType::WEBHOOK, topic, action_name).id,
+            queue_as: queue_as, # send webhook with same priority as move
+          )
+        end
+
+        # NB: only email in certain conditions (should_email?)
+        next unless send_emails && subscription.email_address.present? && should_email?(move)
+
+        NotifyEmailJob.perform_later(
+          notification_id: build_notification(subscription, NotificationType::EMAIL, topic, action_name).id,
+          queue_as: queue_as, # send email with same priority as move
+        )
+      end
+    end
+  end
+
+private
+
+  def find_topic(topic_id)
+    raise NotImplementedError
+  end
+
+  def associated_move(topic)
+    raise NotImplementedError
+  end
+
+  def build_notification(subscription, type_id, topic, action_name)
+    subscription.notifications.create!(
+      notification_type_id: type_id,
+      topic: topic,
+      event_type: event_type(action_name),
+    )
+  end
+
+  def should_email?(move)
+    # NB: only email for:
+    #   * move.status must be :requested, :booked, :in_transit or :cancelled (not :proposed or :completed), AND
+    #   * move must be current (i.e. move.date is not in the past OR move.to_date is not in the past)
+    [Move::MOVE_STATUS_REQUESTED, Move::MOVE_STATUS_BOOKED, Move::MOVE_STATUS_IN_TRANSIT, Move::MOVE_STATUS_CANCELLED].include?(move.status) && move.current?
+  end
+
+  def event_type(action_name)
+    {
+      'create' => 'create_move',
+      'update' => 'update_move',
+      'update_status' => 'update_move_status',
+      'destroy' => 'destroy_move',
+    }[action_name] || action_name
+  end
+end

--- a/app/jobs/prepare_move_notifications_job.rb
+++ b/app/jobs/prepare_move_notifications_job.rb
@@ -1,39 +1,7 @@
 # frozen_string_literal: true
 
 # This job is responsible for preparing a set of notify jobs to run
-class PrepareMoveNotificationsJob < ApplicationJob
-  include QueueDeterminer
-
-  def perform(topic_id:, action_name:, queue_as:, send_webhooks: true, send_emails: true, only_supplier_id: nil)
-    topic = find_topic(topic_id)
-    move = associated_move(topic)
-
-    # if the move has a specified supplier, use it; otherwise use the move.suppliers delegate based on from_location
-    [move.supplier || move.suppliers].flatten.each do |supplier|
-      next unless only_supplier_id.nil? || only_supplier_id == supplier.id
-
-      supplier.subscriptions.kept.each do |subscription|
-        next unless subscription.enabled?
-
-        # NB: always notify the webhook (if defined) on any change, even for back-dated historic moves
-        if send_webhooks && subscription.callback_url.present?
-          NotifyWebhookJob.perform_later(
-            notification_id: build_notification(subscription, NotificationType::WEBHOOK, topic, action_name).id,
-            queue_as: queue_as, # send webhook with same priority as move
-          )
-        end
-
-        # NB: only email in certain conditions (should_email?)
-        next unless send_emails && subscription.email_address.present? && should_email?(move)
-
-        NotifyEmailJob.perform_later(
-          notification_id: build_notification(subscription, NotificationType::EMAIL, topic, action_name).id,
-          queue_as: queue_as, # send email with same priority as move
-        )
-      end
-    end
-  end
-
+class PrepareMoveNotificationsJob < PrepareBaseNotificationsJob
 private
 
   def find_topic(topic_id)
@@ -42,29 +10,5 @@ private
 
   def associated_move(topic)
     topic
-  end
-
-  def build_notification(subscription, type_id, topic, action_name)
-    subscription.notifications.create!(
-      notification_type_id: type_id,
-      topic: topic,
-      event_type: event_type(action_name),
-    )
-  end
-
-  def should_email?(move)
-    # NB: only email for:
-    #   * move.status must be :requested, :booked, :in_transit or :cancelled (not :proposed or :completed), AND
-    #   * move must be current (i.e. move.date is not in the past OR move.to_date is not in the past)
-    [Move::MOVE_STATUS_REQUESTED, Move::MOVE_STATUS_BOOKED, Move::MOVE_STATUS_IN_TRANSIT, Move::MOVE_STATUS_CANCELLED].include?(move.status) && move.current?
-  end
-
-  def event_type(action_name)
-    {
-      'create' => 'create_move',
-      'update' => 'update_move',
-      'update_status' => 'update_move_status',
-      'destroy' => 'destroy_move',
-    }[action_name] || action_name
   end
 end

--- a/app/jobs/prepare_person_escort_record_notifications_job.rb
+++ b/app/jobs/prepare_person_escort_record_notifications_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This job is responsible for preparing a set of notify jobs to run
+class PreparePersonEscortRecordNotificationsJob < PrepareMoveNotificationsJob
+private
+
+  def find_topic(topic_id)
+    PersonEscortRecord.find(topic_id)
+  end
+
+  def associated_move(topic)
+    topic.move
+  end
+end

--- a/app/jobs/prepare_person_escort_record_notifications_job.rb
+++ b/app/jobs/prepare_person_escort_record_notifications_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # This job is responsible for preparing a set of notify jobs to run
-class PreparePersonEscortRecordNotificationsJob < PrepareMoveNotificationsJob
+class PreparePersonEscortRecordNotificationsJob < PrepareBaseNotificationsJob
 private
 
   def find_topic(topic_id)

--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class BaseMailer < GovukNotifyRails::Mailer
+  TIME_FORMAT = '%d/%m/%Y %T'
+  DATE_FORMAT = '%d/%m/%Y'
+
+  def common_personalisation(notification, move)
+    {
+      'move-reference': move.reference,
+      'from-location': move.from_location.title,
+      # NB: to_location isn't set for prison_recall moves, so use N/A instead (GovUK Notify will error if nil is supplied)
+      'to-location': move.to_location&.title || 'N/A',
+      # NB: date isn't set for proposed moves, so use N/A instead (GovUK Notify will error if nil is supplied)
+      'move-date': move.date&.strftime(DATE_FORMAT) || 'N/A',
+      'move-date-from': move.date_from&.strftime(DATE_FORMAT) || 'N/A',
+      'move-date-to': move.date_to&.strftime(DATE_FORMAT) || 'N/A',
+      'move-created-at': move.created_at.strftime(TIME_FORMAT),
+      'notification-created-at': Time.zone.now.strftime(TIME_FORMAT),
+      'move-status': move.status,
+      'environment': ENV.fetch('SERVER_FQDN', Rails.env),
+      'supplier': notification.subscription.supplier.name,
+      'event-type': notification.event_type,
+    }
+  end
+end

--- a/app/mailers/move_mailer.rb
+++ b/app/mailers/move_mailer.rb
@@ -1,30 +1,16 @@
 # frozen_string_literal: true
 
-class MoveMailer < GovukNotifyRails::Mailer
-  TIME_FORMAT = '%d/%m/%Y %T'
-  DATE_FORMAT = '%d/%m/%Y'
-
+class MoveMailer < BaseMailer
   def notify(notification)
-    set_template(ENV.fetch('GOVUK_NOTIFY_TEMPLATE_ID', nil))
+    # TODO: Remove use of GOVUK_NOTIFY_TEMPLATE_ID
+    set_template(ENV.fetch('GOVUK_NOTIFY_MOVE_TEMPLATE_ID', ENV.fetch('GOVUK_NOTIFY_TEMPLATE_ID', nil)))
     set_reference(notification.id)
     notification.topic.tap do |move|
       set_personalisation(
-        'move-reference': move.reference,
-        'from-location': move.from_location.title,
-        # NB: to_location isn't set for prison_recall moves, so use N/A instead (GovUK Notify will error if nil is supplied)
-        'to-location': move.to_location&.title || 'N/A',
-        # NB: date isn't set for proposed moves, so use N/A instead (GovUK Notify will error if nil is supplied)
-        'move-date': move.date&.strftime(DATE_FORMAT) || 'N/A',
-        'move-date-from': move.date_from&.strftime(DATE_FORMAT) || 'N/A',
-        'move-date-to': move.date_to&.strftime(DATE_FORMAT) || 'N/A',
-        'move-created-at': move.created_at.strftime(TIME_FORMAT),
-        'move-updated-at': move.updated_at.strftime(TIME_FORMAT),
-        'notification-created-at': Time.zone.now.strftime(TIME_FORMAT),
-        'move-action': move.status, # this is the same as the move status and will only be "requested", "booked", "in_transit" or "cancelled"
-        'move-status': move.status,
-        'environment': ENV.fetch('SERVER_FQDN', Rails.env),
-        'supplier': notification.subscription.supplier.name,
-        'event-type': notification.event_type,
+        common_personalisation(notification, move).merge(
+          'move-updated-at': move.updated_at.strftime(TIME_FORMAT),
+          'move-action': move.status, # this is the same as the move status and will only be "requested", "booked", "in_transit" or "cancelled"
+        ),
       )
     end
     mail(to: notification.subscription.email_address)

--- a/app/mailers/person_escort_record_mailer.rb
+++ b/app/mailers/person_escort_record_mailer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class PersonEscortRecordMailer < BaseMailer
+  def notify(notification)
+    set_template(ENV.fetch('GOVUK_NOTIFY_PER_TEMPLATE_ID', nil))
+    set_reference(notification.id)
+    notification.topic.tap do |per|
+      set_personalisation(
+        common_personalisation(notification, per.move).merge(
+          'per-amended-at': per.amended_at.strftime(TIME_FORMAT),
+        ),
+      )
+    end
+    mail(to: notification.subscription.email_address)
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -39,4 +39,12 @@ class Notification < ApplicationRecord
   def for_feed
     attributes.slice(*FEED_ATTRIBUTES)
   end
+
+  def mailer
+    if topic.is_a?(PersonEscortRecord)
+      PersonEscortRecordMailer
+    else
+      MoveMailer
+    end
+  end
 end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# NB: at the moment this serializer only supports Move topics. In the future we should also support Person topics.
 class NotificationSerializer
   include JSONAPI::Serializer
 
@@ -10,11 +9,11 @@ class NotificationSerializer
 
   attribute :timestamp, &:created_at
 
-  belongs_to :topic, polymorphic: true, key: :move, if: proc { |object| move?(object) }, links: {
+  belongs_to :move, id_method_name: :topic_id, if: proc { |object| object.topic.is_a?(Move) }, links: {
     self: ->(object) { Rails.application.routes.url_helpers.api_move_url(object.topic.id) },
   }
 
-  def self.move?(object)
-    object.topic.is_a?(Move)
-  end
+  belongs_to :person_escort_record, id_method_name: :topic_id, if: proc { |object| object.topic.is_a?(PersonEscortRecord) }, links: {
+    self: ->(object) { Rails.application.routes.url_helpers.api_person_escort_record_url(object.topic.id) },
+  }
 end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -12,7 +12,11 @@ class Notifier
     when Profile
       PrepareProfileNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
     when PersonEscortRecord, YouthRiskAssessment
-      PrepareAssessmentNotificationsJob.perform_later(topic_id: topic.id, topic_class: topic.class.name, queue_as: :notifications_medium)
+      if topic.is_a?(PersonEscortRecord) && action_name == 'amend'
+        PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: move_queue_priority(topic.move))
+      else
+        PrepareAssessmentNotificationsJob.perform_later(topic_id: topic.id, topic_class: topic.class.name, queue_as: :notifications_medium)
+      end
     end
   end
 end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -12,7 +12,7 @@ class Notifier
     when Profile
       PrepareProfileNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
     when PersonEscortRecord, YouthRiskAssessment
-      if topic.is_a?(PersonEscortRecord) && action_name == 'amend'
+      if topic.is_a?(PersonEscortRecord) && action_name == 'amend_person_escort_record'
         PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: move_queue_priority(topic.move))
       else
         PrepareAssessmentNotificationsJob.perform_later(topic_id: topic.id, topic_class: topic.class.name, queue_as: :notifications_medium)

--- a/config/initializers/gov_uk_notify.rb
+++ b/config/initializers/gov_uk_notify.rb
@@ -6,6 +6,7 @@ if ENV['GOVUK_NOTIFY_ENABLED'] =~ /true/i
     Raven.capture_message('GOVUK_NOTIFY_API_KEY env var is not set; emails cannot be sent', { level: 'warning' })
   end
 
+  # TODO: Remove use of GOVUK_NOTIFY_TEMPLATE_ID - change to GOVUK_NOTIFY_MOVE_TEMPLATE_ID & GOVUK_NOTIFY_PER_TEMPLATE_ID
   if ENV['GOVUK_NOTIFY_TEMPLATE_ID'].blank?
     Rails.logger.warn('GOVUK_NOTIFY_TEMPLATE_ID env var is not set; emails cannot be sent')
     Raven.capture_message('GOVUK_NOTIFY_TEMPLATE_ID env var is not set; emails cannot be sent', { level: 'warning' })

--- a/spec/factories/framework_assessment.rb
+++ b/spec/factories/framework_assessment.rb
@@ -39,6 +39,10 @@ FactoryBot.define do
     trait :prefilled do
       association(:prefill_source, factory: :person_escort_record)
     end
+
+    trait :amended do
+      amended_at { Time.zone.now }
+    end
   end
 
   factory :youth_risk_assessment, class: 'YouthRiskAssessment', parent: :framework_assessmentable do

--- a/spec/jobs/notify_email_job_spec.rb
+++ b/spec/jobs/notify_email_job_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe NotifyEmailJob, type: :job do
   let(:notification) { create(:notification, :email, subscription: subscription, delivered_at: delivered_at, delivery_attempted_at: nil) }
   let(:delivered_at) { nil }
   let(:govuk_notify_api_key) { 'GOVUK_NOTIFY_API_KEY' }
-  let(:govuk_notify_template_id) { 'GOVUK_NOTIFY_TEMPLATE_ID' }
+  let(:govuk_notify_move_template_id) { 'GOVUK_NOTIFY_MOVE_TEMPLATE_ID' }
 
   before do
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with('GOVUK_NOTIFY_API_KEY', nil).and_return(govuk_notify_api_key)
-    allow(ENV).to receive(:fetch).with('GOVUK_NOTIFY_TEMPLATE_ID', nil).and_return(govuk_notify_template_id)
+    allow(ENV).to receive(:fetch).with('GOVUK_NOTIFY_MOVE_TEMPLATE_ID', nil).and_return(govuk_notify_move_template_id)
     ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery, api_key: govuk_notify_api_key
   end
 
@@ -29,8 +29,8 @@ RSpec.describe NotifyEmailJob, type: :job do
     end
   end
 
-  context 'when GOVUK_NOTIFY_TEMPLATE_ID env var is not set' do
-    let(:govuk_notify_template_id) { nil }
+  context 'when GOVUK_NOTIFY_MOVE_TEMPLATE_ID env var is not set' do
+    let(:govuk_notify_move_template_id) { nil }
 
     it 'raises an ArgumentError' do
       expect { perform! }.to raise_error(ArgumentError, /Missing template ID/)

--- a/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe PreparePersonEscortRecordNotificationsJob, type: :job do
+  subject(:perform) do
+    described_class.perform_now(topic_id: per.id, action_name: action_name, queue_as: :some_queue_name, send_webhooks: send_webhooks, send_emails: send_emails, only_supplier_id: only_supplier_id)
+  end
+
+  let(:subscription) { create :subscription }
+  let(:supplier) { create :supplier, name: 'test', subscriptions: [subscription] }
+  let(:location) { create :location, suppliers: [supplier] }
+  let(:move) { create :move, from_location: location, supplier: supplier }
+  let(:per) { create :person_escort_record, :amended, move: move }
+  let(:action_name) { 'amended' }
+  let(:send_webhooks) { true }
+  let(:send_emails) { true }
+  let(:only_supplier_id) { nil }
+
+  before do
+    create(:notification_type, :webhook)
+    create(:notification_type, :email)
+
+    allow(NotifyWebhookJob).to receive(:perform_later)
+    allow(NotifyEmailJob).to receive(:perform_later)
+  end
+
+  context 'when amending a person escort record' do
+    let(:action_name) { 'confirm_person_escort_record' }
+
+    it 'creates a webhook notification record' do
+      expect { perform }.to change(Notification.webhooks, :count).by(1)
+    end
+
+    it 'creates an email notification record' do
+      expect { perform }.to change(Notification.emails, :count).by(1)
+    end
+
+    it 'schedules NotifyWebhookJob' do
+      perform
+      expect(NotifyWebhookJob).to have_received(:perform_later).with(notification_id: Notification.webhooks.last.id, queue_as: :some_queue_name)
+    end
+
+    it 'schedules NotifyEmailJob' do
+      perform
+      expect(NotifyEmailJob).to have_received(:perform_later).with(notification_id: Notification.emails.last.id, queue_as: :some_queue_name)
+    end
+  end
+end

--- a/spec/mailer/person_escort_record_mailer_spec.rb
+++ b/spec/mailer/person_escort_record_mailer_spec.rb
@@ -2,18 +2,19 @@
 
 require 'rails_helper'
 
-RSpec.describe MoveMailer, type: :mailer do
+RSpec.describe PersonEscortRecordMailer, type: :mailer do
   subject(:mail) { described_class.notify(notification) }
 
   let(:supplier) { create(:supplier, name: 'Test Supplier') }
   let(:subscription) { create(:subscription, supplier: supplier, email_address: 'user@foo.bar') }
-  let(:notification) { create(:notification, :email, subscription: subscription, topic: move) }
+  let(:notification) { create(:notification, :email, subscription: subscription, topic: per) }
   let(:move) { create(:move, reference: 'MOVEREF1', status: Move::MOVE_STATUS_REQUESTED) }
+  let(:per) { create(:person_escort_record, :amended, move: move) }
 
   before do
     ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery, api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY', nil)
     allow(ENV).to receive(:fetch).and_call_original
-    allow(ENV).to receive(:fetch).with('GOVUK_NOTIFY_MOVE_TEMPLATE_ID', nil).and_return('some-template-id')
+    allow(ENV).to receive(:fetch).with('GOVUK_NOTIFY_PER_TEMPLATE_ID', nil).and_return('some-template-id')
     allow(ENV).to receive(:fetch).with('SERVER_FQDN', Rails.env).and_return('www.example.org')
   end
 
@@ -39,28 +40,9 @@ RSpec.describe MoveMailer, type: :mailer do
     it { is_expected.to include('move-date-from': move.date_from.strftime('%d/%m/%Y')) }
     it { is_expected.to include('move-date-to': 'N/A') }
     it { is_expected.to include('move-created-at': move.created_at.strftime('%d/%m/%Y %T')) }
-    it { is_expected.to include('move-updated-at': move.updated_at.strftime('%d/%m/%Y %T')) }
-    it { is_expected.to include('move-action': 'requested') }
+    it { is_expected.to include('per-amended-at': per.amended_at.strftime('%d/%m/%Y %T')) }
     it { is_expected.to include('move-status': 'requested') }
     it { is_expected.to include('environment': 'www.example.org') }
     it { is_expected.to include('supplier': 'Test Supplier') }
-  end
-
-  context 'when move is a prison recall' do
-    let(:move) { create(:move, :prison_recall, :requested) }
-
-    describe 'govuk_notify_personalisation' do
-      subject(:govuk_notify_personalisation) { mail.govuk_notify_personalisation }
-
-      it { is_expected.to include('move-reference': move.reference) }
-      it { is_expected.to include('from-location': move.from_location.title) }
-      it { is_expected.to include('to-location': 'N/A') }
-      it { is_expected.to include('move-created-at': move.created_at.strftime('%d/%m/%Y %T')) }
-      it { is_expected.to include('move-updated-at': move.updated_at.strftime('%d/%m/%Y %T')) }
-      it { is_expected.to include('move-action': 'requested') }
-      it { is_expected.to include('move-status': 'requested') }
-      it { is_expected.to include('environment': 'www.example.org') }
-      it { is_expected.to include('supplier': 'Test Supplier') }
-    end
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -83,4 +83,20 @@ RSpec.describe Notification, type: :model do
       expect(notification.for_feed).to include_json(expected_json)
     end
   end
+
+  describe 'mailer' do
+    it 'returns correct mailer class for a PersonEscortRecord' do
+      topic = create(:person_escort_record)
+      notification = build(:notification, topic: topic)
+
+      expect(notification.mailer).to eq(PersonEscortRecordMailer)
+    end
+
+    it 'returns correct mailer class for a Move' do
+      topic = create(:move)
+      notification = build(:notification, topic: topic)
+
+      expect(notification.mailer).to eq(MoveMailer)
+    end
+  end
 end

--- a/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe Api::FrameworkResponsesController do
         expect(notification).to have_attributes(
           topic: person_escort_record,
           notification_type: notification_type_webhook,
-          event_type: 'amend',
+          event_type: 'amend_person_escort_record',
         )
       end
 
@@ -358,7 +358,7 @@ RSpec.describe Api::FrameworkResponsesController do
         expect(notification).to have_attributes(
           topic: person_escort_record,
           notification_type: notification_type_email,
-          event_type: 'amend',
+          event_type: 'amend_person_escort_record',
         )
       end
 

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::FrameworkResponsesController do
     include_context 'with supplier with spoofed access token'
 
     subject(:patch_response) do
-      patch "/api/v1/framework_responses/#{framework_response_id}?include=#{includes}", params: framework_response_params, headers: headers, as: :json
+      patch "/api/framework_responses/#{framework_response_id}?include=#{includes}", params: framework_response_params, headers: headers, as: :json
     end
 
     let(:schema) { load_yaml_schema('patch_framework_response_responses.yaml') }

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Api::FrameworkResponsesController do
         expect(notification).to have_attributes(
           topic: person_escort_record,
           notification_type: notification_type_webhook,
-          event_type: 'amend',
+          event_type: 'amend_person_escort_record',
         )
       end
 
@@ -376,7 +376,7 @@ RSpec.describe Api::FrameworkResponsesController do
         expect(notification).to have_attributes(
           topic: person_escort_record,
           notification_type: notification_type_email,
-          event_type: 'amend',
+          event_type: 'amend_person_escort_record',
         )
       end
 

--- a/spec/serializers/notification_serializer_spec.rb
+++ b/spec/serializers/notification_serializer_spec.rb
@@ -20,17 +20,6 @@ RSpec.describe NotificationSerializer do
             "event_type": 'move_created',
             "timestamp": notification.created_at.iso8601,
           },
-          "relationships": {
-            "move": {
-              "data": {
-                "id": notification.topic.id,
-                "type": 'moves',
-              },
-              "links": {
-                "self": "http://localhost:4000/api/v1/moves/#{notification.topic.id}",
-              },
-            },
-          },
         },
       }
     end
@@ -52,16 +41,29 @@ RSpec.describe NotificationSerializer do
     end
 
     context 'when topic is a Move' do
-      it 'contains a move relationship data' do
+      it 'contains move relationship data' do
         expect(result[:data][:relationships][:move][:data]).to eql(id: notification.topic.id, type: 'moves')
       end
 
-      it 'contains a move relationship links' do
+      it 'contains move relationship links' do
         expect(result[:data][:relationships][:move][:links]).to eql(self: "http://localhost:4000/api/v1/moves/#{notification.topic.id}")
       end
     end
 
-    context 'when topic is not a Move' do
+    context 'when topic is a PersonEscortRecord' do
+      let(:per) { create(:person_escort_record) }
+      let(:notification) { create(:notification, topic: per) }
+
+      it 'contains person_escort_record relationship data' do
+        expect(result[:data][:relationships][:person_escort_record][:data]).to eql(id: per.id, type: 'person_escort_records')
+      end
+
+      it 'contains person_escort_record relationship links' do
+        expect(result[:data][:relationships][:person_escort_record][:links]).to eql(self: "http://localhost:4000/api/v1/person_escort_records/#{per.id}")
+      end
+    end
+
+    context 'when topic is not a Move or PersonEscortRecord' do
       let(:allocation) { create(:allocation) }
       let(:notification) { create(:notification, topic: allocation) }
 

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Notifier do
   context 'when scheduled with a person_escort_record amendment' do
     let(:move) { create(:move, date: Time.zone.tomorrow) }
     let(:topic) { create(:person_escort_record, move: move) }
-    let(:action_name) { 'amend' }
+    let(:action_name) { 'amend_person_escort_record' }
 
     it 'queues a job' do
       expect(PreparePersonEscortRecordNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -57,7 +57,17 @@ RSpec.describe Notifier do
     end
   end
 
-  context 'when scheduled with a person_escort_record' do
+  context 'when scheduled with a person_escort_record amendment' do
+    let(:move) { create(:move, date: Time.zone.tomorrow) }
+    let(:topic) { create(:person_escort_record, move: move) }
+    let(:action_name) { 'amend' }
+
+    it 'queues a job' do
+      expect(PreparePersonEscortRecordNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
+    end
+  end
+
+  context 'when scheduled with another person_escort_record action' do
     let(:topic) { create(:person_escort_record) }
 
     it 'queues a job' do


### PR DESCRIPTION
### Jira link

P4-2627

### What?

- [x] Lots and lots of refactoring (see below) to support new notifications when completed PER's are amended.

### Why?

- This requires a new Gov notify template as the email content is different than for moves, and updates to the webhook serializer as we want to send notifications (including a link) related directly to the PER. This presents some interesting challenges as there is a lot of shared behaviour for both notifications and we also need to be careful not to break and notification jobs that may be currently queued in sidekiq, so cannot change any method signatures or underlying behaviour.

- The approach I've taken is to add a new mailer class for the PER, but refactored the existing MoveMailer to extract common personalisation attributes to a new BaseMailer. The new PER mailer then needs to be called rather than the MoveMailer from the Notification class; that already has support for polymorphic attachment to any model, but was hardcoded to always use the MoveMailer. That has been refactored to support invoking the appropriate mailer based on the notifiable topic (either a Move or PersonEscortRecord).

- Notification jobs for all record types are ultimately delegated to PrepareMoveNotificationsJob - this too makes the assumption that the underlying topic is always a move. The new PreparePersonEscortRecordNotificationsJob descends from that class and overrides two key methods (without changing the method signature for backwards sidekiq compatibility) to resolve the correct PER and the move associated with the PER.

- The Notifier service has been updated to use the new PER job only for the case of amendments to a completed PER. For other assessment changes (PER or Youth Risk) the original PrepareAssessmentNotificationsJob is retained (which ultimately delegates to a move notification). This is slightly confusing and perhaps something that will be changed over time, but I didn't want to introduce a breaking change to the existing PER webhooks and potentially break any queued sidekiq jobs.

- Finally the FrameworkResponsesController is updated to invoke notifications for PER amendments (i.e. changes to the responses for a completed PER) - we can detect these when the PER has a populated `amended_at` attribute. Youth Risk Assessments do not have this attribute but share the same controller for updating responses.

- In a follow up PR the legacy ENV var for GOVUK_NOTIFY_TEMPLATE_ID will be removed (we have two templates now so it makes sense to rename this). The deploy repo already populates correct values for the two new ENV vars - see https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy/pull/127

### Have you? (optional)

- [x] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Changes an api that is used in production; new emails and webhooks will be sent to suppliers when PER's are amended so they will need some advance warning of this. Flagging as a breaking change for this reason.