### PR TITLE
Add import task for journeys without ending status

### DIFF
--- a/app/lib/imports/journeys_without_ending_state.rb
+++ b/app/lib/imports/journeys_without_ending_state.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+class Imports::JourneysWithoutEndingState
+  def self.call(...)
+    new(...).call
+  end
+
+  def initialize(csv_path:, columns:)
+    @csv_path = csv_path
+    @column_mapper = Imports::ColumnMapper.new({
+      journey_id: columns.fetch(:journey_id),
+      move_id: columns.fetch(:move_id),
+      old_state: { source: columns.fetch(:old_state), downcase: true },
+      new_state: { source: columns.fetch(:new_state), downcase: true },
+    })
+  end
+
+  private_class_method :new
+
+  def call
+    results
+  end
+
+private
+
+  attr_reader :csv_path, :column_mapper
+
+  def results
+    @results ||= records.each_with_object(Imports::Results.new) do |record, results|
+      journey = Journey.find_by(id: record[:journey_id], move_id: record[:move_id], state: record[:old_state])
+      if journey.nil?
+        results.record_failure(record, reason: 'Could not find journey.')
+        next
+      end
+
+      new_state = record[:new_state]
+
+      event = find_event(journey, new_state)
+      if event.nil?
+        results.record_failure(record, reason: 'Could not find associated event.')
+        next
+      end
+
+      journey.state_machine.restore!(find_pre_trigger_state(new_state)) # to ensure event state transition is valid
+      event.eventable = journey  # to ensure we are modifying the same object
+
+      event.trigger(dry_run: true)
+
+      if journey.state != new_state
+        results.record_failure(record, reason: 'Event did not trigger state change.')
+        next
+      end
+
+      results.save(journey, record)
+    end
+  end
+
+  def find_event(journey, new_state)
+    case new_state
+    when 'cancelled'
+      GenericEvent::JourneyCancel.find_by(eventable: journey)
+    when 'rejected'
+      GenericEvent::JourneyReject.find_by(eventable: journey)
+    when 'completed'
+      GenericEvent::JourneyComplete.find_by(eventable: journey)
+    end
+  end
+
+  def find_pre_trigger_state(new_state)
+    case new_state
+    when 'rejected'
+      :proposed
+    else
+      :in_progress
+    end
+  end
+
+  def records
+    @records ||= column_mapper.map(CSV.table(csv_path))
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -15,6 +15,21 @@ namespace :import do
     end
   end
 
+  namespace :journeys_without_ending_state do
+    desc "Import journeys which don't have an ending state using Serco's spreadsheets."
+    task :serco, [:csv_path] => :environment do |_, args|
+      csv_path = args.fetch(:csv_path)
+      columns = {
+        journey_id: :basm_id,
+        move_id: :basm_moveid,
+        old_state: :basm_state,
+        new_state: :sers_status,
+      }
+
+      print Imports::JourneysWithoutEndingState.call(csv_path: csv_path, columns: columns).summary
+    end
+  end
+
   namespace :missing_move_ending_events do
     desc "Import events for moves which are missing an ending event using Serco's spreadsheets."
     task :serco, [:csv_path] => :environment do |_, args|

--- a/spec/lib/imports/journeys_without_ending_state_spec.rb
+++ b/spec/lib/imports/journeys_without_ending_state_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Imports::JourneysWithoutEndingState do
+  let(:journey_without_event) { create(:journey) }
+  let(:journey_to_be_completed) { create(:journey) }
+  let(:journey_to_be_cancelled) { create(:journey) }
+  let(:journey_to_be_rejected) { create(:journey) }
+
+  let(:csv) do
+    [
+      'journey_id,move_id,old_state,new_state',
+      'abc,abc,abc,abc',
+      "#{journey_without_event.id},#{journey_without_event.move_id},rejected,Completed",
+      "#{journey_without_event.id},#{journey_without_event.move_id},#{journey_without_event.state},Completed",
+      "#{journey_to_be_completed.id},#{journey_to_be_completed.move_id},#{journey_to_be_completed.state},Completed",
+      "#{journey_to_be_cancelled.id},#{journey_to_be_cancelled.move_id},#{journey_to_be_cancelled.state},Cancelled",
+      "#{journey_to_be_rejected.id},#{journey_to_be_rejected.move_id},#{journey_to_be_rejected.state},Rejected",
+    ].join("\n")
+  end
+
+  let(:csv_path) do
+    file = Tempfile.new('csv')
+    file.write(csv)
+    file.close
+    file.path
+  end
+
+  let(:columns) do
+    {
+      journey_id: :journey_id,
+      move_id: :move_id,
+      old_state: :old_state,
+      new_state: :new_state,
+    }
+  end
+
+  before do
+    create(:event_journey_complete, eventable: journey_to_be_completed)
+    create(:event_journey_cancel, eventable: journey_to_be_cancelled)
+    create(:event_journey_reject, eventable: journey_to_be_rejected)
+  end
+
+  describe '#call' do
+    subject(:results) { described_class.call(csv_path: csv_path, columns: columns) }
+
+    it 'imports all rows' do
+      expect(results.total).to eq(6)
+    end
+
+    it 'records failures' do
+      expect(results.failures).to match_array([
+        { journey_id: journey_without_event.id, move_id: journey_without_event.move_id, old_state: 'rejected', new_state: 'completed', reason: 'Could not find journey.' },
+        { journey_id: 'abc', move_id: 'abc', old_state: 'abc', new_state: 'abc', reason: 'Could not find journey.' },
+        { journey_id: journey_without_event.id, move_id: journey_without_event.move_id, old_state: journey_without_event.state, new_state: 'completed', reason: 'Could not find associated event.' },
+      ])
+    end
+
+    it 'records successes' do
+      expect(results.successes).to match_array([
+        { journey_id: journey_to_be_completed.id, move_id: journey_to_be_completed.move_id, old_state: journey_to_be_completed.state, new_state: 'completed' },
+        { journey_id: journey_to_be_cancelled.id, move_id: journey_to_be_cancelled.move_id, old_state: journey_to_be_cancelled.state, new_state: 'cancelled' },
+        { journey_id: journey_to_be_rejected.id, move_id: journey_to_be_rejected.move_id, old_state: journey_to_be_rejected.state, new_state: 'rejected' },
+      ])
+    end
+
+    it 'sets new state on successful journeys' do
+      results # to execute import
+
+      expect(journey_to_be_completed.reload.completed?).to be(true)
+      expect(journey_to_be_cancelled.reload.cancelled?).to be(true)
+      expect(journey_to_be_rejected.reload.rejected?).to be(true)
+    end
+  end
+end

--- a/spec/lib/tasks/imports/journeys_without_ending_state_spec.rb
+++ b/spec/lib/tasks/imports/journeys_without_ending_state_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Rake::Task['import:journeys_without_ending_state:serco'] do
+  let(:results) { instance_double('Imports::Results') }
+
+  before do
+    allow(results).to receive(:summary).and_return('Summary')
+    allow(Imports::JourneysWithoutEndingState).to receive(:call).and_return(results)
+    described_class.reenable
+  end
+
+  it 'calls the importer with the right parameters' do
+    expect(Imports::JourneysWithoutEndingState).to receive(:call).with(
+      csv_path: 'data.csv',
+      columns: {
+        journey_id: :basm_id,
+        move_id: :basm_moveid,
+        old_state: :basm_state,
+        new_state: :sers_status,
+      },
+    )
+
+    expect { described_class.invoke('data.csv') }
+      .to output('Summary').to_stdout
+  end
+end


### PR DESCRIPTION
This updates the status of journeys to the one specified in the spreadsheet. This is designed to fix the state of journeys which have an event but the incorrect associated journey status.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3300)