### PR TITLE
P4 3117/validate event occurred at order

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -198,6 +198,22 @@ class GenericEvent < ApplicationRecord
     end
   end
 
+  def self.validate_occurs_before(before_type)
+    validate do
+      next if eventable.generic_events.where('occurred_at < ?', occurred_at).where(type: before_type).empty?
+
+      errors.add(:base, "#{type} may not occur after #{before_type}")
+    end
+  end
+
+  def self.validate_occurs_after(after_type)
+    validate do
+      next if eventable.generic_events.where('occurred_at > ?', occurred_at).where(type: after_type).empty?
+
+      errors.add(:base, "#{type} may not occur before #{after_type}")
+    end
+  end
+
   def self.eventable_types(*types)
     define_singleton_method(:eventable_types) do
       instance_variable_get('@eventable_types')

--- a/app/models/generic_event/journey_complete.rb
+++ b/app/models/generic_event/journey_complete.rb
@@ -1,6 +1,7 @@
 class GenericEvent
   class JourneyComplete < GenericEvent
     eventable_types 'Journey'
+    validate_occurs_after 'GenericEvent::JourneyStart'
 
     def trigger(*)
       eventable.complete

--- a/app/models/generic_event/journey_start.rb
+++ b/app/models/generic_event/journey_start.rb
@@ -1,6 +1,7 @@
 class GenericEvent
   class JourneyStart < GenericEvent
     eventable_types 'Journey'
+    validate_occurs_before 'GenericEvent::JourneyComplete'
 
     def trigger(*)
       eventable.start

--- a/app/models/generic_event/move_complete.rb
+++ b/app/models/generic_event/move_complete.rb
@@ -1,6 +1,7 @@
 class GenericEvent
   class MoveComplete < GenericEvent
     eventable_types 'Move'
+    validate_occurs_after 'GenericEvent::MoveStart'
 
     def trigger(*)
       eventable.complete

--- a/app/models/generic_event/move_start.rb
+++ b/app/models/generic_event/move_start.rb
@@ -1,6 +1,7 @@
 class GenericEvent
   class MoveStart < GenericEvent
     eventable_types 'Move'
+    validate_occurs_before 'GenericEvent::MoveComplete'
 
     def trigger(*)
       eventable.start

--- a/spec/models/generic_event/journey_complete_spec.rb
+++ b/spec/models/generic_event/journey_complete_spec.rb
@@ -6,4 +6,6 @@ RSpec.describe GenericEvent::JourneyComplete do
   it_behaves_like 'a journey event', :complete do
     subject(:generic_event) { build(:event_journey_complete) }
   end
+
+  it_behaves_like 'an event that must not occur before', 'GenericEvent::JourneyStart'
 end

--- a/spec/models/generic_event/journey_start_spec.rb
+++ b/spec/models/generic_event/journey_start_spec.rb
@@ -6,4 +6,6 @@ RSpec.describe GenericEvent::JourneyStart do
   it_behaves_like 'a journey event', :start do
     subject(:generic_event) { build(:event_journey_start) }
   end
+
+  it_behaves_like 'an event that must not occur after', 'GenericEvent::JourneyComplete'
 end

--- a/spec/models/generic_event/move_complete_spec.rb
+++ b/spec/models/generic_event/move_complete_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe GenericEvent::MoveComplete do
   subject(:generic_event) { build(:event_move_complete) }
 
   it_behaves_like 'a move event'
+  it_behaves_like 'an event that must not occur before', 'GenericEvent::MoveStart'
 
   describe '#trigger' do
     it 'does not persist changes to the eventable' do

--- a/spec/models/generic_event/move_start_spec.rb
+++ b/spec/models/generic_event/move_start_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe GenericEvent::MoveStart do
   subject(:move_start_event) { build(:event_move_start, eventable: create(:move, move_status)) }
 
+  it_behaves_like 'an event that must not occur after', 'GenericEvent::MoveComplete'
+
   shared_examples 'the move changes but is not saved' do
     it do
       expect { move_start_event.trigger }.to change(move, :changed?)

--- a/spec/support/an_event_that_must_not_occur_after.rb
+++ b/spec/support/an_event_that_must_not_occur_after.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an event that must not occur after' do |type|
+  context type do
+    describe '.save' do
+      before do
+        Timecop.freeze('2021-01-01 00:00:00')
+      end
+
+      context "when a #{type} event occurs before a #{described_class} event" do
+        before do
+          type.constantize.create!(
+            occurred_at: Time.zone.local(2020, 12, 1),
+            recorded_at: Time.zone.now,
+            eventable: generic_event.eventable,
+          )
+        end
+
+        it 'adds an error to errors' do
+          expect(generic_event.save).to eq(false)
+          expect(generic_event.errors.errors.to_s).to include("#{described_class} may not occur after #{type}")
+        end
+      end
+
+      context "when a #{type} event occurs after a #{described_class} event" do
+        before do
+          type.constantize.create!(
+            occurred_at: Time.zone.local(2021, 1, 2),
+            recorded_at: Time.zone.now,
+            eventable: generic_event.eventable,
+          )
+        end
+
+        it 'saves' do
+          expect(generic_event.save).to eq(true)
+        end
+      end
+
+      context "when a #{type} event does not occur" do
+        it 'saves' do
+          expect(generic_event.save).to eq(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/an_event_that_must_not_occur_before.rb
+++ b/spec/support/an_event_that_must_not_occur_before.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an event that must not occur before' do |type|
+  context type do
+    describe '.save' do
+      before do
+        Timecop.freeze('2021-01-01 00:00:00')
+      end
+
+      context "when a #{type} event occurs before a #{described_class} event" do
+        before do
+          type.constantize.create!(
+            occurred_at: Time.zone.local(2020, 12, 1),
+            recorded_at: Time.zone.now,
+            eventable: generic_event.eventable,
+          )
+        end
+
+        it 'saves' do
+          expect(generic_event.save).to eq(true)
+        end
+      end
+
+      context "when a #{type} event occurs after a #{described_class} event" do
+        before do
+          type.constantize.create!(
+            occurred_at: Time.zone.local(2021, 1, 2),
+            recorded_at: Time.zone.now,
+            eventable: generic_event.eventable,
+          )
+        end
+
+        it 'adds an error to errors' do
+          expect(generic_event.save).to eq(false)
+          expect(generic_event.errors.errors.to_s).to include("#{described_class} may not occur before #{type}")
+        end
+      end
+
+      context "when a #{type} event does not occur" do
+        it 'saves' do
+          expect(generic_event.save).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

P4-3117

### What?

I have added/removed/altered:

- [x] Added order validation to GenericEvent
- [x] Added order validation to Move/Journey Start/Complete

### Why?

I am doing this because:

- It will ensure that events occur in the right order, for example: JourneyComplete can not occur before JourneyStart