### PR TITLE
[P4-2836] Notify Slack when circle audit job fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,36 @@ aliases:
     slack/notify:
       event: fail
       branch_pattern: main
+      channel: pecs-dev
+      custom: |
+        {
+          "blocks": [
+            {
+              "type": "context",
+              "elements": [
+                {
+                  "type": "mrkdwn",
+                  "text": ":circleci-${CCI_STATUS}: CircleCI job *${CIRCLE_JOB}* ${CCI_STATUS}"
+                }
+              ]
+            },
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "*${CIRCLE_PROJECT_REPONAME}* failed ${CIRCLE_JOB}"
+              },
+              "accessory": {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "text": "View job"
+                },
+                "url": "${CIRCLE_BUILD_URL}"
+              }
+            }
+          ]
+        }
   - &notify_slack_on_release_start
     slack/notify:
       channel: $BUILD_NOTIFICATIONS_CHANNEL_ID
@@ -379,6 +409,7 @@ jobs:
       - run:
           name: Run security audit
           command: bundle exec bundle audit check
+      - *notify_slack_on_failure
 
   notify_of_approval:
     resource_class: small


### PR DESCRIPTION
### Jira link

P4-2836

### What?

I have added/removed/altered:

- [x] Added a Slack notification when the CircleCI audit job fails

### Why?

I am doing this because:

- It will make the failed audit more visible, so that it can be actioned faster.
