### PR TITLE
Warn when NOMIS rejects court dates due to location mismatch 

### DIFF
--- a/app/lib/nomis_client/court_hearings.rb
+++ b/app/lib/nomis_client/court_hearings.rb
@@ -2,6 +2,8 @@
 
 module NomisClient
   class CourtHearings < NomisClient::Base
+    class PrisonBookingLocationMismatch < StandardError; end
+
     class << self
       def get(booking_id, start_date, end_date)
         court_hearings_path = "/bookings/#{booking_id}/court-hearings?fromDate=#{start_date.iso8601}&toDate=#{end_date.iso8601}"
@@ -17,11 +19,20 @@ module NomisClient
       def post(booking_id:, court_case_id:, body_params: {})
         court_hearings_path = "/bookings/#{booking_id}/court-cases/#{court_case_id}/prison-to-court-hearings"
 
-        NomisClient::Base.post(court_hearings_path, body: body_params.to_json)
-      rescue OAuth2::Error => e
-        log_exception('CourtHearings::CreateInNomis Error!', court_hearings_path, body_params, e)
+        begin
+          NomisClient::Base.post(court_hearings_path, body: body_params.to_json)
+        rescue OAuth2::Error => e
+          if e.response.body =~ /Prison location does not match the bookings location/
+            raise PrisonBookingLocationMismatch
+          end
 
-        e.response
+          log_exception('CourtHearings::CreateInNomis Error!', court_hearings_path, body_params, e)
+
+          e.response
+        end
+      rescue PrisonBookingLocationMismatch => e
+        Sentry.capture_exception(e, { extra: sentry_extra(court_hearings_path, body_params, e.cause), level: :warning })
+        e.cause.response
       end
     end
   end

--- a/spec/support/captures_sentry_message.rb
+++ b/spec/support/captures_sentry_message.rb
@@ -1,8 +1,0 @@
-RSpec.shared_examples 'captures a message in Sentry' do
-  before { allow(Sentry).to receive(:capture_message) }
-
-  it 'captures a message in Sentry' do
-    subject
-    expect(Sentry).to have_received(:capture_message).with(sentry_message, sentry_options)
-  end
-end

--- a/spec/support/sentry.rb
+++ b/spec/support/sentry.rb
@@ -1,0 +1,17 @@
+RSpec.shared_examples 'captures a message in Sentry' do
+  before { allow(Sentry).to receive(:capture_message) }
+
+  it 'captures a message in Sentry' do
+    subject
+    expect(Sentry).to have_received(:capture_message).with(sentry_message, sentry_options)
+  end
+end
+
+RSpec.shared_examples 'captures an exception in Sentry' do
+  before { allow(Sentry).to receive(:capture_exception) }
+
+  it 'captures an exception in Sentry' do
+    subject
+    expect(Sentry).to have_received(:capture_exception).with(instance_of(sentry_exception), sentry_options)
+  end
+end


### PR DESCRIPTION
At the moment we get an exception whenever a court date is rejected because of a location mismatch (where NOMIS doesn’t understand that a prisoner may be in a different location in the future). Rather than reporting this as an error in Sentry, we want to call it out as its own type of warning so we can focus on other errors and get a better idea of how much of a problem this one is.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-2157)