### PR TITLE
Reduce number of trace samples

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -23,6 +23,6 @@ Sentry.init do |config|
     transaction_context = sampling_context[:transaction_context]
     transaction_name = transaction_context[:name]
 
-    transaction_name.in?(EXCLUDE_PATHS) ? 0.0 : 0.5
+    transaction_name.in?(EXCLUDE_PATHS) ? 0.0 : 0.25
   end
 end


### PR DESCRIPTION
We're hitting our monthly rate limit, and we probably don't need to capture all possible traces, so we can reduce the number we capture to ensure we get results throughout the month.

Related to https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/1874