### PR TITLE
Fix security audit executor to use the test executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,10 +251,6 @@ executors:
       - image: rodolpheche/wiremock:2.27.1-alpine
         command: --port 8888
 
-  auditor:
-    docker:
-      - image: circleci/ruby:2-buster
-
 commands:
   build-base:
     description: "Checkout app code and fetch dependencies for running tests"
@@ -375,7 +371,7 @@ commands:
 
 jobs:
   security_audit:
-    executor: auditor
+    executor: test-executor
     steps:
       - checkout
       - build-base


### PR DESCRIPTION
The executor was using the wrong ruby version. Removed special executor as not needed, using the test executor now.

