### PR TITLE
Add NotificationFailedResponseError

### DIFF
--- a/spec/jobs/notify_webhook_job_spec.rb
+++ b/spec/jobs/notify_webhook_job_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe NotifyWebhookJob, type: :job do
         let(:response) { instance_double(Faraday::Response, success?: false, status: 503, reason_phrase: 'Server error', body: { message: 'some message', error: 'some error' }.to_json) }
 
         it 'raises Notification failed error' do
-          expect { perform! }.to raise_error(RetryJobError, /non-success status received/)
+          expect { perform! }.to raise_error(RetryJobError, /Non-success status received/)
         end
 
         it 'updates delivery_attempts' do


### PR DESCRIPTION
This is a new error which is raised when a notification webhook returns with a non-success response. I've introduced this so we can better organise the errors in Sentry as there will be a clear exception. It also allows us to record these as warnings in Sentry, rather than errors.