### PR TITLE
Change eta classification

### DIFF
--- a/app/models/generic_event/move_notify_premises_of_arrival_in_30_mins.rb
+++ b/app/models/generic_event/move_notify_premises_of_arrival_in_30_mins.rb
@@ -1,5 +1,5 @@
 class GenericEvent
-  class MoveNotifyPremisesOfArrivalIn30Mins < Notification
+  class MoveNotifyPremisesOfArrivalIn30Mins < GenericEvent
     eventable_types 'Move'
   end
 end

--- a/app/models/generic_event/move_notify_premises_of_drop_off_eta.rb
+++ b/app/models/generic_event/move_notify_premises_of_drop_off_eta.rb
@@ -1,5 +1,5 @@
 class GenericEvent
-  class MoveNotifyPremisesOfDropOffEta < Notification
+  class MoveNotifyPremisesOfDropOffEta < GenericEvent
     details_attributes :expected_at
     eventable_types 'Move'
 

--- a/app/models/generic_event/move_notify_premises_of_eta.rb
+++ b/app/models/generic_event/move_notify_premises_of_eta.rb
@@ -1,6 +1,6 @@
 # TODO: remove this event once we have migrated over to MoveNotifyPremisesOfDropOffEta + MoveNotifyPremisesOfPickupEta
 class GenericEvent
-  class MoveNotifyPremisesOfEta < Notification
+  class MoveNotifyPremisesOfEta < GenericEvent
     details_attributes :expected_at
     eventable_types 'Move'
 

--- a/app/models/generic_event/move_notify_premises_of_expected_collection_time.rb
+++ b/app/models/generic_event/move_notify_premises_of_expected_collection_time.rb
@@ -1,11 +1,10 @@
 class GenericEvent
-  class MoveNotifyPremisesOfExpectedCollectionTime < Notification
+  class MoveNotifyPremisesOfExpectedCollectionTime < GenericEvent
     details_attributes :expected_at
 
     eventable_types 'Move'
 
     validates :expected_at, presence: true
-
     validates :expected_at, iso_date_time: true
   end
 end

--- a/app/models/generic_event/move_notify_premises_of_pickup_eta.rb
+++ b/app/models/generic_event/move_notify_premises_of_pickup_eta.rb
@@ -1,5 +1,5 @@
 class GenericEvent
-  class MoveNotifyPremisesOfPickupEta < Notification
+  class MoveNotifyPremisesOfPickupEta < GenericEvent
     details_attributes :expected_at
     eventable_types 'Move'
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -307,13 +307,13 @@ class Move < VersionedModel
 
   def expected_time_of_arrival
     # Process in memory to avoid n+1 queries in serializers
-    notification_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfDropOffEta' }.max_by(&:occurred_at)&.expected_at
+    generic_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfDropOffEta' }.max_by(&:occurred_at)&.expected_at
   end
 
   def expected_collection_time
     # Process in memory to avoid n+1 queries in serializers
     # TODO: use GenericEvent::MoveNotifyPremisesOfPickupEta when it is available
-    notification_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime' }.max_by(&:occurred_at)&.expected_at
+    generic_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime' }.max_by(&:occurred_at)&.expected_at
   end
 
 private

--- a/lib/tasks/data_maintenance.rake
+++ b/lib/tasks/data_maintenance.rake
@@ -69,4 +69,16 @@ namespace :data_maintenance do
   task remap_eta_events: :environment do
     GenericEvent.where(type: 'GenericEvent::MoveNotifyPremisesOfEta').update_all(type: 'GenericEvent::MoveNotifyPremisesOfDropOffEta')
   end
+
+  desc 'Change notification classification on ETA events'
+  task update_eta_notifications: :environment do
+    default_event_types = [
+      'GenericEvent::MoveNotifyPremisesOfEta',
+      'GenericEvent::MoveNotifyPremisesOfPickupEta',
+      'GenericEvent::MoveNotifyPremisesOfDropOffEta',
+      'GenericEvent::MoveNotifyPremisesOfArrivalIn30Mins',
+      'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime',
+    ]
+    GenericEvent.where(type: default_event_types).update_all(classification: 'default')
+  end
 end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -619,4 +619,8 @@ FactoryBot.define do
       }
     end
   end
+
+  factory :generic_event_notification, parent: :generic_event, class: 'GenericEvent::Notification' do
+    eventable { association(:move) }
+  end
 end

--- a/spec/models/generic_event/move_notify_premises_of_arrival_in30_mins_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_arrival_in30_mins_spec.rb
@@ -4,6 +4,4 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfArrivalIn30Mins do
   subject(:generic_event) { build(:event_move_notify_premises_of_arrival_in30_mins) }
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Move]) }
-
-  it_behaves_like 'an event about a notification', :event_move_notify_premises_of_arrival_in30_mins
 end

--- a/spec/models/generic_event/move_notify_premises_of_drop_off_eta_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_drop_off_eta_spec.rb
@@ -17,6 +17,4 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfDropOffEta do
     generic_event.expected_at = '16-06-2020 10:20:30+01:00'
     expect(generic_event).not_to be_valid
   end
-
-  it_behaves_like 'an event about a notification', :event_move_notify_premises_of_drop_off_eta
 end

--- a/spec/models/generic_event/move_notify_premises_of_expected_collection_time_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_expected_collection_time_spec.rb
@@ -17,6 +17,4 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime do
     generic_event.expected_at = '16-06-2020 10:20:30+01:00'
     expect(generic_event).not_to be_valid
   end
-
-  it_behaves_like 'an event about a notification', :event_move_notify_premises_of_expected_collection_time
 end

--- a/spec/models/generic_event/move_notify_premises_of_pickup_eta_spec.rb
+++ b/spec/models/generic_event/move_notify_premises_of_pickup_eta_spec.rb
@@ -17,6 +17,4 @@ RSpec.describe GenericEvent::MoveNotifyPremisesOfPickupEta do
     generic_event.expected_at = '16-06-2020 10:20:30+01:00'
     expect(generic_event).not_to be_valid
   end
-
-  it_behaves_like 'an event about a notification', :event_move_notify_premises_of_pickup_eta
 end

--- a/spec/models/generic_event/notification_spec.rb
+++ b/spec/models/generic_event/notification_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe GenericEvent::Notification, type: :model do
     end
 
     it 'is automatically assigned on creation' do
-      event = create(:event_move_notify_premises_of_arrival_in30_mins, classification: nil)
+      # no real events currently have a notification classification, so use a fake one for now
+      event = create(:generic_event_notification, classification: nil)
 
       expect(event.classification).to eq 'notification'
     end

--- a/spec/requests/api/moves_controller_filtered_spec.rb
+++ b/spec/requests/api/moves_controller_filtered_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Api::MovesController do
     end
 
     describe 'meta fields' do
-      let(:notification_events) do
+      let(:events) do
         [
           create(:event_move_notify_premises_of_expected_collection_time, expected_at: '2019-06-17T10:20:30+01:00'),
           create(:event_move_notify_premises_of_drop_off_eta, expected_at: '2019-06-19T10:20:30+01:00'),
@@ -174,7 +174,7 @@ RSpec.describe Api::MovesController do
           :move,
           1,
           :with_journey,
-          notification_events: notification_events,
+          generic_events: events,
         )
       end
 


### PR DESCRIPTION
### Jira link

P4-<TODO>

### What?

I have added/removed/altered:

- [x] Changed classification of ETA events from `notification` to `default`
- [x] Added rake task to update existing events

### Why?

I am doing this because:

- they render better in the frontend without notifications



