### PR TITLE
Update Swagger docs

### DIFF
--- a/app/controllers/api/journey_events_controller.rb
+++ b/app/controllers/api/journey_events_controller.rb
@@ -9,6 +9,7 @@ module Api
     around_action :idempotent_action
 
     COMMON_PARAMS = [:type, { attributes: %i[timestamp notes] }].freeze
+    START_COMPLETE_PARAMS = [:type, { attributes: %i[timestamp notes vehicle_reg] }].freeze
     LOCKOUT_PARAMS = [:type, { attributes: %i[timestamp notes], relationships: { from_location: {} } }].freeze
     LODGING_PARAMS = [:type, { attributes: %i[timestamp notes], relationships: { to_location: {} } }].freeze
 
@@ -19,8 +20,8 @@ module Api
     end
 
     def complete
-      JourneyEvents::ParamsValidator.new(common_params).validate!
-      process_event(journey, GenericEvent::JourneyComplete, common_params)
+      JourneyEvents::ParamsValidator.new(start_complete_params).validate!
+      process_event(journey, GenericEvent::JourneyComplete, start_complete_params)
       render status: :no_content
     end
 
@@ -43,8 +44,8 @@ module Api
     end
 
     def start
-      JourneyEvents::ParamsValidator.new(common_params).validate!
-      process_event(journey, GenericEvent::JourneyStart, common_params)
+      JourneyEvents::ParamsValidator.new(start_complete_params).validate!
+      process_event(journey, GenericEvent::JourneyStart, start_complete_params)
       render status: :no_content
     end
 
@@ -72,6 +73,10 @@ module Api
 
     def common_params
       @common_params ||= params.require(:data).permit(COMMON_PARAMS).to_h
+    end
+
+    def start_complete_params
+      @start_complete_params ||= params.require(:data).permit(START_COMPLETE_PARAMS).to_h
     end
 
     def journey

--- a/swagger/v1/post_journey_complete.yaml
+++ b/swagger/v1/post_journey_complete.yaml
@@ -19,3 +19,5 @@ PostJourneyComplete:
           $ref: timestamp_attribute.yaml#/Timestamp
         notes:
           $ref: notes_attribute.yaml#/Notes
+        vehicle_reg:
+          $ref: vehicle_reg_attribute.yaml#/Notes

--- a/swagger/v1/post_journey_start.yaml
+++ b/swagger/v1/post_journey_start.yaml
@@ -19,3 +19,5 @@ PostJourneyStart:
           $ref: timestamp_attribute.yaml#/Timestamp
         notes:
           $ref: notes_attribute.yaml#/Notes
+        vehicle_reg:
+          $ref: vehicle_reg_attribute.yaml#/Notes

--- a/swagger/v1/vehicle_reg_attribute.yaml
+++ b/swagger/v1/vehicle_reg_attribute.yaml
@@ -1,0 +1,4 @@
+Notes:
+  type: string
+  example: AB12 CDE
+  description: Registration number of the related vehicle


### PR DESCRIPTION
### Jira link

P4-3232

### What?

I have added/removed/altered:

- [x] Updated the Swagger docs for JourneyStart and JourneyComplete to include vehicle_reg

### Why?

I am doing this because:

- It will allow our suppliers to see that they can supply vehicle_reg to these events.

### Have you? (optional)

- [x] Updated API docs if necessary	