### PR TITLE
chore: Enable Sentry performance tracking

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -20,5 +20,5 @@ Sentry.init do |config|
   # Half of all requests will be used in performance sampling.
   # Currently the MoJ plan does not allow this. Turn on when
   # plan has been updated in July 2021
-  # config.traces_sample_rate = 0.5
+  config.traces_sample_rate = 0.5
 end


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [x] Turned on performance tracing

### Why?

I am doing this because:

- CP have enabled a trial for the performance features of Sentry
