### PR TITLE
Add Athena query_id to sentry extras

### DIFF
--- a/app/services/gps_report.rb
+++ b/app/services/gps_report.rb
@@ -100,6 +100,9 @@ private
     sleep 1.second while %w[QUEUED RUNNING].include?(athena_client.get_query_execution(query_execution_id: query_id).query_execution.status.state)
 
     athena_client.get_query_results(query_execution_id: query_id)
+  rescue Aws::Athena::Errors::InvalidRequestException => e
+    Sentry.capture_exception(e, extra: { query_execution_id: query_id })
+    raise e
   end
 
   def athena_client

--- a/spec/services/gps_report_spec.rb
+++ b/spec/services/gps_report_spec.rb
@@ -141,10 +141,12 @@ RSpec.describe GPSReport do
         allow(athena_client).to receive(:get_query_results).and_raise(error)
         query_execution = Aws::Athena::Types::GetQueryExecutionOutput.new(query_execution: Aws::Athena::Types::QueryExecution.new(status: Aws::Athena::Types::QueryExecutionStatus.new(state: 'FAILED')))
         allow(athena_client).to receive(:get_query_execution).and_return(query_execution)
+        allow(Sentry).to receive(:capture_exception)
       end
 
-      it 'is raised' do
+      it 'is raised and logs the query_execution_id in sentry' do
         expect { gps_report.generate }.to raise_exception(error)
+        expect(Sentry).to have_received(:capture_exception).with(error, extra: { query_execution_id: 'repair' })
       end
     end
   end


### PR DESCRIPTION
### Jira link

P4-2944

### What?

I have added/removed/altered:

- [x] Added failed athena query ids to sentry logging

### Why?

I am doing this because:

- It will help us understand why the gps data report has failed