### PR TITLE
P4-2902 auto confirm PER on move start

### DIFF
--- a/spec/models/generic_event/move_start_spec.rb
+++ b/spec/models/generic_event/move_start_spec.rb
@@ -1,18 +1,140 @@
 require 'rails_helper'
 
 RSpec.describe GenericEvent::MoveStart do
-  subject(:generic_event) { build(:event_move_start) }
+  subject(:move_start_event) { build(:event_move_start, eventable: create(:move, move_status)) }
 
-  it_behaves_like 'a move event'
-
-  describe '#trigger' do
-    it 'does not persist changes to the eventable' do
-      generic_event.trigger
-      expect(generic_event.eventable).not_to be_persisted
+  shared_examples 'the move changes but is not saved' do
+    it do
+      expect { move_start_event.trigger }.to change(move, :changed?)
     end
+  end
 
-    it 'sets the eventable `status` to in_transit' do
-      expect { generic_event.trigger }.to change { generic_event.eventable.status }.from('booked').to('in_transit')
+  shared_examples 'the move status does not change' do
+    it do
+      expect { move_start_event.trigger }.not_to change(move, :status)
     end
+  end
+
+  shared_examples_for 'the move status changes to in_transit' do
+    it do
+      expect { move_start_event.trigger }.to change(move, :status).from('booked').to('in_transit')
+    end
+  end
+
+  shared_examples_for 'the PER status does not change' do
+    it do
+      expect { move_start_event.trigger }.not_to change(person_escort_record, :status).from(person_escort_record_status)
+    end
+  end
+
+  shared_examples_for 'the PER status changes to confirmed' do
+    it do
+      expect { move_start_event.trigger }.to change(person_escort_record, :status).from(person_escort_record_status).to('confirmed')
+    end
+  end
+
+  shared_examples_for 'a GenericEvent::PerConfirmation event is created' do
+    it do
+      expect { move_start_event.trigger }.to change { person_escort_record.generic_events.where(type: 'GenericEvent::PerConfirmation').count }.from(0).to(1)
+    end
+  end
+
+  shared_examples_for 'a GenericEvent::PerConfirmation event is not created' do
+    it do
+      expect { move_start_event.trigger }.not_to change { person_escort_record.generic_events.where(type: 'GenericEvent::PerConfirmation').exists? }.from(false)
+    end
+  end
+
+  shared_examples_for 'a per confirmation webhook is sent' do
+    before { allow(Notifier).to receive(:prepare_notifications) }
+
+    it do
+      move_start_event.trigger
+      expect(Notifier).to have_received(:prepare_notifications).with(topic: person_escort_record, action_name: 'confirm_person_escort_record')
+    end
+  end
+
+  shared_examples_for 'a per confirmation webhook is not sent' do
+    before { allow(Notifier).to receive(:prepare_notifications) }
+
+    it do
+      move_start_event.trigger
+      expect(Notifier).not_to have_received(:prepare_notifications).with(topic: person_escort_record, action_name: 'confirm_person_escort_record')
+    end
+  end
+
+  let(:move) { move_start_event.eventable }
+
+  context 'when the move status is requested' do
+    let(:move_status) { :requested }
+
+    it_behaves_like 'the move status does not change'
+  end
+
+  context 'when the move status is booked' do
+    let(:move_status) { :booked }
+
+    it_behaves_like 'the move changes but is not saved'
+    it_behaves_like 'the move status changes to in_transit'
+
+    context 'when the move has an associated PER' do
+      subject(:move_start_event) { build(:event_move_start, eventable: create(:move, move_status, :with_person_escort_record, person_escort_record_status: person_escort_record_status)) }
+
+      let(:person_escort_record) { move.person_escort_record }
+
+      context 'when the PER status is unstarted' do
+        let(:person_escort_record_status) { 'unstarted' }
+
+        it_behaves_like 'the move status changes to in_transit'
+        it_behaves_like 'the PER status does not change'
+        it_behaves_like 'a GenericEvent::PerConfirmation event is not created'
+        it_behaves_like 'a per confirmation webhook is not sent'
+      end
+
+      context 'when the PER status is in_progress' do
+        let(:person_escort_record_status) { 'in_progress' }
+
+        it_behaves_like 'the move status changes to in_transit'
+        it_behaves_like 'the PER status does not change'
+        it_behaves_like 'a GenericEvent::PerConfirmation event is not created'
+        it_behaves_like 'a per confirmation webhook is not sent'
+      end
+
+      context 'when the PER status is completed' do
+        let(:person_escort_record_status) { 'completed' }
+
+        it_behaves_like 'the move status changes to in_transit'
+        it_behaves_like 'the PER status changes to confirmed'
+        it_behaves_like 'a GenericEvent::PerConfirmation event is created'
+        it_behaves_like 'a per confirmation webhook is sent'
+      end
+
+      context 'when the PER status is confirmed' do
+        let(:person_escort_record_status) { 'confirmed' }
+
+        it_behaves_like 'the move status changes to in_transit'
+        it_behaves_like 'the PER status does not change'
+        it_behaves_like 'a GenericEvent::PerConfirmation event is not created'
+        it_behaves_like 'a per confirmation webhook is not sent'
+      end
+    end
+  end
+
+  context 'when the move status is in_transit' do
+    let(:move_status) { :in_transit }
+
+    it_behaves_like 'the move status does not change'
+  end
+
+  context 'when the move status is completed' do
+    let(:move_status) { :completed }
+
+    it_behaves_like 'the move status does not change'
+  end
+
+  context 'with generic event validation' do
+    subject(:move_start_event) { build(:event_move_start) }
+
+    it_behaves_like 'a move event'
   end
 end

--- a/spec/support/an_event_with_eventable_types.rb
+++ b/spec/support/an_event_with_eventable_types.rb
@@ -5,5 +5,7 @@ RSpec.shared_examples 'an event with eventable types' do |*types|
     end
   end
 
-  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(types) }
+  # NB: the shoulda matcher validate_inclusion_of mutates the subject during the test; so use an unsaved subject
+  # (build vs create) to avoid low-level "wrong constant name shoulda-matchers test string" rspec problems
+  it { expect(subject).to validate_inclusion_of(:eventable_type).in_array(types) }
 end


### PR DESCRIPTION
### Jira link

P4-2902

### What?

I have added/removed/altered:

- [x] Auto-confirms completed PERs when a move starts


### Why?

I am doing this because:

- because a large number of PERs are not being confirmed, which means they cannot be used for pre-fill later


### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

