### PR TITLE
Fix the name of the env var holding the slack mentions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ aliases:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "${BUILD_NOTIFICATIONS_MENTION_IDS}"
+                      "text": "${BUILD_NOTIFICATIONS_MENTION_ID}"
                     }
                   ]
                 },


### PR DESCRIPTION
The mentions env var was slightly wrong and so the notification for approval never went out.
