### PR TITLE
Make importer ignore objects which aren't valid

### DIFF
--- a/app/lib/imports/journeys_missing_vehicle.rb
+++ b/app/lib/imports/journeys_missing_vehicle.rb
@@ -30,6 +30,8 @@ private
         next
       end
 
+      next unless results.ensure_valid(journey, record)
+
       journey.vehicle_registration = record[:vehicle_registration]
       results.save(journey, record)
     end

--- a/app/lib/imports/journeys_without_ending_state.rb
+++ b/app/lib/imports/journeys_without_ending_state.rb
@@ -35,6 +35,8 @@ private
         next
       end
 
+      next unless results.ensure_valid(journey, record)
+
       new_state = record[:new_state]
 
       event = find_event(journey, new_state)

--- a/app/lib/imports/missing_journey_ending_events.rb
+++ b/app/lib/imports/missing_journey_ending_events.rb
@@ -40,6 +40,8 @@ private
         next
       end
 
+      next unless results.ensure_valid(journey, record)
+
       @current_journey = journey
 
       process_event(journey, event_name(state: record[:new_state]), {

--- a/app/lib/imports/missing_journey_start_events.rb
+++ b/app/lib/imports/missing_journey_start_events.rb
@@ -33,6 +33,8 @@ private
         next
       end
 
+      next unless results.ensure_valid(journey, record)
+
       @current_journey = journey
 
       process_event(journey, GenericEvent::JourneyStart, {

--- a/app/lib/imports/missing_move_ending_events.rb
+++ b/app/lib/imports/missing_move_ending_events.rb
@@ -41,6 +41,8 @@ private
         next
       end
 
+      next unless results.ensure_valid(move, record)
+
       @current_move = move
 
       process_event(move, "GenericEvent::#{record[:event_type]}".constantize, {

--- a/app/lib/imports/missing_move_start_events.rb
+++ b/app/lib/imports/missing_move_start_events.rb
@@ -33,6 +33,8 @@ private
         next
       end
 
+      next unless results.ensure_valid(move, record)
+
       @current_move = move
 
       process_event(move, GenericEvent::MoveStart, {

--- a/app/lib/imports/moves_without_ending_state.rb
+++ b/app/lib/imports/moves_without_ending_state.rb
@@ -34,6 +34,8 @@ private
         next
       end
 
+      next unless results.ensure_valid(move, record)
+
       new_status = record[:new_status]
 
       event = find_event(move, new_status)

--- a/app/lib/imports/results.rb
+++ b/app/lib/imports/results.rb
@@ -28,6 +28,13 @@ class Imports::Results
     end
   end
 
+  def ensure_valid(obj, record)
+    return true if obj.valid?
+
+    record_failure(record, reason: 'Record is not valid.')
+    false
+  end
+
   def summary
     string = "Imported #{total} records with #{failures.count} failures.\n"
 

--- a/app/lib/imports/results.rb
+++ b/app/lib/imports/results.rb
@@ -21,8 +21,10 @@ class Imports::Results
   def save(obj, record)
     if obj.save
       record_success(record)
+      true
     else
       record_failure(record, reason: 'Could not save record.')
+      false
     end
   end
 

--- a/spec/lib/imports/results_spec.rb
+++ b/spec/lib/imports/results_spec.rb
@@ -42,8 +42,9 @@ RSpec.describe Imports::Results do
       before { allow(obj).to receive(:save).and_return(true) }
 
       it 'records a successful record' do
-        results.save(obj, record)
+        return_value = results.save(obj, record)
 
+        expect(return_value).to be(true)
         expect(results.successes).to match_array([record])
         expect(results.failures).to be_empty
       end
@@ -53,8 +54,9 @@ RSpec.describe Imports::Results do
       before { allow(obj).to receive(:save).and_return(false) }
 
       it 'records a failed record' do
-        results.save(obj, record)
+        return_value = results.save(obj, record)
 
+        expect(return_value).to be(false)
         expect(results.successes).to be_empty
         expect(results.failures).to match_array([record.merge(reason: 'Could not save record.')])
       end

--- a/spec/lib/imports/results_spec.rb
+++ b/spec/lib/imports/results_spec.rb
@@ -63,6 +63,35 @@ RSpec.describe Imports::Results do
     end
   end
 
+  describe '#ensure_valid' do
+    let(:obj) { double }
+    let(:record) { { id: 1 } }
+
+    context 'when object is valid' do
+      before { allow(obj).to receive(:valid?).and_return(true) }
+
+      it 'does not record a result' do
+        return_value = results.ensure_valid(obj, record)
+
+        expect(return_value).to be(true)
+        expect(results.successes).to be_empty
+        expect(results.failures).to be_empty
+      end
+    end
+
+    context 'when object is not valid' do
+      before { allow(obj).to receive(:valid?).and_return(false) }
+
+      it 'records a failed record' do
+        return_value = results.ensure_valid(obj, record)
+
+        expect(return_value).to be(false)
+        expect(results.successes).to be_empty
+        expect(results.failures).to match_array([record.merge(reason: 'Record is not valid.')])
+      end
+    end
+  end
+
   describe '#summary' do
     subject(:summary) { results.summary }
 


### PR DESCRIPTION
This updates the various importers to check objects are valid before attempting to update them. This avoids problems where an object might be invalid prior to the import and processing an event calls `save!` which raises an exception and terminates the entire import.

Example Sentry issue: https://sentry.io/organizations/ministryofjustice/issues/2794490913/?project=2014776&query=is%3Aunresolved