### PR TITLE
Add bundler audit scheduled job to circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,10 @@ executors:
       - image: rodolpheche/wiremock:2.27.1-alpine
         command: --port 8888
 
+  auditor:
+    docker:
+      - image: circleci/ruby:2-buster
+
 commands:
   build-base:
     description: "Checkout app code and fetch dependencies for running tests"
@@ -370,6 +374,16 @@ commands:
             - *notify_slack_on_release_end
 
 jobs:
+  security_audit:
+    executor: auditor
+    steps:
+      - checkout
+      - build-base
+      - *attach-tmp-workspace
+      - run:
+          name: Run security audit
+          command: bundle exec bundle audit check
+
   notify_of_approval:
     resource_class: small
     executor: basic-executor
@@ -607,3 +621,13 @@ workflows:
       - schedule:
           cron: "0 9 * * 1"
           <<: *only_main
+
+  scheduled:
+    triggers:
+      - schedule:
+          cron: "0 7 * * 1-5"
+          filters:
+            branches:
+              only: main
+    jobs:
+      - security_audit

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'bundler-audit'
   gem 'listen'
   gem 'rails-erd'
   gem 'rubocop-govuk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,9 @@ GEM
     bootsnap (1.7.3)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bundler-audit (0.8.0)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     byebug (11.1.3)
     cancancan (3.2.1)
     childprocess (0.9.0)
@@ -446,6 +449,7 @@ DEPENDENCIES
   aws-sdk-s3
   bcrypt
   bootsnap (>= 1.1.0)
+  bundler-audit
   cancancan
   climate_control
   discard


### PR DESCRIPTION
### What?

I have added/removed/altered:
- scheduled security audit job for circle ci

### Why?

I am doing this because:

- we currently have no way of automatically getting alerted of security vulnerabilities

