### PR TITLE
Small cleanup of legacy ENV vars for Govuk notify service

### DIFF
--- a/app/mailers/move_mailer.rb
+++ b/app/mailers/move_mailer.rb
@@ -2,8 +2,7 @@
 
 class MoveMailer < BaseMailer
   def notify(notification)
-    # TODO: Remove use of GOVUK_NOTIFY_TEMPLATE_ID
-    set_template(ENV.fetch('GOVUK_NOTIFY_MOVE_TEMPLATE_ID', ENV.fetch('GOVUK_NOTIFY_TEMPLATE_ID', nil)))
+    set_template(ENV.fetch('GOVUK_NOTIFY_MOVE_TEMPLATE_ID', nil))
     set_reference(notification.id)
     notification.topic.tap do |move|
       set_personalisation(

--- a/config/initializers/gov_uk_notify.rb
+++ b/config/initializers/gov_uk_notify.rb
@@ -1,15 +1,11 @@
 # We only send emails if GOVUK_NOTIFY_ENABLED is true - and should generally only be enabled on the Sidekiq pod
 # Note that the app pod and metrics containers should not send GovUk Notify emails
 if ENV['GOVUK_NOTIFY_ENABLED'] =~ /true/i
-  if ENV['GOVUK_NOTIFY_API_KEY'].blank?
-    Rails.logger.warn('GOVUK_NOTIFY_API_KEY env var is not set; emails cannot be sent')
-    Raven.capture_message('GOVUK_NOTIFY_API_KEY env var is not set; emails cannot be sent', { level: 'warning' })
-  end
-
-  # TODO: Remove use of GOVUK_NOTIFY_TEMPLATE_ID - change to GOVUK_NOTIFY_MOVE_TEMPLATE_ID & GOVUK_NOTIFY_PER_TEMPLATE_ID
-  if ENV['GOVUK_NOTIFY_TEMPLATE_ID'].blank?
-    Rails.logger.warn('GOVUK_NOTIFY_TEMPLATE_ID env var is not set; emails cannot be sent')
-    Raven.capture_message('GOVUK_NOTIFY_TEMPLATE_ID env var is not set; emails cannot be sent', { level: 'warning' })
+  %w[GOVUK_NOTIFY_API_KEY GOVUK_NOTIFY_MOVE_TEMPLATE_ID GOVUK_NOTIFY_PER_TEMPLATE_ID].each do |name|
+    if ENV[name].blank?
+      Rails.logger.warn("#{name} env var is not set; emails cannot be sent")
+      Raven.capture_message("#{name} env var is not set; emails cannot be sent", { level: 'warning' })
+    end
   end
 
   ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery, api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY', nil)


### PR DESCRIPTION
### Jira link

P4-2627

### What?

- [x] Remove references to old `GOVUK_NOTIFY_TEMPLATE_ID` env var

### Why?

- The `GOVUK_NOTIFY_TEMPLATE_ID` variable has now been retired and replaced with `GOVUK_NOTIFY_MOVE_TEMPLATE_ID` and `GOVUK_NOTIFY_PER_TEMPLATE_ID`.