### PR TITLE
Add basic validation on prison numbers

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -35,6 +35,7 @@ class Person < VersionedModel
 
   validates :last_name, presence: true
   validates :first_names, presence: true
+  validates :prison_number, prison_number: true
   validate :validate_age
 
   auto_strip_attributes :nomis_prison_number, :prison_number, :criminal_records_office, :police_national_computer

--- a/app/validators/prison_number_validator.rb
+++ b/app/validators/prison_number_validator.rb
@@ -1,0 +1,9 @@
+class PrisonNumberValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    if value.include?(':')
+      record.errors.add(attribute, options[:message] || 'is not a valid prison number')
+    end
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe Person do
       person = create(:person, prison_number: '')
       expect(person.reload.prison_number).to be_nil
     end
+
+    it 'validates the format' do
+      person = build(:person, prison_number: 'in:valid')
+      expect(person).not_to be_valid
+      expect(person.errors.messages[:prison_number]).to include('is not a valid prison number')
+    end
   end
 
   # TODO: Remove nomis_prison_number once we remove v1 from our system


### PR DESCRIPTION
This adds some basic validation to ensure they don't contain a colon character to prevent an exception happening when communicating with NOMIS.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-2127)