### PR TITLE
Reduce Sentry transaction sample rate

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -23,6 +23,6 @@ Sentry.init do |config|
     transaction_context = sampling_context[:transaction_context]
     transaction_name = transaction_context[:name]
 
-    transaction_name.in?(EXCLUDE_PATHS) ? 0.0 : 0.25
+    transaction_name.in?(EXCLUDE_PATHS) ? 0.0 : 0.1
   end
 end


### PR DESCRIPTION
We're still experiencing a problem where the MoJ Sentry account gets rate limited after a couple of weeks because too many transactions are being reported.

This reduces the sample rate from 25% to 10%.