### PR TITLE
Fix name of GPS data report rake task

### DIFF
--- a/lib/tasks/gps_data_report.rake
+++ b/lib/tasks/gps_data_report.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 desc 'Posts a report of the past weeks GPS data to slack'
-task feed: :environment do
+task gps_data_report: :environment do
   GPSReportWorker.perform_async
 
   puts 'The GPS data report worker been queued.'


### PR DESCRIPTION
### Jira link

P4-2944

### What?

I have added/removed/altered:

- [x] Changed GPS data report rake task name

### Why?

I am doing this because:

- Copy/paste error