### PR TITLE
Allow suppliers to manage moves of other suppliers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     govuk_notify_rails (2.2.0)
       notifications-ruby-client (~> 5.1)
       rails (>= 4.1.0)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     jmespath (1.5.0)
     json-schema (2.8.1)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,15 +7,14 @@ class Ability
     return unless application # no permissions
 
     if application.owner
-      # owner is a supplier, suppliers can manage only their own locations
-      # Note: the permission :manage represents any action on object - See https://github.com/CanCanCommunity/cancancan/wiki/defining-abilities
-      can :manage, Move, Move.where(supplier: application.owner) do |move|
-        move.supplier == application.owner
+      can :manage, Move, Move.for_supplier(application.owner) do |move|
+        move.supplier == application.owner ||
+          move.from_location&.suppliers&.include?(application.owner) ||
+          move.to_location&.suppliers&.include?(application.owner)
       end
+
       can :manage, Journey, supplier_id: application.owner_id
     else
-      # temporarily give all permissions to non-supplier accounts so as not to break compatibility with
-      # the frontend application
       can :manage, Move
       can :manage, Journey
     end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -135,6 +135,12 @@ class Move < VersionedModel
            :cancelled?,
            to: :state_machine
 
+  def self.for_supplier(supplier)
+    where(supplier: supplier)
+      .or(Move.where(from_location: supplier.locations))
+      .or(Move.where(to_location: supplier.locations))
+  end
+
   def approve(date:)
     assign_attributes(date: date) if date.present?
     state_machine.approve

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -20,6 +20,38 @@ RSpec.describe Ability, type: :model do
     it { is_expected.not_to be_able_to(:manage, Move.new(supplier: another_supplier)) }
   end
 
+  context 'when application is owned by cross-supplier move' do
+    let(:supplier_a) { create :supplier }
+    let(:supplier_b) { create :supplier }
+    let(:move) do
+      location_a = create(:location, suppliers: [supplier_a])
+      location_b = create(:location, suppliers: [supplier_b])
+      create(:move, from_location: location_a, to_location: location_b)
+    end
+
+    shared_examples 'move is accessible' do
+      let(:application) { Doorkeeper::Application.create(name: 'test', owner: supplier) }
+
+      it { is_expected.to be_able_to(:manage, move) }
+
+      it 'finds the move when queried' do
+        expect(Move.accessible_by(ability)).to eq([move])
+      end
+    end
+
+    context 'and as supplier A' do
+      let(:supplier) { supplier_a }
+
+      include_examples 'move is accessible'
+    end
+
+    context 'and as supplier B' do
+      let(:supplier) { supplier_b }
+
+      include_examples 'move is accessible'
+    end
+  end
+
   context 'when application is owned by frontend application' do
     let(:application) { Doorkeeper::Application.create(name: 'test') }
 

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -235,6 +235,23 @@ RSpec.describe Move do
     it { is_expected.to validate_presence_of(:reference) }
   end
 
+  describe '#for_supplier' do
+    subject(:moves) { described_class.for_supplier(supplier) }
+
+    let(:supplier) { create(:supplier) }
+    let(:location) { create(:location, suppliers: [supplier]) }
+
+    let(:move1) { create(:move, supplier: supplier) }
+    let(:move2) { create(:move, to_location: location) }
+    let(:move3) { create(:move, from_location: location) }
+    let(:move4) { create(:move) }
+
+    it { is_expected.to include(move1) }
+    it { is_expected.to include(move2) }
+    it { is_expected.to include(move3) }
+    it { is_expected.not_to include(move4) }
+  end
+
   describe '#reference' do
     subject(:move) { described_class.new }
 


### PR DESCRIPTION
This is only allows if the move is between locations owned by different suppliers. For example, if location A is managed by supplier A and location B is managed by supplier B, and there is a move booked which goes between location A and B, both suppliers should have permission to manage this move.

This functionality allows us to support "supplier to supplier" moves where the person is handed over to a different supplier during the course of the move.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3436)