### PR TITLE
remove presence validation on PerCourtHearing

### DIFF
--- a/app/models/generic_event/per_court_hearing.rb
+++ b/app/models/generic_event/per_court_hearing.rb
@@ -6,8 +6,8 @@ class GenericEvent
     relationship_attributes location_id: :locations
     eventable_types 'PersonEscortRecord'
 
-    validates :is_virtual,       presence: true, inclusion: [true, false]
-    validates :is_trial,         presence: true, inclusion: [true, false]
+    validates :is_virtual,       inclusion: [true, false]
+    validates :is_trial,         inclusion: [true, false]
     validates :court_listing_at, presence: true, iso_date_time: true
     validates :started_at,       presence: true, iso_date_time: true
     validates :ended_at,         presence: true, iso_date_time: true

--- a/spec/models/generic_event/per_court_hearing_spec.rb
+++ b/spec/models/generic_event/per_court_hearing_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe GenericEvent::PerCourtHearing do
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a location in the feed', :location_id
 
-  it { is_expected.to validate_presence_of(:is_virtual) }
-  it { is_expected.to validate_presence_of(:is_trial) }
+  it { is_expected.to allow_value(true).for(:is_virtual) }
+  it { is_expected.to allow_value(false).for(:is_virtual) }
+  it { is_expected.to allow_value(true).for(:is_trial) }
+  it { is_expected.to allow_value(false).for(:is_trial) }
   it { is_expected.to validate_presence_of(:court_listing_at) }
   it { is_expected.to validate_presence_of(:started_at) }
   it { is_expected.to validate_presence_of(:ended_at) }


### PR DESCRIPTION
### Jira link

P4-2667
### What?

I have added/removed/altered:

- [x] Removed presence validation on PerCourtHearing

### Why?

I am doing this because:

- presence validation is not a valid validation for boolean attributes

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

