### PR TITLE
Allow including to_location in timeline events

### DIFF
--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -71,6 +71,7 @@ module V2
       important_events
       timeline_events
       timeline_events.eventable
+      timeline_events.to_location
       journeys
       journeys.from_location
       journeys.to_location

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe V2::MoveSerializer do
   end
 
   describe 'timeline_events' do
-    let(:includes) { %i[timeline_events timeline_events.eventable] }
+    let(:includes) { %i[timeline_events timeline_events.eventable timeline_events.to_location] }
     let(:adapter_options) { { include: includes, params: { included: includes } } }
 
     context 'with generic events' do
@@ -157,6 +157,10 @@ RSpec.describe V2::MoveSerializer do
 
         it 'contains included events' do
           expect(included_event).to be_present
+        end
+
+        it 'contains included location' do
+          expect(result[:included]).to include(hash_including(id: event.to_location.id, type: 'locations'))
         end
 
         it 'contains the correct relationships for the event include' do


### PR DESCRIPTION
This follows on from https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1554 where we added support for including journey information when requesting a move. Unfortunately this doesn't cover the case where an event might include a location which isn't referenced in any journey, and therefore will be missing from the relationships.

This change ensures the locations are included in the output and therefore we can show the full event information on the frontend.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3148)