### PR TITLE
Use events to transition move status

### DIFF
--- a/app/lib/imports/moves_without_ending_state.rb
+++ b/app/lib/imports/moves_without_ending_state.rb
@@ -30,8 +30,54 @@ private
         next
       end
 
-      move.status = record[:new_status].downcase
+      new_status = record[:new_status]
+
+      event = find_event(move, new_status)
+      if event.nil?
+        results.record_failure(record, reason: 'Could not find associated event.')
+        next
+      end
+
+      move.state_machine.restore!(find_pre_trigger_status(new_status)) # to ensure event state transition is valid
+      event.eventable = move  # to ensure we are modifying the same object
+
+      event.trigger(dry_run: true)
+
+      if move.status != find_expected_status(new_status)
+        results.record_failure(record, reason: 'Event did not trigger state change.')
+        next
+      end
+
       results.save(move, record)
+    end
+  end
+
+  def find_event(move, new_status)
+    case new_status
+    when 'cancelled'
+      GenericEvent::MoveCancel.find_by(eventable: move)
+    when 'rejected'
+      GenericEvent::MoveReject.find_by(eventable: move)
+    when 'completed'
+      GenericEvent::MoveComplete.find_by(eventable: move)
+    end
+  end
+
+  def find_pre_trigger_status(new_status)
+    case new_status
+    when 'rejected'
+      :requested
+    else
+      :in_transit
+    end
+  end
+
+  def find_expected_status(new_status)
+    case new_status
+    when 'completed'
+      'completed'
+    else
+      'cancelled'
     end
   end
 
@@ -39,8 +85,8 @@ private
     @records ||= CSV.table(csv_path).map do |record|
       {
         move_id: record[columns.fetch(:move_id)],
-        old_status: record[columns.fetch(:old_status)],
-        new_status: record[columns.fetch(:new_status)],
+        old_status: record[columns.fetch(:old_status)].downcase,
+        new_status: record[columns.fetch(:new_status)].downcase,
       }
     end
   end

--- a/spec/lib/imports/moves_without_ending_state_spec.rb
+++ b/spec/lib/imports/moves_without_ending_state_spec.rb
@@ -3,10 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe Imports::MovesWithoutEndingState do
-  let(:move) { create(:move) }
+  let(:move_without_event) { create(:move) }
+  let(:move_to_be_completed) { create(:move) }
+  let(:move_to_be_cancelled) { create(:move) }
+  let(:move_to_be_rejected) { create(:move) }
 
   let(:csv) do
-    "move_id,old_status,new_status\n#{move.id},#{move.status},Completed\n#{move.id},rejected,Completed\nabc,abc,abc"
+    [
+      'move_id,old_status,new_status',
+      'abc,abc,abc',
+      "#{move_without_event.id},rejected,Completed",
+      "#{move_without_event.id},#{move_without_event.status},Completed",
+      "#{move_to_be_completed.id},#{move_to_be_completed.status},Completed",
+      "#{move_to_be_cancelled.id},#{move_to_be_cancelled.status},Cancelled",
+      "#{move_to_be_rejected.id},#{move_to_be_rejected.status},Rejected",
+    ].join("\n")
   end
 
   let(:csv_path) do
@@ -24,30 +35,41 @@ RSpec.describe Imports::MovesWithoutEndingState do
     }
   end
 
+  before do
+    create(:event_move_complete, eventable: move_to_be_completed)
+    create(:event_move_cancel, eventable: move_to_be_cancelled)
+    create(:event_move_reject, eventable: move_to_be_rejected)
+  end
+
   describe '#call' do
     subject(:results) { described_class.call(csv_path: csv_path, columns: columns) }
 
     it 'imports all rows' do
-      expect(results.total).to eq(3)
+      expect(results.total).to eq(6)
     end
 
     it 'records failures' do
       expect(results.failures).to match_array([
-        { move_id: move.id, old_status: 'rejected', new_status: 'Completed', reason: 'Could not find move.' },
+        { move_id: move_without_event.id, old_status: 'rejected', new_status: 'completed', reason: 'Could not find move.' },
         { move_id: 'abc', old_status: 'abc', new_status: 'abc', reason: 'Could not find move.' },
+        { move_id: move_without_event.id, old_status: move_without_event.status, new_status: 'completed', reason: 'Could not find associated event.' },
       ])
     end
 
     it 'records successes' do
       expect(results.successes).to match_array([
-        { move_id: move.id, old_status: move.status, new_status: 'Completed' },
+        { move_id: move_to_be_completed.id, old_status: move_to_be_completed.status, new_status: 'completed' },
+        { move_id: move_to_be_cancelled.id, old_status: move_to_be_cancelled.status, new_status: 'cancelled' },
+        { move_id: move_to_be_rejected.id, old_status: move_to_be_rejected.status, new_status: 'rejected' },
       ])
     end
 
-    it 'sets new status on move' do
+    it 'sets new status on successful moves' do
       results # to execute import
-      expect(move.reload.status).to eq('completed')
-      expect(move.completed?).to be(true)
+
+      expect(move_to_be_completed.reload.completed?).to be(true)
+      expect(move_to_be_cancelled.reload.cancelled?).to be(true)
+      expect(move_to_be_rejected.reload.rejected?).to be(true)
     end
   end
 end


### PR DESCRIPTION
This modifies the import process for moves without an ending state to rely on the existing event which should already be there. This change is so we can support cancelled or rejected moves that do more than just change the status of the move, they also assign a `cancellation_reason` field.