### PR TITLE
refactor: Revert exception handling changes and tracing config for sentry

### DIFF
--- a/app/jobs/notify_email_job.rb
+++ b/app/jobs/notify_email_job.rb
@@ -28,10 +28,7 @@ class NotifyEmailJob < ApplicationJob
         delivery_attempts: notification.delivery_attempts.succ,
         delivery_attempted_at: Time.zone.now,
       )
-      Sentry.with_scope do |scope|
-        scope.set_tags(supplier: notification.subscription.supplier.name)
-        Sentry.capture_exception(e)
-      end
+      Sentry.capture_exception(e)
       raise e # re-raise the error to force the notification to be retried by sidekiq later
     end
   end

--- a/app/jobs/notify_webhook_job.rb
+++ b/app/jobs/notify_webhook_job.rb
@@ -33,10 +33,7 @@ class NotifyWebhookJob < ApplicationJob
         delivery_attempts: notification.delivery_attempts.succ,
         delivery_attempted_at: Time.zone.now,
       )
-      Sentry.with_scope do |scope|
-        scope.set_tags(supplier: subscription.supplier.name)
-        Sentry.capture_exception(e)
-      end
+      Sentry.capture_exception(e)
       raise e # re-raise the error to force the notification to be retried by sidekiq later
     end
   end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -14,6 +14,8 @@ Sentry.init do |config|
   # This will remove the request body from the information sent to sentry
   config.send_default_pii = false
 
-  # Half of all requests will be used in perfomace sampling. 
-  config.traces_sample_rate = 0.5
+  # Half of all requests will be used in performance sampling.
+  # Currently the MoJ plan does not allow this. Turn on when
+  # plan has been updated in July 2021
+  # config.traces_sample_rate = 0.5
 end


### PR DESCRIPTION
Notification errors are missing from the sentry events on staging, even though they have happened and can be found in the logs. This reverts the change to how we handle those exceptions and also comments out the tracing config as it can't be used right now and we're getting errors from sentry about it.

