### PR TITLE
Document how to filter moves on the reference

### DIFF
--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -758,6 +758,15 @@
             items:
               type: string
               format: uuid
+        - name: filter[reference]
+          description: Filters results to only include moves with a given reference
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
         - name: sort[by]
           description: field to sort results by
           in: query

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -485,6 +485,15 @@
             items:
               type: string
               format: uuid
+        - name: filter[reference]
+          description: Filters results to only include moves with a given reference
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
         - name: sort[by]
           description: field to sort results by
           in: query


### PR DESCRIPTION
This is a feature that was added to allow suppliers and our frontend to find a move by searching for the reference (d98bd8eeca71369eaaa0d916bfc9e0021ca7952a). The documentation wasn't updated when it was originally added so this commits ensures the documentation is there now.