### PR TITLE
Revert "Add delay to import move start events"

### DIFF
--- a/app/lib/imports/missing_move_start_events.rb
+++ b/app/lib/imports/missing_move_start_events.rb
@@ -46,8 +46,6 @@ private
       @current_move = nil
 
       results.save(move, record)
-
-      sleep 3
     end
   end
 


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-api#1712

We no longer need this as the import has finished.