### PR TITLE
Use Slack webhook instead of API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'sentry-sidekiq'
 gem 'sidekiq'
-gem 'slack-ruby-client'
+gem 'slack-notifier'
 gem 'uk_postcode', '~> 2'
 gem 'validate_url', '~> 1.0.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,8 +166,6 @@ GEM
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
-    faraday_middleware (1.0.0)
-      faraday (~> 1.0)
     ffi (1.15.3)
     fiber-local (1.0.0)
     finite_machine (0.14.0)
@@ -189,13 +187,11 @@ GEM
       octokit (~> 4.6)
       rainbow (>= 2.2.1)
       rake (>= 10.0)
-    gli (2.20.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk_notify_rails (2.1.2)
       notifications-ruby-client (~> 5.1)
       rails (>= 4.1.0)
-    hashie (4.1.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
@@ -423,12 +419,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
-    slack-ruby-client (0.17.0)
-      faraday (>= 1.0)
-      faraday_middleware
-      gli
-      hashie
-      websocket-driver
+    slack-notifier (2.4.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -524,7 +515,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   simplecov
-  slack-ruby-client
+  slack-notifier
   spring
   spring-watcher-listen
   timecop


### PR DESCRIPTION
### Jira link

P4-2944

### What?

I have added/removed/altered:

- [x] Changed Slack posting to use the webhook instead of API.

### Why?

I am doing this because:

- It's much easier to use the webhook that we already have than to try to get an OAuth token.  We'll have to have a think about how best to supply the csv files to the suppliers. Possibly upload them to AWS.

### Have you? (optional)

- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

