### PR TITLE
Raise RetryJobError on job errors

### DIFF
--- a/app/jobs/notify_email_job.rb
+++ b/app/jobs/notify_email_job.rb
@@ -34,7 +34,7 @@ class NotifyEmailJob < ApplicationJob
         scope.set_tags(move: notification.topic.reference) if notification.topic.is_a?(Move)
         Sentry.capture_exception(e)
       end
-      raise e # re-raise the error to force the notification to be retried by sidekiq later
+      raise RetryJobError, e
     end
   end
 end

--- a/app/jobs/notify_webhook_job.rb
+++ b/app/jobs/notify_webhook_job.rb
@@ -38,7 +38,7 @@ class NotifyWebhookJob < ApplicationJob
         scope.set_tags(move: notification.topic.reference) if notification.topic.is_a?(Move)
         Sentry.capture_exception(e)
       end
-      raise e # re-raise the error to force the notification to be retried by sidekiq later
+      raise RetryJobError, e
     end
   end
 

--- a/app/services/retry_job_error.rb
+++ b/app/services/retry_job_error.rb
@@ -1,0 +1,2 @@
+class RetryJobError < StandardError
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -14,6 +14,9 @@ Sentry.init do |config|
   # This will remove the request body from the information sent to sentry
   config.send_default_pii = false
 
+  # Don't log RetryJobError exceptions in Sentry as they will have already been logged as part of the failed job
+  config.excluded_exceptions += ['RetryJobError']
+
   # Half of all requests will be used in performance sampling.
   # Currently the MoJ plan does not allow this. Turn on when
   # plan has been updated in July 2021

--- a/spec/jobs/notify_email_job_spec.rb
+++ b/spec/jobs/notify_email_job_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe NotifyEmailJob, type: :job do
     let(:govuk_notify_api_key) { nil }
 
     it 'raises an NoMethodError' do
-      expect { perform! }.to raise_error(NoMethodError, /undefined method `length' for nil/)
+      expect { perform! }.to raise_error(RetryJobError, /undefined method `length' for nil/)
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe NotifyEmailJob, type: :job do
     let(:govuk_notify_move_template_id) { nil }
 
     it 'raises an ArgumentError' do
-      expect { perform! }.to raise_error(ArgumentError, /Missing template ID/)
+      expect { perform! }.to raise_error(RetryJobError, /Missing template ID/)
     end
   end
 
@@ -143,7 +143,7 @@ RSpec.describe NotifyEmailJob, type: :job do
       end
 
       it 'raises an error' do
-        expect { perform! }.to raise_error(RuntimeError, 'govuk_notify_response is missing')
+        expect { perform! }.to raise_error(RetryJobError, 'govuk_notify_response is missing')
       end
     end
 

--- a/spec/jobs/notify_webhook_job_spec.rb
+++ b/spec/jobs/notify_webhook_job_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe NotifyWebhookJob, type: :job do
         let(:response) { instance_double(Faraday::Response, success?: false, status: 503, reason_phrase: 'Server error', body: { message: 'some message', error: 'some error' }.to_json) }
 
         it 'raises Notification failed error' do
-          expect { perform! }.to raise_error(RuntimeError, /non-success status received/)
+          expect { perform! }.to raise_error(RetryJobError, /non-success status received/)
         end
 
         it 'updates delivery_attempts' do
@@ -116,7 +116,7 @@ RSpec.describe NotifyWebhookJob, type: :job do
       end
 
       it 'raises Notification failed error' do
-        expect { perform! }.to raise_error(Faraday::ClientError, 'Internet is unplugged')
+        expect { perform! }.to raise_error(RetryJobError, 'Internet is unplugged')
       end
 
       it 'updates delivery_attempts' do


### PR DESCRIPTION
Raise RetryJobError on job errors, to avoid duplicate Sentry errors

### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Added new error `RetryJobError`
- [x] Raise the new error within jobs
- [x] Filter the new error from Sentry

### Why?

I am doing this because:

- we were getting duplicate errors in Sentry

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

