### PR TITLE
Validate CourtHearing comments field length

### DIFF
--- a/app/models/court_hearing.rb
+++ b/app/models/court_hearing.rb
@@ -2,4 +2,5 @@ class CourtHearing < ApplicationRecord
   belongs_to :move, optional: true
 
   validates :start_time, presence: true
+  validates :comments, length: { maximum: 240 }
 end

--- a/spec/models/court_hearing_spec.rb
+++ b/spec/models/court_hearing_spec.rb
@@ -1,23 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe CourtHearing, type: :model do
-  subject(:court_hearing) do
-    build(:court_hearing, start_time: start_time, move: create(:move))
+  describe 'default factory' do
+    subject { build(:court_hearing) }
+
+    it { is_expected.to be_valid }
   end
 
-  context 'when the start_time is missing' do
-    let(:start_time) { nil }
+  describe 'start_time field' do
+    subject { build(:court_hearing, start_time: start_time) }
 
-    it 'is not valid' do
-      expect(court_hearing).not_to be_valid
+    context 'when nil' do
+      let(:start_time) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when set' do
+      let(:start_time) { Time.zone.now }
+
+      it { is_expected.to be_valid }
     end
   end
 
-  context 'when the start_time is not missing' do
-    let(:start_time) { Time.zone.now }
+  describe 'comments field' do
+    subject { build(:court_hearing, comments: comments) }
 
-    it 'is not valid' do
-      expect(court_hearing).to be_valid
+    context 'when nil' do
+      let(:comments) { nil }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'when set to a short string' do
+      let(:comments) { 'This is a comment.' }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'when set to a long string' do
+      let(:comments) { SecureRandom.alphanumeric(1000) }
+
+      it { is_expected.not_to be_valid }
     end
   end
 end


### PR DESCRIPTION
This ensures that the comments field of court hearings is always less than 240 characters as this is a requirement from NOMIS. This validation should prevent us getting a 400 error when communicating with NOMIS and instead pass the error up to the user who can fix the problem.

This should resolve: https://sentry.io/organizations/ministryofjustice/issues/2277351361/events/eb493612c82141d09387381ad3c22829/