### PR TITLE
Add new webhook (no email) for PER handover event

### DIFF
--- a/app/controllers/api/framework_assessments_controller.rb
+++ b/app/controllers/api/framework_assessments_controller.rb
@@ -2,8 +2,6 @@
 
 module Api
   class FrameworkAssessmentsController < ApiController
-    after_action :send_notification, only: :update
-
     NEW_ASSESSMENT_PERMITTED_PARAMS = [
       :type,
       attributes: [:version],
@@ -60,15 +58,11 @@ module Api
     end
 
     def confirm_assessment!(assessment)
-      assessment.confirm!(update_assessment_status)
+      raise NotImplementedError
     end
 
     def render_assessment(assessment, status)
       render_json assessment, serializer: assessment_serializer, include: included_relationships, status: status
-    end
-
-    def send_notification
-      Notifier.prepare_notifications(topic: assessment, action_name: 'update')
     end
 
     def assessment_class

--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -37,6 +37,7 @@ module Api
 
     def create_confirmation_event_and_notification!
       create_automatic_event!(eventable: assessment, event_class: GenericEvent::PerConfirmation, details: { confirmed_at: assessment.confirmed_at.iso8601 })
+      # TODO: Remove derivation of action_name 'confirm_person_escort_record' within PrepareAssessmentNotificationsJob and pass explicitly
       Notifier.prepare_notifications(topic: assessment, action_name: nil)
     end
 

--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -21,9 +21,9 @@ module Api
       assessment.confirm!(update_assessment_status, handover_details, handover_occurred_at)
 
       if handover_details.present? && handover_occurred_at.present?
-        create_handover_event!
+        create_handover_event_and_notification!
       else
-        create_confirmation_event!
+        create_confirmation_event_and_notification!
       end
     end
 
@@ -35,12 +35,14 @@ module Api
       PersonEscortRecordSerializer
     end
 
-    def create_confirmation_event!
+    def create_confirmation_event_and_notification!
       create_automatic_event!(eventable: assessment, event_class: GenericEvent::PerConfirmation, details: { confirmed_at: assessment.confirmed_at.iso8601 })
+      Notifier.prepare_notifications(topic: assessment, action_name: nil)
     end
 
-    def create_handover_event!
+    def create_handover_event_and_notification!
       create_automatic_event!(eventable: assessment, event_class: GenericEvent::PerHandover, occurred_at: assessment.handover_occurred_at, details: assessment.handover_details)
+      Notifier.prepare_notifications(topic: assessment, action_name: 'handover_person_escort_record')
     end
   end
 end

--- a/app/controllers/api/youth_risk_assessments_controller.rb
+++ b/app/controllers/api/youth_risk_assessments_controller.rb
@@ -6,6 +6,7 @@ module Api
 
     def confirm_assessment!(assessment)
       assessment.confirm!(update_assessment_status)
+      # TODO: Remove derivation of action_name 'confirm_youth_risk_assessment' within PrepareAssessmentNotificationsJob and pass explicitly
       Notifier.prepare_notifications(topic: assessment, action_name: nil)
     end
 

--- a/app/controllers/api/youth_risk_assessments_controller.rb
+++ b/app/controllers/api/youth_risk_assessments_controller.rb
@@ -4,6 +4,11 @@ module Api
   class YouthRiskAssessmentsController < FrameworkAssessmentsController
   private
 
+    def confirm_assessment!(assessment)
+      assessment.confirm!(update_assessment_status)
+      Notifier.prepare_notifications(topic: assessment, action_name: nil)
+    end
+
     def assessment_class
       YouthRiskAssessment
     end

--- a/app/jobs/concerns/queue_determiner.rb
+++ b/app/jobs/concerns/queue_determiner.rb
@@ -2,7 +2,7 @@ module QueueDeterminer
   extend ActiveSupport::Concern
 
   def move_queue_priority(move)
-    case move.date
+    case move&.date
     when Time.zone.today
       # moves for today are high priority
       :notifications_high

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -11,12 +11,16 @@ class Notifier
       PreparePersonNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
     when Profile
       PrepareProfileNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
-    when PersonEscortRecord, YouthRiskAssessment
-      if topic.is_a?(PersonEscortRecord) && action_name == 'amend_person_escort_record'
+    when PersonEscortRecord
+      if action_name == 'amend_person_escort_record'
         PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: move_queue_priority(topic.move))
+      elsif action_name == 'handover_person_escort_record'
+        PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, send_emails: false, queue_as: move_queue_priority(topic.move))
       else
         PrepareAssessmentNotificationsJob.perform_later(topic_id: topic.id, topic_class: topic.class.name, queue_as: :notifications_medium)
       end
+    when YouthRiskAssessment
+      PrepareAssessmentNotificationsJob.perform_later(topic_id: topic.id, topic_class: topic.class.name, queue_as: :notifications_medium)
     end
   end
 end

--- a/spec/jobs/concerns/queue_determiner_spec.rb
+++ b/spec/jobs/concerns/queue_determiner_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe QueueDeterminer do
   let(:target) do
     # anonymous class to test concern against
@@ -36,6 +38,12 @@ RSpec.describe QueueDeterminer do
 
     context 'with move last week' do
       let(:move) { build(:move, date: Time.zone.today - 7) }
+
+      it { is_expected.to be(:notifications_low) }
+    end
+
+    context 'with nil move' do
+      let(:move) { nil }
 
       it { is_expected.to be(:notifications_low) }
     end

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe Notifier do
     end
   end
 
+  context 'when scheduled with a person_escort_record handover' do
+    let(:move) { create(:move, date: Time.zone.tomorrow) }
+    let(:topic) { create(:person_escort_record, move: move) }
+    let(:action_name) { 'handover_person_escort_record' }
+
+    it 'queues a job' do
+      expect(PreparePersonEscortRecordNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, action_name: action_name, send_emails: false, queue_as: :notifications_medium)
+    end
+  end
+
   context 'when scheduled with another person_escort_record action' do
     let(:topic) { create(:person_escort_record) }
 


### PR DESCRIPTION
### Jira link

P4-2560

### What?

- [x] Send a dedicated webhook for PER handover

### Why?

- This is sent rather than PER confirmation when the update PER endpoint includes handover attributes (i.e. has been called from the updated front end handover page). This means a change in behaviour as the previous PER confirmation webhook and email will not be sent. Youth Risk assessment behaviour is unchanged.

### Deployment risks (optional)

- Suppliers need to be ready to receive the new webhook; if not then we can disable individual webhooks with an environment variable