### PR TITLE
Allow including location in timeline events

### DIFF
--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -71,6 +71,10 @@ module V2
       important_events
       timeline_events
       timeline_events.eventable
+      timeline_events.location
+      timeline_events.court_location
+      timeline_events.from_location
+      timeline_events.to_location
       journeys
       journeys.from_location
       journeys.to_location

--- a/app/services/include_param_handler.rb
+++ b/app/services/include_param_handler.rb
@@ -24,6 +24,8 @@ private
   end
 
   def to_active_record_include_hash(value)
+    return {} if NOT_DATABASE_ASSOCIATIONS.include?(value)
+
     parts = value.split('.', 2)
     db_name = db_alias(parts.first)
 
@@ -66,4 +68,13 @@ private
       name.to_sym
     end
   end
+
+  # Includes which are not possible to query using ActiveRecord eager loading, and instead must come from multiple
+  # calls to the database.
+  NOT_DATABASE_ASSOCIATIONS = %w[
+    timeline_events.location
+    timeline_events.court_location
+    timeline_events.from_location
+    timeline_events.to_location
+  ].freeze
 end

--- a/spec/requests/api/moves_controller_show_v2_spec.rb
+++ b/spec/requests/api/moves_controller_show_v2_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe Api::MovesController do
           court_hearings: [court_hearing],
         )
 
-        get "/api/moves#{query_params}", params: params, headers: headers
+        create(:event_move_accept, eventable: move)
+        create(:event_move_redirect, eventable: move)
+
+        get "/api/moves/#{move.id}#{query_params}", params: params, headers: headers
       end
 
       context 'when not including the include query param' do
@@ -69,6 +72,15 @@ RSpec.describe Api::MovesController do
         it 'includes the requested includes in the response' do
           returned_types = response_json['included'].map { |r| r['type'] }.uniq
           expect(returned_types).to contain_exactly('profiles')
+        end
+      end
+
+      context 'when including non-database fields' do
+        let(:query_params) { '?include=timeline_events,timeline_events.to_location' }
+
+        it 'includes the requested includes in the response' do
+          returned_types = response_json['included'].map { |r| r['type'] }.uniq
+          expect(returned_types).to contain_exactly('events', 'locations')
         end
       end
 

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe V2::MoveSerializer do
   end
 
   describe 'timeline_events' do
-    let(:includes) { %i[timeline_events timeline_events.eventable] }
+    let(:includes) { %i[timeline_events timeline_events.eventable timeline_events.to_location] }
     let(:adapter_options) { { include: includes, params: { included: includes } } }
 
     context 'with generic events' do
@@ -153,6 +153,10 @@ RSpec.describe V2::MoveSerializer do
 
         it 'contains timeline_events relationship' do
           expect(result[:data][:relationships][:timeline_events]).to eq(data: expected_event_relationships)
+        end
+
+        it 'contains included location' do
+          expect(result[:included]).to include(hash_including(id: event.to_location.id, type: 'locations'))
         end
 
         it 'contains included events' do


### PR DESCRIPTION
This follows on from https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1554 where we added support for including journey information when requesting a move. Unfortunately this doesn't cover the case where an event might include a location which isn't referenced in any journey, and therefore will be missing from the relationships.

This change ensures the locations are included in the output and therefore we can show the full event information on the frontend.

Note this is a re-attempt of https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1625 after we had to reverse it when we discovered an issue where the fields are not accessible on the database. This change might incur a performance hit which we should monitor.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3148)