### PR TITLE
Quick and dirty hack to reinstate PER confirmation Webhook for GeoAmey

### DIFF
--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -44,6 +44,9 @@ module Api
     def create_handover_event_and_notification!
       create_automatic_event!(eventable: assessment, event_class: GenericEvent::PerHandover, occurred_at: assessment.handover_occurred_at, details: assessment.handover_details)
       Notifier.prepare_notifications(topic: assessment, action_name: 'handover_person_escort_record')
+
+      # TODO: Remove this webhook once GeoAmey have confirmed they can process the new handover webhook instead
+      Notifier.prepare_notifications(topic: assessment, action_name: nil)
     end
   end
 end

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -210,6 +210,8 @@ RSpec.describe Api::PersonEscortRecordsController do
         end
 
         it 'does not create an email notification' do
+          pending 'awaiting GeoAmey to confirm ability to handle new webhook and removal of duplicate notifications'
+
           notification = subscription.notifications.find_by(notification_type: notification_type_email)
 
           expect(notification).to be_nil


### PR DESCRIPTION
### Jira link

P4-2560

### What?

- [x] Temporarily send legacy PER confirmation webhook for PER handover

### Why?

- This is a temporary measure to support GeoAmey integration with PER Webhooks - they're not currently able to process the new PER handover webhook. This will be reverted as soon as they are able to process the new webhook.