### PR TITLE
Add include support to move journeys endpoint

### DIFF
--- a/app/controllers/api/journeys_controller.rb
+++ b/app/controllers/api/journeys_controller.rb
@@ -22,7 +22,7 @@ module Api
     ].freeze
 
     def index
-      paginate journeys, serializer: JourneySerializer
+      paginate journeys, serializer: JourneysSerializer, include: included_relationships
     end
 
     def show
@@ -47,7 +47,12 @@ module Api
     end
 
     def supported_relationships
-      JourneySerializer::SUPPORTED_RELATIONSHIPS
+      # for performance reasons, we support fewer include relationships on the index action
+      if action_name == 'index'
+        JourneysSerializer::SUPPORTED_RELATIONSHIPS
+      else
+        JourneySerializer::SUPPORTED_RELATIONSHIPS
+      end
     end
 
     def move

--- a/app/serializers/journey_serializer.rb
+++ b/app/serializers/journey_serializer.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
-class JourneySerializer
-  include JSONAPI::Serializer
-
+class JourneySerializer < JourneysSerializer
   set_type :journeys
-
-  attributes :state, :billable, :vehicle
-  attribute :timestamp, &:client_timestamp
 
   has_one :from_location, serializer: LocationSerializer
   has_one :to_location, serializer: LocationSerializer

--- a/app/serializers/journeys_serializer.rb
+++ b/app/serializers/journeys_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class JourneysSerializer
+  include JSONAPI::Serializer
+
+  set_type :journeys
+
+  attributes :state, :billable, :vehicle
+  attribute :timestamp, &:client_timestamp
+
+  has_one :from_location, serializer: LocationsSerializer
+  has_one :to_location, serializer: LocationsSerializer
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    from_location
+    to_location
+  ].freeze
+end

--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -1,24 +1,7 @@
 # frozen_string_literal: true
 
-class LocationSerializer
-  include JSONAPI::Serializer
-
+class LocationSerializer < LocationsSerializer
   set_type :locations
-
-  attributes :key,
-             :title,
-             :location_type,
-             :nomis_agency_id,
-             :can_upload_documents,
-             :young_offender_institution,
-             :premise,
-             :locality,
-             :city,
-             :country,
-             :postcode,
-             :latitude,
-             :longitude,
-             :disabled_at
 
   has_many :suppliers
 

--- a/app/serializers/locations_serializer.rb
+++ b/app/serializers/locations_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class LocationsSerializer
+  include JSONAPI::Serializer
+
+  set_type :locations
+
+  attributes :key,
+             :title,
+             :location_type,
+             :nomis_agency_id,
+             :can_upload_documents,
+             :young_offender_institution,
+             :premise,
+             :locality,
+             :city,
+             :country,
+             :postcode,
+             :latitude,
+             :longitude,
+             :disabled_at
+end

--- a/spec/requests/api/journeys_controller_index_spec.rb
+++ b/spec/requests/api/journeys_controller_index_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe Api::JourneysController do
         it { is_expected.not_to include(other_supplier_journey.id) } # NB: should not contain another supplier's journey in the same move
       end
 
+      describe 'with included locations' do
+        let(:params) do
+          { include: 'from_location,to_location' }
+        end
+
+        it 'includes the requested includes in the response' do
+          returned_types = response_json['included'].map { |r| r['type'] }.uniq
+          expect(returned_types).to contain_exactly('locations')
+        end
+      end
+
       describe 'paginating results' do
         let(:intermediate_journeys_count) { 4 }
         let(:meta_pagination) do

--- a/spec/serializers/journeys_serializer_spec.rb
+++ b/spec/serializers/journeys_serializer_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe JourneysSerializer do
+  subject(:serializer) { described_class.new(journey, adapter_options) }
+
+  let(:journey) { create :journey, client_timestamp: '2020-05-04T08:00:00Z' }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:adapter_options) { {} }
+
+  it 'contains a type property' do
+    expect(result[:data][:type]).to eql 'journeys'
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eql journey.id
+  end
+
+  it 'contains a `billable` attribute' do
+    expect(result[:data][:attributes][:billable]).to be false
+  end
+
+  it 'contains a `state` attribute' do
+    expect(result[:data][:attributes][:state]).to eql 'proposed'
+  end
+
+  it 'contains a `timestamp` attribute' do
+    expect(result[:data][:attributes][:timestamp]).to eql '2020-05-04T09:00:00+01:00'
+  end
+
+  it 'contains vehicle attributes' do
+    expect(result[:data][:attributes][:vehicle]).to eql(id: '12345678ABC', registration: 'AB12 CDE')
+  end
+
+  it 'contains a `from_location` relationship' do
+    expect(result[:data][:relationships][:from_location]).to eql(data: { id: journey.from_location.id, type: 'locations' })
+  end
+
+  it 'contains a `to_location` relationship' do
+    expect(result[:data][:relationships][:to_location]).to eql(data: { id: journey.to_location.id, type: 'locations' })
+  end
+
+  describe 'included relationships' do
+    let(:adapter_options) do
+      {
+        include: %w[from_location to_location],
+      }
+    end
+    let(:expected_json) do
+      [
+        {
+          id: journey.from_location_id,
+          type: 'locations',
+          attributes: { location_type: journey.from_location.location_type, title: journey.from_location.title },
+        },
+        {
+          id: journey.to_location_id,
+          type: 'locations',
+          attributes: { location_type: journey.to_location.location_type, title: journey.to_location.title },
+        },
+      ]
+    end
+
+    it 'contains an included from and to location' do
+      expect(result[:included]).to(include_json(expected_json))
+    end
+  end
+end

--- a/spec/serializers/locations_serializer_spec.rb
+++ b/spec/serializers/locations_serializer_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LocationsSerializer do
+  subject(:serializer) { described_class.new(location) }
+
+  let(:disabled_at) { Time.zone.local(2019, 1, 1) }
+  let(:location) { create :location, :with_address, :with_coordinates, disabled_at: disabled_at }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:result_data) { result[:data] }
+  let(:attributes) { result_data[:attributes] }
+
+  it 'contains a type property' do
+    expect(result_data[:type]).to eql 'locations'
+  end
+
+  it 'contains an id property' do
+    expect(result_data[:id]).to eql location.id
+  end
+
+  it 'has a can_upload_documents property' do
+    expect(attributes[:can_upload_documents]).to eql location.can_upload_documents
+  end
+
+  it 'contains a location_type attribute' do
+    expect(attributes[:location_type]).to eql 'prison'
+  end
+
+  it 'contains a key attribute' do
+    expect(attributes[:key]).to eql location.key
+  end
+
+  it 'contains a title attribute' do
+    expect(attributes[:title]).to eql location.title
+  end
+
+  it 'contains a premise attribute' do
+    expect(attributes[:premise]).to eql location.premise
+  end
+
+  it 'contains a locality attribute' do
+    expect(attributes[:locality]).to eql location.locality
+  end
+
+  it 'contains a city attribute' do
+    expect(attributes[:city]).to eql location.city
+  end
+
+  it 'contains a country attribute' do
+    expect(attributes[:country]).to eql location.country
+  end
+
+  it 'contains a postcode attribute' do
+    expect(attributes[:postcode]).to eql location.postcode
+  end
+
+  it 'contains a latitude attribute' do
+    expect(attributes[:latitude]).to eql location.latitude
+  end
+
+  it 'contains a longitude attribute' do
+    expect(attributes[:longitude]).to eql location.longitude
+  end
+
+  it 'contains a nomis_agency_id attribute' do
+    expect(attributes[:nomis_agency_id]).to eql 'PEI'
+  end
+
+  it 'contains a young_offender_institution attribute' do
+    expect(attributes[:young_offender_institution]).to eql location.young_offender_institution
+  end
+
+  it 'contains a disabled_at attribute' do
+    expect(attributes[:disabled_at]).to eql disabled_at.iso8601
+  end
+end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -1571,7 +1571,7 @@
             from the logged-in account).
           schema:
             "$ref": "../v1/post_journey.yaml#/PostJourney"
-        - "$ref": "../v1/journey_include_parameter.yaml#/JourneyIncludeParameter"
+        - "$ref": "../v1/journeys_include_parameter.yaml#/JourneysIncludeParameter"
       responses:
         "201":
           description: created

--- a/swagger/v1/journeys_include_parameter.yaml
+++ b/swagger/v1/journeys_include_parameter.yaml
@@ -1,0 +1,12 @@
+JourneysIncludeParameter:
+  name: include
+  description: Returns a specific list of related resources to the journeys
+  in: query
+  style: form
+  explode: false
+  schema:
+    type: string
+    enum:
+      - from_location
+      - to_location
+  example: from_location


### PR DESCRIPTION
### Jira link

P4-2693

### What?

- [x] Add support for `include=from_location,to_location` to `GET /moves/{id}/journeys` endpoint

### Why?

- This was previously documented as supporting the same includes as a single journey, but in fact had no include support at all. Added support for a limited set of includes (just the from and to location) as it's less useful to return the suppliers for multiple journeys. Added new serializers for journeys and locations to avoid N+1 queries.

### Have you? (optional)

- [x] Updated API docs if necessary