### PR TITLE
Raise an error when creating/redirecting move to/from inactive location

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Location < ApplicationRecord
+  include Discard::Model
+  # TODO: rename disabled_at column to discarded_at and remove this line
+  self.discard_column = :disabled_at
+
   LOCATION_TYPE_COURT = 'court'
   LOCATION_TYPE_POLICE = 'police'
   LOCATION_TYPE_PRISON = 'prison'

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -12,10 +12,6 @@ class Subscription < ApplicationRecord
   validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP, allow_nil: true }, presence: false
   validate :email_address_or_callback_url_required
 
-  def kept?
-    !discarded?
-  end
-
   def secret=(value)
     self[:encrypted_secret] = Encryptor.encrypt(value)
   end

--- a/app/services/locations/importer.rb
+++ b/app/services/locations/importer.rb
@@ -29,9 +29,9 @@ module Locations
 
       active_agency_ids = items.map { |item| item[:nomis_agency_id] }
       Location.where.not(nomis_agency_id: active_agency_ids).find_each do |location|
-        if location.disabled_at.blank?
+        if location.kept?
           disabled_locations << location.nomis_agency_id
-          location.update(disabled_at: Time.zone.now)
+          location.discard
         end
       end
     end

--- a/app/services/moves/move_type_validator.rb
+++ b/app/services/moves/move_type_validator.rb
@@ -6,6 +6,8 @@ module Moves
 
     def validate(record)
       @record = record
+      validate_active_locations
+
       return if record.move_type.blank?
 
       # Apply more complex validation rules for specific move types
@@ -28,32 +30,37 @@ module Moves
       record.move_type.to_s.humanize(capitalize: false)
     end
 
+    def validate_active_locations
+      record.errors.add(:from_location, :inactive_location, message: 'must be an active location') if record.from_location&.discarded?
+      record.errors.add(:to_location, :inactive_location, message: 'must be an active location') if record.to_location&.discarded?
+    end
+
     def validate_court_to_location
-      record.errors.add(:to_location, "must be a court location for #{human_move_type} move") unless record.to_location&.court?
+      record.errors.add(:to_location, :invalid_location, message: "must be a court location for #{human_move_type} move") unless record.to_location&.court?
     end
 
     def validate_detained_from_location
-      record.errors.add(:from_location, "must be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.from_location&.detained?
+      record.errors.add(:from_location, :invalid_location, message: "must be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.from_location&.detained?
     end
 
     def validate_detained_to_location
-      record.errors.add(:to_location, "must be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.to_location&.detained?
+      record.errors.add(:to_location, :invalid_location, message: "must be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.to_location&.detained?
     end
 
     def validate_hospital_to_location
-      record.errors.add(:to_location, "must be a hospital or high security hospital location for #{human_move_type} move") unless record.to_location&.high_security_hospital? || record.to_location&.hospital?
+      record.errors.add(:to_location, :invalid_location, message: "must be a hospital or high security hospital location for #{human_move_type} move") unless record.to_location&.high_security_hospital? || record.to_location&.hospital?
     end
 
     def validate_not_detained_to_location
-      record.errors.add(:to_location, "must not be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.to_location&.not_detained?
+      record.errors.add(:to_location, :invalid_location, message: "must not be a prison, secure training centre or secure childrens hospital for #{human_move_type} move") unless record.to_location&.not_detained?
     end
 
     def validate_police_from_location
-      record.errors.add(:from_location, "must be a police location for #{human_move_type} move") unless record.from_location&.police?
+      record.errors.add(:from_location, :invalid_location, message: "must be a police location for #{human_move_type} move") unless record.from_location&.police?
     end
 
     def validate_police_to_location
-      record.errors.add(:to_location, "must be a police location for #{human_move_type} move") unless record.to_location&.police?
+      record.errors.add(:to_location, :invalid_location, message: "must be a police location for #{human_move_type} move") unless record.to_location&.police?
     end
   end
 end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     location_type { Location::LOCATION_TYPE_PRISON }
     nomis_agency_id { 'PEI' }
 
+    trait :inactive do
+      disabled_at { Time.zone.now }
+    end
+
     trait :with_moves do
       after(:create) do |location, _|
         create_list :move, 2, from_location: location

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -164,6 +164,23 @@ RSpec.describe Api::MoveEventsController do
             [{
               'title' => 'Unprocessable entity',
               'detail' => 'To location must be a hospital or high security hospital location for hospital move',
+              'source' => { 'pointer' => '/data/attributes/to_location' },
+              'code' => 'invalid_location',
+            }]
+          end
+        end
+      end
+
+      context 'with a redirection to an inactive location' do
+        let(:new_location) { create(:location, :inactive) }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [{
+              'title' => 'Unprocessable entity',
+              'detail' => 'To location must be an active location',
+              'source' => { 'pointer' => '/data/attributes/to_location' },
+              'code' => 'inactive_location',
             }]
           end
         end

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -560,6 +560,24 @@ RSpec.describe Api::MovesController do
       end
     end
 
+    context 'when the move is to an inactive location' do
+      let(:to_location) { create :location, :court, :inactive }
+      let(:errors_422) do
+        [
+          {
+            'title' => 'Unprocessable entity',
+            'detail' => 'To location must be an active location',
+            'source' => { 'pointer' => '/data/attributes/to_location' },
+            'code' => 'inactive_location',
+          },
+        ]
+      end
+
+      it_behaves_like 'an endpoint that responds with error 422' do
+        before { do_post }
+      end
+    end
+
     context 'when the profile is for an unsupported prisoner category' do
       let(:profile) { create(:profile, :category_not_supported) }
       let(:category_key) { profile.category.key.humanize.downcase }

--- a/spec/services/moves/move_type_validator_spec.rb
+++ b/spec/services/moves/move_type_validator_spec.rb
@@ -18,10 +18,34 @@ RSpec.describe Moves::MoveTypeValidator do
 
   before { target.move_type = move_type }
 
-  context 'when valid' do
+  context 'when move_type is nil' do
     let(:move_type) { nil }
 
     it { is_expected.to be_valid }
+  end
+
+  context 'when move_type is not nil' do
+    let(:move_type) { 'prison_transfer' }
+
+    it 'validates `from_location` and `to_location` are active' do
+      target.from_location = build(:location)
+      target.to_location = build(:location)
+      expect(target).to be_valid
+    end
+
+    it 'has an error if `from_location` is not active' do
+      target.from_location = build(:location, :inactive)
+      target.to_location = build(:location)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:from_location]).to match_array('must be an active location')
+    end
+
+    it 'has an error if `to_location` is not active' do
+      target.from_location = build(:location)
+      target.to_location = build(:location, :inactive)
+      expect(target).not_to be_valid # NB: need to check for validity before reading the error messages
+      expect(target.errors[:to_location]).to match_array('must be an active location')
+    end
   end
 
   context 'with court_appearance `move_type`' do


### PR DESCRIPTION
### Jira link

P4-2636

### What?

- [x] Updated `MoveTypeValidator` to ensure that from/to location are active

### Why?

- To prevent API clients from creating or redirecting moves to locations which are no longer active in Nomis (i.e. `disabled_at` is not `nil`). Updated MoveTypeValidator to include new rules and also add an explicit code for each error for easier localisation within the front end (message shown to the user can be customised based on the error `code`).

- Leveraged existing discard gem for this - which adds handy mixin scopes and methods rather than directly working with `disabled_at` column. We should look at making further use of that in AssessmentQuestion, Ethnicity, Gender, IdentifierType, Nationality and PrisonTransferReason models, and perhaps standardise to rename the column to `discarded_at` for consistency with Document, Notification and Subscription models.

### Deployment risks (optional)

- Changes an api that is used in production: adds a new business rule which means clients will see additional error messages