### PR TITLE
Fix error when a journey has 1 gps point

### DIFF
--- a/app/services/gps_report.rb
+++ b/app/services/gps_report.rb
@@ -43,7 +43,7 @@ private
   def journey_failures
     failures = journeys.filter_map do |journey|
       gps_data = gps_data_map[journey.id]
-      next { move: journey.move, reason: 'no_gps_data' } if gps_data.blank?
+      next { move: journey.move, reason: 'no_gps_data' } if gps_data.blank? || gps_data.length < 2
 
       intervals = gps_data.each_with_index.filter_map { |t, i| i < gps_data.count - 1 ? gps_data[i + 1] - t : nil }
       { move: journey.move, reason: 'gps_data_gap' } if intervals.max > 60.seconds


### PR DESCRIPTION
### Jira link

P4-2944

### What?

I have added/removed/altered:

- [x] Fixed an error that was being thrown due to journeys only having 1 gps point

### Why?

I am doing this because:

- It's stopping the gps data report from running