### PR TITLE
Add dates to journeys

### DIFF
--- a/app/controllers/api/journeys_controller.rb
+++ b/app/controllers/api/journeys_controller.rb
@@ -12,13 +12,13 @@ module Api
 
     PERMITTED_NEW_JOURNEY_PARAMS = [
       :type,
-      { attributes: [:timestamp, :billable, { vehicle: {} }],
+      { attributes: [:timestamp, :billable, { vehicle: {} }, :date],
         relationships: [from_location: {}, to_location: {}, supplier: {}] },
     ].freeze
 
     PERMITTED_UPDATE_JOURNEY_PARAMS = [
       :type,
-      { attributes: [:timestamp, :billable, { vehicle: {} }] },
+      { attributes: [:timestamp, :billable, { vehicle: {} }, :date] },
     ].freeze
 
     def index
@@ -99,6 +99,7 @@ module Api
         attribs.merge!(
           move: move,
           client_timestamp: Time.zone.parse(timestamp),
+          date: attribs.delete(:date) || move.date,
           from_location: find_location(new_journey_params.require(:relationships).require(:from_location).require(:data).require(:id)),
           to_location: find_location(new_journey_params.require(:relationships).require(:to_location).require(:data).require(:id)),
           supplier: supplier,
@@ -138,6 +139,7 @@ module Api
     def update_journey_attributes
       @update_journey_attributes ||= update_journey_params.to_h[:attributes].tap do |attribs|
         attribs.delete(:timestamp) # throw the timestamp away for updates
+        attribs.delete(:date) if attribs[:date].nil?
       end
     end
 

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -23,6 +23,7 @@ class Journey < ApplicationRecord
     move_id
     billable
     state
+    date
     vehicle_registration
     client_timestamp
     created_at

--- a/app/serializers/journeys_serializer.rb
+++ b/app/serializers/journeys_serializer.rb
@@ -5,7 +5,7 @@ class JourneysSerializer
 
   set_type :journeys
 
-  attributes :state, :billable, :vehicle
+  attributes :state, :billable, :vehicle, :date
   attribute :timestamp, &:client_timestamp
 
   has_one :from_location, serializer: LocationsSerializer

--- a/app/services/feeds/journey.rb
+++ b/app/services/feeds/journey.rb
@@ -8,8 +8,8 @@ module Feeds
     end
 
     def call
-      ::Journey.includes(:supplier, :from_location).updated_at_range(@updated_at_from, @updated_at_to).find_each do |move|
-        @feed << move.for_feed.to_json
+      ::Journey.includes(:supplier, :from_location).updated_at_range(@updated_at_from, @updated_at_to).find_each do |journey|
+        @feed << journey.for_feed.to_json
       end
 
       @feed.join("\n")

--- a/app/services/journeys/params_validator.rb
+++ b/app/services/journeys/params_validator.rb
@@ -4,7 +4,7 @@ module Journeys
   class ParamsValidator
     include ActiveModel::Validations
 
-    attr_reader :timestamp, :billable
+    attr_reader :timestamp, :billable, :date
 
     validates :billable, inclusion: { in: [true, false] }, allow_nil: true, on: :update # NB: billable is optional on update
     validates :billable, inclusion: { in: [true, false] }, on: :create # NB: billable is required on create
@@ -13,10 +13,16 @@ module Journeys
     rescue ArgumentError
       record.errors.add(attr, 'must be formatted as a valid ISO-8601 date-time')
     end
+    validates_each :date do |record, attr, value|
+      Date.iso8601(value) if value.present?
+    rescue ArgumentError
+      record.errors.add(attr, 'must be formatted as a valid ISO-8601 date')
+    end
 
     def initialize(params)
       @timestamp = params.dig(:attributes, :timestamp)
       @billable = params.dig(:attributes, :billable)
+      @date = params.dig(:attributes, :date)
     end
   end
 end

--- a/db/migrate/20220131135817_add_date_to_journeys.rb
+++ b/db/migrate/20220131135817_add_date_to_journeys.rb
@@ -1,0 +1,5 @@
+class AddDateToJourneys < ActiveRecord::Migration[6.1]
+  def change
+    add_column :journeys, :date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_25_102025) do
+ActiveRecord::Schema.define(version: 2022_01_31_135817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -294,6 +294,7 @@ ActiveRecord::Schema.define(version: 2022_01_25_102025) do
     t.datetime "client_timestamp", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "date"
     t.index ["client_timestamp"], name: "index_journeys_on_client_timestamp"
     t.index ["from_location_id"], name: "index_journeys_on_from_location_id"
     t.index ["move_id", "client_timestamp"], name: "index_journeys_on_move_id_and_client_timestamp"

--- a/spec/factories/journeys.rb
+++ b/spec/factories/journeys.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     association(:to_location, :court, factory: :location)
     client_timestamp { Time.zone.now.utc + rand(-60..60).seconds } # NB: the client_timestamp will never be perfectly in sync with system clock
     vehicle { { id: '12345678ABC', registration: 'AB12 CDE' } }
+    date { Time.zone.today }
 
     # NB we need to initialize_state because FactoryBot fires the after_initialize callback before the attributes are initialised!
     after(:build, &:initialize_state)

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe Journey, type: :model do
         'to_location': 'GUICCT',
         'to_location_type': 'court',
         'billable': false,
+        'date': be_a(Date),
         'state': 'proposed',
         'vehicle_registration': 'AB12 CDE',
         'client_timestamp': be_a(Time),

--- a/spec/serializers/journey_serializer_spec.rb
+++ b/spec/serializers/journey_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe JourneySerializer do
   subject(:serializer) { described_class.new(journey, adapter_options) }
 
-  let(:journey) { create :journey, client_timestamp: '2020-05-04T08:00:00Z' }
+  let(:journey) { create :journey, client_timestamp: '2020-05-04T08:00:00Z', date: '2020-05-04' }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
   let(:adapter_options) { {} }
 
@@ -27,6 +27,10 @@ RSpec.describe JourneySerializer do
 
   it 'contains a `timestamp` attribute' do
     expect(result[:data][:attributes][:timestamp]).to eql '2020-05-04T09:00:00+01:00'
+  end
+
+  it 'contains a `date` attribute' do
+    expect(result[:data][:attributes][:date]).to eql '2020-05-04'
   end
 
   it 'contains vehicle attributes' do

--- a/spec/serializers/journeys_serializer_spec.rb
+++ b/spec/serializers/journeys_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe JourneysSerializer do
   subject(:serializer) { described_class.new(journey, adapter_options) }
 
-  let(:journey) { create :journey, client_timestamp: '2020-05-04T08:00:00Z' }
+  let(:journey) { create :journey, client_timestamp: '2020-05-04T08:00:00Z', date: '2020-05-04' }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
   let(:adapter_options) { {} }
 
@@ -27,6 +27,10 @@ RSpec.describe JourneysSerializer do
 
   it 'contains a `timestamp` attribute' do
     expect(result[:data][:attributes][:timestamp]).to eql '2020-05-04T09:00:00+01:00'
+  end
+
+  it 'contains a `date` attribute' do
+    expect(result[:data][:attributes][:date]).to eql '2020-05-04'
   end
 
   it 'contains vehicle attributes' do

--- a/spec/services/journeys/params_validator_spec.rb
+++ b/spec/services/journeys/params_validator_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Journeys::ParamsValidator do
 
   let(:billable) { false }
   let(:timestamp) { '2020-04-29T22:45:59.000Z' }
+  let(:date) { '2020-04-29' }
+  let(:params) { { attributes: { billable: billable, timestamp: timestamp, date: date } } }
 
   shared_examples('it validates required billable') do
     context 'when invalid' do
@@ -68,23 +70,53 @@ RSpec.describe Journeys::ParamsValidator do
     end
   end
 
+  shared_examples('it validates optional date') do
+    context 'when blank' do
+      let(:date) { '' }
+
+      it { is_expected.to be_valid(validation_context) }
+    end
+
+    context 'when nil' do
+      let(:date) { nil }
+
+      it { is_expected.to be_valid(validation_context) }
+    end
+
+    context 'when missing' do
+      before { params[:attributes].delete(:date) }
+
+      it { is_expected.to be_valid(validation_context) }
+    end
+  end
+
+  shared_examples('it validates date format') do
+    context 'when invalid' do
+      let(:date) { 'foo' }
+
+      it { is_expected.not_to be_valid(validation_context) }
+    end
+  end
+
   context 'when creating' do
     let(:validation_context) { :create }
-    let(:params) { { attributes: { billable: billable, timestamp: timestamp } } }
 
     it { is_expected.to be_valid(validation_context) }
 
     it_behaves_like 'it validates required billable'
+    it_behaves_like 'it validates optional date'
     it_behaves_like 'it validates timestamp'
+    it_behaves_like 'it validates date format'
   end
 
   context 'when updating' do
     let(:validation_context) { :update }
-    let(:params) { { attributes: { billable: billable, timestamp: timestamp } } }
 
     it { is_expected.to be_valid(validation_context) }
 
     it_behaves_like 'it validates optional billable'
+    it_behaves_like 'it validates optional date'
     it_behaves_like 'it validates timestamp'
+    it_behaves_like 'it validates date format'
   end
 end

--- a/swagger/v1/get_journey.yaml
+++ b/swagger/v1/get_journey.yaml
@@ -21,6 +21,7 @@ GetJourney:
       required:
       - timestamp
       - billable
+      - date
       - state
       properties:
         timestamp:
@@ -29,6 +30,11 @@ GetJourney:
           type: boolean
           example: true
           description: true indicates that the journey is billable, otherwise false
+        date:
+          type: string
+          format: date
+          example: '2020-04-21'
+          description: the date of when the journey is to occur
         state:
           type: string
           enum:

--- a/swagger/v1/patch_journey.yaml
+++ b/swagger/v1/patch_journey.yaml
@@ -15,6 +15,7 @@ PatchJourney:
       required:
       - timestamp
       - billable
+      - date
       properties:
         timestamp:
           $ref: timestamp_attribute.yaml#/Timestamp
@@ -22,6 +23,11 @@ PatchJourney:
           type: boolean
           example: true
           description: true indicates that the journey is billable, otherwise false
+        date:
+          type: string
+          format: date
+          example: '2020-04-21'
+          description: the date of when the journey is to occur
         vehicle:
           type: object
           properties:

--- a/swagger/v1/post_journey.yaml
+++ b/swagger/v1/post_journey.yaml
@@ -15,6 +15,7 @@ PostJourney:
       required:
       - timestamp
       - billable
+      - date
       properties:
         timestamp:
           $ref: timestamp_attribute.yaml#/Timestamp
@@ -22,6 +23,11 @@ PostJourney:
           type: boolean
           example: true
           description: true indicates that the journey is billable, otherwise false
+        date:
+          type: string
+          format: date
+          example: '2020-04-21'
+          description: the date of when the journey is to occur
         vehicle:
           type: object
           properties:


### PR DESCRIPTION
This adds the concept of journey dates which we're adding to support moves which happen across multiple days.

Once this has been deployed, the next step will be to backfill the journey dates to match with the move date.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3337)