### PR TITLE
Handle when assessment has no classification

### DIFF
--- a/app/services/framework_nomis_mappings/assessments.rb
+++ b/app/services/framework_nomis_mappings/assessments.rb
@@ -43,9 +43,7 @@ module FrameworkNomisMappings
     end
 
     def assessment_comments(assessment)
-      comments = assessment[:classification]
-      comments += " — #{assessment[:assessment_comment]}" if assessment[:assessment_comment].present?
-      comments
+      [assessment[:classification], assessment[:assessment_comment]].filter(&:present?).join(' — ')
     end
 
     def valid_assessment?(assessment)

--- a/spec/services/framework_nomis_mappings/assessments_spec.rb
+++ b/spec/services/framework_nomis_mappings/assessments_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe FrameworkNomisMappings::Assessments do
             expect(mappings).not_to be_empty
           end
         end
+
+        context 'without a classification' do
+          let(:nomis_assessments) { [nomis_assessment(classification: nil)] }
+
+          it 'is returned' do
+            expect(mappings.first.comments).to eq('')
+          end
+        end
       end
 
       context 'with an out-of-date assessment' do


### PR DESCRIPTION
This resolves an issue we saw in Sentry this morning https://sentry.io/organizations/ministryofjustice/issues/2554016969 where the assessment was imported without a classification, and therefore it was `nil` when trying to build the comment.