### PR TITLE
Import journeys missing ending events

### DIFF
--- a/app/lib/imports/missing_journey_ending_events.rb
+++ b/app/lib/imports/missing_journey_ending_events.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+class Imports::MissingJourneyEndingEvents
+  include Eventable
+
+  def self.call(...)
+    new(...).call
+  end
+
+  def initialize(csv_path:, columns:)
+    @csv_path = csv_path
+    @column_mapper = Imports::ColumnMapper.new(columns)
+    @current_move = nil
+  end
+
+  private_class_method :new
+
+  def call
+    results
+  end
+
+private
+
+  attr_reader :csv_path, :column_mapper
+
+  ALLOWED_JOURNEY_STATES = %w[Completed Cancelled].freeze
+
+  def results
+    @results ||= records.each_with_object(Imports::Results.new) do |record, results|
+      unless ALLOWED_JOURNEY_STATES.include?(record[:new_state])
+        results.record_failure(record, reason: 'New state not allowed.')
+        next
+      end
+
+      journey = Journey.find_by(id: record[:journey_id], move_id: record[:move_id], state: 'in_progress')
+      if journey.nil?
+        results.record_failure(record, reason: 'Could not find journey.')
+        next
+      end
+
+      @current_journey = journey
+
+      process_event(journey, event_name(state: record[:new_state]), {
+        attributes: {
+          timestamp: record[:event_timestamp],
+        },
+      })
+
+      @current_journey = nil
+
+      results.save(journey, record)
+    end
+  end
+
+  def records
+    @records ||= column_mapper.map(CSV.table(csv_path))
+  end
+
+  def event_name(state:)
+    case state
+    when 'Cancelled'
+      GenericEvent::JourneyCancel
+    when 'Rejected'
+      GenericEvent::JourneyReject
+    when 'Completed'
+      GenericEvent::JourneyComplete
+    end
+  end
+
+  def doorkeeper_application_owner
+    @current_journey&.supplier
+  end
+
+  def created_by
+    doorkeeper_application_owner&.name
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -30,6 +30,21 @@ namespace :import do
     end
   end
 
+  namespace :missing_journey_ending_events do
+    desc "Import events for journeys which are missing an ending event using Serco's spreadsheets."
+    task :serco, [:csv_path] => :environment do |_, args|
+      csv_path = args.fetch(:csv_path)
+      columns = {
+        journey_id: :basm_id,
+        move_id: :basm_moveid,
+        new_state: :sers_status,
+        event_timestamp: :basm_client_timestamp,
+      }
+
+      print Imports::MissingJourneyEndingEvents.call(csv_path: csv_path, columns: columns).summary
+    end
+  end
+
   namespace :missing_move_ending_events do
     desc "Import events for moves which are missing an ending event using Serco's spreadsheets."
     task :serco, [:csv_path] => :environment do |_, args|

--- a/spec/lib/imports/missing_journey_ending_events_spec.rb
+++ b/spec/lib/imports/missing_journey_ending_events_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Imports::MissingJourneyEndingEvents do
+  let(:completed_journey) { create(:journey, :in_progress) }
+  let(:cancelled_journey) { create(:journey, :in_progress) }
+
+  let(:csv) do
+    [
+      'journey_id,move_id,new_state,event_timestamp',
+      'abc,abc,Rejected,2020-01-01',
+      'abc,abc,Completed,2020-01-01',
+      "#{completed_journey.id},#{completed_journey.move_id},Completed,2020-01-01",
+      "#{cancelled_journey.id},#{cancelled_journey.move_id},Cancelled,2020-01-01",
+    ].join("\n")
+  end
+
+  let(:csv_path) do
+    file = Tempfile.new('csv')
+    file.write(csv)
+    file.close
+    file.path
+  end
+
+  let(:columns) do
+    {
+      journey_id: :journey_id,
+      move_id: :move_id,
+      new_state: :new_state,
+      event_timestamp: :event_timestamp,
+    }
+  end
+
+  describe '#call' do
+    subject(:results) { described_class.call(csv_path: csv_path, columns: columns) }
+
+    it 'imports all rows' do
+      expect(results.total).to eq(4)
+    end
+
+    it 'records failures' do
+      expect(results.failures).to match_array([
+        { journey_id: 'abc', move_id: 'abc', new_state: 'Rejected', event_timestamp: '2020-01-01', reason: 'New state not allowed.' },
+        { journey_id: 'abc', move_id: 'abc', new_state: 'Completed', event_timestamp: '2020-01-01', reason: 'Could not find journey.' },
+      ])
+    end
+
+    it 'records successes' do
+      expect(results.successes).to match_array([
+        { journey_id: completed_journey.id, move_id: completed_journey.move_id, new_state: 'Completed', event_timestamp: '2020-01-01' },
+        { journey_id: cancelled_journey.id, move_id: cancelled_journey.move_id, new_state: 'Cancelled', event_timestamp: '2020-01-01' },
+      ])
+    end
+
+    describe 'events' do
+      before { results } # to execute import
+
+      let(:complete_event) { GenericEvent::JourneyComplete.first }
+      let(:cancel_event) { GenericEvent::JourneyCancel.first }
+
+      it 'records the events' do
+        expect(complete_event.eventable).to eq(completed_journey)
+        expect(cancel_event.eventable).to eq(cancelled_journey)
+      end
+
+      it 'records the timestamp' do
+        expect(complete_event.occurred_at).to eq(Date.new(2020, 1, 1))
+        expect(cancel_event.occurred_at).to eq(Date.new(2020, 1, 1))
+      end
+
+      it 'records the supplier on the events' do
+        expect(complete_event.supplier).to eq(completed_journey.supplier)
+        expect(cancel_event.supplier).to eq(cancelled_journey.supplier)
+      end
+    end
+
+    it 'updates the journey statuses' do
+      results # to execute import
+
+      expect(completed_journey.reload.state).to eq('completed')
+      expect(completed_journey.completed?).to be(true)
+
+      expect(cancelled_journey.reload.state).to eq('cancelled')
+      expect(cancelled_journey.cancelled?).to be(true)
+    end
+  end
+end

--- a/spec/lib/tasks/imports/missing_journey_ending_events_spec.rb
+++ b/spec/lib/tasks/imports/missing_journey_ending_events_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Rake::Task['import:missing_journey_ending_events:serco'] do
+  let(:results) { instance_double('Imports::Results') }
+
+  before do
+    allow(results).to receive(:summary).and_return('Summary')
+    allow(Imports::MissingJourneyEndingEvents).to receive(:call).and_return(results)
+    described_class.reenable
+  end
+
+  it 'calls the importer with the right parameters' do
+    expect(Imports::MissingJourneyEndingEvents).to receive(:call).with(
+      csv_path: 'data.csv',
+      columns: {
+        journey_id: :basm_id,
+        move_id: :basm_moveid,
+        new_state: :sers_status,
+        event_timestamp: :basm_client_timestamp,
+      },
+    )
+
+    expect { described_class.invoke('data.csv') }
+      .to output('Summary').to_stdout
+  end
+end


### PR DESCRIPTION
This adds a task for import journeys which don't have ending events. This is similar to the one for moves which don't have ending events.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3300)