### PR TITLE
Add a test for when a profile has no category

### DIFF
--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -617,6 +617,14 @@ RSpec.describe Api::MovesController do
       end
     end
 
+    context 'when the profile has no prisoner category' do
+      let(:profile) { create(:profile, category: nil) }
+
+      it_behaves_like 'an endpoint that responds with success 201' do
+        before { do_post }
+      end
+    end
+
     context 'when the profile is for an unsupported prisoner category' do
       let(:profile) { create(:profile, :category_not_supported) }
       let(:category_key) { profile.category.key.humanize.downcase }


### PR DESCRIPTION
Category is an optional association on a profile, but we don't have a test for what happens when a move is created with a profile which doesn't have one. This test shows that currently the move is created (with a 201 status code being returned).

This test is effectively the same as https://github.com/ministryofjustice/hmpps-book-secure-move-api/blob/2d712137bb42b96bf83813326c33c97b20ea47a0/spec/requests/api/moves_controller_create_v2_spec.rb#L65-L67 but I think that's fine as it's more explicit and the behaviour is now well defined. If we decided to change the behaviour in the future such that a category was always required, we may decide to change the first `let(:profile`) in this test file to be one with a supported category (and then remove the test lower down in the file which tests that explicitly).

### Jira link

[P4-2974](https://dsdmoj.atlassian.net/browse/P4-2974)

### What?

I have added/removed/altered:

- [x] Added test for when a profile has no category

### Why?

So the behaviour is well documented in the code.