### PR TITLE
P4-2831: Add created_at to locations + filter

### DIFF
--- a/app/controllers/api/reference/locations_controller.rb
+++ b/app/controllers/api/reference/locations_controller.rb
@@ -27,7 +27,7 @@ module Api
         render_json location, serializer: LocationSerializer, include: included_relationships, status: status
       end
 
-      PERMITTED_FILTER_PARAMS = %i[location_type nomis_agency_id supplier_id location_id region_id young_offender_institution].freeze
+      PERMITTED_FILTER_PARAMS = %i[location_type nomis_agency_id supplier_id location_id region_id young_offender_institution created_at].freeze
 
       def filter_params
         params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h

--- a/app/serializers/locations_serializer.rb
+++ b/app/serializers/locations_serializer.rb
@@ -18,5 +18,6 @@ class LocationsSerializer
              :postcode,
              :latitude,
              :longitude,
+             :created_at,
              :disabled_at
 end

--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -72,7 +72,7 @@ module Locations
     def apply_created_at_filters(scope)
       return scope if filter_params[:created_at].blank?
 
-      date = Date.strptime(filter_params[:created_at])
+      date = Date.strptime(filter_params[:created_at], '%Y-%m-%d')
       scope = scope.where(created_at: date.midnight..date.end_of_day)
       scope
     end

--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -36,6 +36,7 @@ module Locations
       scope = apply_location_filters(scope)
       scope = apply_region_filters(scope)
       scope = apply_young_offender_institution_filters(scope)
+      scope = apply_created_at_filters(scope)
       scope
     end
 
@@ -65,6 +66,14 @@ module Locations
     def apply_young_offender_institution_filters(scope)
       scope = scope.where(young_offender_institution: true) if filter_params[:young_offender_institution].to_s == 'true'
       scope = scope.where(young_offender_institution: false) if filter_params[:young_offender_institution].to_s == 'false'
+      scope
+    end
+
+    def apply_created_at_filters(scope)
+      return scope if filter_params[:created_at].blank?
+
+      date = Date.strptime(filter_params[:created_at])
+      scope = scope.where(created_at: date.midnight..date.end_of_day)
       scope
     end
   end

--- a/spec/requests/api/reference/locations_controller_spec.rb
+++ b/spec/requests/api/reference/locations_controller_spec.rb
@@ -169,7 +169,8 @@ RSpec.describe Api::Reference::LocationsController do
     describe 'filters' do
       let!(:supplier) { create :supplier }
       let!(:location) { create :location, suppliers: [supplier] }
-      let(:filters) { { location_type: 'prison', nomis_agency_id: 'PEI', supplier_id: supplier.id, young_offender_institution: nil } }
+      let(:created_at) { Date.new(2020, 5, 6) }
+      let(:filters) { { location_type: 'prison', nomis_agency_id: 'PEI', supplier_id: supplier.id, young_offender_institution: nil, created_at: created_at } }
       let(:params) { { filter: filters } }
 
       before do
@@ -186,6 +187,7 @@ RSpec.describe Api::Reference::LocationsController do
             nomis_agency_id: location.nomis_agency_id,
             supplier_id: supplier.id,
             young_offender_institution: nil,
+            created_at: created_at.to_s,
           },
           active_record_relationships: nil,
         )

--- a/spec/serializers/location_serializer_spec.rb
+++ b/spec/serializers/location_serializer_spec.rb
@@ -5,9 +5,10 @@ require 'rails_helper'
 RSpec.describe LocationSerializer do
   subject(:serializer) { described_class.new(location, include: %i[suppliers]) }
 
+  let(:created_at) { Time.zone.local(2018, 6, 1) }
   let(:disabled_at) { Time.zone.local(2019, 1, 1) }
   let(:supplier) { create(:supplier) }
-  let(:location) { create :location, :with_address, :with_coordinates, disabled_at: disabled_at, suppliers: [supplier] }
+  let(:location) { create :location, :with_address, :with_coordinates, created_at: created_at, disabled_at: disabled_at, suppliers: [supplier] }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
   let(:result_data) { result[:data] }
   let(:attributes) { result_data[:attributes] }
@@ -70,6 +71,10 @@ RSpec.describe LocationSerializer do
 
   it 'contains a young_offender_institution attribute' do
     expect(attributes[:young_offender_institution]).to eql location.young_offender_institution
+  end
+
+  it 'contains a created_at attribute' do
+    expect(attributes[:created_at]).to eql created_at.iso8601
   end
 
   it 'contains a disabled_at attribute' do

--- a/spec/serializers/locations_serializer_spec.rb
+++ b/spec/serializers/locations_serializer_spec.rb
@@ -5,8 +5,9 @@ require 'rails_helper'
 RSpec.describe LocationsSerializer do
   subject(:serializer) { described_class.new(location) }
 
+  let(:created_at) { Time.zone.local(2018, 6, 1) }
   let(:disabled_at) { Time.zone.local(2019, 1, 1) }
-  let(:location) { create :location, :with_address, :with_coordinates, disabled_at: disabled_at }
+  let(:location) { create :location, :with_address, :with_coordinates, created_at: created_at, disabled_at: disabled_at }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
   let(:result_data) { result[:data] }
   let(:attributes) { result_data[:attributes] }
@@ -69,6 +70,10 @@ RSpec.describe LocationsSerializer do
 
   it 'contains a young_offender_institution attribute' do
     expect(attributes[:young_offender_institution]).to eql location.young_offender_institution
+  end
+
+  it 'contains a created_at attribute' do
+    expect(attributes[:created_at]).to eql created_at.iso8601
   end
 
   it 'contains a disabled_at attribute' do

--- a/spec/services/locations/finder_spec.rb
+++ b/spec/services/locations/finder_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe Locations::Finder do
       end
     end
 
+    context 'with a created_at' do
+      let(:filter_params) { { created_at: '2020-05-06' } }
+
+      before do
+        create(:location, title: '2020-05-06 Location', created_at: Time.zone.local(2020, 5, 6, 23, 59, 59))
+        create(:location, title: '2020-05-07 Location', created_at: Time.zone.local(2020, 5, 7, 0, 0, 0))
+      end
+
+      it 'returns locations with specified id' do
+        expect(location_finder.call.pluck(:created_at)).to contain_exactly(Time.zone.local(2020, 5, 6, 23, 59, 59))
+      end
+    end
+
     context 'with young_offender_institution true' do
       let(:filter_params) { { young_offender_institution: true } }
 
@@ -66,7 +79,7 @@ RSpec.describe Locations::Finder do
         create(:location, young_offender_institution: false, title: 'Non YOI')
       end
 
-      it 'returns YOI only locations' do
+      it 'returns only YOI locations' do
         expect(location_finder.call.pluck(:title)).to contain_exactly('YOI Location')
       end
     end
@@ -79,7 +92,7 @@ RSpec.describe Locations::Finder do
         create(:location, young_offender_institution: false, title: 'Non YOI')
       end
 
-      it 'returns YOI only locations' do
+      it 'returns only non-YOI locations' do
         expect(location_finder.call.pluck(:title)).to contain_exactly('Non YOI')
       end
     end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -3582,6 +3582,13 @@
             type: string
           format: uuid
           example: 950ef512-a25f-46d7-8ced-7ad09510659b
+        - name: filter[created_at]
+          in: query
+          description: Filters results to only include locations created on the given date
+          schema:
+            type: string
+          format: date
+          example: "2019-05-15"
         - name: filter[young_offender_institution]
           in: query
           explode: false

--- a/swagger/v1/location.yaml
+++ b/swagger/v1/location.yaml
@@ -97,6 +97,13 @@ Location:
           type: boolean
           example: false
           description: Indicates that the location is a Youth Offenders Institute (note that some locations may have mixed populations so have a differing location type).
+        created_at:
+          oneOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          example: '2017-07-21T17:32:28Z'
+          description: The date-time at which the location was created, in ISO-8601 format
         disabled_at:
           oneOf:
           - type: string

--- a/swagger/v1/location.yaml
+++ b/swagger/v1/location.yaml
@@ -103,7 +103,7 @@ Location:
             format: date-time
           - type: 'null'
           example: '2017-07-21T17:32:28Z'
-          description: The date-time at which the location was created, in ISO-8601 format
+          description: The date-time at which the location was imported into Book a Secure Move, in ISO-8601 format
         disabled_at:
           oneOf:
           - type: string


### PR DESCRIPTION
### Jira link

P4-2831

### What?

I have added/removed/altered:

- [x] Added created_at to the locations filters, it takes a date in `yyyy-MM-dd` format
- [x] Added created_at to the locations serialization, it returns the datetime the location was created in ISO-8601 format

### Why?

I am doing this because:

- It will allow JPC to automatically recognise new locations

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production

