### PR TITLE
Make import column names lowercase

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -6,9 +6,9 @@ namespace :import do
     task :serco, [:csv_path] => :environment do |_, args|
       csv_path = args.fetch(:csv_path)
       columns = {
-        journey_id: :BASMMOJJourneyID,
-        move_id: :BASMMOJMoveID,
-        vehicle_registration: :SERs_vehicleReg,
+        journey_id: :basmmojjourneyid,
+        move_id: :basmmojmoveid,
+        vehicle_registration: :sers_vehiclereg,
       }
 
       print Imports::JourneysMissingVehicle.call(csv_path: csv_path, columns: columns).summary
@@ -20,11 +20,11 @@ namespace :import do
     task :serco, [:csv_path] => :environment do |_, args|
       csv_path = args.fetch(:csv_path)
       columns = {
-        move_id: :BASMMOJMoveID,
-        event_type: :SERSEndingEvent,
-        event_timestamp: :TimeOfEndingEvent,
-        cancellation_reason: :CancellationReason,
-        rejection_reason: :CancellationReason,
+        move_id: :basmmojmoveid,
+        event_type: :sersendingevent,
+        event_timestamp: :timeofendingevent,
+        cancellation_reason: :cancellationreason,
+        rejection_reason: :cancellationreason,
       }
 
       print Imports::MissingMoveEndingEvents.call(csv_path: csv_path, columns: columns).summary
@@ -49,9 +49,9 @@ namespace :import do
     task :serco, [:csv_path] => :environment do |_, args|
       csv_path = args.fetch(:csv_path)
       columns = {
-        move_id: :BASMMOJMoveID,
-        old_status: :BASMMoveStatus,
-        new_status: :SERs_journeyStatus,
+        move_id: :basmmojmoveid,
+        old_status: :basmmovestatus,
+        new_status: :sers_journeystatus,
       }
 
       print Imports::MovesWithoutEndingState.call(csv_path: csv_path, columns: columns).summary

--- a/spec/lib/tasks/imports/journeys_missing_vehicle_spec.rb
+++ b/spec/lib/tasks/imports/journeys_missing_vehicle_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Rake::Task['import:journeys_missing_vehicle:serco'] do
     expect(Imports::JourneysMissingVehicle).to receive(:call).with(
       csv_path: 'data.csv',
       columns: {
-        journey_id: :BASMMOJJourneyID,
-        move_id: :BASMMOJMoveID,
-        vehicle_registration: :SERs_vehicleReg,
+        journey_id: :basmmojjourneyid,
+        move_id: :basmmojmoveid,
+        vehicle_registration: :sers_vehiclereg,
       },
     )
 

--- a/spec/lib/tasks/imports/missing_move_ending_events_spec.rb
+++ b/spec/lib/tasks/imports/missing_move_ending_events_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Rake::Task['import:missing_move_ending_events:serco'] do
     expect(Imports::MissingMoveEndingEvents).to receive(:call).with(
       csv_path: 'data.csv',
       columns: {
-        move_id: :BASMMOJMoveID,
-        event_type: :SERSEndingEvent,
-        event_timestamp: :TimeOfEndingEvent,
-        cancellation_reason: :CancellationReason,
-        rejection_reason: :CancellationReason,
+        move_id: :basmmojmoveid,
+        event_type: :sersendingevent,
+        event_timestamp: :timeofendingevent,
+        cancellation_reason: :cancellationreason,
+        rejection_reason: :cancellationreason,
       },
     )
 

--- a/spec/lib/tasks/imports/moves_without_ending_state_spec.rb
+++ b/spec/lib/tasks/imports/moves_without_ending_state_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Rake::Task['import:moves_without_ending_state:serco'] do
     expect(Imports::MovesWithoutEndingState).to receive(:call).with(
       csv_path: 'data.csv',
       columns: {
-        move_id: :BASMMOJMoveID,
-        old_status: :BASMMoveStatus,
-        new_status: :SERs_journeyStatus,
+        move_id: :basmmojmoveid,
+        old_status: :basmmovestatus,
+        new_status: :sers_journeystatus,
       },
     )
 


### PR DESCRIPTION
It turns out that the CSV parser automatically converts the columns to lowercase, so we need to specify the same. The spreadsheets as they come to us from Serco are not all in lowercase.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3254)