### PR TITLE
Fix column name for moves_without_ending_state import

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -51,7 +51,7 @@ namespace :import do
       columns = {
         move_id: :basmmojmoveid,
         old_status: :basmmovestatus,
-        new_status: :sers_journeystatus,
+        new_status: :sersstatus,
       }
 
       print Imports::MovesWithoutEndingState.call(csv_path: csv_path, columns: columns).summary

--- a/spec/lib/tasks/imports/moves_without_ending_state_spec.rb
+++ b/spec/lib/tasks/imports/moves_without_ending_state_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Rake::Task['import:moves_without_ending_state:serco'] do
       columns: {
         move_id: :basmmojmoveid,
         old_status: :basmmovestatus,
-        new_status: :sers_journeystatus,
+        new_status: :sersstatus,
       },
     )
 


### PR DESCRIPTION
This was accidentally set to SERs_journeyStatus in dbf5fe1ef26e0b4dac72d92eeacf2ecb0e2ce6d3 when it should have been SERSStatus instead.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3289)