### PR TITLE
Add task for importing moves without a to location

### DIFF
--- a/app/lib/imports/moves_without_to_location.rb
+++ b/app/lib/imports/moves_without_to_location.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+class Imports::MovesWithoutToLocation
+  def self.call(...)
+    new(...).call
+  end
+
+  def initialize(csv_path:, columns:)
+    @csv_path = csv_path
+    @column_mapper = Imports::ColumnMapper.new({
+      move_id: columns.fetch(:move_id),
+      location_key: { source: columns.fetch(:location_key), downcase: true },
+    })
+  end
+
+  private_class_method :new
+
+  def call
+    results
+  end
+
+private
+
+  attr_reader :csv_path, :column_mapper
+
+  def results
+    @results ||= records.each_with_object(Imports::Results.new) do |record, results|
+      move = Move.find_by(id: record[:move_id])
+      if move.nil?
+        results.record_failure(record, reason: 'Could not find move.')
+        next
+      end
+
+      next unless results.ensure_valid(move, record)
+
+      location = Location.find_by(key: record[:location_key])
+      if location.nil?
+        results.record_failure(record, reason: 'Could not find location.')
+        next
+      end
+
+      move.to_location = location
+
+      results.save(move, record)
+    end
+  end
+
+  def records
+    @records ||= column_mapper.map(CSV.table(csv_path))
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -100,4 +100,17 @@ namespace :import do
       print Imports::MovesWithoutEndingState.call(csv_path: csv_path, columns: columns).summary
     end
   end
+
+  namespace :moves_without_to_location do
+    desc "Import moves which don't have a to location using Serco's spreadsheets."
+    task :serco, [:csv_path] => :environment do |_, args|
+      csv_path = args.fetch(:csv_path)
+      columns = {
+        move_id: :id,
+        location_key: :mojdestlocationcode,
+      }
+
+      print Imports::MovesWithoutToLocation.call(csv_path: csv_path, columns: columns).summary
+    end
+  end
 end

--- a/spec/lib/imports/moves_without_to_location_spec.rb
+++ b/spec/lib/imports/moves_without_to_location_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Imports::MovesWithoutToLocation do
+  let(:move) { create(:move, :prison_recall) }
+  let(:location) { create(:location) }
+
+  let(:csv) do
+    [
+      'move_id,location_key',
+      'abc,abc',
+      "#{move.id},abc",
+      "#{move.id},#{location.key}",
+    ].join("\n")
+  end
+
+  let(:csv_path) do
+    file = Tempfile.new('csv')
+    file.write(csv)
+    file.close
+    file.path
+  end
+
+  let(:columns) do
+    {
+      move_id: :move_id,
+      location_key: :location_key,
+    }
+  end
+
+  describe '#call' do
+    subject(:results) { described_class.call(csv_path: csv_path, columns: columns) }
+
+    it 'imports all rows' do
+      expect(results.total).to eq(3)
+    end
+
+    it 'records failures' do
+      expect(results.failures).to match_array([
+        { move_id: 'abc', location_key: 'abc', reason: 'Could not find move.' },
+        { move_id: move.id, location_key: 'abc', reason: 'Could not find location.' },
+      ])
+    end
+
+    it 'records successes' do
+      expect(results.successes).to match_array([
+        { move_id: move.id, location_key: location.key },
+      ])
+    end
+
+    it 'sets new status on successful moves' do
+      results # to execute import
+
+      expect(move.reload.to_location).to eq(location)
+    end
+  end
+end

--- a/spec/lib/tasks/imports/moves_without_to_location_spec.rb
+++ b/spec/lib/tasks/imports/moves_without_to_location_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Rake::Task['import:moves_without_to_location:serco'] do
+  let(:results) { instance_double('Imports::Results') }
+
+  before do
+    allow(results).to receive(:summary).and_return('Summary')
+    allow(Imports::MovesWithoutToLocation).to receive(:call).and_return(results)
+    described_class.reenable
+  end
+
+  it 'calls the importer with the right parameters' do
+    expect(Imports::MovesWithoutToLocation).to receive(:call).with(
+      csv_path: 'data.csv',
+      columns: {
+        move_id: :id,
+        location_key: :mojdestlocationcode,
+      },
+    )
+
+    expect { described_class.invoke('data.csv') }
+      .to output('Summary').to_stdout
+  end
+end


### PR DESCRIPTION
This adds a task for importing and fixing moves which are missing a `to_location` value.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3364)