### PR TITLE
Add cancellation reason for database corrections

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -64,6 +64,7 @@ class Move < VersionedModel
     CANCELLATION_REASON_SUPPLIER_DECLINED_TO_MOVE = 'supplier_declined_to_move',
     CANCELLATION_REASON_CANCELLED_BY_PMU = 'cancelled_by_pmu',
     CANCELLATION_REASON_REJECTED = 'rejected',
+    CANCELLATION_REASON_DATABASE_CORRECTION = 'database_correction',
     CANCELLATION_REASON_OTHER = 'other',
   ].freeze
 


### PR DESCRIPTION
We need to manually fix the data on moves which were left uncancelled, however if the supplier has lost information such as the cancellation reason we need to pick one. Rather than using `other`, we can be explicit and say that we don't know the correct cancellation reason and that the data is not 100% accurate.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3400)