### PR TITLE
Allow importing journeys to be rejected

### DIFF
--- a/app/lib/imports/missing_journey_ending_events.rb
+++ b/app/lib/imports/missing_journey_ending_events.rb
@@ -25,16 +25,17 @@ private
 
   attr_reader :csv_path, :column_mapper
 
-  ALLOWED_JOURNEY_STATES = %w[Completed Cancelled].freeze
+  ALLOWED_EXISTING_JOURNEY_STATES = %w[proposed in_progress].freeze
+  ALLOWED_NEW_JOURNEY_STATES = %w[Completed Cancelled Rejected].freeze
 
   def results
     @results ||= records.each_with_object(Imports::Results.new) do |record, results|
-      unless ALLOWED_JOURNEY_STATES.include?(record[:new_state])
+      unless ALLOWED_NEW_JOURNEY_STATES.include?(record[:new_state])
         results.record_failure(record, reason: 'New state not allowed.')
         next
       end
 
-      journey = Journey.find_by(id: record[:journey_id], move_id: record[:move_id], state: 'in_progress')
+      journey = Journey.find_by(id: record[:journey_id], move_id: record[:move_id], state: ALLOWED_EXISTING_JOURNEY_STATES)
       if journey.nil?
         results.record_failure(record, reason: 'Could not find journey.')
         next

--- a/spec/lib/imports/missing_journey_ending_events_spec.rb
+++ b/spec/lib/imports/missing_journey_ending_events_spec.rb
@@ -5,14 +5,16 @@ require 'rails_helper'
 RSpec.describe Imports::MissingJourneyEndingEvents do
   let(:completed_journey) { create(:journey, :in_progress) }
   let(:cancelled_journey) { create(:journey, :in_progress) }
+  let(:rejected_journey) { create(:journey, :proposed) }
 
   let(:csv) do
     [
       'journey_id,move_id,new_state,event_timestamp',
-      'abc,abc,Rejected,2020-01-01',
+      'abc,abc,Unknown,2020-01-01',
       'abc,abc,Completed,2020-01-01',
       "#{completed_journey.id},#{completed_journey.move_id},Completed,2020-01-01",
       "#{cancelled_journey.id},#{cancelled_journey.move_id},Cancelled,2020-01-01",
+      "#{rejected_journey.id},#{rejected_journey.move_id},Rejected,2020-01-01",
     ].join("\n")
   end
 
@@ -36,12 +38,12 @@ RSpec.describe Imports::MissingJourneyEndingEvents do
     subject(:results) { described_class.call(csv_path: csv_path, columns: columns) }
 
     it 'imports all rows' do
-      expect(results.total).to eq(4)
+      expect(results.total).to eq(5)
     end
 
     it 'records failures' do
       expect(results.failures).to match_array([
-        { journey_id: 'abc', move_id: 'abc', new_state: 'Rejected', event_timestamp: '2020-01-01', reason: 'New state not allowed.' },
+        { journey_id: 'abc', move_id: 'abc', new_state: 'Unknown', event_timestamp: '2020-01-01', reason: 'New state not allowed.' },
         { journey_id: 'abc', move_id: 'abc', new_state: 'Completed', event_timestamp: '2020-01-01', reason: 'Could not find journey.' },
       ])
     end
@@ -50,6 +52,7 @@ RSpec.describe Imports::MissingJourneyEndingEvents do
       expect(results.successes).to match_array([
         { journey_id: completed_journey.id, move_id: completed_journey.move_id, new_state: 'Completed', event_timestamp: '2020-01-01' },
         { journey_id: cancelled_journey.id, move_id: cancelled_journey.move_id, new_state: 'Cancelled', event_timestamp: '2020-01-01' },
+        { journey_id: rejected_journey.id, move_id: rejected_journey.move_id, new_state: 'Rejected', event_timestamp: '2020-01-01' },
       ])
     end
 
@@ -58,20 +61,24 @@ RSpec.describe Imports::MissingJourneyEndingEvents do
 
       let(:complete_event) { GenericEvent::JourneyComplete.first }
       let(:cancel_event) { GenericEvent::JourneyCancel.first }
+      let(:reject_event) { GenericEvent::JourneyReject.first }
 
       it 'records the events' do
         expect(complete_event.eventable).to eq(completed_journey)
         expect(cancel_event.eventable).to eq(cancelled_journey)
+        expect(reject_event.eventable).to eq(rejected_journey)
       end
 
       it 'records the timestamp' do
         expect(complete_event.occurred_at).to eq(Date.new(2020, 1, 1))
         expect(cancel_event.occurred_at).to eq(Date.new(2020, 1, 1))
+        expect(reject_event.occurred_at).to eq(Date.new(2020, 1, 1))
       end
 
       it 'records the supplier on the events' do
         expect(complete_event.supplier).to eq(completed_journey.supplier)
         expect(cancel_event.supplier).to eq(cancelled_journey.supplier)
+        expect(reject_event.supplier).to eq(rejected_journey.supplier)
       end
     end
 
@@ -83,6 +90,9 @@ RSpec.describe Imports::MissingJourneyEndingEvents do
 
       expect(cancelled_journey.reload.state).to eq('cancelled')
       expect(cancelled_journey.cancelled?).to be(true)
+
+      expect(rejected_journey.reload.state).to eq('rejected')
+      expect(rejected_journey.rejected?).to be(true)
     end
   end
 end


### PR DESCRIPTION
Currently we can only import journeys which are then to be completed or cancelled. This change allows us to import journeys which are proposed and to be rejected.