### PR TITLE
Ensure moves and journeys locations are different

### DIFF
--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -51,6 +51,7 @@ class Journey < ApplicationRecord
   validates :supplier, presence: true
   validates :from_location, presence: true
   validates :to_location, presence: true
+  validates_with DifferentToFromLocationValidator
   validates :client_timestamp, presence: true
   validates :billable, exclusion: { in: [nil] }
   validates :state, presence: true, inclusion: { in: states }

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -95,6 +95,8 @@ class Move < VersionedModel
 
   validates :from_location, presence: true
   validates :to_location, presence: true, unless: -> { prison_recall? || video_remand? }
+  validates_with DifferentToFromLocationValidator
+
   validates :move_type, inclusion: { in: move_types }
   validates_with Moves::MoveTypeValidator
 

--- a/app/validators/different_to_from_location_validator.rb
+++ b/app/validators/different_to_from_location_validator.rb
@@ -1,0 +1,9 @@
+class DifferentToFromLocationValidator < ActiveModel::Validator
+  def validate(record)
+    return if record.to_location_id.blank?
+    return if record.from_location_id.blank?
+    return if record.to_location_id != record.from_location_id
+
+    record.errors.add(:to_location_id, 'should be different to the from location')
+  end
+end

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe Journey, type: :model do
     end
   end
 
+  context 'when the from_location and to_location are the same' do
+    subject(:journey) { build(:journey, to_location: location, from_location: location) }
+
+    let(:location) { create(:location) }
+
+    it 'is not valid' do
+      expect(journey).not_to be_valid
+      expect(journey.errors[:to_location_id]).to eq(['should be different to the from location'])
+    end
+  end
+
   shared_examples 'model is synchronised with state_machine' do |expected_state|
     describe 'machine state' do
       it { expect(state_machine_state).to eql expected_state.to_sym }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -175,6 +175,17 @@ RSpec.describe Move do
     expect(build(:move, date_from: '2020-03-04', date_to: '2020-03-04')).to be_valid
   end
 
+  context 'when the from_location and to_location are the same' do
+    subject(:move) { build(:move, to_location: location, from_location: location) }
+
+    let(:location) { create(:location) }
+
+    it 'is not valid' do
+      expect(move).not_to be_valid
+      expect(move.errors[:to_location_id]).to eq(['should be different to the from location'])
+    end
+  end
+
   context 'when the profile has a prisoner category' do
     it 'prevents an unsupported category from being moved' do
       expect(build(:move, profile: build(:profile, :category_not_supported))).not_to be_valid


### PR DESCRIPTION
This adds validation on moves and journeys to ensure that the `from_location` and `to_location` fields are different. It shouldn't be valid for a move to have the same source/destination location.

We may need to hold off on deploying this until both of our suppliers are aware and comfortable of the validation.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3363)