### PR TITLE
Add vehicle_reg to more journey events

### DIFF
--- a/app/models/generic_event/journey_admit_to_reception.rb
+++ b/app/models/generic_event/journey_admit_to_reception.rb
@@ -2,10 +2,17 @@ class GenericEvent
   class JourneyAdmitToReception < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
+    details_attributes :vehicle_reg
     relationship_attributes location_id: :locations
     eventable_types 'Journey'
 
     include LocationValidations
     include LocationFeed
+
+    def trigger(*)
+      if vehicle_reg.blank?
+        Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
+      end
+    end
   end
 end

--- a/app/models/generic_event/journey_arrive_at_outer_gate.rb
+++ b/app/models/generic_event/journey_arrive_at_outer_gate.rb
@@ -2,10 +2,17 @@ class GenericEvent
   class JourneyArriveAtOuterGate < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
+    details_attributes :vehicle_reg
     relationship_attributes location_id: :locations
     eventable_types 'Journey'
 
     include LocationValidations
     include LocationFeed
+
+    def trigger(*)
+      if vehicle_reg.blank?
+        Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
+      end
+    end
   end
 end

--- a/app/models/generic_event/journey_exit_through_outer_gate.rb
+++ b/app/models/generic_event/journey_exit_through_outer_gate.rb
@@ -2,10 +2,17 @@ class GenericEvent
   class JourneyExitThroughOuterGate < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
+    details_attributes :vehicle_reg
     relationship_attributes location_id: :locations
     eventable_types 'Journey'
 
     include LocationValidations
     include LocationFeed
+
+    def trigger(*)
+      if vehicle_reg.blank?
+        Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
+      end
+    end
   end
 end

--- a/app/models/generic_event/journey_person_leave_vehicle.rb
+++ b/app/models/generic_event/journey_person_leave_vehicle.rb
@@ -1,5 +1,12 @@
 class GenericEvent
   class JourneyPersonLeaveVehicle < GenericEvent
+    details_attributes :vehicle_reg
     eventable_types 'Journey'
+
+    def trigger(*)
+      if vehicle_reg.blank?
+        Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
+      end
+    end
   end
 end

--- a/app/models/generic_event/journey_ready_to_exit.rb
+++ b/app/models/generic_event/journey_ready_to_exit.rb
@@ -2,10 +2,17 @@ class GenericEvent
   class JourneyReadyToExit < GenericEvent
     LOCATION_ATTRIBUTE_KEY = :location_id
 
+    details_attributes :vehicle_reg
     relationship_attributes location_id: :locations
     eventable_types 'Journey'
 
     include LocationValidations
     include LocationFeed
+
+    def trigger(*)
+      if vehicle_reg.blank?
+        Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
+      end
+    end
   end
 end

--- a/spec/models/generic_event/journey_admit_to_reception_spec.rb
+++ b/spec/models/generic_event/journey_admit_to_reception_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe GenericEvent::JourneyAdmitToReception do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a location in the feed', :location_id
+  it_behaves_like 'an event that will require a vehicle registration'
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
 end

--- a/spec/models/generic_event/journey_arrive_at_outer_gate_spec.rb
+++ b/spec/models/generic_event/journey_arrive_at_outer_gate_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe GenericEvent::JourneyArriveAtOuterGate do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a location in the feed', :location_id
+  it_behaves_like 'an event that will require a vehicle registration'
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
 end

--- a/spec/models/generic_event/journey_complete_spec.rb
+++ b/spec/models/generic_event/journey_complete_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe GenericEvent::JourneyComplete do
   subject(:generic_event) { build(:event_journey_complete) }
 
   it_behaves_like 'a journey event', :complete
+  it_behaves_like 'an event that will require a vehicle registration'
 
   context 'when supplied a vehicle_reg' do
     before do
@@ -17,16 +18,11 @@ RSpec.describe GenericEvent::JourneyComplete do
   end
 
   context 'when not supplied a vehicle_reg' do
-    let(:supplier) { create(:supplier, :serco) }
-
     before do
       generic_event.vehicle_reg = nil
-      generic_event.supplier = supplier
-      allow(Sentry).to receive(:capture_message)
     end
 
-    it 'does not set the vehicle_registration on the eventable and logs to sentry' do
-      expect(Sentry).to receive(:capture_message).with('GenericEvent::JourneyComplete created without vehicle_reg', level: 'warning', extra: { supplier: supplier&.key })
+    it 'does not set the vehicle_registration on the eventable' do
       generic_event.trigger
       expect(generic_event.eventable.vehicle_registration).to eq('AB12 CDE')
     end

--- a/spec/models/generic_event/journey_exit_through_outer_gate_spec.rb
+++ b/spec/models/generic_event/journey_exit_through_outer_gate_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe GenericEvent::JourneyExitThroughOuterGate do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a location in the feed', :location_id
+  it_behaves_like 'an event that will require a vehicle registration'
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
 end

--- a/spec/models/generic_event/journey_person_leave_vehicle_spec.rb
+++ b/spec/models/generic_event/journey_person_leave_vehicle_spec.rb
@@ -3,5 +3,7 @@ require 'rails_helper'
 RSpec.describe GenericEvent::JourneyPersonLeaveVehicle do
   subject(:generic_event) { build(:event_journey_person_leave_vehicle) }
 
+  it_behaves_like 'an event that will require a vehicle registration'
+
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
 end

--- a/spec/models/generic_event/journey_ready_to_exit_spec.rb
+++ b/spec/models/generic_event/journey_ready_to_exit_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe GenericEvent::JourneyReadyToExit do
   it_behaves_like 'an event with relationships', location_id: :locations
   it_behaves_like 'an event requiring a location', :location_id
   it_behaves_like 'an event with a location in the feed', :location_id
+  it_behaves_like 'an event that will require a vehicle registration'
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[Journey]) }
 end

--- a/spec/models/generic_event/journey_start_spec.rb
+++ b/spec/models/generic_event/journey_start_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe GenericEvent::JourneyStart do
   subject(:generic_event) { build(:event_journey_start) }
 
   it_behaves_like 'a journey event', :start
+  it_behaves_like 'an event that will require a vehicle registration'
 
   context 'when supplied a vehicle_reg' do
     before do
@@ -17,16 +18,11 @@ RSpec.describe GenericEvent::JourneyStart do
   end
 
   context 'when not supplied a vehicle_reg' do
-    let(:supplier) { create(:supplier, :serco) }
-
     before do
       generic_event.vehicle_reg = nil
-      generic_event.supplier = supplier
-      allow(Sentry).to receive(:capture_message)
     end
 
-    it 'does not set the vehicle_registration on the eventable and logs to sentry' do
-      expect(Sentry).to receive(:capture_message).with('GenericEvent::JourneyStart created without vehicle_reg', level: 'warning', extra: { supplier: supplier&.key })
+    it 'does not set the vehicle_registration on the eventable' do
       generic_event.trigger
       expect(generic_event.eventable.vehicle_registration).to eq('AB12 CDE')
     end

--- a/spec/support/an_event_that_will_require_a_vehicle_registration.rb
+++ b/spec/support/an_event_that_will_require_a_vehicle_registration.rb
@@ -1,0 +1,16 @@
+RSpec.shared_examples 'an event that will require a vehicle registration' do
+  context 'when not supplied a vehicle_reg' do
+    let(:supplier) { create(:supplier, :serco) }
+
+    before do
+      generic_event.vehicle_reg = nil
+      generic_event.supplier = supplier
+      allow(Sentry).to receive(:capture_message)
+    end
+
+    it 'logs to sentry' do
+      expect(Sentry).to receive(:capture_message).with("#{generic_event.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
+      generic_event.trigger
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

P4-3234

### What?

I have added/removed/altered:

- [x] Added vehicle_reg to JourneyAdmitToReception, JourneyArriveAtOuterGate, JourneyExitThroughOuterGate, JourneyPersonLeaveVehicle, JourneyReadyToExit.

### Why?

I am doing this because:

- Currently, in the frontend, when we are displaying these events, we're using the Journey's vehicle reg, if the vehicle changes during a journey, we are showing the new vehicle's registration number on the old events. This is the backend part of the fix for this, next change is to make frontend show the vehicle reg stored on the events instead of the journey.

### Have you? (optional)

- [ ] Updated API docs if necessary	