### PR TITLE
Revert "Allow including to_location in timeline events"

### DIFF
--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -71,7 +71,6 @@ module V2
       important_events
       timeline_events
       timeline_events.eventable
-      timeline_events.to_location
       journeys
       journeys.from_location
       journeys.to_location

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe V2::MoveSerializer do
   end
 
   describe 'timeline_events' do
-    let(:includes) { %i[timeline_events timeline_events.eventable timeline_events.to_location] }
+    let(:includes) { %i[timeline_events timeline_events.eventable] }
     let(:adapter_options) { { include: includes, params: { included: includes } } }
 
     context 'with generic events' do
@@ -157,10 +157,6 @@ RSpec.describe V2::MoveSerializer do
 
         it 'contains included events' do
           expect(included_event).to be_present
-        end
-
-        it 'contains included location' do
-          expect(result[:included]).to include(hash_including(id: event.to_location.id, type: 'locations'))
         end
 
         it 'contains the correct relationships for the event include' do


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-api#1625

This wasn't as straight forward as I'd expected. Although the serialiser supported the new include, the database query did not because it's not a field in the database, it's included in the `details` of the event.

We started seeing this error in Sentry: https://sentry.io/organizations/ministryofjustice/issues/2753985288/?project=2014776&query=is%3Aunresolved

```
ActiveRecord::AssociationNotFoundError
Association named 'to_location' was not found on GenericEvent::MoveDateChanged; perhaps you misspelled it?
Did you mean?  supplier
               eventable
```