### PR TITLE
Expand scope of supplier locations endpoint

### DIFF
--- a/app/controllers/api/suppliers_controller.rb
+++ b/app/controllers/api/suppliers_controller.rb
@@ -11,9 +11,12 @@ module Api
     def locations_from_supplier_moves
       supplier = Supplier.find(params[:supplier_id])
 
-      Location.joins(:moves_from)
-              .includes(:suppliers)
-              .where(moves: { supplier_id: supplier.id })
+      ids_from_moves = supplier.moves.select(:from_location_id)
+      ids_from_supplier_locations = supplier.supplier_locations.effective_on(Time.zone.today).select(:location_id)
+
+      Location.includes(:suppliers)
+              .where(id: ids_from_moves)
+              .or(Location.where(id: ids_from_supplier_locations))
               .order(key: :asc)
               .distinct
     end

--- a/spec/requests/api/suppliers_controller_locations_spec.rb
+++ b/spec/requests/api/suppliers_controller_locations_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Api::SuppliersController do
     let(:location_a) { create(:location, suppliers: [supplier], key: 'key_aaa') }
     let(:location_b) { create(:location, suppliers: [supplier], key: 'key_bbb') }
 
+    before { create(:location, suppliers: [supplier], key: 'key_ccc') }
+
     it_behaves_like 'an endpoint that responds with success 200' do
       before do
         create(:move, :requested, supplier: supplier)
@@ -36,7 +38,7 @@ RSpec.describe Api::SuppliersController do
                                  .select { |e| e['type'] == 'locations' }
                                  .map { |l| l['attributes']['key'] }
 
-      expect(response_location_keys).to eq(%w[key_aaa key_bbb])
+      expect(response_location_keys).to eq(%w[key_aaa key_bbb key_ccc])
     end
 
     context 'when other locations are present' do
@@ -52,7 +54,7 @@ RSpec.describe Api::SuppliersController do
                                      .select { |e| e['type'] == 'locations' }
                                      .map { |l| l['attributes']['key'] }
 
-        expect(response_location_keys).to eq(%w[key_aaa])
+        expect(response_location_keys).to eq(%w[key_aaa key_ccc])
       end
     end
   end


### PR DESCRIPTION
Currently, this endpoint only returns locations for a supplier if there's a move booked from that location for the associated supplier. This means when new locations are added and assigned to a supplier, it won't be included in this endpoint until a move has been booked from it.

We'd like to expand the scope of this so we have this existing behaviour, plus we return any locations where moves may (in the future) be booked from, allowing the suppliers to be aware of all possible locations. In particular, this helps our supplier users (for example contract delivery managers) see all the locations in the system.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3389)