### PR TITLE
Add indexes for some location fields

### DIFF
--- a/db/migrate/20220125102025_add_indexes_to_locations.rb
+++ b/db/migrate/20220125102025_add_indexes_to_locations.rb
@@ -1,0 +1,8 @@
+class AddIndexesToLocations < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :locations, :location_type, algorithm: :concurrently
+    add_index :locations, :nomis_agency_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_08_080712) do
+ActiveRecord::Schema.define(version: 2022_01_25_102025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -326,6 +326,8 @@ ActiveRecord::Schema.define(version: 2021_12_08_080712) do
     t.float "latitude"
     t.float "longitude"
     t.index ["category_id"], name: "index_locations_on_category_id"
+    t.index ["location_type"], name: "index_locations_on_location_type"
+    t.index ["nomis_agency_id"], name: "index_locations_on_nomis_agency_id"
     t.index ["young_offender_institution"], name: "index_locations_on_young_offender_institution"
   end
 


### PR DESCRIPTION
I've noticed that when the database is under high load, queries to the `/api/v1/reference/locations` endpoint often seem to take a long time, and even time out. Looking in the logs, the most common query parameters on this endpoint are `location_type` and `nomis_agency_id`, so I'm hoping that by putting in these indexes it will stop these timeouts from happening.

The indexes have been added concurrently which should mean the database table isn't locked as the migrations run.

See
https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1d,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:fb2e6550-0186-11ec-a2cf-6b21ca2b1d39,key:log_processed.kubernetes_namespace,negate:!f,params:(query:hmpps-book-secure-move-api-production),type:phrase,value:hmpps-book-secure-move-api-production),query:(match:(log_processed.kubernetes_namespace:(query:hmpps-book-secure-move-api-production,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:fb2e6550-0186-11ec-a2cf-6b21ca2b1d39,key:log_processed.status,negate:!f,params:(query:499),type:phrase,value:'499'),query:(match:(log_processed.status:(query:499,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:fb2e6550-0186-11ec-a2cf-6b21ca2b1d39,key:log_processed.http_user_agent,negate:!f,params:(query:Appian),type:phrase,value:Appian),query:(match:(log_processed.http_user_agent:(query:Appian,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:fb2e6550-0186-11ec-a2cf-6b21ca2b1d39,key:log_processed.request_path,negate:!f,params:(query:%2Fapi%2Fv1%2Freference%2Flocations),type:phrase,value:%2Fapi%2Fv1%2Freference%2Flocations),query:(match:(log_processed.request_path:(query:%2Fapi%2Fv1%2Freference%2Flocations,type:phrase))))),index:fb2e6550-0186-11ec-a2cf-6b21ca2b1d39,interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))
for more details on the timeouts to the `/api/v1/reference/locations`
endpoint.