### PR TITLE
P4-2737 disable webhooks for proposed moves

### DIFF
--- a/spec/jobs/prepare_move_notifications_job_spec.rb
+++ b/spec/jobs/prepare_move_notifications_job_spec.rb
@@ -135,6 +135,15 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
     it_behaves_like 'it schedules NotifyEmailJob'
   end
 
+  context 'when creating a proposed move' do
+    let(:move) { create :move, :proposed, from_location: location, date_from: Time.zone.today, supplier: supplier }
+
+    it_behaves_like 'it does not create a webhook notification record'
+    it_behaves_like 'it does not create an email notification record'
+    it_behaves_like 'it does not schedule NotifyWebhookJob'
+    it_behaves_like 'it does not schedule NotifyEmailJob'
+  end
+
   context 'when send_webhooks is false' do
     let(:send_webhooks) { false }
 

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -185,12 +185,26 @@ RSpec.describe Api::MovesController do
         }
       end
 
-      it 'creates the correct notification' do
-        perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
-          do_post
-        end
+      context 'with a requested move' do
+        it 'creates the correct notification' do
+          perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
+            do_post
+          end
 
-        expect(subscription.notifications.last.attributes).to include_json(expected_notification_attributes)
+          expect(subscription.notifications.last.attributes).to include_json(expected_notification_attributes)
+        end
+      end
+
+      context 'with a proposed move' do
+        let(:move_attributes) { attributes_for(:move).except(:date).merge(move_type: 'court_appearance', status: 'proposed') }
+
+        it 'creates the correct notification' do
+          perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
+            do_post
+          end
+
+          expect(subscription.notifications.last).to be_nil
+        end
       end
     end
 


### PR DESCRIPTION
### Jira link

P4-<2737>

### What?

I have added/removed/altered:

- [x] Added rule to prevent webhooks being sent for proposed moves

### Why?

I am doing this because:

- proposed moves are internal to Book a Secure Move and should not cause notifications to suppliers until they are requested


### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

