### PR TITLE
P4-2816 drop-off and pickup ETA events

### DIFF
--- a/app/controllers/api/generic_events_controller.rb
+++ b/app/controllers/api/generic_events_controller.rb
@@ -57,7 +57,7 @@ module Api
     end
 
     def event_type
-      @event_type ||= 'GenericEvent::' + event_params.dig('attributes', 'event_type')
+      @event_type ||= 'GenericEvent::' + event_remap(event_params.dig('attributes', 'event_type'))
     end
 
     def event_specific_relationships
@@ -66,6 +66,12 @@ module Api
 
     def run_event_logs
       GenericEvents::Runner.new(eventable).call
+    end
+
+    def event_remap(original_event)
+      {
+        'MoveNotifyPremisesOfEta' => 'MoveNotifyPremisesOfDropOffEta',
+      }[original_event] || original_event
     end
   end
 end

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -46,6 +46,8 @@ class GenericEvent < ApplicationRecord
     MoveLodgingStart
     MoveNotifyPremisesOfArrivalIn30Mins
     MoveNotifyPremisesOfEta
+    MoveNotifyPremisesOfDropOffEta
+    MoveNotifyPremisesOfPickupEta
     MoveNotifyPremisesOfExpectedCollectionTime
     MoveOperationHmcts
     MoveOperationSafeguard

--- a/app/models/generic_event/move_notify_premises_of_drop_off_eta.rb
+++ b/app/models/generic_event/move_notify_premises_of_drop_off_eta.rb
@@ -1,0 +1,8 @@
+class GenericEvent
+  class MoveNotifyPremisesOfDropOffEta < Notification
+    details_attributes :expected_at
+    eventable_types 'Move'
+
+    validates :expected_at, presence: true, iso_date_time: true
+  end
+end

--- a/app/models/generic_event/move_notify_premises_of_eta.rb
+++ b/app/models/generic_event/move_notify_premises_of_eta.rb
@@ -1,3 +1,4 @@
+# TODO: remove this event once we have migrated over to MoveNotifyPremisesOfDropOffEta + MoveNotifyPremisesOfPickupEta
 class GenericEvent
   class MoveNotifyPremisesOfEta < Notification
     details_attributes :expected_at

--- a/app/models/generic_event/move_notify_premises_of_pickup_eta.rb
+++ b/app/models/generic_event/move_notify_premises_of_pickup_eta.rb
@@ -1,0 +1,8 @@
+class GenericEvent
+  class MoveNotifyPremisesOfPickupEta < Notification
+    details_attributes :expected_at
+    eventable_types 'Move'
+
+    validates :expected_at, presence: true, iso_date_time: true
+  end
+end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -307,11 +307,12 @@ class Move < VersionedModel
 
   def expected_time_of_arrival
     # Process in memory to avoid n+1 queries in serializers
-    notification_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfEta' }.max_by(&:occurred_at)&.expected_at
+    notification_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfDropOffEta' }.max_by(&:occurred_at)&.expected_at
   end
 
   def expected_collection_time
     # Process in memory to avoid n+1 queries in serializers
+    # TODO: use GenericEvent::MoveNotifyPremisesOfPickupEta when it is available
     notification_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime' }.max_by(&:occurred_at)&.expected_at
   end
 

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -55,11 +55,18 @@ namespace :data_maintenance do
     notification_event_types = [
       'GenericEvent::MoveNotifyPremisesOfArrivalIn30Mins',
       'GenericEvent::MoveNotifyPremisesOfEta',
+      'GenericEvent::MoveNotifyPremisesOfDropOffEta',
+      'GenericEvent::MoveNotifyPremisesOfPickupEta',
       'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime',
     ]
 
     GenericEvent.where(type: medical_event_type).update_all(classification: 'medical')
     GenericEvent.where(type: incident_event_types).update_all(classification: 'incident')
     GenericEvent.where(type: notification_event_types).update_all(classification: 'notification')
+  end
+
+  desc 'remap ETA events: MoveNotifyPremisesOfEta to MoveNotifyPremisesOfDropOffEta'
+  task remap_eta_events: :environment do
+    GenericEvent.where(type: 'GenericEvent::MoveNotifyPremisesOfEta').update_all(type: 'GenericEvent::MoveNotifyPremisesOfDropOffEta')
   end
 end

--- a/lib/tasks/fake_data/notification_events.rb
+++ b/lib/tasks/fake_data/notification_events.rb
@@ -35,7 +35,8 @@ module Tasks
 
       def random_event
         [
-          GenericEvent::MoveNotifyPremisesOfEta,
+          GenericEvent::MoveNotifyPremisesOfDropoffEta,
+          GenericEvent::MoveNotifyPremisesOfPickupEta,
           GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime,
         ].sample
       end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -132,7 +132,16 @@ FactoryBot.define do
     eventable { association(:move) }
   end
 
-  factory :event_move_notify_premises_of_eta, parent: :generic_event, class: 'GenericEvent::MoveNotifyPremisesOfEta' do
+  factory :event_move_notify_premises_of_drop_off_eta, parent: :generic_event, class: 'GenericEvent::MoveNotifyPremisesOfDropOffEta' do
+    eventable { association(:move) }
+    details do
+      {
+        expected_at: '2020-06-16T10:20:30+01:00',
+      }
+    end
+  end
+
+  factory :event_move_notify_premises_of_pickup_eta, parent: :generic_event, class: 'GenericEvent::MoveNotifyPremisesOfPickupEta' do
     eventable { association(:move) }
     details do
       {

--- a/spec/models/generic_event/move_notify_premises_of_drop_off_eta_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_drop_off_eta_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::MoveNotifyPremisesOfDropOffEta do
+  subject(:generic_event) { build(:event_move_notify_premises_of_drop_off_eta) }
+
+  it_behaves_like 'an event with details', :expected_at
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Move]) }
+  it { is_expected.to validate_presence_of(:expected_at) }
+
+  it 'is valid when the expected_at value is a valid iso8601 datetime' do
+    generic_event.expected_at = '2020-06-16T10:20:30+01:00'
+    expect(generic_event).to be_valid
+  end
+
+  it 'is invalid when the expected_at value is not a valid iso8601 datetime' do
+    generic_event.expected_at = '16-06-2020 10:20:30+01:00'
+    expect(generic_event).not_to be_valid
+  end
+
+  it_behaves_like 'an event about a notification', :event_move_notify_premises_of_drop_off_eta
+end

--- a/spec/models/generic_event/move_notify_premises_of_pickup_eta_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_pickup_eta_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe GenericEvent::MoveNotifyPremisesOfEta do
-  subject(:generic_event) { build(:event_move_notify_premises_of_eta) }
+RSpec.describe GenericEvent::MoveNotifyPremisesOfPickupEta do
+  subject(:generic_event) { build(:event_move_notify_premises_of_pickup_eta) }
 
   it_behaves_like 'an event with details', :expected_at
 
@@ -18,5 +18,5 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfEta do
     expect(generic_event).not_to be_valid
   end
 
-  it_behaves_like 'an event about a notification', :event_move_notify_premises_of_eta
+  it_behaves_like 'an event about a notification', :event_move_notify_premises_of_pickup_eta
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -863,14 +863,14 @@ RSpec.describe Move do
     end
 
     it 'returns the expected time of arrival for a vehicle' do
-      event = create(:event_move_notify_premises_of_eta, expected_at: '2019-06-16T10:20:30+01:00')
+      event = create(:event_move_notify_premises_of_drop_off_eta, expected_at: '2019-06-16T10:20:30+01:00')
       move = create(:move, notification_events: [event])
 
       expect(move.expected_time_of_arrival).to eq('2019-06-16T10:20:30+01:00')
     end
 
     it 'returns the expected time of arrival for a vehicle if multiple different notification events exist' do
-      event1 = create(:event_move_notify_premises_of_eta, expected_at: '2019-06-16T10:20:30+01:00', occurred_at: 2.minutes.ago)
+      event1 = create(:event_move_notify_premises_of_drop_off_eta, expected_at: '2019-06-16T10:20:30+01:00', occurred_at: 2.minutes.ago)
       event2 = create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-17T10:20:30+01:00', occurred_at: 1.minute.ago)
       move = create(:move, notification_events: [event2, event1])
 
@@ -878,8 +878,8 @@ RSpec.describe Move do
     end
 
     it 'returns the latest expected time of arrival for a vehicle if multiple events present' do
-      event1 = create(:event_move_notify_premises_of_eta, expected_at: '2019-06-16T10:20:30+01:00', occurred_at: 2.minutes.ago)
-      event2 = create(:event_move_notify_premises_of_eta, expected_at: '2019-06-17T10:20:30+01:00', occurred_at: 1.minute.ago)
+      event1 = create(:event_move_notify_premises_of_drop_off_eta, expected_at: '2019-06-16T10:20:30+01:00', occurred_at: 2.minutes.ago)
+      event2 = create(:event_move_notify_premises_of_drop_off_eta, expected_at: '2019-06-17T10:20:30+01:00', occurred_at: 1.minute.ago)
       move = create(:move, notification_events: [event2, event1])
 
       expect(move.expected_time_of_arrival).to eq('2019-06-17T10:20:30+01:00')
@@ -908,7 +908,7 @@ RSpec.describe Move do
 
     it 'returns the expected collection time for a vehicle if multiple different notification events exist' do
       event1 = create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-16T10:20:30+01:00', occurred_at: 2.minutes.ago)
-      event2 = create(:event_move_notify_premises_of_eta, expected_at: '2019-06-17T10:20:30+01:00', occurred_at: 1.minute.ago)
+      event2 = create(:event_move_notify_premises_of_drop_off_eta, expected_at: '2019-06-17T10:20:30+01:00', occurred_at: 1.minute.ago)
       move = create(:move, notification_events: [event2, event1])
 
       expect(move.expected_collection_time).to eq('2019-06-16T10:20:30+01:00')

--- a/spec/requests/api/moves_controller_filtered_spec.rb
+++ b/spec/requests/api/moves_controller_filtered_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Api::MovesController do
       let(:notification_events) do
         [
           create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-17T10:20:30+01:00'),
-          create(:event_move_notify_premises_of_eta, expected_at: '2019-06-19T10:20:30+01:00'),
+          create(:event_move_notify_premises_of_drop_off_eta, expected_at: '2019-06-19T10:20:30+01:00'),
         ]
       end
       let!(:moves) do

--- a/spec/requests/api/moves_controller_index_v2_spec.rb
+++ b/spec/requests/api/moves_controller_index_v2_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe Api::MovesController do
       let(:notification_events) do
         [
           create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-17T10:20:30+01:00'),
-          create(:event_move_notify_premises_of_eta, expected_at: '2019-06-19T10:20:30+01:00'),
+          create(:event_move_notify_premises_of_drop_off_eta, expected_at: '2019-06-19T10:20:30+01:00'),
         ]
       end
       let!(:moves) do

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe V2::MovesSerializer do
   end
 
   context 'with expected_time_of_arrival params set to true' do
-    let(:event) { create(:event_move_notify_premises_of_eta, expected_at: '2019-06-16T10:20:30+01:00') }
+    let(:event) { create(:event_move_notify_premises_of_drop_off_eta, expected_at: '2019-06-16T10:20:30+01:00') }
     let(:move) { create :move, notification_events: [event] }
     let(:options) do
       { params: { expected_time_of_arrival: true } }
@@ -103,7 +103,7 @@ RSpec.describe V2::MovesSerializer do
   end
 
   context 'with expected_time_of_arrival params set to false' do
-    let(:event) { create(:event_move_notify_premises_of_eta, expected_at: '2019-06-16T10:20:30+01:00') }
+    let(:event) { create(:event_move_notify_premises_of_drop_off_eta, expected_at: '2019-06-16T10:20:30+01:00') }
     let(:move) { create :move, notification_events: [event] }
     let(:options) do
       { params: { expected_time_of_arrival: false } }


### PR DESCRIPTION
now re-maps MoveNotifyPremisesOfEta to MoveNotifyPremisesOfDropOffEta

### Jira link

P4-2816

### What?

I have added/removed/altered:

- [x] Added events `MoveNotifyPremisesOfDropOffEta` and `MoveNotifyPremisesOfPickupEta`
- [x] Re-mapped old event `MoveNotifyPremisesOfEta` to `MoveNotifyPremisesOfDropOffEta`
- [x] Added rake task to re-map existing event data

### Why?

I am doing this because:

- so we have clear visibility of whether the ETA is for collection or drop-off


### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Frontend templates will require updating prior to deployment

