### PR TITLE
Import journeys which should be cancelled or rejected

### DIFF
--- a/app/lib/imports/cancel_or_reject_journeys.rb
+++ b/app/lib/imports/cancel_or_reject_journeys.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+class Imports::CancelOrRejectJourneys
+  include Eventable
+
+  def self.call(...)
+    new(...).call
+  end
+
+  def initialize(csv_path:, columns:)
+    @csv_path = csv_path
+    @column_mapper = Imports::ColumnMapper.new(columns)
+    @current_move = nil
+  end
+
+  private_class_method :new
+
+  def call
+    results
+  end
+
+private
+
+  attr_reader :csv_path, :column_mapper
+
+  def results
+    @results ||= records.each_with_object(Imports::Results.new) do |record, results|
+      journey = Journey.find_by(id: record[:journey_id], move_id: record[:move_id])
+      if journey.nil?
+        results.record_failure(record, reason: 'Could not find journey.')
+        next
+      end
+
+      next unless results.ensure_valid(journey, record)
+
+      @current_journey = journey
+
+      event_sti_classes_for(state: journey.state).each do |event_sti_class|
+        process_event(journey, event_sti_class, {
+          attributes: {
+            timestamp: record[:event_timestamp],
+          },
+        })
+      end
+
+      @current_journey = nil
+
+      results.save(journey, record)
+    end
+  end
+
+  def records
+    @records ||= column_mapper.map(CSV.table(csv_path))
+  end
+
+  def event_sti_classes_for(state:)
+    case state
+    when 'proposed'
+      [GenericEvent::JourneyReject]
+    when 'in_progress'
+      [GenericEvent::JourneyCancel]
+    when 'completed'
+      [GenericEvent::JourneyUncomplete, GenericEvent::JourneyCancel]
+    else  # cancelled or rejected, nothing to do
+      []
+    end
+  end
+
+  def doorkeeper_application_owner
+    @current_journey&.supplier
+  end
+
+  def created_by
+    doorkeeper_application_owner&.name
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
 namespace :import do
+  namespace :cancel_or_reject_journeys do
+    desc "Cancels or rejects journeys using Serco's spreadsheets."
+    task :serco, [:csv_path] => :environment do |_, args|
+      csv_path = args.fetch(:csv_path)
+      columns = {
+        journey_id: :id,
+        move_id: :move_id,
+        event_timestamp: :timeofendingevent,
+      }
+
+      print Imports::CancelOrRejectJourneys.call(csv_path: csv_path, columns: columns).summary
+    end
+  end
+
   namespace :delete_events do
     desc "Deletes events which are invalid a vehicle using Serco's spreadsheets."
     task :serco, [:csv_path] => :environment do |_, args|

--- a/spec/lib/imports/cancel_or_reject_journeys_spec.rb
+++ b/spec/lib/imports/cancel_or_reject_journeys_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Imports::CancelOrRejectJourneys do
+  let(:completed_journey) { create(:journey, :completed) }
+  let(:cancelled_journey) { create(:journey, :cancelled) }
+  let(:rejected_journey) { create(:journey, :rejected) }
+  let(:in_progress_journey) { create(:journey, :in_progress) }
+  let(:proposed_journey) { create(:journey, :proposed) }
+
+  let(:csv) do
+    [
+      'journey_id,move_id,event_timestamp',
+      'abc,abc,2020-01-01',
+      "#{completed_journey.id},#{completed_journey.move_id},2020-01-01",
+      "#{cancelled_journey.id},#{cancelled_journey.move_id},2020-01-01",
+      "#{rejected_journey.id},#{rejected_journey.move_id},2020-01-01",
+      "#{in_progress_journey.id},#{in_progress_journey.move_id},2020-01-01",
+      "#{proposed_journey.id},#{proposed_journey.move_id},2020-01-01",
+    ].join("\n")
+  end
+
+  let(:csv_path) do
+    file = Tempfile.new('csv')
+    file.write(csv)
+    file.close
+    file.path
+  end
+
+  let(:columns) do
+    {
+      journey_id: :journey_id,
+      move_id: :move_id,
+      event_timestamp: :event_timestamp,
+    }
+  end
+
+  describe '#call' do
+    subject(:results) { described_class.call(csv_path: csv_path, columns: columns) }
+
+    it 'imports all rows' do
+      expect(results.total).to eq(6)
+    end
+
+    it 'records failures' do
+      expect(results.failures).to match_array([
+        { journey_id: 'abc', move_id: 'abc', event_timestamp: '2020-01-01', reason: 'Could not find journey.' },
+      ])
+    end
+
+    it 'records successes' do
+      expect(results.successes).to match_array([
+        { journey_id: completed_journey.id, move_id: completed_journey.move_id, event_timestamp: '2020-01-01' },
+        { journey_id: cancelled_journey.id, move_id: cancelled_journey.move_id, event_timestamp: '2020-01-01' },
+        { journey_id: rejected_journey.id, move_id: rejected_journey.move_id, event_timestamp: '2020-01-01' },
+        { journey_id: in_progress_journey.id, move_id: in_progress_journey.move_id, event_timestamp: '2020-01-01' },
+        { journey_id: proposed_journey.id, move_id: proposed_journey.move_id, event_timestamp: '2020-01-01' },
+      ])
+    end
+
+    describe 'events' do
+      before { results } # to execute import
+
+      it 'uncompletes and cancels completed journeys' do
+        expect(completed_journey.generic_events.map(&:class)).to match_array([
+          GenericEvent::JourneyUncomplete,
+          GenericEvent::JourneyCancel,
+        ])
+      end
+
+      it 'leaves cancelled journeys' do
+        expect(cancelled_journey.generic_events).to be_empty
+      end
+
+      it 'leaves rejected journeys' do
+        expect(rejected_journey.generic_events).to be_empty
+      end
+
+      it 'cancels in progress journeys' do
+        expect(in_progress_journey.generic_events.map(&:class)).to match_array([
+          GenericEvent::JourneyCancel,
+        ])
+      end
+
+      it 'rejects proposed journeys' do
+        expect(proposed_journey.generic_events.map(&:class)).to match_array([
+          GenericEvent::JourneyReject,
+        ])
+      end
+    end
+
+    it 'updates the journey statuses' do
+      results # to execute import
+
+      expect(completed_journey.reload.cancelled?).to be(true)
+      expect(cancelled_journey.reload.cancelled?).to be(true)
+      expect(rejected_journey.reload.rejected?).to be(true)
+      expect(in_progress_journey.reload.cancelled?).to be(true)
+      expect(proposed_journey.reload.rejected?).to be(true)
+    end
+  end
+end

--- a/spec/lib/tasks/imports/cancel_or_reject_journeys_spec.rb
+++ b/spec/lib/tasks/imports/cancel_or_reject_journeys_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Rake::Task['import:cancel_or_reject_journeys:serco'] do
+  let(:results) { instance_double('Imports::Results') }
+
+  before do
+    allow(results).to receive(:summary).and_return('Summary')
+    allow(Imports::CancelOrRejectJourneys).to receive(:call).and_return(results)
+    described_class.reenable
+  end
+
+  it 'calls the importer with the right parameters' do
+    expect(Imports::CancelOrRejectJourneys).to receive(:call).with(
+      csv_path: 'data.csv',
+      columns: {
+        journey_id: :id,
+        move_id: :move_id,
+        event_timestamp: :timeofendingevent,
+      },
+    )
+
+    expect { described_class.invoke('data.csv') }
+      .to output('Summary').to_stdout
+  end
+end


### PR DESCRIPTION
This adds a new import task for cancelling or rejecting journeys which are duplicates and therefore shouldn't really exist. We don't want to delete the journeys as it may affect payments.