### PR TITLE
Fix postcode error handling

### DIFF
--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -4,7 +4,7 @@ class PostcodeValidator < ActiveModel::EachValidator
       ukpc = UKPostcode.parse(value)
 
       unless ukpc.full_valid?
-        record.errors[attribute] << 'not recognised as a UK postcode'
+        record.errors.add(attribute, 'not recognised as a UK postcode')
       end
     end
   end

--- a/spec/jobs/notify_email_job_spec.rb
+++ b/spec/jobs/notify_email_job_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe NotifyEmailJob, type: :job do
   subject(:perform!) { described_class.perform_now(notification_id: notification.id) }
 

--- a/spec/jobs/notify_webhook_job_spec.rb
+++ b/spec/jobs/notify_webhook_job_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe NotifyWebhookJob, type: :job do
   subject(:perform!) { described_class.perform_now(notification_id: notification.id) }
 

--- a/spec/jobs/prepare_move_notifications_job_spec.rb
+++ b/spec/jobs/prepare_move_notifications_job_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe PrepareMoveNotificationsJob, type: :job do
   subject(:perform) do
     described_class.perform_now(topic_id: move.id, action_name: action_name, queue_as: :some_queue_name, send_webhooks: send_webhooks, send_emails: send_emails, only_supplier_id: only_supplier_id)

--- a/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe PreparePersonEscortRecordNotificationsJob, type: :job do
   subject(:perform) do
     described_class.perform_now(topic_id: per.id, action_name: action_name, queue_as: :some_queue_name, send_webhooks: send_webhooks, send_emails: send_emails, only_supplier_id: only_supplier_id)

--- a/spec/jobs/prepare_person_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_notifications_job_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe PreparePersonNotificationsJob, type: :job do
   let(:person) { create :person }
   let!(:move_today) { create :move, profile: person.latest_profile, date: Time.zone.today }

--- a/spec/jobs/prepare_profile_notifications_job_spec.rb
+++ b/spec/jobs/prepare_profile_notifications_job_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe PrepareProfileNotificationsJob, type: :job do
   let(:person) { create(:person) }
   let(:profile) { create :profile, person: person }

--- a/spec/models/generic_event/journey_admit_through_outer_gate_spec.rb
+++ b/spec/models/generic_event/journey_admit_through_outer_gate_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyAdmitThroughOuterGate do
   subject(:generic_event) { build(:event_journey_admit_through_outer_gate) }
 

--- a/spec/models/generic_event/journey_admit_to_reception_spec.rb
+++ b/spec/models/generic_event/journey_admit_to_reception_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyAdmitToReception do
   subject(:generic_event) { build(:event_journey_admit_to_reception) }
 

--- a/spec/models/generic_event/journey_arrive_at_outer_gate_spec.rb
+++ b/spec/models/generic_event/journey_arrive_at_outer_gate_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyArriveAtOuterGate do
   subject(:generic_event) { build(:event_journey_arrive_at_outer_gate) }
 

--- a/spec/models/generic_event/journey_cancel_spec.rb
+++ b/spec/models/generic_event/journey_cancel_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyCancel do
   subject(:generic_event) { build(:event_journey_cancel) }
 

--- a/spec/models/generic_event/journey_change_vehicle_spec.rb
+++ b/spec/models/generic_event/journey_change_vehicle_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyChangeVehicle do
   subject(:generic_event) { build(:event_journey_change_vehicle) }
 

--- a/spec/models/generic_event/journey_complete_spec.rb
+++ b/spec/models/generic_event/journey_complete_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyComplete do
   subject(:generic_event) { build(:event_journey_complete) }
 

--- a/spec/models/generic_event/journey_create_spec.rb
+++ b/spec/models/generic_event/journey_create_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyCreate do
   subject(:generic_event) { build(:event_journey_cancel) }
 

--- a/spec/models/generic_event/journey_exit_through_outer_gate_spec.rb
+++ b/spec/models/generic_event/journey_exit_through_outer_gate_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyExitThroughOuterGate do
   subject(:generic_event) { build(:event_journey_exit_through_outer_gate) }
 

--- a/spec/models/generic_event/journey_handover_to_destination_spec.rb
+++ b/spec/models/generic_event/journey_handover_to_destination_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyHandoverToDestination do
   subject(:generic_event) { build(:event_journey_handover_to_destination) }
 

--- a/spec/models/generic_event/journey_handover_to_supplier_spec.rb
+++ b/spec/models/generic_event/journey_handover_to_supplier_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyHandoverToSupplier do
   subject(:generic_event) { build(:event_journey_handover_to_supplier) }
 

--- a/spec/models/generic_event/journey_lockout_spec.rb
+++ b/spec/models/generic_event/journey_lockout_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyLockout do
   subject(:generic_event) { build(:event_journey_lockout) }
 

--- a/spec/models/generic_event/journey_lodging_spec.rb
+++ b/spec/models/generic_event/journey_lodging_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyLodging do
   subject(:generic_event) { build(:event_journey_lodging) }
 

--- a/spec/models/generic_event/journey_person_boards_vehicle_spec.rb
+++ b/spec/models/generic_event/journey_person_boards_vehicle_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyPersonBoardsVehicle do
   subject(:generic_event) { build(:event_journey_person_boards_vehicle) }
 

--- a/spec/models/generic_event/journey_person_leave_vehicle_spec.rb
+++ b/spec/models/generic_event/journey_person_leave_vehicle_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyPersonLeaveVehicle do
   subject(:generic_event) { build(:event_journey_person_leave_vehicle) }
 

--- a/spec/models/generic_event/journey_ready_to_exit_spec.rb
+++ b/spec/models/generic_event/journey_ready_to_exit_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyReadyToExit do
   subject(:generic_event) { build(:event_journey_ready_to_exit) }
 

--- a/spec/models/generic_event/journey_reject_spec.rb
+++ b/spec/models/generic_event/journey_reject_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyReject do
   subject(:generic_event) { build(:event_journey_reject) }
 

--- a/spec/models/generic_event/journey_start_spec.rb
+++ b/spec/models/generic_event/journey_start_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyStart do
   subject(:generic_event) { build(:event_journey_start) }
 

--- a/spec/models/generic_event/journey_uncancel_spec.rb
+++ b/spec/models/generic_event/journey_uncancel_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyUncancel do
   subject(:generic_event) { build(:event_journey_uncancel) }
 

--- a/spec/models/generic_event/journey_uncomplete_spec.rb
+++ b/spec/models/generic_event/journey_uncomplete_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyUncomplete do
   subject(:generic_event) { build(:event_journey_uncomplete) }
 

--- a/spec/models/generic_event/journey_update_spec.rb
+++ b/spec/models/generic_event/journey_update_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::JourneyUpdate do
   subject(:generic_event) { build(:event_journey_update) }
 

--- a/spec/models/generic_event/move_accept_spec.rb
+++ b/spec/models/generic_event/move_accept_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveAccept do
   subject(:generic_event) { build(:event_move_accept) }
 

--- a/spec/models/generic_event/move_approve_spec.rb
+++ b/spec/models/generic_event/move_approve_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveApprove do
   subject(:generic_event) { build(:event_move_approve, eventable: eventable, details: details) }
 

--- a/spec/models/generic_event/move_cancel_spec.rb
+++ b/spec/models/generic_event/move_cancel_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveCancel do
   subject(:generic_event) { build(:event_move_cancel) }
 

--- a/spec/models/generic_event/move_collection_by_escort_spec.rb
+++ b/spec/models/generic_event/move_collection_by_escort_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveCollectionByEscort do
   subject(:generic_event) { build(:event_move_collection_by_escort) }
 

--- a/spec/models/generic_event/move_complete_spec.rb
+++ b/spec/models/generic_event/move_complete_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveComplete do
   subject(:generic_event) { build(:event_move_complete) }
 

--- a/spec/models/generic_event/move_cross_supplier_drop_off_spec.rb
+++ b/spec/models/generic_event/move_cross_supplier_drop_off_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveCrossSupplierDropOff do
   subject(:generic_event) { build(:event_move_cross_supplier_drop_off) }
 

--- a/spec/models/generic_event/move_cross_supplier_pick_up_spec.rb
+++ b/spec/models/generic_event/move_cross_supplier_pick_up_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveCrossSupplierPickUp do
   subject(:generic_event) { build(:event_move_cross_supplier_pick_up) }
 

--- a/spec/models/generic_event/move_lockout_spec.rb
+++ b/spec/models/generic_event/move_lockout_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveLockout do
   subject(:generic_event) { build(:event_move_lockout) }
 

--- a/spec/models/generic_event/move_lodging_end_spec.rb
+++ b/spec/models/generic_event/move_lodging_end_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveLodgingEnd do
   subject(:generic_event) { build(:event_move_lodging_end) }
 

--- a/spec/models/generic_event/move_lodging_start_spec.rb
+++ b/spec/models/generic_event/move_lodging_start_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveLodgingStart do
   subject(:generic_event) { build(:event_move_lodging_start) }
 

--- a/spec/models/generic_event/move_notify_premises_of_arrival_in30_mins_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_arrival_in30_mins_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveNotifyPremisesOfArrivalIn30Mins do
   subject(:generic_event) { build(:event_move_notify_premises_of_arrival_in30_mins) }
 

--- a/spec/models/generic_event/move_notify_premises_of_eta_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_eta_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveNotifyPremisesOfEta do
   subject(:generic_event) { build(:event_move_notify_premises_of_eta) }
 

--- a/spec/models/generic_event/move_notify_premises_of_expected_collection_time_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_expected_collection_time_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime do
   subject(:generic_event) { build(:event_move_notify_premises_of_expected_collection_time) }
 

--- a/spec/models/generic_event/move_operation_hmcts_spec.rb
+++ b/spec/models/generic_event/move_operation_hmcts_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveOperationHmcts do
   subject(:generic_event) { build(:event_move_operation_hmcts) }
 

--- a/spec/models/generic_event/move_operation_safeguard_spec.rb
+++ b/spec/models/generic_event/move_operation_safeguard_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveOperationSafeguard do
   subject(:generic_event) { build(:event_move_operation_safeguard) }
 

--- a/spec/models/generic_event/move_operation_tornado_spec.rb
+++ b/spec/models/generic_event/move_operation_tornado_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveOperationTornado do
   subject(:generic_event) { build(:event_move_operation_tornado) }
 

--- a/spec/models/generic_event/move_proposed_spec.rb
+++ b/spec/models/generic_event/move_proposed_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveProposed do
   subject(:generic_event) { build(:event_move_proposed) }
 

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveRedirect do
   subject(:generic_event) { build(:event_move_redirect) }
 

--- a/spec/models/generic_event/move_reject_spec.rb
+++ b/spec/models/generic_event/move_reject_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveReject do
   subject(:generic_event) { build(:event_move_reject) }
 

--- a/spec/models/generic_event/move_requested_spec.rb
+++ b/spec/models/generic_event/move_requested_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveRequested do
   subject(:generic_event) { build(:event_move_requested) }
 

--- a/spec/models/generic_event/move_start_spec.rb
+++ b/spec/models/generic_event/move_start_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::MoveStart do
   subject(:generic_event) { build(:event_move_start) }
 

--- a/spec/models/generic_event/per_confirmation_spec.rb
+++ b/spec/models/generic_event/per_confirmation_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerConfirmation do
   subject(:generic_event) { build(:event_per_confirmation) }
 

--- a/spec/models/generic_event/per_court_all_documentation_provided_to_supplier_spec.rb
+++ b/spec/models/generic_event/per_court_all_documentation_provided_to_supplier_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtAllDocumentationProvidedToSupplier do
   subject(:generic_event) { build(:event_per_court_all_documentation_provided_to_supplier) }
 

--- a/spec/models/generic_event/per_court_assign_cell_in_custody_spec.rb
+++ b/spec/models/generic_event/per_court_assign_cell_in_custody_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtAssignCellInCustody do
   subject(:generic_event) { build(:event_per_court_assign_cell_in_custody) }
 

--- a/spec/models/generic_event/per_court_cell_share_risk_assessment_spec.rb
+++ b/spec/models/generic_event/per_court_cell_share_risk_assessment_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtCellShareRiskAssessment do
   subject(:generic_event) { build(:event_per_court_cell_share_risk_assessment) }
 

--- a/spec/models/generic_event/per_court_excessive_delay_not_due_to_supplier_spec.rb
+++ b/spec/models/generic_event/per_court_excessive_delay_not_due_to_supplier_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtExcessiveDelayNotDueToSupplier do
   subject(:generic_event) { build(:event_per_court_excessive_delay_not_due_to_supplier) }
 

--- a/spec/models/generic_event/per_court_hearing_spec.rb
+++ b/spec/models/generic_event/per_court_hearing_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtHearing do
   subject(:generic_event) { build(:event_per_court_hearing) }
 

--- a/spec/models/generic_event/per_court_pre_release_checks_completed_spec.rb
+++ b/spec/models/generic_event/per_court_pre_release_checks_completed_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtPreReleaseChecksCompleted do
   subject(:generic_event) { build(:event_per_court_pre_release_checks_completed) }
 

--- a/spec/models/generic_event/per_court_ready_in_custody_spec.rb
+++ b/spec/models/generic_event/per_court_ready_in_custody_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtReadyInCustody do
   subject(:generic_event) { build(:event_per_court_ready_in_custody) }
 

--- a/spec/models/generic_event/per_court_release_on_bail_spec.rb
+++ b/spec/models/generic_event/per_court_release_on_bail_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtReleaseOnBail do
   subject(:generic_event) { build(:event_per_court_release_on_bail) }
 

--- a/spec/models/generic_event/per_court_release_spec.rb
+++ b/spec/models/generic_event/per_court_release_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtRelease do
   subject(:generic_event) { build(:event_per_court_release) }
 

--- a/spec/models/generic_event/per_court_return_to_custody_area_from_dock_spec.rb
+++ b/spec/models/generic_event/per_court_return_to_custody_area_from_dock_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtReturnToCustodyAreaFromDock do
   subject(:generic_event) { build(:event_per_court_return_to_custody_area_from_dock) }
 

--- a/spec/models/generic_event/per_court_return_to_custody_area_from_visitor_area_spec.rb
+++ b/spec/models/generic_event/per_court_return_to_custody_area_from_visitor_area_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtReturnToCustodyAreaFromVisitorArea do
   subject(:generic_event) { build(:event_per_court_return_to_custody_area_from_visitor_area) }
 

--- a/spec/models/generic_event/per_court_take_from_custody_to_dock_spec.rb
+++ b/spec/models/generic_event/per_court_take_from_custody_to_dock_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtTakeFromCustodyToDock do
   subject(:generic_event) { build(:event_per_court_take_from_custody_to_dock) }
 

--- a/spec/models/generic_event/per_court_take_to_see_visitors_spec.rb
+++ b/spec/models/generic_event/per_court_take_to_see_visitors_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtTakeToSeeVisitors do
   subject(:generic_event) { build(:event_per_court_take_to_see_visitors) }
 

--- a/spec/models/generic_event/per_court_task_spec.rb
+++ b/spec/models/generic_event/per_court_task_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerCourtTask do
   subject(:generic_event) { build(:event_per_court_task) }
 

--- a/spec/models/generic_event/per_generic_spec.rb
+++ b/spec/models/generic_event/per_generic_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerGeneric do
   subject(:generic_event) { build(:event_per_generic) }
 

--- a/spec/models/generic_event/per_handover_spec.rb
+++ b/spec/models/generic_event/per_handover_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerHandover do
   subject(:generic_event) { build(:event_per_handover) }
 

--- a/spec/models/generic_event/per_medical_aid_spec.rb
+++ b/spec/models/generic_event/per_medical_aid_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerMedicalAid do
   subject(:generic_event) { build(:event_per_medical_aid) }
 

--- a/spec/models/generic_event/per_prisoner_welfare_spec.rb
+++ b/spec/models/generic_event/per_prisoner_welfare_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PerPrisonerWelfare do
   subject(:generic_event) { build(:event_per_prisoner_welfare) }
 

--- a/spec/models/generic_event/person_move_assault_spec.rb
+++ b/spec/models/generic_event/person_move_assault_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveAssault do
   subject(:generic_event) { build(:event_person_move_assault) }
 

--- a/spec/models/generic_event/person_move_booked_into_receiving_establishment_spec.rb
+++ b/spec/models/generic_event/person_move_booked_into_receiving_establishment_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveBookedIntoReceivingEstablishment do
   subject(:generic_event) { build(:event_person_move_booked_into_receiving_establishment) }
 

--- a/spec/models/generic_event/person_move_death_in_custody_spec.rb
+++ b/spec/models/generic_event/person_move_death_in_custody_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveDeathInCustody do
   subject(:generic_event) { build(:event_person_move_death_in_custody) }
 

--- a/spec/models/generic_event/person_move_major_incident_other_spec.rb
+++ b/spec/models/generic_event/person_move_major_incident_other_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveMajorIncidentOther do
   subject(:generic_event) { build(:event_person_move_major_incident_other) }
 

--- a/spec/models/generic_event/person_move_minor_incident_other_spec.rb
+++ b/spec/models/generic_event/person_move_minor_incident_other_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveMinorIncidentOther do
   subject(:generic_event) { build(:event_person_move_minor_incident_other) }
 

--- a/spec/models/generic_event/person_move_person_escaped_kpi_spec.rb
+++ b/spec/models/generic_event/person_move_person_escaped_kpi_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMovePersonEscapedKpi do
   subject(:generic_event) { build(:event_person_move_person_escaped_kpi) }
 

--- a/spec/models/generic_event/person_move_person_escaped_spec.rb
+++ b/spec/models/generic_event/person_move_person_escaped_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMovePersonEscaped do
   subject(:generic_event) { build(:event_person_move_person_escaped) }
 

--- a/spec/models/generic_event/person_move_released_error_spec.rb
+++ b/spec/models/generic_event/person_move_released_error_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveReleasedError do
   subject(:generic_event) { build(:event_person_move_released_error) }
 

--- a/spec/models/generic_event/person_move_road_traffic_accident_spec.rb
+++ b/spec/models/generic_event/person_move_road_traffic_accident_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveRoadTrafficAccident do
   subject(:generic_event) { build(:event_person_move_road_traffic_accident) }
 

--- a/spec/models/generic_event/person_move_serious_injury_spec.rb
+++ b/spec/models/generic_event/person_move_serious_injury_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveSeriousInjury do
   subject(:generic_event) { build(:event_person_move_serious_injury) }
 

--- a/spec/models/generic_event/person_move_used_force_spec.rb
+++ b/spec/models/generic_event/person_move_used_force_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveUsedForce do
   subject(:generic_event) { build(:event_person_move_used_force) }
 

--- a/spec/models/generic_event/person_move_vehicle_broke_down_spec.rb
+++ b/spec/models/generic_event/person_move_vehicle_broke_down_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe GenericEvent::PersonMoveVehicleBrokeDown do
       generic_event.postcode = 'totally broken'
     end
 
-    it { is_expected.not_to be_valid }
+    it 'includes error details' do
+      expect(generic_event).not_to be_valid
+      expect(generic_event.errors.details[:postcode]).to eq([{ error: 'not recognised as a UK postcode' }])
+    end
   end
 
   context 'when reported_at is not a valid iso8601 date' do

--- a/spec/models/generic_event/person_move_vehicle_broke_down_spec.rb
+++ b/spec/models/generic_event/person_move_vehicle_broke_down_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveVehicleBrokeDown do
   subject(:generic_event) { build(:event_person_move_vehicle_broke_down) }
 

--- a/spec/models/generic_event/person_move_vehicle_systems_failed_spec.rb
+++ b/spec/models/generic_event/person_move_vehicle_systems_failed_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe GenericEvent::PersonMoveVehicleSystemsFailed do
   subject(:generic_event) { build(:event_person_move_vehicle_systems_failed) }
 

--- a/spec/services/feeds/event_spec.rb
+++ b/spec/services/feeds/event_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Feeds::Event do
   subject(:feed) { described_class.new(updated_at_from, updated_at_to) }
 

--- a/spec/services/feeds/journey_spec.rb
+++ b/spec/services/feeds/journey_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Feeds::Journey do
   let(:updated_at_from) { Time.zone.yesterday.beginning_of_day }
   let(:updated_at_to) { Time.zone.yesterday.end_of_day }

--- a/spec/services/feeds/move_spec.rb
+++ b/spec/services/feeds/move_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Feeds::Move do
   subject(:feed) { described_class.new(updated_at_from, updated_at_to) }
 

--- a/spec/services/feeds/notification_spec.rb
+++ b/spec/services/feeds/notification_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Feeds::Notification do
   subject(:feed) { described_class.new(updated_at_from, updated_at_to) }
 

--- a/spec/services/feeds/person_spec.rb
+++ b/spec/services/feeds/person_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Feeds::Person do
   subject(:feed) { described_class.new(updated_at_from, updated_at_to) }
 

--- a/spec/services/feeds/profile_spec.rb
+++ b/spec/services/feeds/profile_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Feeds::Profile do
   subject(:feed) { described_class.new(updated_at_from, updated_at_to) }
 

--- a/spec/services/people/build_person_and_profile_v1_spec.rb
+++ b/spec/services/people/build_person_and_profile_v1_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe People::BuildPersonAndProfileV1 do
   subject(:service) { described_class.new(nomis_attributes) }
 

--- a/spec/services/people/import_from_nomis_spec.rb
+++ b/spec/services/people/import_from_nomis_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe People::ImportFromNomis do
   context 'when the person is present in NOMIS', with_nomis_client_authentication: true do
     subject(:import) { described_class.new([prison_number, non_existent_prison_number]) }

--- a/spec/services/supplier_chooser_spec.rb
+++ b/spec/services/supplier_chooser_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe SupplierChooser do
   subject(:service) { described_class.new(move_or_allocation) }
 


### PR DESCRIPTION
### Jira link

P4-2682

### What?

- [x] Fix population of postcode validation errors in models
- [x] Ensure that all specs can be run individually

### Why?

- Exceptions have been raised in Sentry relating to invalid postcode passed as a detail attribute when creating a generic event. Reproduced and traced the problem to the `PostcodeValidator` class - this was not setting `errors.details` on the relevant model, which then caused an exception to be thrown within the `validation_errors` method in `ApiController`.

- Also added explicit `require` line to every spec file that was missing this so that specs can be run individually - otherwise a `NameError` exception is thrown.