### PR TITLE
Add support for importing prison addresses from Nomis

### DIFF
--- a/app/lib/nomis_client/location_details.rb
+++ b/app/lib/nomis_client/location_details.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module NomisClient
+  class LocationDetails
+    class << self
+      def get
+        attributes_for(
+          NomisClient::Base.get('/agencies/prison',
+                                headers: { 'Page-Limit' => '5000' }).parsed,
+        )
+      end
+
+      def attributes_for(nomis_data)
+        {}.tap do |details_hash|
+          nomis_data.map do |item|
+            details_hash[item['agencyId']] = {
+              premise: item['premise'],
+              locality: item['locality'],
+              city: item['city'],
+              country: item['country'],
+              postcode: item['postCode'],
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -11,6 +11,11 @@ class LocationSerializer
              :nomis_agency_id,
              :can_upload_documents,
              :young_offender_institution,
+             :premise,
+             :locality,
+             :city,
+             :country,
+             :postcode,
              :disabled_at
 
   has_many :suppliers

--- a/app/services/locations/importer.rb
+++ b/app/services/locations/importer.rb
@@ -2,21 +2,33 @@
 
 module Locations
   class Importer
-    attr_accessor :items, :added_locations, :updated_locations, :disabled_locations
+    attr_accessor :locations, :location_details, :added_locations, :updated_locations, :disabled_locations
 
-    def initialize(items)
-      @items = items
+    def initialize(locations, location_details)
+      @locations = locations
+      @location_details = location_details
       @added_locations = []
       @updated_locations = []
       @disabled_locations = []
     end
 
     def call
+      update_locations
+      disable_unused_locations
+    end
+
+  private
+
+    def update_locations
       # NB: the `GET /agencies` endpoint will only return active locations - so any locations which we have which are no
       # longer in the endpoint should be marked as disabled. Ignore the "active" flag returned by Nomis.
-      items.each do |item|
-        location = Location.find_or_initialize_by(nomis_agency_id: item[:nomis_agency_id])
+      locations.each do |item|
+        agency_id = item[:nomis_agency_id]
+        location = Location.find_or_initialize_by(nomis_agency_id: agency_id)
+        address_attributes = location_details[agency_id]
+
         location.assign_attributes(item.slice(:title, :location_type, :key, :can_upload_documents))
+        location.assign_attributes(address_attributes) if address_attributes.present?
         location.disabled_at = nil
 
         if location.new_record?
@@ -26,8 +38,10 @@ module Locations
         end
         location.save
       end
+    end
 
-      active_agency_ids = items.map { |item| item[:nomis_agency_id] }
+    def disable_unused_locations
+      active_agency_ids = locations.map { |item| item[:nomis_agency_id] }
       Location.where.not(nomis_agency_id: active_agency_ids).find_each do |location|
         if location.kept?
           disabled_locations << location.nomis_agency_id

--- a/db/migrate/20210224144350_add_address_to_locations.rb
+++ b/db/migrate/20210224144350_add_address_to_locations.rb
@@ -1,0 +1,9 @@
+class AddAddressToLocations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :locations, :premise, :string
+    add_column :locations, :locality, :string
+    add_column :locations, :city, :string
+    add_column :locations, :country, :string
+    add_column :locations, :postcode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_01_121439) do
+ActiveRecord::Schema.define(version: 2021_02_24_144350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -327,6 +327,11 @@ ActiveRecord::Schema.define(version: 2021_02_01_121439) do
     t.boolean "can_upload_documents", default: false, null: false
     t.uuid "category_id"
     t.boolean "young_offender_institution", default: false
+    t.string "premise"
+    t.string "locality"
+    t.string "city"
+    t.string "country"
+    t.string "postcode"
     t.index ["category_id"], name: "index_locations_on_category_id"
     t.index ["young_offender_institution"], name: "index_locations_on_young_offender_institution"
   end

--- a/lib/tasks/reference_data.rake
+++ b/lib/tasks/reference_data.rake
@@ -4,7 +4,9 @@ namespace :reference_data do
   desc 'create locations'
   task create_locations: :environment do
     puts 'Importing locations...'
-    importer = Locations::Importer.new(NomisClient::Locations.get)
+    locations = NomisClient::Locations.get
+    location_details = NomisClient::LocationDetails.get
+    importer = Locations::Importer.new(locations, location_details)
     importer.call
 
     puts "NEW LOCATIONS (#{importer.added_locations.length}):"

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -17,6 +17,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_address do
+      premise { 'The Big Building' }
+      locality { 'District 9' }
+      city { Faker::Address.city }
+      country { 'England' }
+      postcode { 'B1 2JP' }
+    end
+
     trait :prison do
       # This is already the default
     end

--- a/spec/fixtures/files/nomis/get_location_details_200.json
+++ b/spec/fixtures/files/nomis/get_location_details_200.json
@@ -1,0 +1,60 @@
+[
+  {
+    "agencyId":"ACI",
+    "description":"ALTCOURSE (HMP)",
+    "formattedDescription":"Altcourse (HMP)",
+    "addressType":"BUS",
+    "premise":"HMP ALTCOURSE",
+    "locality":"Fazakerley",
+    "city":"Liverpool",
+    "country":"England",
+    "postCode":"L9 7LH",
+    "phones":[{"number":"0151 522 2000", "type":"BUS"}, {"number":"0151 522 2121", "type":"FAX"}]
+  },
+  {
+    "agencyId":"AGI",
+    "description":"ASKHAM GRANGE (HMP & YOI)",
+    "formattedDescription":"Askham Grange (HMP & YOI)",
+    "addressType":"BUS",
+    "premise":"HMP & YOI ASKHAM GRANGE",
+    "city":"York",
+    "country":"England",
+    "postCode":"YO23 3FT",
+    "phones":[{"number":"01904 772001", "type":"FAX"}, {"number":"01904 772000", "type":"BUS"}]
+  },
+  {
+    "agencyId":"ASI",
+    "description":"ASHFIELD (HMP)",
+    "formattedDescription":"Ashfield (HMP)",
+    "addressType":"BUS",
+    "premise":"HMP & YOI ASHFIELD",
+    "locality":"Pucklechurch",
+    "city":"Bristol",
+    "country":"England",
+    "postCode":"BS16 9QJ",
+    "phones":[{"number":"0117 303 8000", "type":"BUS"}, {"number":"0117 303 8001", "type":"FAX"}]
+  },
+  {
+    "agencyId":"AYI",
+    "description":"AYLESBURY (HMP)",
+    "formattedDescription":"Aylesbury (HMP)",
+    "addressType":"BUS",
+    "premise":"HMP AYLESBURY",
+    "city":"Aylesbury",
+    "country":"England",
+    "postCode":"HP20 1EH",
+    "phones":[{"number":"01296 444001", "type":"FAX"}, {"number":"01296 444000", "type":"BUS"}]
+  },
+  {
+    "agencyId":"BAI",
+    "description":"BELMARSH (HMP)",
+    "formattedDescription":"Belmarsh (HMP)",
+    "addressType":"BUS",
+    "premise":"HMP BELMARSH",
+    "locality":"Thamesmead",
+    "city":"London",
+    "country":"England",
+    "postCode":"SE28 0EB",
+    "phones":[{"number":"020 8331 4401", "type":"FAX"}, {"number":"020 8331 4400", "type":"BUS"}]
+  }
+]

--- a/spec/lib/nomis_client/location_details_spec.rb
+++ b/spec/lib/nomis_client/location_details_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NomisClient::LocationDetails, with_nomis_client_authentication: true do
+  describe '.get' do
+    let(:response) { described_class.get }
+    let(:api_endpoint) { '/agencies/prison' }
+    let(:response_status) { 200 }
+    let(:response_body) { file_fixture('nomis/get_location_details_200.json').read }
+
+    it 'has the correct number of results' do
+      expect(response.count).to eq 5
+    end
+
+    it 'returns a hash keyed by agency id' do
+      expect(response.keys).to match_array(%w[ACI AGI ASI AYI BAI])
+    end
+
+    it 'returns correct attributes for each location' do
+      expect(response.values.first)
+        .to eq(premise: 'HMP ALTCOURSE', locality: 'Fazakerley', city: 'Liverpool', country: 'England', postcode: 'L9 7LH')
+    end
+  end
+end

--- a/spec/serializers/location_serializer_spec.rb
+++ b/spec/serializers/location_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LocationSerializer do
 
   let(:disabled_at) { Time.zone.local(2019, 1, 1) }
   let(:supplier) { create(:supplier) }
-  let(:location) { create :location, disabled_at: disabled_at, suppliers: [supplier] }
+  let(:location) { create :location, :with_address, disabled_at: disabled_at, suppliers: [supplier] }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
   let(:result_data) { result[:data] }
   let(:attributes) { result_data[:attributes] }
@@ -34,6 +34,26 @@ RSpec.describe LocationSerializer do
 
   it 'contains a title attribute' do
     expect(attributes[:title]).to eql location.title
+  end
+
+  it 'contains a premise attribute' do
+    expect(attributes[:premise]).to eql location.premise
+  end
+
+  it 'contains a locality attribute' do
+    expect(attributes[:locality]).to eql location.locality
+  end
+
+  it 'contains a city attribute' do
+    expect(attributes[:city]).to eql location.city
+  end
+
+  it 'contains a country attribute' do
+    expect(attributes[:country]).to eql location.country
+  end
+
+  it 'contains a postcode attribute' do
+    expect(attributes[:postcode]).to eql location.postcode
   end
 
   it 'contains a nomis_agency_id attribute' do

--- a/swagger/v1/location.yaml
+++ b/swagger/v1/location.yaml
@@ -47,6 +47,36 @@ Location:
           example: court
           description: Location type indicates whether this a prison, police station,
             court etc.
+        premise:
+          oneOf:
+          - type: string
+          - type: 'null'
+          example: HMP ALTCOURSE
+          description: Optional premise (building name) for this location
+        locality:
+          oneOf:
+          - type: string
+          - type: 'null'
+          example: Fazakerley
+          description: Optional local area name for this location
+        city:
+          oneOf:
+          - type: string
+          - type: 'null'
+          example: Liverpool
+          description: Optional city name for this location
+        country:
+          oneOf:
+          - type: string
+          - type: 'null'
+          example: England
+          description: Optional country name for this location
+        postcode:
+          oneOf:
+          - type: string
+          - type: 'null'
+          example: L9 7LH
+          description: Optional postcode for this location
         nomis_agency_id:
           type: string
           example: BAI


### PR DESCRIPTION
### Jira link

P4-2683

### What?

- [x] Update `reference_data:create_locations` rake task to import prison addresses from Nomis
- [x] Extend `LocationSerializer` to include new address attributes
- [x] Add new `NomisClient::LocationDetails` class to fetch prison addresses from Nomis 

### Why?

- This allows address details for prisons to be exposed to API clients. A future PR will geocode these addresses to provide latitude and longitude coordinates to API clients, which will support the display of locations on a map. We want to do this geocoding in the backend so that it only has to be done once (locations are reference data) and are available to multiple clients.

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production; extends existing location JSON with additional attributes. This affects all endpoints that include location details.

