### PR TITLE
Allow filtering moves by profile or person

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -13,10 +13,7 @@ module Api
     end
 
     def csv
-      csv_moves = Moves::Finder.new(filter_params: filter_params,
-                                    ability: current_ability,
-                                    order_params: params[:sort] || {},
-                                    active_record_relationships: CSV_INCLUDES).call
+      csv_moves = find_moves(active_record_relationships: CSV_INCLUDES)
       send_file(Moves::Exporter.new(csv_moves).call, type: 'text/csv', disposition: :inline)
     end
 
@@ -38,11 +35,17 @@ module Api
 
   private
 
+    def find_moves(active_record_relationships:)
+      Moves::Finder.new(
+        filter_params: filter_params,
+        ability: current_ability,
+        order_params: params[:sort] || {},
+        active_record_relationships: active_record_relationships,
+      ).call
+    end
+
     def moves
-      @moves ||= Moves::Finder.new(filter_params: filter_params,
-                                   ability: current_ability,
-                                   order_params: params[:sort] || {},
-                                   active_record_relationships: active_record_relationships).call
+      @moves ||= find_moves(active_record_relationships: active_record_relationships)
     end
 
     def validate_filter_params

--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -72,6 +72,7 @@ module Api
       ready_for_transit
       profile_id
       person_id
+      reference
     ].freeze
 
     PERMITTED_FILTERED_PARAMS = [

--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -53,7 +53,23 @@ module Api
     end
 
     PERMITTED_FILTER_PARAMS = %i[
-      date_from date_to created_at_from created_at_to date_of_birth_from date_of_birth_to location_type status from_location_id to_location_id location_id supplier_id move_type cancellation_reason rejection_reason has_relationship_to_allocation ready_for_transit
+      date_from
+      date_to
+      created_at_from
+      created_at_to
+      date_of_birth_from
+      date_of_birth_to
+      location_type
+      status
+      from_location_id
+      to_location_id
+      location_id
+      supplier_id
+      move_type
+      cancellation_reason
+      rejection_reason
+      has_relationship_to_allocation
+      ready_for_transit
     ].freeze
 
     PERMITTED_FILTERED_PARAMS = [

--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -70,6 +70,7 @@ module Api
       rejection_reason
       has_relationship_to_allocation
       ready_for_transit
+      profile_id
     ].freeze
 
     PERMITTED_FILTERED_PARAMS = [

--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -71,6 +71,7 @@ module Api
       has_relationship_to_allocation
       ready_for_transit
       profile_id
+      person_id
     ].freeze
 
     PERMITTED_FILTERED_PARAMS = [

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -59,6 +59,7 @@ module Moves
       scope = apply_location_filters(scope)
       scope = apply_allocation_relationship_filters(scope)
       scope = apply_ready_for_transit_filters(scope)
+      scope = apply_person_filters(scope)
       SIMPLE_FIELD_FILTERS.reduce(scope) { |s, filter| apply_filter(s, filter) }
     end
 
@@ -127,6 +128,14 @@ module Moves
       else
         scope.where.not('person_escort_records.status' => 'confirmed').or(scope.where('person_escort_records.id' => nil))
       end
+    end
+
+    def apply_person_filters(scope)
+      return scope unless filter_params.key?(:person_id)
+
+      scope
+        .joins(:profile)
+        .where(profiles: { person_id: filter_params[:person_id] })
     end
   end
 end

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -49,6 +49,7 @@ module Moves
       cancellation_reason
       rejection_reason
       profile_id
+      reference
     ].freeze
 
     def apply_filters(scope)

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -55,11 +55,11 @@ module Moves
       scope = scope.accessible_by(ability)
       scope = apply_date_range_filters(scope)
       scope = apply_date_of_birth_filters(scope)
-      scope = apply_location_type_filters(scope)
+      scope = apply_second_degree_filter(scope, :location_type, joins: :to_location, where: :locations)
       scope = apply_location_filters(scope)
       scope = apply_allocation_relationship_filters(scope)
       scope = apply_ready_for_transit_filters(scope)
-      scope = apply_person_filters(scope)
+      scope = apply_second_degree_filter(scope, :person_id, joins: :profile, where: :profiles)
       SIMPLE_FIELD_FILTERS.reduce(scope) { |s, filter| apply_filter(s, filter) }
     end
 
@@ -75,6 +75,14 @@ module Moves
       else
         scope
       end
+    end
+
+    def apply_second_degree_filter(scope, param_name, joins:, where:)
+      return scope unless filter_params.key?(param_name)
+
+      scope
+        .joins(joins)
+        .where(where => { param_name => filter_params[param_name] })
     end
 
     def apply_date_range_filters(scope)
@@ -94,14 +102,6 @@ module Moves
       scope = scope.where('people.date_of_birth >= ?', filter_params[:date_of_birth_from]) if filter_params.key?(:date_of_birth_from)
       scope = scope.where('people.date_of_birth <= ?', filter_params[:date_of_birth_to]) if filter_params.key?(:date_of_birth_to)
       scope
-    end
-
-    def apply_location_type_filters(scope)
-      return scope unless filter_params.key?(:location_type)
-
-      scope
-        .joins(:to_location)
-        .where(locations: { location_type: filter_params[:location_type] })
     end
 
     def apply_location_filters(scope)
@@ -128,14 +128,6 @@ module Moves
       else
         scope.where.not('person_escort_records.status' => 'confirmed').or(scope.where('person_escort_records.id' => nil))
       end
-    end
-
-    def apply_person_filters(scope)
-      return scope unless filter_params.key?(:person_id)
-
-      scope
-        .joins(:profile)
-        .where(profiles: { person_id: filter_params[:person_id] })
     end
   end
 end

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -42,6 +42,15 @@ module Moves
       end
     end
 
+    SIMPLE_FIELD_FILTERS = %i[
+      supplier_id
+      status
+      move_type
+      cancellation_reason
+      rejection_reason
+      profile_id
+    ].freeze
+
     def apply_filters(scope)
       scope = scope.accessible_by(ability)
       scope = apply_date_range_filters(scope)
@@ -50,11 +59,7 @@ module Moves
       scope = apply_location_filters(scope)
       scope = apply_allocation_relationship_filters(scope)
       scope = apply_ready_for_transit_filters(scope)
-      scope = apply_filter(scope, :supplier_id)
-      scope = apply_filter(scope, :status)
-      scope = apply_filter(scope, :move_type)
-      scope = apply_filter(scope, :cancellation_reason)
-      apply_filter(scope, :rejection_reason)
+      SIMPLE_FIELD_FILTERS.reduce(scope) { |s, filter| apply_filter(s, filter) }
     end
 
     def split_params(name)

--- a/spec/requests/api/moves_controller_filter_spec.rb
+++ b/spec/requests/api/moves_controller_filter_spec.rb
@@ -279,5 +279,14 @@ RSpec.describe Api::MovesController do
 
       it_behaves_like 'an api that filters moves correctly'
     end
+
+    describe 'by reference' do
+      let(:reference) { SecureRandom.uuid }
+      let(:filter_params) { { filter: { reference: reference } } }
+      let(:expected_moves) { create_list :move, 1, reference: reference }
+      let(:unexpected_moves) { create_list :move, 1 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
   end
 end

--- a/spec/requests/api/moves_controller_filter_spec.rb
+++ b/spec/requests/api/moves_controller_filter_spec.rb
@@ -261,5 +261,14 @@ RSpec.describe Api::MovesController do
         it_behaves_like 'an api that filters moves correctly'
       end
     end
+
+    describe 'by profile_id' do
+      let(:profile) { create(:profile) }
+      let(:filter_params) { { filter: { profile_id: profile.id } } }
+      let(:expected_moves) { create_list :move, 1, profile: profile }
+      let(:unexpected_moves) { create_list :move, 1 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
   end
 end

--- a/spec/requests/api/moves_controller_filter_spec.rb
+++ b/spec/requests/api/moves_controller_filter_spec.rb
@@ -270,5 +270,14 @@ RSpec.describe Api::MovesController do
 
       it_behaves_like 'an api that filters moves correctly'
     end
+
+    describe 'by person_id' do
+      let(:person) { create(:person) }
+      let(:filter_params) { { filter: { person_id: person.id } } }
+      let(:expected_moves) { create_list :move, 1, person: person }
+      let(:unexpected_moves) { create_list :move, 1 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
   end
 end

--- a/spec/requests/api/moves_controller_filter_v2_spec.rb
+++ b/spec/requests/api/moves_controller_filter_v2_spec.rb
@@ -286,5 +286,14 @@ RSpec.describe Api::MovesController do
 
       it_behaves_like 'an api that filters moves correctly'
     end
+
+    describe 'by reference' do
+      let(:reference) { SecureRandom.uuid }
+      let(:filter_params) { { filter: { reference: reference } } }
+      let(:expected_moves) { create_list :move, 1, reference: reference }
+      let(:unexpected_moves) { create_list :move, 1 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
   end
 end

--- a/spec/requests/api/moves_controller_filter_v2_spec.rb
+++ b/spec/requests/api/moves_controller_filter_v2_spec.rb
@@ -277,5 +277,14 @@ RSpec.describe Api::MovesController do
 
       it_behaves_like 'an api that filters moves correctly'
     end
+
+    describe 'by person_id' do
+      let(:person) { create(:person) }
+      let(:filter_params) { { filter: { person_id: person.id } } }
+      let(:expected_moves) { create_list :move, 1, person: person }
+      let(:unexpected_moves) { create_list :move, 1 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
   end
 end

--- a/spec/requests/api/moves_controller_filter_v2_spec.rb
+++ b/spec/requests/api/moves_controller_filter_v2_spec.rb
@@ -268,5 +268,14 @@ RSpec.describe Api::MovesController do
         it_behaves_like 'an api that filters moves correctly'
       end
     end
+
+    describe 'by profile_id' do
+      let(:profile) { create(:profile) }
+      let(:filter_params) { { filter: { profile_id: profile.id } } }
+      let(:expected_moves) { create_list :move, 1, profile: profile }
+      let(:unexpected_moves) { create_list :move, 1 }
+
+      it_behaves_like 'an api that filters moves correctly'
+    end
   end
 end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -597,5 +597,35 @@ RSpec.describe Moves::Finder do
         end
       end
     end
+
+    describe 'by reference' do
+      let(:reference) { SecureRandom.uuid }
+      let!(:move) { create :move, reference: reference }
+
+      context 'with matching profile filter' do
+        let(:filter_params) { { reference: reference } }
+
+        it 'returns moves matching the profile' do
+          expect(results).to contain_exactly(move)
+        end
+      end
+
+      context 'with two profile filters' do
+        let(:second_move) { create :move }
+        let(:filter_params) { { reference: [reference, second_move.reference] } }
+
+        it 'returns moves matching multiple locations' do
+          expect(results).to contain_exactly(move, second_move)
+        end
+      end
+
+      context 'with mis-matching location filter' do
+        let(:filter_params) { { reference: Random.uuid } }
+
+        it 'returns empty results set' do
+          expect(results).to be_empty
+        end
+      end
+    end
   end
 end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -537,5 +537,35 @@ RSpec.describe Moves::Finder do
         expect(results.map(&:to_location).pluck(:title)).to eql(%w[LOCATION1 LOCATION3 Location2]) # NB: case-sensitive order
       end
     end
+
+    describe 'by profile_id' do
+      let(:profile) { create :profile }
+      let!(:move) { create :move, profile: profile }
+
+      context 'with matching profile filter' do
+        let(:filter_params) { { profile_id: profile.id } }
+
+        it 'returns moves matching the profile' do
+          expect(results).to contain_exactly(move)
+        end
+      end
+
+      context 'with two profile filters' do
+        let(:second_move) { create :move }
+        let(:filter_params) { { profile_id: [profile.id, second_move.profile_id] } }
+
+        it 'returns moves matching multiple locations' do
+          expect(results).to contain_exactly(move, second_move)
+        end
+      end
+
+      context 'with mis-matching location filter' do
+        let(:filter_params) { { profile_id: Random.uuid } }
+
+        it 'returns empty results set' do
+          expect(results).to be_empty
+        end
+      end
+    end
   end
 end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -567,5 +567,35 @@ RSpec.describe Moves::Finder do
         end
       end
     end
+
+    describe 'by person_id' do
+      let(:person) { create :person }
+      let!(:move) { create :move, person: person }
+
+      context 'with matching profile filter' do
+        let(:filter_params) { { person_id: person.id } }
+
+        it 'returns moves matching the profile' do
+          expect(results).to contain_exactly(move)
+        end
+      end
+
+      context 'with two profile filters' do
+        let(:second_move) { create :move }
+        let(:filter_params) { { person_id: [person.id, second_move.person_id] } }
+
+        it 'returns moves matching multiple locations' do
+          expect(results).to contain_exactly(move, second_move)
+        end
+      end
+
+      context 'with mis-matching location filter' do
+        let(:filter_params) { { person_id: Random.uuid } }
+
+        it 'returns empty results set' do
+          expect(results).to be_empty
+        end
+      end
+    end
   end
 end

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -748,6 +748,16 @@
             items:
               type: string
               format: uuid
+        - name: filter[person_id]
+          description: Filters results to only include moves for the given person UUIDs
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: sort[by]
           description: field to sort results by
           in: query

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -738,6 +738,16 @@
           schema:
             type: boolean
             example: true
+        - name: filter[profile_id]
+          description: Filters results to only include moves for the given profile UUIDs
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: sort[by]
           description: field to sort results by
           in: query

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -475,6 +475,16 @@
             items:
               type: string
               format: uuid
+        - name: filter[person_id]
+          description: Filters results to only include moves for the given person UUIDs
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: sort[by]
           description: field to sort results by
           in: query

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -465,6 +465,16 @@
           schema:
             type: boolean
             example: true
+        - name: filter[profile_id]
+          description: Filters results to only include moves for the given profile UUIDs
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: sort[by]
           description: field to sort results by
           in: query


### PR DESCRIPTION
### Jira link

[P4-3019](https://dsdmoj.atlassian.net/browse/P4-3019)

### What

I've added two new filters to the move endpoint, `profile_id` and `person_id` that allows a user to filter the moves based on those values. I've also refactored some of the code in this area.

### Why

We want to build a page which displays the moves for a specific profile/person, so we need this filter in the API to support that. We don't necessarily need both filters, but I figured there was no harm in having more options.