### PR TITLE
Avoid NoMethodError with an array filter

### DIFF
--- a/app/controllers/api/people_controller.rb
+++ b/app/controllers/api/people_controller.rb
@@ -109,7 +109,7 @@ module Api
     end
 
     def filter_params
-      params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h
+      params.permit(filter: {}).permit(filter: PERMITTED_FILTER_PARAMS).to_h.fetch(:filter, {})
     end
   end
 end

--- a/spec/requests/api/people_controller_index_spec.rb
+++ b/spec/requests/api/people_controller_index_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe Api::PeopleController do
       end
     end
 
+    context 'when called with an array of filters' do
+      let(:params) { { filter: %w[a] } }
+
+      before { get_people }
+
+      it_behaves_like 'an endpoint that responds with success 200'
+    end
+
     context 'when called with police_national_computer filter' do
       let(:params) { { filter: { police_national_computer: 'AB/1234567' } } }
 


### PR DESCRIPTION
This changes how we use Strong Parameters to ensure that the value is first a hash before trying to execute `permit` on it, which avoids an unnecessary NoMethodError we've got in Sentry: https://sentry.io/organizations/ministryofjustice/issues/2510208419/