### PR TITLE
Fix typo in column name

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -50,7 +50,7 @@ namespace :import do
     task :serco, [:csv_path] => :environment do |_, args|
       csv_path = args.fetch(:csv_path)
       columns = {
-        move_id: :journeyid,
+        journey_id: :journeyid,
         event_timestamp: :timeofjourneystartevent,
       }
 

--- a/spec/lib/tasks/imports/missing_journey_start_events_spec.rb
+++ b/spec/lib/tasks/imports/missing_journey_start_events_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Rake::Task['import:missing_journey_start_events:serco'] do
     expect(Imports::MissingJourneyStartEvents).to receive(:call).with(
       csv_path: 'data.csv',
       columns: {
-        move_id: :journeyid,
+        journey_id: :journeyid,
         event_timestamp: :timeofjourneystartevent,
       },
     )


### PR DESCRIPTION
This fixes a small typo in 053c6a6791273a645beca53108ab0c0e0f3e49f2 where the column name was incorrect.