### PR TITLE
P4 2836/make audit notify slack on fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,7 +652,7 @@ workflows:
   scheduled:
     triggers:
       - schedule:
-          cron: "0 7 * * 1-5"
+          cron: "0 6 * * 1-5"
           filters:
             branches:
               only: main


### PR DESCRIPTION
### Jira link

P4-2836

### What?

I have added/removed/altered:

- [x] Changed the audit schedule time to 6 AM from 7 AM.

### Why?

I am doing this because:

- The CircleCI job has stopped running and we believe that it's waiting for a new commit, because the last run failed.