### PR TITLE
Include `updated_at` attribute for serialized PERs and Youth risk assessments

### DIFF
--- a/app/serializers/framework_assessment_serializer.rb
+++ b/app/serializers/framework_assessment_serializer.rb
@@ -9,7 +9,7 @@ class FrameworkAssessmentSerializer
   has_many_if_included :responses, serializer: FrameworkResponseSerializer, &:framework_responses
   has_many_if_included :flags, serializer: FrameworkFlagSerializer, &:framework_flags
 
-  attributes :completed_at, :confirmed_at, :created_at, :nomis_sync_status
+  attributes :completed_at, :confirmed_at, :created_at, :updated_at, :nomis_sync_status
 
   attribute :version do |object|
     object.framework.version

--- a/app/serializers/person_escort_records_serializer.rb
+++ b/app/serializers/person_escort_records_serializer.rb
@@ -8,7 +8,7 @@ class PersonEscortRecordsSerializer
 
   has_many_if_included :flags, serializer: FrameworkFlagsSerializer, &:framework_flags
 
-  attributes :created_at, :completed_at, :amended_at, :confirmed_at, :nomis_sync_status, :handover_details, :handover_occurred_at
+  attributes :created_at, :updated_at, :completed_at, :amended_at, :confirmed_at, :nomis_sync_status, :handover_details, :handover_occurred_at
 
   attribute :status do |object|
     object.status == 'unstarted' ? 'not_started' : object.status

--- a/spec/serializers/framework_assessment_serializer_spec.rb
+++ b/spec/serializers/framework_assessment_serializer_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe FrameworkAssessmentSerializer do
     expect(result[:data][:attributes][:created_at]).to eq(assessment.created_at.iso8601)
   end
 
+  it 'contains an `updated_at` attribute' do
+    expect(result[:data][:attributes][:updated_at]).to eq(assessment.updated_at.iso8601)
+  end
+
   it 'contains a `nomis_sync_status` attribute' do
     expect(result[:data][:attributes][:nomis_sync_status]).to eq(assessment.nomis_sync_status)
   end

--- a/spec/serializers/person_escort_records_serializer_spec.rb
+++ b/spec/serializers/person_escort_records_serializer_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe PersonEscortRecordsSerializer do
     expect(result[:data][:attributes][:created_at]).to eq(person_escort_record.created_at.iso8601)
   end
 
+  it 'contains an `updated_at` attribute' do
+    expect(result[:data][:attributes][:updated_at]).to eq(person_escort_record.updated_at.iso8601)
+  end
+
   it 'contains a `nomis_sync_status` attribute' do
     expect(result[:data][:attributes][:nomis_sync_status]).to eq(person_escort_record.nomis_sync_status)
   end

--- a/swagger/v1/person_escort_record.yaml
+++ b/swagger/v1/person_escort_record.yaml
@@ -72,14 +72,18 @@ PersonEscortRecord:
             format: date-time
             description: Timestamp of when the person escort record handover occurred
             example: "2020-07-24T17:29:26.338Z"
+        updated_at:
+          example: "2020-07-24T17:29:26.338Z"
+          type: string
+          format: date-time
+          description: Timestamp of when the person_escort_record was last updated
+          readOnly: true
         created_at:
           example: "2020-07-24T17:29:26.338Z"
-          oneOf:
-          - type: 'null'
-          - type: string
-            format: date-time
-            description: Timestamp of when the person_escort_record was created
-            readOnly: true
+          type: string
+          format: date-time
+          description: Timestamp of when the person_escort_record was created
+          readOnly: true
         completed_at:
           example: "2020-07-24T17:29:26.338Z"
           oneOf:

--- a/swagger/v1/youth_risk_assessment.yaml
+++ b/swagger/v1/youth_risk_assessment.yaml
@@ -60,14 +60,18 @@ YouthRiskAssessment:
                 type: string
           readOnly: true
           description: A list of all NOMIS resources imported when creating the youth risk assessment, and the status of the import, either successful or failed. The timestamp and error message are also included.
+        updated_at:
+          example: "2020-07-24T17:29:26.338Z"
+          type: string
+          format: date-time
+          description: Timestamp of when the youth_risk_assessment was last updated
+          readOnly: true
         created_at:
           example: "2020-07-24T17:29:26.338Z"
-          oneOf:
-          - type: 'null'
-          - type: string
-            format: date-time
-            description: Timestamp of when the youth_risk_assessment was created
-            readOnly: true
+          type: string
+          format: date-time
+          description: Timestamp of when the youth_risk_assessment was created
+          readOnly: true
         completed_at:
           example: "2020-07-24T17:29:26.338Z"
           oneOf:


### PR DESCRIPTION
### Jira link

P4-2659

### What?

- [x] Include `updated_at` attribute for serialized PERs and Youth risk assessments

### Why?

- This will be used in the front end to show last updated at timestamp prior to other more relevant timestamps being shown once the assessment is completed.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production; adds a new attribute to existing PER and Youth risk assessment endpoints but is backwards compatible with existing clients.

