### PR TITLE
Ensure S3 env vars are available during migrations

### DIFF
--- a/k8s_migrate_job.yml
+++ b/k8s_migrate_job.yml
@@ -28,3 +28,18 @@ spec:
                 secretKeyRef:
                   name: rds-instance-hmpps-book-secure-move-api-__ENV__
                   key: url
+            - name: S3_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: book-a-secure-move-documents-s3-bucket
+                    key: access_key_id
+            - name: S3_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: book-a-secure-move-documents-s3-bucket
+                    key: secret_access_key
+            - name: S3_BUCKET_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: book-a-secure-move-documents-s3-bucket
+                    key: bucket_name


### PR DESCRIPTION
Some of our migrations require ActiveStorage to be available. Specifically this was most recently added in the Rails 6.1 upgrade in 7842199ed4186824fb96289bc7f36af9a99db12b.

Without these environment variables defined, trying to run migrations fails with the following error message:

```
Caused by:
Aws::Sigv4::Errors::MissingCredentialsError: missing credentials, provide credentials with one of the following options:
  - :access_key_id and :secret_access_key
  - :credentials
  - :credentials_provider
```

This is required to deploy #1527