### PR TITLE
bump rexml to 3.2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,7 @@ GEM
     request_store (1.5.0)
       rack (>= 1.4)
     retriable (3.1.2)
-    rexml (3.2.4)
+    rexml (3.2.5)
     routing-filter (0.6.3)
       actionpack (>= 4.2)
       activesupport (>= 4.2)


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [x] Bump rexml gem from 3.2.4 to 3.2.5


### Why?

I am doing this because:

- there are security issues with version 3.2.4