### PR TITLE
Relax rules on per_medical_aid treated_at and treated_by

### DIFF
--- a/app/models/generic_event/per_medical_aid.rb
+++ b/app/models/generic_event/per_medical_aid.rb
@@ -13,8 +13,7 @@ class GenericEvent
 
     validates :advised_at, presence: true, iso_date_time: true
     validates :advised_by, presence: true
-    validates :treated_at, presence: true, iso_date_time: true
-    validates :treated_by, presence: true
+    validates :treated_at, allow_nil: true, iso_date_time: true
 
     def event_classification
       :medical

--- a/spec/models/generic_event/per_medical_aid_spec.rb
+++ b/spec/models/generic_event/per_medical_aid_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe GenericEvent::PerMedicalAid do
 
   it { is_expected.to validate_presence_of(:advised_at) }
   it { is_expected.to validate_presence_of(:advised_by) }
-  it { is_expected.to validate_presence_of(:treated_at) }
-  it { is_expected.to validate_presence_of(:treated_by) }
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 
@@ -34,6 +32,15 @@ RSpec.describe GenericEvent::PerMedicalAid do
     let(:treated_at) { '2019/01/01T18:00:00' }
 
     it { is_expected.not_to be_valid }
+  end
+
+  context 'when the treated_at and treated_by are nil' do
+    before do
+      generic_event.treated_by = nil
+      generic_event.treated_at = nil
+    end
+
+    it { is_expected.to be_valid }
   end
 
   describe '#event_classification' do


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Relax rules to allow treated_at and treated_by to be nil in per_medical_aid event

### Why?

I am doing this because:

- requested change by suppliers to handle event where aid is requested but not required

### Have you? (optional)

- [ ] Updated API docs if necessary	


### Deployment risks (optional)

- minimal

