### PR TITLE
Change gps failure file expiry to 1 week

### DIFF
--- a/app/workers/gps_report_worker.rb
+++ b/app/workers/gps_report_worker.rb
@@ -94,7 +94,7 @@ private
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: ":white_check_mark: #{supplier}: #{move_count - failures.count}/#{move_count} (#{percent_passed.floor(1).to_s.sub(/\.0+$/, '')}%) moves met the criteria#{file.present? ? ", <#{file.presigned_url(:get)}|failure file>" : ''}",
+        text: ":white_check_mark: #{supplier}: #{move_count - failures.count}/#{move_count} (#{percent_passed.floor(1).to_s.sub(/\.0+$/, '')}%) moves met the criteria#{file.present? ? ", <#{file.presigned_url(:get, expires_in: 604_800)}|failure file>" : ''}",
       },
     }
   end
@@ -106,7 +106,7 @@ private
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: ":x: #{supplier}: #{move_count - failures.count}/#{move_count} (#{percent_passed.floor(1).to_s.sub(/\.0+$/, '')}%) moves met the criteria#{file.present? ? ", <#{file.presigned_url(:get)}|failure file>" : ''}",
+        text: ":x: #{supplier}: #{move_count - failures.count}/#{move_count} (#{percent_passed.floor(1).to_s.sub(/\.0+$/, '')}%) moves met the criteria#{file.present? ? ", <#{file.presigned_url(:get, expires_in: 604_800)}|failure file>" : ''}",
       },
     }
   end


### PR DESCRIPTION
### Jira link

P4-2944

### What?

I have added/removed/altered:

- [x] Altered the GPS data report failure file download link expiry to be 1 week (the maximum).

### Why?

I am doing this because:

- It will allow us more time to download the files (currently 15 minutes at 6 AM)