### PR TITLE
Record failure reason in import results

### DIFF
--- a/app/lib/imports/journeys_missing_vehicle.rb
+++ b/app/lib/imports/journeys_missing_vehicle.rb
@@ -26,7 +26,7 @@ private
     @results ||= records.each_with_object(Imports::Results.new) do |record, results|
       journey = Journey.find_by(id: record[:journey_id], move_id: record[:move_id])
       if journey.nil?
-        results.record_failure(record)
+        results.record_failure(record, reason: 'Could not find journey.')
         next
       end
 

--- a/app/lib/imports/missing_move_ending_events.rb
+++ b/app/lib/imports/missing_move_ending_events.rb
@@ -30,14 +30,14 @@ private
 
   def results
     @results ||= records.each_with_object(Imports::Results.new) do |record, results|
-      move = Move.find_by(id: record[:move_id], status: EXPECTED_MOVE_STATUSES)
-      if move.nil?
-        results.record_failure(record)
+      unless ALLOWED_EVENT_TYPES.include?(record[:event_type])
+        results.record_failure(record, reason: 'Event type not allowed.')
         next
       end
 
-      unless ALLOWED_EVENT_TYPES.include?(record[:event_type])
-        results.record_failure(record)
+      move = Move.find_by(id: record[:move_id], status: EXPECTED_MOVE_STATUSES)
+      if move.nil?
+        results.record_failure(record, reason: 'Could not find move.')
         next
       end
 

--- a/app/lib/imports/missing_move_start_events.rb
+++ b/app/lib/imports/missing_move_start_events.rb
@@ -29,7 +29,7 @@ private
     @results ||= records.each_with_object(Imports::Results.new) do |record, results|
       move = Move.find_by(id: record[:move_id])
       if move.nil?
-        results.record_failure(record)
+        results.record_failure(record, reason: 'Could not find move.')
         next
       end
 

--- a/app/lib/imports/moves_without_ending_state.rb
+++ b/app/lib/imports/moves_without_ending_state.rb
@@ -26,7 +26,7 @@ private
     @results ||= records.each_with_object(Imports::Results.new) do |record, results|
       move = Move.find_by(id: record[:move_id], status: record[:old_status])
       if move.nil?
-        results.record_failure(record)
+        results.record_failure(record, reason: 'Could not find move.')
         next
       end
 

--- a/app/lib/imports/results.rb
+++ b/app/lib/imports/results.rb
@@ -14,15 +14,15 @@ class Imports::Results
     successes.append(record)
   end
 
-  def record_failure(record)
-    failures.append(record)
+  def record_failure(record, reason:)
+    failures.append(record.merge(reason: reason))
   end
 
   def save(obj, record)
     if obj.save
       record_success(record)
     else
-      record_failure(record)
+      record_failure(record, reason: 'Could not save record.')
     end
   end
 

--- a/spec/lib/imports/journeys_missing_vehicle_spec.rb
+++ b/spec/lib/imports/journeys_missing_vehicle_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Imports::JourneysMissingVehicle do
 
     it 'records failures' do
       expect(results.failures).to match_array([
-        { journey_id: journey.id, move_id: 'abc', vehicle_registration: 'ABC DEF' },
-        { journey_id: 'abc', move_id: 'abc', vehicle_registration: 'ABC DEF' },
+        { journey_id: journey.id, move_id: 'abc', vehicle_registration: 'ABC DEF', reason: 'Could not find journey.' },
+        { journey_id: 'abc', move_id: 'abc', vehicle_registration: 'ABC DEF', reason: 'Could not find journey.' },
       ])
     end
 

--- a/spec/lib/imports/missing_move_ending_events_spec.rb
+++ b/spec/lib/imports/missing_move_ending_events_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Imports::MissingMoveEndingEvents do
   let(:rejected_move) { create(:move, :requested) }
 
   let(:csv) do
-    "move_id,event_type,event_timestamp,cancellation_reason,rejection_reason\nabc,abc,abc,,\n#{completed_move.id},MoveComplete,2020-01-01,,\n#{cancelled_move.id},MoveCancel,2020-01-01,made_in_error,\n#{rejected_move.id},MoveReject,2020-01-01,,no_space_at_receiving_prison"
+    "move_id,event_type,event_timestamp,cancellation_reason,rejection_reason\nabc,abc,abc,,\nabc,MoveComplete,abc,,\n#{completed_move.id},MoveComplete,2020-01-01,,\n#{cancelled_move.id},MoveCancel,2020-01-01,made_in_error,\n#{rejected_move.id},MoveReject,2020-01-01,,no_space_at_receiving_prison"
   end
 
   let(:csv_path) do
@@ -32,12 +32,13 @@ RSpec.describe Imports::MissingMoveEndingEvents do
     subject(:results) { described_class.call(csv_path: csv_path, columns: columns) }
 
     it 'imports all rows' do
-      expect(results.total).to eq(4)
+      expect(results.total).to eq(5)
     end
 
     it 'records failures' do
       expect(results.failures).to match_array([
-        { move_id: 'abc', event_type: 'abc', event_timestamp: 'abc', cancellation_reason: nil, rejection_reason: nil },
+        { move_id: 'abc', event_type: 'MoveComplete', event_timestamp: 'abc', cancellation_reason: nil, rejection_reason: nil, reason: 'Could not find move.' },
+        { move_id: 'abc', event_type: 'abc', event_timestamp: 'abc', cancellation_reason: nil, rejection_reason: nil, reason: 'Event type not allowed.' },
       ])
     end
 

--- a/spec/lib/imports/missing_move_start_events_spec.rb
+++ b/spec/lib/imports/missing_move_start_events_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Imports::MissingMoveStartEvents do
 
     it 'records failures' do
       expect(results.failures).to match_array([
-        { move_id: 'abc', event_timestamp: 'abc' },
+        { move_id: 'abc', event_timestamp: 'abc', reason: 'Could not find move.' },
       ])
     end
 

--- a/spec/lib/imports/moves_without_ending_state_spec.rb
+++ b/spec/lib/imports/moves_without_ending_state_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Imports::MovesWithoutEndingState do
 
     it 'records failures' do
       expect(results.failures).to match_array([
-        { move_id: move.id, old_status: 'rejected', new_status: 'Completed' },
-        { move_id: 'abc', old_status: 'abc', new_status: 'abc' },
+        { move_id: move.id, old_status: 'rejected', new_status: 'Completed', reason: 'Could not find move.' },
+        { move_id: 'abc', old_status: 'abc', new_status: 'abc', reason: 'Could not find move.' },
       ])
     end
 

--- a/spec/lib/imports/results_spec.rb
+++ b/spec/lib/imports/results_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Imports::Results do
     end
 
     context 'with a failure recorded' do
-      before { results.record_failure({ id: 1 }) }
+      before { results.record_failure({ id: 1 }, reason: 'Reason') }
 
       it { is_expected.to eq(1) }
     end
@@ -27,7 +27,7 @@ RSpec.describe Imports::Results do
     context 'with a success and a failure recorded' do
       before do
         results.record_success({ id: 0 })
-        results.record_failure({ id: 1 })
+        results.record_failure({ id: 1 }, reason: 'Reason')
       end
 
       it { is_expected.to eq(2) }
@@ -36,7 +36,7 @@ RSpec.describe Imports::Results do
 
   describe '#save' do
     let(:obj) { double }
-    let(:record) { double }
+    let(:record) { { id: 1 } }
 
     context 'when save is successful' do
       before { allow(obj).to receive(:save).and_return(true) }
@@ -56,7 +56,7 @@ RSpec.describe Imports::Results do
         results.save(obj, record)
 
         expect(results.successes).to be_empty
-        expect(results.failures).to match_array([record])
+        expect(results.failures).to match_array([record.merge(reason: 'Could not save record.')])
       end
     end
   end
@@ -75,18 +75,18 @@ RSpec.describe Imports::Results do
     end
 
     context 'with a failure recorded' do
-      before { results.record_failure({ id: 1 }) }
+      before { results.record_failure({ id: 1 }, reason: 'Reason') }
 
-      it { is_expected.to eq("Imported 1 records with 1 failures.\n\nid\n1\n") }
+      it { is_expected.to eq("Imported 1 records with 1 failures.\n\nid,reason\n1,Reason\n") }
     end
 
     context 'with a success and a failure recorded' do
       before do
         results.record_success({ id: 0 })
-        results.record_failure({ id: 1 })
+        results.record_failure({ id: 1 }, reason: 'Reason')
       end
 
-      it { is_expected.to eq("Imported 2 records with 1 failures.\n\nid\n1\n") }
+      it { is_expected.to eq("Imported 2 records with 1 failures.\n\nid,reason\n1,Reason\n") }
     end
   end
 end


### PR DESCRIPTION
This adds the ability to record a reason if a record fails to import, so we can better investigate why it might have failed.