### PR TITLE
Add PNC number validation to Person

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -36,6 +36,7 @@ class Person < VersionedModel
   validates :last_name, presence: true
   validates :first_names, presence: true
   validate :validate_age
+  validate :validate_pnc
 
   auto_strip_attributes :nomis_prison_number, :prison_number, :criminal_records_office, :police_national_computer
 
@@ -88,11 +89,34 @@ class Person < VersionedModel
     People::RetrieveImage.call(self, force_update: true)
   end
 
+  def self.is_valid_pnc?(pnc)
+    return true if pnc.blank?
+
+    pnc = pnc.to_s.upcase
+    regex = /^([0-9]{2}|[0-9]{4})\/[0-9]+[A-Z]$/
+    return false if regex.match(pnc).nil?
+
+    mod23chars = 'ZABCDEFGHJKLMNPQRTUVWXY'.split('')
+    year, number = pnc.split('/')
+    check_digit = pnc.last
+    derived_pnc = "#{year.last(2)}#{number[..-2].rjust(7, '0')}"
+    i = derived_pnc.to_i % 23
+    return false if mod23chars[i] != check_digit
+
+    true
+  end
+
 private
 
   def validate_age
-    if date_of_birth.present? && date_of_birth.year < 1900
-      errors.add(:birth_date, 'must be after 1900-01-01.')
-    end
+    return if date_of_birth.blank? || date_of_birth.year >= 1900
+
+    errors.add(:birth_date, 'must be after 1900-01-01.')
+  end
+
+  def validate_pnc
+    return if self.class.is_valid_pnc?(police_national_computer)
+
+    errors.add(:police_national_computer, 'must be in the correct format. (e.g. 08/012345P)')
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -96,14 +96,15 @@ class Person < VersionedModel
     regex = /^([0-9]{2}|[0-9]{4})\/[0-9]+[A-Z]$/
     return false if regex.match(pnc).nil?
 
-    mod23chars = 'ZABCDEFGHJKLMNPQRTUVWXY'.split('')
     year, number = pnc.split('/')
-    check_digit = pnc.last
     derived_pnc = "#{year.last(2)}#{number[..-2].rjust(7, '0')}"
-    i = derived_pnc.to_i % 23
-    return false if mod23chars[i] != check_digit
+    return false if pnc_checkdigit(derived_pnc) != pnc.last
 
     true
+  end
+
+  def self.pnc_checkdigit(derived_pnc)
+    'ZABCDEFGHJKLMNPQRTUVWXY'[derived_pnc.to_i % 23]
   end
 
 private

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+def generate_pnc(seq)
+  year = '16'
+  number = seq.to_s
+
+  mod23chars = 'ZABCDEFGHJKLMNPQRTUVWXY'.split('')
+  derived_pnc = "#{year.last(2)}#{number.rjust(7, '0')}"
+  i = derived_pnc.to_i % 23
+
+  "#{year}/#{number}#{mod23chars[i]}"
+end
+
 FactoryBot.define do
   factory :person do
     association(:ethnicity)
@@ -11,7 +22,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     date_of_birth { Date.new(1980, 10, 20) }
 
-    sequence(:police_national_computer) { |seq| sprintf('AB/%07d', seq) }
+    sequence(:police_national_computer) { |seq| generate_pnc(seq) }
     sequence(:prison_number)            { |seq| sprintf('D%04dZZ', seq) }
     sequence(:criminal_records_office)  { |seq| sprintf('CRO/%05d', seq) }
 
@@ -37,7 +48,7 @@ FactoryBot.define do
 
     date_of_birth { Date.new(1980, 10, 20) }
 
-    sequence(:police_national_computer) { |seq| sprintf('AB/%07d', seq) }
+    sequence(:police_national_computer) { |seq| generate_pnc(seq) }
     sequence(:prison_number)            { |seq| sprintf('D%04dZZ', seq) }
     sequence(:criminal_records_office)  { |seq| sprintf('CRO/%05d', seq) }
   end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -3,12 +3,9 @@
 def generate_pnc(seq)
   year = '16'
   number = seq.to_s
-
-  mod23chars = 'ZABCDEFGHJKLMNPQRTUVWXY'.split('')
   derived_pnc = "#{year.last(2)}#{number.rjust(7, '0')}"
-  i = derived_pnc.to_i % 23
 
-  "#{year}/#{number}#{mod23chars[i]}"
+  "#{year}/#{number}#{Person.pnc_checkdigit(derived_pnc)}"
 end
 
 FactoryBot.define do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Person do
 
   describe '#police_national_computer' do
     it 'is case insensitive' do
-      person = create(:person, police_national_computer: 'FLIBBLE')
-      expect(described_class.where(police_national_computer: 'flibble')).to include(person)
+      person = create(:person, police_national_computer: '06/4169X')
+      expect(described_class.where(police_national_computer: '06/4169x')).to include(person)
     end
 
     it 'stores blank values as nil' do
@@ -40,8 +40,8 @@ RSpec.describe Person do
 
   describe '#criminal_records_office' do
     it 'is case insensitive' do
-      person = create(:person, criminal_records_office: 'FLIBBLE')
-      expect(described_class.where(criminal_records_office: 'flibble')).to include(person)
+      person = create(:person, criminal_records_office: '06/4169X')
+      expect(described_class.where(criminal_records_office: '06/4169x')).to include(person)
     end
 
     it 'stores blank values as nil' do
@@ -52,8 +52,8 @@ RSpec.describe Person do
 
   describe '#prison_number' do
     it 'is case insensitive' do
-      person = create(:person, prison_number: 'FLIBBLE')
-      expect(described_class.where(prison_number: 'flibble')).to include(person)
+      person = create(:person, prison_number: '06/4169X')
+      expect(described_class.where(prison_number: '06/4169x')).to include(person)
     end
 
     it 'stores blank values as nil' do
@@ -65,8 +65,8 @@ RSpec.describe Person do
   # TODO: Remove nomis_prison_number once we remove v1 from our system
   describe '#nomis_prison_number' do
     it 'is case insensitive' do
-      person = create(:person, nomis_prison_number: 'FLIBBLE')
-      expect(described_class.where(nomis_prison_number: 'flibble')).to include(person)
+      person = create(:person, nomis_prison_number: '06/4169X')
+      expect(described_class.where(nomis_prison_number: '06/4169x')).to include(person)
     end
 
     it 'stores blank values as nil' do
@@ -185,6 +185,41 @@ RSpec.describe Person do
 
     it 'returns the value obtained from BookingDetails' do
       expect(person.csra).to eq('Standard')
+    end
+  end
+
+  describe '.is_valid_pnc?' do
+    let(:valid_pnc_numbers) do
+      [
+        nil,
+        '',
+        '96/2663652J',
+        '1996/2663652J',
+        '14/2400766Q',
+        '2014/2400766Q',
+        '06/0000222G',
+        '2006/0000222G',
+        '06/4169X',
+        '2006/4169X',
+      ]
+    end
+
+    let(:invalid_pnc_numbers) do
+      [
+        796_507,
+        '796507',
+        '996/0607652B',
+        '08012345P',
+        '08/012345',
+        '012345P',
+        'ABCDEF',
+        '08/P',
+      ]
+    end
+
+    it 'correctly identifies valid PNC numbers' do
+      valid_pnc_numbers.each { |pnc| expect(described_class.is_valid_pnc?(pnc)).to eq(true) }
+      invalid_pnc_numbers.each { |pnc| expect(described_class.is_valid_pnc?(pnc)).to eq(false) }
     end
   end
 end

--- a/spec/requests/api/people_controller_create_spec.rb
+++ b/spec/requests/api/people_controller_create_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Api::PeopleController do
   let(:response_json) { JSON.parse(response.body) }
   let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:pnc) { "11/2853#{Person.pnc_checkdigit('110002853')}" }
 
   let(:headers) do
     {
@@ -37,7 +38,7 @@ RSpec.describe Api::PeopleController do
               { title: risk_type_2.title, assessment_question_id: risk_type_2.id },
             ],
             identifiers: [
-              { identifier_type: 'police_national_computer', value: 'ABC123' },
+              { identifier_type: 'police_national_computer', value: pnc },
               { identifier_type: 'prison_number', value: 'XYZ987' },
             ],
           },
@@ -72,7 +73,7 @@ RSpec.describe Api::PeopleController do
               { title: risk_type_2.title, assessment_question_id: risk_type_2.id },
             ],
             identifiers: [
-              { identifier_type: 'police_national_computer', value: 'ABC123' },
+              { identifier_type: 'police_national_computer', value: pnc },
               { identifier_type: 'prison_number', value: 'XYZ987' },
             ],
           },

--- a/spec/requests/api/people_controller_create_v2_spec.rb
+++ b/spec/requests/api/people_controller_create_v2_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Api::PeopleController do
   let(:response_json) { JSON.parse(response.body) }
   let(:access_token) { 'spoofed-token' }
   let(:content_type) { ApiController::CONTENT_TYPE }
+  let(:pnc) { "11/2313#{Person.pnc_checkdigit('110002313')}" }
 
   let(:headers) do
     {
@@ -31,7 +32,7 @@ RSpec.describe Api::PeopleController do
             date_of_birth: Date.new(1980, 1, 1),
             prison_number: 'G3239GV',
             criminal_records_office: 'CRO0111d',
-            police_national_computer: 'AB/1234567',
+            police_national_computer: pnc,
             gender_additional_information: 'info about Bob',
           },
           relationships: {
@@ -61,7 +62,7 @@ RSpec.describe Api::PeopleController do
           date_of_birth: Date.new(1980, 1, 1).iso8601,
           prison_number: 'G3239GV',
           criminal_records_office: 'CRO0111d',
-          police_national_computer: 'AB/1234567',
+          police_national_computer: pnc,
           gender_additional_information: 'info about Bob',
         },
         relationships: {

--- a/spec/requests/api/people_controller_index_spec.rb
+++ b/spec/requests/api/people_controller_index_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Api::PeopleController do
   let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:response_json) { JSON.parse(response.body) }
+  let(:pnc) { "17/39#{Person.pnc_checkdigit('170000039')}" }
 
   let(:schema) { load_yaml_schema('get_people_responses.yaml') }
 
@@ -41,9 +42,9 @@ RSpec.describe Api::PeopleController do
     end
 
     context 'when called with police_national_computer filter' do
-      let(:params) { { filter: { police_national_computer: 'AB/1234567' } } }
+      let(:params) { { filter: { police_national_computer: pnc } } }
 
-      before { create_list :person, 5, :nomis_synced, police_national_computer: 'AB/1234567' }
+      before { create_list :person, 5, :nomis_synced, police_national_computer: pnc }
 
       it 'returns the correct data' do
         get_people
@@ -57,7 +58,7 @@ RSpec.describe Api::PeopleController do
 
         get_people
 
-        expect(People::Finder).to have_received(:new).with(police_national_computer: 'AB/1234567')
+        expect(People::Finder).to have_received(:new).with(police_national_computer: pnc)
       end
     end
 
@@ -113,7 +114,7 @@ RSpec.describe Api::PeopleController do
 
     describe 'included relationships' do
       before do
-        create_list :person, 2, police_national_computer: 'AB/1234567'
+        create_list :person, 2, police_national_computer: pnc
         get "/api/v1/people#{query_params}", headers: headers, params: params
       end
 

--- a/spec/requests/api/people_controller_index_v2_spec.rb
+++ b/spec/requests/api/people_controller_index_v2_spec.rb
@@ -107,11 +107,11 @@ RSpec.describe Api::PeopleController do
     end
 
     describe 'filtering results by police_national_computer' do
-      let!(:person) { create(:person, police_national_computer: 'AB/1234567') }
+      let!(:person) { create(:person) }
       let(:filters) do
         {
           bar: 'bar',
-          police_national_computer: 'AB/1234567',
+          police_national_computer: person.police_national_computer,
           foo: 'foo',
         }
       end
@@ -130,13 +130,13 @@ RSpec.describe Api::PeopleController do
 
     describe 'filtering results by multiple filters' do
       let!(:person) do
-        create(:person, criminal_records_office: 'CRO0105d', police_national_computer: 'AB/00001d')
+        create(:person, criminal_records_office: 'CRO0105d')
       end
       let(:filters) do
         {
           bar: 'bar',
           criminal_records_office: 'CRO0105d',
-          police_national_computer: 'AB/00001d',
+          police_national_computer: person.police_national_computer,
           foo: 'foo',
         }
       end

--- a/spec/requests/api/people_controller_patch_v2_spec.rb
+++ b/spec/requests/api/people_controller_patch_v2_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::PeopleController do
             date_of_birth: Date.new(1980, 1, 1),
             prison_number: 'G3239GV',
             criminal_records_office: 'CRO0111d',
-            police_national_computer: 'AB/1234567',
+            police_national_computer: person.police_national_computer,
             gender_additional_information: 'info about Bob',
           },
           relationships: {
@@ -62,7 +62,7 @@ RSpec.describe Api::PeopleController do
           date_of_birth: '1980-01-01',
           prison_number: 'G3239GV',
           criminal_records_office: 'CRO0111d',
-          police_national_computer: 'AB/1234567',
+          police_national_computer: person.police_national_computer,
           gender_additional_information: 'info about Bob',
         },
         relationships: {

--- a/spec/requests/api/people_controller_update_spec.rb
+++ b/spec/requests/api/people_controller_update_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Api::PeopleController do
     let(:risk_type_1) { create :assessment_question, :risk }
     let(:risk_type_2) { create :assessment_question, :risk }
     let(:gender_additional_information) { nil }
+    let(:pnc) { "17/35#{Person.pnc_checkdigit('170000035')}" }
     let(:person_params) do
       {
         data: {
@@ -40,7 +41,7 @@ RSpec.describe Api::PeopleController do
               { title: 'Violent', assessment_question_id: risk_type_2.id },
             ],
             identifiers: [
-              { identifier_type: 'police_national_computer', value: 'ABC123' },
+              { identifier_type: 'police_national_computer', value: pnc },
               { identifier_type: 'prison_number', value: 'XYZ987' },
             ],
             gender_additional_information: gender_additional_information,
@@ -85,7 +86,7 @@ RSpec.describe Api::PeopleController do
               { title: risk_type_2.title, assessment_question_id: risk_type_2.id },
             ],
             identifiers: [
-              { identifier_type: 'police_national_computer', value: 'ABC123' },
+              { identifier_type: 'police_national_computer', value: pnc },
               { identifier_type: 'prison_number', value: 'XYZ987' },
             ],
           },

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe PersonSerializer do
     let(:profile_identifiers) do
       [
         {
-          value: 'ABC123456',
+          value: person.police_national_computer,
           identifier_type: 'police_national_computer',
         },
         {
@@ -92,7 +92,6 @@ RSpec.describe PersonSerializer do
     end
 
     before do
-      person.police_national_computer = 'ABC123456'
       person.prison_number = 'XYZ123456'
       person.criminal_records_office = nil
       person.save!

--- a/spec/services/people/creator_spec.rb
+++ b/spec/services/people/creator_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe People::Creator do
   end
 
   context 'with identifiers' do
+    let(:pnc) { "11/2333#{Person.pnc_checkdigit('110002333')}" }
     let(:params) do
       {
         type: 'people',
@@ -106,7 +107,7 @@ RSpec.describe People::Creator do
           last_name: 'Roberts',
           date_of_birth: Date.civil(1980, 1, 1),
           identifiers: [
-            { identifier_type: 'police_national_computer', value: 'ABC123' },
+            { identifier_type: 'police_national_computer', value: pnc },
             { identifier_type: 'prison_number', value: 'XYZ987' },
           ],
         },
@@ -123,7 +124,7 @@ RSpec.describe People::Creator do
 
       expect(identifiers).to eq(
         'criminal_records_office' => nil,
-        'police_national_computer' => 'ABC123',
+        'police_national_computer' => pnc,
         'prison_number' => 'XYZ987',
       )
     end

--- a/spec/services/people/finder_spec.rb
+++ b/spec/services/people/finder_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 RSpec.describe People::Finder do
   subject(:people_finder) { described_class.new(filter_params) }
 
-  let!(:person) { create(:person, police_national_computer: 'CD/765432', prison_number: 'GFEDCBA') }
+  let!(:person) { create(:person) }
 
   describe 'filtering' do
     context 'when filtering by police_national_computer' do
-      let(:filter_params) { { police_national_computer: 'CD/765432' } }
+      let(:filter_params) { { police_national_computer: person.police_national_computer } }
 
       it 'returns people matching the police_national_computer' do
         expect(people_finder.call).to eq [person]
@@ -18,7 +18,7 @@ RSpec.describe People::Finder do
 
     context 'when filtering by empty police_national_computer' do
       let(:filter_params) { { police_national_computer: nil } }
-      let!(:other_person) { create(:person, police_national_computer: nil, prison_number: 'GFEDCBA') }
+      let!(:other_person) { create(:person, police_national_computer: nil, prison_number: person.prison_number) }
 
       it 'returns people matching the police_national_computer' do
         expect(people_finder.call).to eq [other_person]
@@ -26,7 +26,7 @@ RSpec.describe People::Finder do
     end
 
     context 'when filtering by prison_number' do
-      let(:filter_params) { { prison_number: 'GFEDCBA' } }
+      let(:filter_params) { { prison_number: person.prison_number } }
 
       it 'returns people matching the prison_number' do
         expect(people_finder.call).to eq [person]

--- a/spec/services/people/updater_spec.rb
+++ b/spec/services/people/updater_spec.rb
@@ -15,12 +15,13 @@ RSpec.describe People::Updater do
       person: person,
     }
   end
+  let(:pnc) { "17/1553#{Person.pnc_checkdigit('170001553')}" }
   let(:original_person_attributes) do
     {
       first_names: 'Robbie',
       last_name: 'Roberts',
       date_of_birth: Date.civil(1980, 6, 1),
-      police_national_computer: 'ABC123',
+      police_national_computer: pnc,
     }
   end
   let(:person) { create(:person, original_person_attributes) }
@@ -68,7 +69,7 @@ RSpec.describe People::Updater do
     end
 
     it 'does not change original identifiers for the Person' do
-      expect(updated_person.police_national_computer).to eq('ABC123')
+      expect(updated_person.police_national_computer).to eq(pnc)
     end
   end
 
@@ -85,7 +86,7 @@ RSpec.describe People::Updater do
             { title: risk_type_2.title, assessment_question_id: risk_type_2.id },
           ],
           identifiers: [
-            { identifier_type: 'police_national_computer', value: 'ABC123' },
+            { identifier_type: 'police_national_computer', value: pnc },
             { identifier_type: 'prison_number', value: 'XYZ987' },
           ],
         },

--- a/spec/services/v2/people/finder_spec.rb
+++ b/spec/services/v2/people/finder_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe V2::People::Finder do
   describe 'filtering' do
     describe 'by police_national_computer' do
       context 'with matching police_national_computer' do
-        let(:filter_params) { { police_national_computer: 'AB/00006' } }
-        let!(:person) { create(:person, police_national_computer: 'AB/00006') }
+        let!(:person) { create(:person) }
+        let(:filter_params) { { police_national_computer: person.police_national_computer } }
 
         it 'returns people matching police_national_computer' do
           expect(finder.call).to contain_exactly(person)
@@ -20,9 +20,9 @@ RSpec.describe V2::People::Finder do
       end
 
       context 'with multiple police_national_computer values' do
-        let(:filter_params) { { police_national_computer: 'AB/00006,AB/00007' } }
-        let!(:person1) { create(:person, police_national_computer: 'AB/00006') }
-        let!(:person2) { create(:person, police_national_computer: 'AB/00007') }
+        let!(:person1) { create(:person) }
+        let!(:person2) { create(:person) }
+        let(:filter_params) { { police_national_computer: [person1, person2].map(&:police_national_computer).join(',') } }
 
         it 'returns people matching police_national_computer' do
           expect(finder.call).to contain_exactly(person1, person2)
@@ -124,16 +124,16 @@ RSpec.describe V2::People::Finder do
     end
 
     context 'with multiple matching filters' do
+      let!(:person) do
+        create(:person, prison_number: 'D00007', criminal_records_office: 'CR00006')
+      end
+
       let(:filter_params) do
         {
-          police_national_computer: 'ab/00006',
+          police_national_computer: person.police_national_computer,
           prison_number: 'd00007',
           criminal_records_office: 'cr00006',
         }
-      end
-
-      let!(:person) do
-        create(:person, police_national_computer: 'AB/00006', prison_number: 'D00007', criminal_records_office: 'CR00006')
       end
 
       it 'does not return people if filters do not all match records' do
@@ -142,16 +142,16 @@ RSpec.describe V2::People::Finder do
     end
 
     context 'with multiple mismatching filters' do
+      let(:person) { create(:person) }
       let(:filter_params) do
         {
-          police_national_computer: 'AB/00006',
+          police_national_computer: person.police_national_computer,
           prison_number: 'D00007',
           criminal_records_office: 'CR00006',
         }
       end
 
       before do
-        create(:person, police_national_computer: 'AB/00006')
         create(:person, prison_number: 'D00007')
         create(:person, criminal_records_office: 'CR00006')
       end


### PR DESCRIPTION
### Jira link

P4-2828

### What?

I have added/removed/altered:

- [x] Added PNC number validation to Person

### Why?

I am doing this because:

- It will stop our users from inputting invalid PNC numbers

### Deployment risks (optional)

- Changes an api that is used in production