### PR TITLE
Revert "Expand scope of supplier locations endpoint"

### DIFF
--- a/app/controllers/api/suppliers_controller.rb
+++ b/app/controllers/api/suppliers_controller.rb
@@ -11,12 +11,9 @@ module Api
     def locations_from_supplier_moves
       supplier = Supplier.find(params[:supplier_id])
 
-      ids_from_moves = supplier.moves.select(:from_location_id)
-      ids_from_supplier_locations = supplier.supplier_locations.effective_on(Time.zone.today).select(:location_id)
-
-      Location.includes(:suppliers)
-              .where(id: ids_from_moves)
-              .or(Location.where(id: ids_from_supplier_locations))
+      Location.joins(:moves_from)
+              .includes(:suppliers)
+              .where(moves: { supplier_id: supplier.id })
               .order(key: :asc)
               .distinct
     end

--- a/spec/requests/api/suppliers_controller_locations_spec.rb
+++ b/spec/requests/api/suppliers_controller_locations_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe Api::SuppliersController do
     let(:location_a) { create(:location, suppliers: [supplier], key: 'key_aaa') }
     let(:location_b) { create(:location, suppliers: [supplier], key: 'key_bbb') }
 
-    before { create(:location, suppliers: [supplier], key: 'key_ccc') }
-
     it_behaves_like 'an endpoint that responds with success 200' do
       before do
         create(:move, :requested, supplier: supplier)
@@ -38,7 +36,7 @@ RSpec.describe Api::SuppliersController do
                                  .select { |e| e['type'] == 'locations' }
                                  .map { |l| l['attributes']['key'] }
 
-      expect(response_location_keys).to eq(%w[key_aaa key_bbb key_ccc])
+      expect(response_location_keys).to eq(%w[key_aaa key_bbb])
     end
 
     context 'when other locations are present' do
@@ -54,7 +52,7 @@ RSpec.describe Api::SuppliersController do
                                      .select { |e| e['type'] == 'locations' }
                                      .map { |l| l['attributes']['key'] }
 
-        expect(response_location_keys).to eq(%w[key_aaa key_ccc])
+        expect(response_location_keys).to eq(%w[key_aaa])
       end
     end
   end


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-api#1687

This seems to make the endpoint much slower and prevents some uses from being able to choose a location: https://sentry.io/organizations/ministryofjustice/issues/2926771799/?project=2014813&referrer=regression-activity-email