### PR TITLE
Fix NameError in move inspector

### DIFF
--- a/app/services/diagnostics/move_inspector.rb
+++ b/app/services/diagnostics/move_inspector.rb
@@ -96,7 +96,7 @@ module Diagnostics
 
             # we need to take care that we don't display any personal details in the error report
             @output << if @include_person_details
-                         "  #{attribute.inspect}\t#{message}\t#{move.send(key)}\n"
+                         "  #{attribute.inspect}\t#{message}\t#{move.send(attribute)}\n"
                        else
                          "  #{attribute.inspect}\t#{message}\t-\n"
                        end
@@ -149,7 +149,7 @@ module Diagnostics
 
                 # we need to take care that we don't display any personal details in the error report
                 @output << if @include_person_details
-                             "  #{attribute.inspect}\t#{message}\t#{journey.send(key)}\n"
+                             "  #{attribute.inspect}\t#{message}\t#{journey.send(attribute)}\n"
                            else
                              "  #{attribute.inspect}\t#{message}\t-\n"
                            end


### PR DESCRIPTION
This was accidentally missed out in 895767b58efe2922c1c3fc221e25be880c5bf7ae and means that the diagnostics endpoint can return a 500 internal server error in certain cases.

The error in this case was something like:

```
NameError (undefined local variable or method `key' for #<Diagnostics::MoveInspector:0x00007fbf44dbbf18>)
```