### PR TITLE
P4 2826 multiple location types

### DIFF
--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -31,7 +31,8 @@ module Locations
     end
 
     def apply_filters(scope)
-      scope = scope.where(filter_params.slice(:location_type, :nomis_agency_id))
+      scope = apply_location_type_filters(scope)
+      scope = apply_nomis_agency_filters(scope)
       scope = apply_supplier_filters(scope)
       scope = apply_location_filters(scope)
       scope = apply_region_filters(scope)
@@ -43,6 +44,16 @@ module Locations
       return if filter_params[name].blank?
 
       filter_params[name].split(',')
+    end
+
+    def apply_location_type_filters(scope)
+      scope = scope.where(location_type: split_params(:location_type)) if filter_params.key?(:location_type)
+      scope
+    end
+
+    def apply_nomis_agency_filters(scope)
+      scope = scope.where(nomis_agency_id: split_params(:nomis_agency_id)) if filter_params.key?(:nomis_agency_id)
+      scope
     end
 
     def apply_supplier_filters(scope)

--- a/spec/services/locations/finder_spec.rb
+++ b/spec/services/locations/finder_spec.rb
@@ -13,15 +13,55 @@ RSpec.describe Locations::Finder do
 
   let(:supplier) { create(:supplier) }
   let(:region) { create(:region) }
-  let(:location1) { create(:location) }
-  let(:location2) { create(:location) }
-  let(:other_location) { create(:location) }
+  let(:location1) { create(:location, :court, nomis_agency_id: 'COURT001') }
+  let(:location2) { create(:location, :prison, nomis_agency_id: 'PRISON002') }
+  let(:other_location) { create(:location, :police, nomis_agency_id: 'POLICE003') }
 
   let(:sort_params) { {} }
   let(:filter_params) { {} }
   let(:active_record_relationships) { [] }
 
   describe 'filtering' do
+    context 'with location_type and nomis_agency filters' do
+      before do
+        location1
+        location2
+        other_location
+      end
+
+      context 'with a single location_type' do
+        let(:filter_params) { { location_type: 'court' } }
+
+        it 'returns locations with matching location_type' do
+          expect(location_finder.call.pluck(:id)).to contain_exactly(location1.id)
+        end
+      end
+
+      context 'with multiple location_types' do
+        let(:filter_params) { { location_type: 'prison,court' } }
+
+        it 'returns locations with matching location_type' do
+          expect(location_finder.call.pluck(:id)).to match_array([location1.id, location2.id])
+        end
+      end
+
+      context 'with a single nomis_agency' do
+        let(:filter_params) { { nomis_agency_id: 'COURT001' } }
+
+        it 'returns locations with matching nomis_agency_id' do
+          expect(location_finder.call.pluck(:id)).to contain_exactly(location1.id)
+        end
+      end
+
+      context 'with multiple nomis_agencies' do
+        let(:filter_params) { { nomis_agency_id: 'COURT001,PRISON002' } }
+
+        it 'returns locations with matching nomis_agency_id' do
+          expect(location_finder.call.pluck(:id)).to match_array([location1.id, location2.id])
+        end
+      end
+    end
+
     context 'with a supplier' do
       let(:filter_params) { { supplier_id: supplier.id } }
 


### PR DESCRIPTION
### Jira link

P4-2826

### What?

I have added/removed/altered:

- [x] Added support for multiple location_types and nomis_agency_ids in the /api/reference/locations endpoint


### Why?

I am doing this because:

- to allow the front end to optimise its calls to the API - see https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/issues/1028
-
-

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

