### PR TITLE
Fix indentation in YAML file

### DIFF
--- a/k8s_migrate_job.yml
+++ b/k8s_migrate_job.yml
@@ -29,17 +29,17 @@ spec:
                   name: rds-instance-hmpps-book-secure-move-api-__ENV__
                   key: url
             - name: S3_ACCESS_KEY_ID
-                valueFrom:
-                  secretKeyRef:
-                    name: book-a-secure-move-documents-s3-bucket
-                    key: access_key_id
+              valueFrom:
+                secretKeyRef:
+                  name: book-a-secure-move-documents-s3-bucket
+                  key: access_key_id
             - name: S3_SECRET_ACCESS_KEY
-                valueFrom:
-                  secretKeyRef:
-                    name: book-a-secure-move-documents-s3-bucket
-                    key: secret_access_key
+              valueFrom:
+                secretKeyRef:
+                  name: book-a-secure-move-documents-s3-bucket
+                  key: secret_access_key
             - name: S3_BUCKET_NAME
-                valueFrom:
-                  secretKeyRef:
-                    name: book-a-secure-move-documents-s3-bucket
-                    key: bucket_name
+              valueFrom:
+                secretKeyRef:
+                  name: book-a-secure-move-documents-s3-bucket
+                  key: bucket_name


### PR DESCRIPTION
To fix the following error:

```
error: error parsing STDIN: error converting YAML to JSON: yaml: line 31: mapping values are not allowed in this context
```