### PR TITLE
Improve additional data for Prison API Sentry errors

### DIFF
--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -76,10 +76,8 @@ module NomisClient
                                extra: {
                                  route: path,
                                  body_params: params,
-                                 nomis_response: {
-                                   status: exception.response.status,
-                                   body: exception.response.body,
-                                 },
+                                 nomis_response_status: exception.response.status,
+                                 nomis_response_body: exception.response.body,
                                },
                                level: 'error')
       end

--- a/app/lib/nomis_client/base.rb
+++ b/app/lib/nomis_client/base.rb
@@ -71,15 +71,30 @@ module NomisClient
         }.deep_merge(params)
       end
 
+      def sentry_extra(path, params, exception)
+        response = exception.response
+
+        message = begin
+          ActiveSupport::JSON.decode(response.body)['developerMessage']
+        rescue StandardError
+          nil
+        end
+
+        {
+          route: path,
+          body_params: params,
+          nomis_response_status: response.status,
+          nomis_response_body: response.body,
+          nomis_response_message: message,
+        }
+      end
+
       def log_exception(description, path, params, exception)
-        Sentry.capture_message(description,
-                               extra: {
-                                 route: path,
-                                 body_params: params,
-                                 nomis_response_status: exception.response.status,
-                                 nomis_response_body: exception.response.body,
-                               },
-                               level: 'error')
+        Sentry.capture_message(
+          description,
+          extra: sentry_extra(path, params, exception),
+          level: 'error',
+        )
       end
     end
   end

--- a/spec/lib/nomis_client/allocations_spec.rb
+++ b/spec/lib/nomis_client/allocations_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
             extra: {
               body_params: {},
               route: '/bookings/1111/prison-to-prison',
-              nomis_response: { body: '{}', status: 500 },
+              nomis_response_status: 500,
+              nomis_response_body: '{}',
             },
             level: 'error',
           }
@@ -77,7 +78,8 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
             extra: {
               body_params: {},
               route: '/bookings/1111/prison-to-prison/2222/cancel',
-              nomis_response: { body: '{}', status: 500 },
+              nomis_response_status: 500,
+              nomis_response_body: '{}',
             },
             level: 'error',
           }

--- a/spec/lib/nomis_client/allocations_spec.rb
+++ b/spec/lib/nomis_client/allocations_spec.rb
@@ -28,24 +28,18 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
 
       let(:response_status) { 500 }
 
-      let(:sentry_args) do
-        [
-          'Allocations::CreateInNomis Error!',
-          { extra: {
-            body_params: {},
-            route: '/bookings/1111/prison-to-prison',
-            nomis_response: { body: '{}', status: 500 },
-          },
-            level: 'error' },
-        ]
-      end
-
-      it 'pushes an error warning to Sentry' do
-        allow(Sentry).to receive(:capture_message)
-
-        prison_transfer_post
-
-        expect(Sentry).to have_received(:capture_message).with(*sentry_args)
+      include_examples 'captures a message in Sentry' do
+        let(:sentry_message) { 'Allocations::CreateInNomis Error!' }
+        let(:sentry_options) do
+          {
+            extra: {
+              body_params: {},
+              route: '/bookings/1111/prison-to-prison',
+              nomis_response: { body: '{}', status: 500 },
+            },
+            level: 'error',
+          }
+        end
       end
     end
   end
@@ -76,24 +70,18 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
 
       let(:response_status) { 500 }
 
-      let(:sentry_args) do
-        [
-          'Allocations::RemoveFromNomis Error!',
-          { extra: {
-            body_params: {},
-            route: '/bookings/1111/prison-to-prison/2222/cancel',
-            nomis_response: { body: '{}', status: 500 },
-          },
-            level: 'error' },
-        ]
-      end
-
-      it 'pushes an error warning to Sentry' do
-        allow(Sentry).to receive(:capture_message)
-
-        prison_transfer_put
-
-        expect(Sentry).to have_received(:capture_message).with(*sentry_args)
+      include_examples 'captures a message in Sentry' do
+        let(:sentry_message) { 'Allocations::RemoveFromNomis Error!' }
+        let(:sentry_options) do
+          {
+            extra: {
+              body_params: {},
+              route: '/bookings/1111/prison-to-prison/2222/cancel',
+              nomis_response: { body: '{}', status: 500 },
+            },
+            level: 'error',
+          }
+        end
       end
     end
   end

--- a/spec/lib/nomis_client/allocations_spec.rb
+++ b/spec/lib/nomis_client/allocations_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
               route: '/bookings/1111/prison-to-prison',
               nomis_response_status: 500,
               nomis_response_body: '{}',
+              nomis_response_message: nil,
             },
             level: 'error',
           }
@@ -70,6 +71,7 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
       end
 
       let(:response_status) { 500 }
+      let(:response_body) { { developerMessage: 'An error message.' }.to_json }
 
       include_examples 'captures a message in Sentry' do
         let(:sentry_message) { 'Allocations::RemoveFromNomis Error!' }
@@ -79,7 +81,8 @@ RSpec.describe NomisClient::Allocations, with_nomis_client_authentication: true 
               body_params: {},
               route: '/bookings/1111/prison-to-prison/2222/cancel',
               nomis_response_status: 500,
-              nomis_response_body: '{}',
+              nomis_response_body: '{"developerMessage":"An error message."}',
+              nomis_response_message: 'An error message.',
             },
             level: 'error',
           }

--- a/spec/lib/nomis_client/court_hearings_spec.rb
+++ b/spec/lib/nomis_client/court_hearings_spec.rb
@@ -52,24 +52,18 @@ RSpec.describe NomisClient::CourtHearings, with_nomis_client_authentication: tru
 
       let(:response_status) { 500 }
 
-      let(:sentry_args) do
-        [
-          'CourtHearings::CreateInNomis Error!',
-          { extra: {
-            body_params: {},
-            route: '/bookings/1111/court-cases/2222/prison-to-court-hearings',
-            nomis_response: { body: '{}', status: 500 },
-          },
-            level: 'error' },
-        ]
-      end
-
-      it 'pushes an error warning to Sentry' do
-        allow(Sentry).to receive(:capture_message)
-
-        court_hearing_post
-
-        expect(Sentry).to have_received(:capture_message).with(*sentry_args)
+      include_examples 'captures a message in Sentry' do
+        let(:sentry_message) { 'CourtHearings::CreateInNomis Error!' }
+        let(:sentry_options) do
+          {
+            extra: {
+              body_params: {},
+              route: '/bookings/1111/court-cases/2222/prison-to-court-hearings',
+              nomis_response: { body: '{}', status: 500 },
+            },
+            level: 'error',
+          }
+        end
       end
     end
   end

--- a/spec/lib/nomis_client/court_hearings_spec.rb
+++ b/spec/lib/nomis_client/court_hearings_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe NomisClient::CourtHearings, with_nomis_client_authentication: tru
       end
 
       let(:response_status) { 500 }
+      let(:response_body) { { developerMessage: 'An error message.' }.to_json }
 
       include_examples 'captures a message in Sentry' do
         let(:sentry_message) { 'CourtHearings::CreateInNomis Error!' }
@@ -60,7 +61,8 @@ RSpec.describe NomisClient::CourtHearings, with_nomis_client_authentication: tru
               body_params: {},
               route: '/bookings/1111/court-cases/2222/prison-to-court-hearings',
               nomis_response_status: 500,
-              nomis_response_body: '{}',
+              nomis_response_body: '{"developerMessage":"An error message."}',
+              nomis_response_message: 'An error message.',
             },
             level: 'error',
           }

--- a/spec/lib/nomis_client/court_hearings_spec.rb
+++ b/spec/lib/nomis_client/court_hearings_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe NomisClient::CourtHearings, with_nomis_client_authentication: tru
             extra: {
               body_params: {},
               route: '/bookings/1111/court-cases/2222/prison-to-court-hearings',
-              nomis_response: { body: '{}', status: 500 },
+              nomis_response_status: 500,
+              nomis_response_body: '{}',
             },
             level: 'error',
           }

--- a/spec/support/captures_sentry_message.rb
+++ b/spec/support/captures_sentry_message.rb
@@ -1,0 +1,8 @@
+RSpec.shared_examples 'captures a message in Sentry' do
+  before { allow(Sentry).to receive(:capture_message) }
+
+  it 'captures a message in Sentry' do
+    subject
+    expect(Sentry).to have_received(:capture_message).with(sentry_message, sentry_options)
+  end
+end


### PR DESCRIPTION
### Jira link

[P4-2982](https://dsdmoj.atlassian.net/browse/P4-2982)

### What?

I have added/removed/altered:

- Added more information to Prison API errors in Sentry
- Refactored tests by including a shared example for testing a message is captured in Sentry

**Probably easier to review commit by commit because of the refactor.**

### Why?

This should allow us to filter Sentry errors on the status of the response from the Prison API meaning ultimately we can focus specifically on the ones which return a `500` error.