### PR TITLE
Allow including journey information on moves

### DIFF
--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -30,6 +30,7 @@ module V2
     belongs_to :to_location,            serializer: LocationSerializer
 
     has_many :court_hearings, serializer: CourtHearingSerializer
+    has_many_if_included :journeys, serializer: JourneySerializer
 
     has_many_if_included :timeline_events, serializer: ->(record, _params) { record.class.serializer }, &:all_events_for_timeline
     has_many_if_included :important_events, serializer: ImportantEventsSerializer, &:important_events
@@ -70,6 +71,9 @@ module V2
       important_events
       timeline_events
       timeline_events.eventable
+      journeys
+      journeys.from_location
+      journeys.to_location
     ].freeze
 
     INCLUDED_FIELDS = {


### PR DESCRIPTION
This should allow clients to get location information of different journeys of a move. We need this because the timeline events sometimes contain references to journeys which are cancelled, and therefore we have no way of including the `to_location` and `from_location` fields of those journeys. This means the timeline view on the frontend is sometimes missing information (this is the case where a journey has a different `to_location` or `from_location` of the move and therefore isn't included).

This might have a performance impact on the endpoint, but we can monitor closely is this becomes a problem. I don't expect many moves to have multiple journeys.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-2988)