### PR TITLE
Organise Gemfile according to GOV.UK conventions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,6 @@ group :development, :test do
   gem 'rspec-json_expectations'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
-  # This needs to be in dev/test to expose the rake task
   gem 'rswag-specs'
   gem 'timecop'
 end
@@ -83,11 +82,10 @@ end
 group :test do
   gem 'climate_control'
   gem 'rack-test', '~> 1.1.0'
-  gem 'service_mock', '~> 0.9' # wrapper for Wiremock
+  gem 'service_mock', '~> 0.9'
   gem 'simplecov', require: false
 end
 
-# don't enable this in dev/test - the insights envs are staging/preprod/prod
 group :production do
   # usage docs for application_insights gem at
   # https://github.com/microsoft/ApplicationInsights-Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -5,15 +5,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby File.read('.ruby-version')
 
-# don't enable this in dev/test - the insights envs are staging/preprod/prod
-group :production do
-  # usage docs for application_insights gem at
-  # https://github.com/microsoft/ApplicationInsights-Ruby
-  # Gem to add insights automatically to a Rack application
-  # enhanced to support a RequestTracker with an ignore list
-  gem 'appinsights', github: 'ministryofjustice/appinsights'
-end
-
 gem 'activerecord-import', '~> 1.0', '>= 1.0.5'
 gem 'auto_strip_attributes', '~> 2.6'
 gem 'aws-sdk-athena'
@@ -94,4 +85,13 @@ group :test do
   gem 'rack-test', '~> 1.1.0'
   gem 'service_mock', '~> 0.9' # wrapper for Wiremock
   gem 'simplecov', require: false
+end
+
+# don't enable this in dev/test - the insights envs are staging/preprod/prod
+group :production do
+  # usage docs for application_insights gem at
+  # https://github.com/microsoft/ApplicationInsights-Ruby
+  # Gem to add insights automatically to a Rack application
+  # enhanced to support a RequestTracker with an ignore list
+  gem 'appinsights', github: 'ministryofjustice/appinsights'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby File.read('.ruby-version')
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,42 +6,42 @@ ruby File.read('.ruby-version')
 
 gem 'rails', '6.0.4'
 
-gem 'activerecord-import', '~> 1.0', '>= 1.0.5'
-gem 'auto_strip_attributes', '~> 2.6'
+gem 'activerecord-import'
+gem 'auto_strip_attributes'
 gem 'aws-sdk-athena'
 gem 'aws-sdk-s3', require: false
 gem 'bcrypt', require: false
-gem 'bootsnap', '>= 1.1.0', require: false
+gem 'bootsnap', require: false
 gem 'cancancan'
 gem 'discard'
 gem 'doorkeeper'
 gem 'faraday'
 gem 'finite_machine'
-gem 'flipper-active_record', '~> 0.19'
-gem 'geocoder', '~> 1.6.5'
-gem 'git', '~> 1.7'
-gem 'govuk_notify_rails', '~> 2.1.2'
-gem 'jsonapi-serializer', '~> 2.1'
+gem 'flipper-active_record'
+gem 'geocoder'
+gem 'git'
+gem 'govuk_notify_rails'
+gem 'jsonapi-serializer'
 gem 'json-schema'
 gem 'kaminari'
 gem 'net-http-persistent'
-gem 'nokogiri', '>= 1.10.4'
-gem 'notifications-ruby-client', '~> 5.1.2'
+gem 'nokogiri'
+gem 'notifications-ruby-client'
 gem 'oauth2'
 gem 'paper_trail'
-gem 'pg', '~> 1'
+gem 'pg'
 gem 'prometheus_exporter'
-gem 'puma', '~> 5'
-gem 'rack-timeout', '~> 0.6.0', require: false
-gem 'redis', '~> 4.2', '>= 4.2.1'
-gem 'routing-filter', '~> 0.6.3'
+gem 'puma'
+gem 'rack-timeout', require: false
+gem 'redis'
+gem 'routing-filter'
 gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'sentry-sidekiq'
 gem 'sidekiq'
 gem 'slack-notifier'
-gem 'uk_postcode', '~> 2'
-gem 'validate_url', '~> 1.0.8'
+gem 'uk_postcode'
+gem 'validate_url'
 
 # Swagger API documentation. We need CORS to enable the Swagger UI to make requests
 # against the API without an Access-Control-Allow-Origin error.
@@ -51,9 +51,9 @@ gem 'rswag-ui'
 
 # Augments Rails logging to output JSON for Fluentd/Kibana
 # on Cloud Platform
-gem 'lograge', '~> 0.11.2'
-gem 'logstash-event', '~> 1.2'
-gem 'logstash-logger', '~> 0.26.1'
+gem 'lograge'
+gem 'logstash-event'
+gem 'logstash-logger'
 
 group :development, :test do
   gem 'dotenv'
@@ -65,8 +65,8 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rspec-json_expectations'
   gem 'rspec-rails'
-  gem 'shoulda-matchers'
   gem 'rswag-specs'
+  gem 'shoulda-matchers'
   gem 'timecop'
 end
 
@@ -81,8 +81,8 @@ end
 
 group :test do
   gem 'climate_control'
-  gem 'rack-test', '~> 1.1.0'
-  gem 'service_mock', '~> 0.9'
+  gem 'rack-test'
+  gem 'service_mock'
   gem 'simplecov', require: false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 ruby File.read('.ruby-version')
 
+gem 'rails', '6.0.4'
+
 gem 'activerecord-import', '~> 1.0', '>= 1.0.5'
 gem 'auto_strip_attributes', '~> 2.6'
 gem 'aws-sdk-athena'
@@ -31,7 +33,6 @@ gem 'pg', '~> 1'
 gem 'prometheus_exporter'
 gem 'puma', '~> 5'
 gem 'rack-timeout', '~> 0.6.0', require: false
-gem 'rails', '~> 6.0.3'
 gem 'redis', '~> 4.2', '>= 4.2.1'
 gem 'routing-filter', '~> 0.6.3'
 gem 'sentry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,13 +458,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-import (~> 1.0, >= 1.0.5)
+  activerecord-import
   appinsights!
-  auto_strip_attributes (~> 2.6)
+  auto_strip_attributes
   aws-sdk-athena
   aws-sdk-s3
   bcrypt
-  bootsnap (>= 1.1.0)
+  bootsnap
   bundler-audit
   cancancan
   climate_control
@@ -476,35 +476,35 @@ DEPENDENCIES
   faker
   faraday
   finite_machine
-  flipper-active_record (~> 0.19)
-  geocoder (~> 1.6.5)
-  git (~> 1.7)
+  flipper-active_record
+  geocoder
+  git
   github_changelog_generator
-  govuk_notify_rails (~> 2.1.2)
+  govuk_notify_rails
   json-schema
-  jsonapi-serializer (~> 2.1)
+  jsonapi-serializer
   kaminari
   listen
-  lograge (~> 0.11.2)
-  logstash-event (~> 1.2)
-  logstash-logger (~> 0.26.1)
+  lograge
+  logstash-event
+  logstash-logger
   net-http-persistent
-  nokogiri (>= 1.10.4)
-  notifications-ruby-client (~> 5.1.2)
+  nokogiri
+  notifications-ruby-client
   oauth2
   paper_trail
-  pg (~> 1)
+  pg
   prometheus_exporter
   pry-byebug
   pry-rails
-  puma (~> 5)
+  puma
   rack-cors
-  rack-test (~> 1.1.0)
-  rack-timeout (~> 0.6.0)
+  rack-test
+  rack-timeout
   rails (= 6.0.4)
   rails-erd
-  redis (~> 4.2, >= 4.2.1)
-  routing-filter (~> 0.6.3)
+  redis
+  routing-filter
   rspec-json_expectations
   rspec-rails
   rswag-api
@@ -514,7 +514,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   sentry-sidekiq
-  service_mock (~> 0.9)
+  service_mock
   shoulda-matchers
   sidekiq
   simplecov
@@ -522,8 +522,8 @@ DEPENDENCIES
   spring
   spring-watcher-listen
   timecop
-  uk_postcode (~> 2)
-  validate_url (~> 1.0.8)
+  uk_postcode
+  validate_url
 
 RUBY VERSION
    ruby 2.7.3p183

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -501,7 +501,7 @@ DEPENDENCIES
   rack-cors
   rack-test (~> 1.1.0)
   rack-timeout (~> 0.6.0)
-  rails (~> 6.0.3)
+  rails (= 6.0.4)
   rails-erd
   redis (~> 4.2, >= 4.2.1)
   routing-filter (~> 0.6.3)


### PR DESCRIPTION
This PR organises the Gemfile [according to the conventions used by GOV.UK at GDS](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html#gemfile-organisation). I think this makes the Gemfile easier to read and understand, and avoids it becoming a bit of a mess.

See individual commits for more details on the changes.