### PR TITLE
Add a new webhook when an assessment is completed

### DIFF
--- a/app/controllers/api/framework_responses_controller.rb
+++ b/app/controllers/api/framework_responses_controller.rb
@@ -108,7 +108,7 @@ module Api
 
     def send_notification
       if assessment.respond_to?(:amended_at) && assessment.amended_at.present?
-        Notifier.prepare_notifications(topic: assessment, action_name: 'amend_person_escort_record')
+        Notifier.prepare_notifications(topic: assessment, action_name: "amend_#{assessment.class.name.underscore}")
       elsif assessment.completed_at.present?
         Notifier.prepare_notifications(topic: assessment, action_name: "complete_#{assessment.class.name.underscore}")
       end

--- a/app/controllers/api/framework_responses_controller.rb
+++ b/app/controllers/api/framework_responses_controller.rb
@@ -109,6 +109,8 @@ module Api
     def send_notification
       if assessment.respond_to?(:amended_at) && assessment.amended_at.present?
         Notifier.prepare_notifications(topic: assessment, action_name: 'amend_person_escort_record')
+      elsif assessment.completed_at.present?
+        Notifier.prepare_notifications(topic: assessment, action_name: "complete_#{assessment.class.name.underscore}")
       end
     end
   end

--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -20,11 +20,7 @@ module Api
       handover_occurred_at = update_assessment_params.to_h.dig(:attributes, :handover_occurred_at)
       assessment.confirm!(update_assessment_status, handover_details, handover_occurred_at)
 
-      if handover_details.present? && handover_occurred_at.present?
-        create_handover_event_and_notification!
-      else
-        create_confirmation_event_and_notification!
-      end
+      create_event_and_notification!
     end
 
     def assessment_class
@@ -35,12 +31,7 @@ module Api
       PersonEscortRecordSerializer
     end
 
-    def create_confirmation_event_and_notification!
-      create_automatic_event!(eventable: assessment, event_class: GenericEvent::PerConfirmation, details: { confirmed_at: assessment.confirmed_at.iso8601 })
-      Notifier.prepare_notifications(topic: assessment, action_name: 'confirm_person_escort_record')
-    end
-
-    def create_handover_event_and_notification!
+    def create_event_and_notification!
       create_automatic_event!(eventable: assessment, event_class: GenericEvent::PerHandover, occurred_at: assessment.handover_occurred_at, details: assessment.handover_details)
       Notifier.prepare_notifications(topic: assessment, action_name: 'handover_person_escort_record')
     end

--- a/app/controllers/api/person_escort_records_controller.rb
+++ b/app/controllers/api/person_escort_records_controller.rb
@@ -37,16 +37,12 @@ module Api
 
     def create_confirmation_event_and_notification!
       create_automatic_event!(eventable: assessment, event_class: GenericEvent::PerConfirmation, details: { confirmed_at: assessment.confirmed_at.iso8601 })
-      # TODO: Remove derivation of action_name 'confirm_person_escort_record' within PrepareAssessmentNotificationsJob and pass explicitly
-      Notifier.prepare_notifications(topic: assessment, action_name: nil)
+      Notifier.prepare_notifications(topic: assessment, action_name: 'confirm_person_escort_record')
     end
 
     def create_handover_event_and_notification!
       create_automatic_event!(eventable: assessment, event_class: GenericEvent::PerHandover, occurred_at: assessment.handover_occurred_at, details: assessment.handover_details)
       Notifier.prepare_notifications(topic: assessment, action_name: 'handover_person_escort_record')
-
-      # TODO: Remove this webhook once GeoAmey have confirmed they can process the new handover webhook instead
-      Notifier.prepare_notifications(topic: assessment, action_name: nil)
     end
   end
 end

--- a/app/controllers/api/youth_risk_assessments_controller.rb
+++ b/app/controllers/api/youth_risk_assessments_controller.rb
@@ -6,8 +6,7 @@ module Api
 
     def confirm_assessment!(assessment)
       assessment.confirm!(update_assessment_status)
-      # TODO: Remove derivation of action_name 'confirm_youth_risk_assessment' within PrepareAssessmentNotificationsJob and pass explicitly
-      Notifier.prepare_notifications(topic: assessment, action_name: nil)
+      Notifier.prepare_notifications(topic: assessment, action_name: 'confirm_youth_risk_assessment')
     end
 
     def assessment_class

--- a/app/jobs/prepare_assessment_notifications_job.rb
+++ b/app/jobs/prepare_assessment_notifications_job.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# TODO: Remove this class - it's deprecated now and only present until we can be sure there are no queued jobs in deployed environments
 class PrepareAssessmentNotificationsJob < ApplicationJob
   include QueueDeterminer
 

--- a/app/jobs/prepare_youth_risk_assessment_notifications_job.rb
+++ b/app/jobs/prepare_youth_risk_assessment_notifications_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This job is responsible for preparing a set of notify jobs to run
+class PrepareYouthRiskAssessmentNotificationsJob < PrepareBaseNotificationsJob
+private
+
+  def find_topic(topic_id)
+    YouthRiskAssessment.find(topic_id)
+  end
+
+  def associated_move(topic)
+    topic.move
+  end
+end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -16,4 +16,8 @@ class NotificationSerializer
   belongs_to :person_escort_record, id_method_name: :topic_id, if: proc { |object| object.topic.is_a?(PersonEscortRecord) }, links: {
     self: ->(object) { Rails.application.routes.url_helpers.api_person_escort_record_url(object.topic.id) },
   }
+
+  belongs_to :youth_risk_assessment, id_method_name: :topic_id, if: proc { |object| object.topic.is_a?(YouthRiskAssessment) }, links: {
+    self: ->(object) { Rails.application.routes.url_helpers.api_youth_risk_assessment_url(object.topic.id) },
+  }
 end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -12,15 +12,10 @@ class Notifier
     when Profile
       PrepareProfileNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
     when PersonEscortRecord
-      if action_name == 'amend_person_escort_record'
-        PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: move_queue_priority(topic.move))
-      elsif action_name == 'handover_person_escort_record'
-        PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, send_emails: false, queue_as: move_queue_priority(topic.move))
-      else
-        PrepareAssessmentNotificationsJob.perform_later(topic_id: topic.id, topic_class: topic.class.name, queue_as: :notifications_medium)
-      end
+      send_emails = action_name == 'amend_person_escort_record'
+      PreparePersonEscortRecordNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, send_emails: send_emails, queue_as: move_queue_priority(topic.move))
     when YouthRiskAssessment
-      PrepareAssessmentNotificationsJob.perform_later(topic_id: topic.id, topic_class: topic.class.name, queue_as: :notifications_medium)
+      PrepareYouthRiskAssessmentNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, send_emails: false, queue_as: move_queue_priority(topic.move))
     end
   end
 end

--- a/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
@@ -365,8 +365,20 @@ RSpec.describe Api::FrameworkResponsesController do
       context 'when the assessment was not previously completed' do
         let(:person_escort_record) { create(:person_escort_record, :in_progress, move: move) }
 
-        it 'does not create notifications' do
-          expect(subscription.notifications).to be_empty
+        it 'creates a webhook notification' do
+          notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
+
+          expect(notification).to have_attributes(
+            topic: person_escort_record,
+            notification_type: notification_type_webhook,
+            event_type: 'complete_person_escort_record',
+          )
+        end
+
+        it 'does not create an email notification' do
+          notification = subscription.notifications.find_by(notification_type: notification_type_email)
+
+          expect(notification).to be_nil
         end
       end
 

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -383,8 +383,20 @@ RSpec.describe Api::FrameworkResponsesController do
       context 'when the assessment was not previously completed' do
         let(:person_escort_record) { create(:person_escort_record, :in_progress, move: move) }
 
-        it 'does not create notifications' do
-          expect(subscription.notifications).to be_empty
+        it 'creates a webhook notification' do
+          notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
+
+          expect(notification).to have_attributes(
+            topic: person_escort_record,
+            notification_type: notification_type_webhook,
+            event_type: 'complete_person_escort_record',
+          )
+        end
+
+        it 'does not create an email notification' do
+          notification = subscription.notifications.find_by(notification_type: notification_type_email)
+
+          expect(notification).to be_nil
         end
       end
 

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -163,25 +163,7 @@ RSpec.describe Api::PersonEscortRecordsController do
         end
       end
 
-      context 'when excluding handover details' do
-        it 'creates a webhook notification' do
-          notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
-
-          expect(notification).to have_attributes(
-            topic: person_escort_record,
-            notification_type: notification_type_webhook,
-            event_type: 'confirm_person_escort_record',
-          )
-        end
-
-        it 'does not create an email notification' do
-          notification = subscription.notifications.find_by(notification_type: notification_type_email)
-
-          expect(notification).to be_nil
-        end
-      end
-
-      context 'when including handover details' do
+      context 'when request is successful' do
         let(:timestamp) { Time.zone.now }
         let(:attributes) do
           {
@@ -217,45 +199,6 @@ RSpec.describe Api::PersonEscortRecordsController do
 
         it 'does not create notifications' do
           expect(subscription.notifications).to be_empty
-        end
-      end
-    end
-
-    context 'with confirmation event' do
-      it 'creates a per confirmation event' do
-        expect { patch_person_escort_record }.to change(GenericEvent, :count).by(1)
-      end
-
-      it 'persists correct attributes to a per confirmation event' do
-        recorded_timestamp = Time.zone.parse('2020-10-07 01:02:03')
-        Timecop.freeze(recorded_timestamp)
-        patch_person_escort_record
-        Timecop.return
-
-        event = GenericEvent.find_by(eventable: person_escort_record, type: 'GenericEvent::PerConfirmation')
-
-        expect(event).to have_attributes(
-          created_by: 'TEST_USER',
-          occurred_at: recorded_timestamp,
-          recorded_at: recorded_timestamp,
-          details: { 'confirmed_at' => person_escort_record.confirmed_at },
-          notes: 'Automatically generated event',
-        )
-      end
-
-      context 'when request is unsuccessful' do
-        let(:status) { 'foo-bar' }
-
-        it 'does not create confirmation event' do
-          expect { patch_person_escort_record }.not_to change(GenericEvent, :count)
-        end
-      end
-
-      context 'when Person Escort Record is already confirmed' do
-        it 'does not create confirmation event' do
-          patch_person_escort_record
-
-          expect { patch_person_escort_record }.not_to change(GenericEvent, :count)
         end
       end
     end

--- a/spec/requests/api/person_escort_records_controller_update_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_update_spec.rb
@@ -168,20 +168,16 @@ RSpec.describe Api::PersonEscortRecordsController do
           notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
 
           expect(notification).to have_attributes(
-            topic: person_escort_record.move,
+            topic: person_escort_record,
             notification_type: notification_type_webhook,
             event_type: 'confirm_person_escort_record',
           )
         end
 
-        it 'creates an email notification' do
+        it 'does not create an email notification' do
           notification = subscription.notifications.find_by(notification_type: notification_type_email)
 
-          expect(notification).to have_attributes(
-            topic: person_escort_record.move,
-            notification_type: notification_type_email,
-            event_type: 'confirm_person_escort_record',
-          )
+          expect(notification).to be_nil
         end
       end
 
@@ -210,8 +206,6 @@ RSpec.describe Api::PersonEscortRecordsController do
         end
 
         it 'does not create an email notification' do
-          pending 'awaiting GeoAmey to confirm ability to handle new webhook and removal of duplicate notifications'
-
           notification = subscription.notifications.find_by(notification_type: notification_type_email)
 
           expect(notification).to be_nil

--- a/spec/requests/api/youth_risk_assessments_controller_update_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_update_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
       before do
         allow(Faraday).to receive(:new).and_return(faraday_client)
         allow(MoveMailer).to receive(:notify).and_return(notify_response)
-        perform_enqueued_jobs(only: [PrepareAssessmentNotificationsJob, NotifyWebhookJob, NotifyEmailJob]) do
+        perform_enqueued_jobs(only: [PrepareYouthRiskAssessmentNotificationsJob, NotifyWebhookJob, NotifyEmailJob]) do
           patch_youth_risk_assessment
         end
       end
@@ -132,20 +132,16 @@ RSpec.describe Api::YouthRiskAssessmentsController do
         notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
 
         expect(notification).to have_attributes(
-          topic: youth_risk_assessment.move,
+          topic: youth_risk_assessment,
           notification_type: notification_type_webhook,
           event_type: 'confirm_youth_risk_assessment',
         )
       end
 
-      it 'creates an email notification' do
+      it 'does not create an email notification' do
         notification = subscription.notifications.find_by(notification_type: notification_type_email)
 
-        expect(notification).to have_attributes(
-          topic: youth_risk_assessment.move,
-          notification_type: notification_type_email,
-          event_type: 'confirm_youth_risk_assessment',
-        )
+        expect(notification).to be_nil
       end
 
       context 'when request is unsuccessful' do

--- a/spec/serializers/notification_serializer_spec.rb
+++ b/spec/serializers/notification_serializer_spec.rb
@@ -63,7 +63,20 @@ RSpec.describe NotificationSerializer do
       end
     end
 
-    context 'when topic is not a Move or PersonEscortRecord' do
+    context 'when topic is a YouthRiskAssessment' do
+      let(:yra) { create(:youth_risk_assessment) }
+      let(:notification) { create(:notification, topic: yra) }
+
+      it 'contains youth_risk_assessment relationship data' do
+        expect(result[:data][:relationships][:youth_risk_assessment][:data]).to eql(id: yra.id, type: 'youth_risk_assessments')
+      end
+
+      it 'contains youth_risk_assessment relationship links' do
+        expect(result[:data][:relationships][:youth_risk_assessment][:links]).to eql(self: "http://localhost:4000/api/v1/youth_risk_assessments/#{yra.id}")
+      end
+    end
+
+    context 'when topic is not a Move, PersonEscortRecord or YouthRiskAssessment' do
       let(:allocation) { create(:allocation) }
       let(:notification) { create(:notification, topic: allocation) }
 

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -63,33 +63,26 @@ RSpec.describe Notifier do
     let(:action_name) { 'amend_person_escort_record' }
 
     it 'queues a job' do
-      expect(PreparePersonEscortRecordNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, action_name: action_name, queue_as: :notifications_medium)
+      expect(PreparePersonEscortRecordNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, action_name: action_name, send_emails: true, queue_as: :notifications_medium)
     end
   end
 
-  context 'when scheduled with a person_escort_record handover' do
+  context 'when scheduled with another person_escort_record action' do
     let(:move) { create(:move, date: Time.zone.tomorrow) }
     let(:topic) { create(:person_escort_record, move: move) }
-    let(:action_name) { 'handover_person_escort_record' }
 
     it 'queues a job' do
       expect(PreparePersonEscortRecordNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, action_name: action_name, send_emails: false, queue_as: :notifications_medium)
     end
   end
 
-  context 'when scheduled with another person_escort_record action' do
-    let(:topic) { create(:person_escort_record) }
-
-    it 'queues a job' do
-      expect(PrepareAssessmentNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, topic_class: 'PersonEscortRecord', queue_as: :notifications_medium)
-    end
-  end
-
   context 'when scheduled with a youth_risk_assessment' do
-    let(:topic) { create(:youth_risk_assessment) }
+    let(:location) { create(:location, :stc) }
+    let(:move) { create(:move, from_location: location, date: Time.zone.tomorrow) }
+    let(:topic) { create(:youth_risk_assessment, move: move) }
 
     it 'queues a job' do
-      expect(PrepareAssessmentNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, topic_class: 'YouthRiskAssessment', queue_as: :notifications_medium)
+      expect(PrepareYouthRiskAssessmentNotificationsJob).to have_been_enqueued.with(topic_id: topic.id, action_name: action_name, send_emails: false, queue_as: :notifications_medium)
     end
   end
 


### PR DESCRIPTION
### Jira link

P4-2670

### What?

- [x] Add new webhook notifications (emails not supported) for `complete_person_escort_record` and `complete_youth_risk_assessment`
- [x] Remove temporary workarounds with notifications introduced for GeoAmey
- [x] Amend existing `confirm_youth_risk_assessment` webhook (also removing email support) to refer to the associated youth risk assessment rather than the move
- [x] Remove support for deprecated `confirm_person_escort_record` notification as this is replaced by existing `handover_person_escort_record`

### Why?

- This now makes the various assessment notifications consistent in both their implementation and behaviour, resolving existing tech debt, temporary workarounds and confusing code. All assessment related notifications now include a relationship to the relevant assessment and unused notifications are now remove.
- A future PR will also remove references to `PrepareAssessmentNotificationsJob` once we are sure there are no jobs queued in sidekiq.

### Have you? (optional)

- [ ] TODO: Update wiki

### Deployment risks (optional)

- Changes an api that is used in production
