### PR TITLE
Don't define a pidfile

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,9 +21,6 @@ port ENV.fetch('PORT') { 3000 }
 #
 environment ENV.fetch('RAILS_ENV') { 'development' }
 
-# Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
-
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together
 # the concurrency of the application would be max `threads` * `workers`.


### PR DESCRIPTION
This was added in the upgrade to Rails 6.1 but we don't need to use it. We are seeing this error if we specify a pidfile:

```
bundler: failed to load command: puma (/usr/local/bundle/bin/puma)
Errno::ENOENT: No such file or directory @ rb_sysopen - tmp/pids/server.pid
  /usr/local/bundle/gems/puma-5.4.0/lib/puma/launcher.rb:247:in `write'
  /usr/local/bundle/gems/puma-5.4.0/lib/puma/launcher.rb:247:in `write_pid'
  /usr/local/bundle/gems/puma-5.4.0/lib/puma/launcher.rb:111:in `write_state'
  /usr/local/bundle/gems/puma-5.4.0/lib/puma/cluster.rb:398:in `run'
  /usr/local/bundle/gems/puma-5.4.0/lib/puma/launcher.rb:181:in `run'
  /usr/local/bundle/gems/puma-5.4.0/lib/puma/cli.rb:80:in `run'
  /usr/local/bundle/gems/puma-5.4.0/bin/puma:10:in `<top (required)>'
  /usr/local/bundle/bin/puma:23:in `load'
  /usr/local/bundle/bin/puma:23:in `<top (required)>'
```