### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/book-a-secure-move


### PR DESCRIPTION
This will tell GitHub which team is responsible for the code and we can use it to set up automatic PR approvals.

Closes #1719 