### PR TITLE
Update notify_webhook_job.rb

### DIFF
--- a/app/jobs/notify_webhook_job.rb
+++ b/app/jobs/notify_webhook_job.rb
@@ -41,7 +41,7 @@ class NotifyWebhookJob < ApplicationJob
 private
 
   def get_client(subscription)
-    client = Faraday.new(headers: { 'Content-Type': 'application/vnd.api+json', 'User-Agent': 'pecs-webhooks/v1' }, request: { timeout: 5 })
+    client = Faraday.new(headers: { 'Content-Type': 'application/vnd.api+json', 'User-Agent': 'pecs-webhooks/v1' }, request: { timeout: ENV.fetch('WEBHOOK_TIMEOUT', 10).to_i })
     if subscription.username.present? && subscription.password.present?
       client.headers['Authorization'] = "Basic #{Base64.strict_encode64(subscription.username + ':' + subscription.password)}"
     end


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Extended default webhook timeout from 5 to 10 seconds
- [x] Allow to be configured by an env var for future tweaking

### Why?

I am doing this because:

- Webhooks are timing out on Geoamey


