### PR TITLE
fix to allow an autoconfirmed PER to be handed over

### DIFF
--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -86,7 +86,7 @@ module FrameworkAssessmentable
   def confirm!(new_status, handover_details = nil, handover_occurred_at = nil)
     return unless new_status == ASSESSMENT_CONFIRMED
 
-    state_machine.confirm!
+    state_machine.confirm! unless state_machine.confirmed? && (handover_details.present? || handover_occurred_at.present?)
     self.handover_details = handover_details if handover_details.present? && respond_to?(:handover_details)
     self.handover_occurred_at = handover_occurred_at if handover_occurred_at.present? && respond_to?(:handover_occurred_at)
     save!

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -102,6 +102,18 @@ RSpec.describe PersonEscortRecord do
       expect(assessment.handover_details).to eq({ 'foo' => 'bar' })
     end
 
+    it 'stores handover_details on an already-confirmed PER if provided' do
+      assessment = create(:person_escort_record, :confirmed)
+      assessment.confirm!('confirmed', { foo: 'bar' })
+
+      expect(assessment.handover_details).to eq({ 'foo' => 'bar' })
+    end
+
+    it 'throws an error if attempting to re-confirm an already confirmed PER without handover details' do
+      assessment = create(:person_escort_record, :confirmed)
+      expect { assessment.confirm!('confirmed', nil) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
     it 'does not store handover_details if blank' do
       assessment = create(:person_escort_record, :completed)
       assessment.confirm!('confirmed', {})


### PR DESCRIPTION
### Jira link

P4-2973

### What?

I have added/removed/altered:

- [x] Allow an auto-confirmed PER to be handed over

### Why?

I am doing this because:

- sometimes the handover record needs to be added after the PER has been auto-confirmed
