### PR TITLE
Consider completed PERs as 'ready for transit'

### DIFF
--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -125,9 +125,9 @@ module Moves
 
       scope = scope.joins('LEFT JOIN profiles ON moves.profile_id = profiles.id LEFT JOIN person_escort_records ON person_escort_records.profile_id = profiles.id')
       if filter_params[:ready_for_transit] == 'true'
-        scope.where('person_escort_records.status' => 'confirmed')
+        scope.where('person_escort_records.status' => %w[completed confirmed])
       else
-        scope.where.not('person_escort_records.status' => 'confirmed').or(scope.where('person_escort_records.id' => nil))
+        scope.where.not('person_escort_records.status' => %w[completed confirmed]).or(scope.where('person_escort_records.id' => nil))
       end
     end
   end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -475,8 +475,9 @@ RSpec.describe Moves::Finder do
       context 'with ready_for_transit set as `true`' do
         let(:filter_params) { { ready_for_transit: 'true' } }
 
-        it 'returns only confirmed moves' do
+        it 'returns completed and confirmed moves' do
           expect(results).to contain_exactly(
+            move_with_completed_person_escort_record,
             move_with_confirmed_person_escort_record,
           )
         end
@@ -485,12 +486,11 @@ RSpec.describe Moves::Finder do
       context 'with ready_for_transit set as `false`' do
         let(:filter_params) { { ready_for_transit: 'false' } }
 
-        it 'returns all non confirmed moves' do
+        it 'returns all non completed or confirmed moves' do
           expect(results).to contain_exactly(
             move_with_no_person_escort_record,
             move_with_unstarted_person_escort_record,
             move_with_in_progress_person_escort_record,
-            move_with_completed_person_escort_record,
           )
         end
       end


### PR DESCRIPTION
This updates the filter for moves such that a completed per is considered ready for transit, rather than just a confirmed one. This change means that moves with a completed, but not confirmed, PER will show in the "ready for transit" section rather than the "incomplete" section.

The old behaviour makes sense when PERs used to have to be confirmed, but now that PERs are automatically confirmed when a move starts, it doesn't make sense to keep the move in the incomplete state until that point.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-2920)