### PR TITLE
Add a task for backfilling journey dates 

### DIFF
--- a/lib/tasks/backfill.rake
+++ b/lib/tasks/backfill.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :backfill do
+  desc 'Populate journeys with dates from the associated move.'
+  task journey_dates: :environment do
+    Journey.where(date: nil).includes(:move).find_each do |journey|
+      journey.update!(date: journey.move.date)
+    end
+  end
+end

--- a/spec/lib/tasks/backfill/journey_dates_spec.rb
+++ b/spec/lib/tasks/backfill/journey_dates_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Rake::Task['backfill:journey_dates'] do
+  before do
+    3.times do
+      move = create(:move, date: Faker::Date.in_date_period)
+      create(:journey, move: move, date: nil)
+    end
+  end
+
+  let!(:journey_to_ignore) { create(:journey, date: '2020-01-01') }
+
+  it 'sets the journey dates to the move date' do
+    described_class.invoke
+
+    expect(Journey.where(date: nil)).not_to exist
+
+    Journey.where.not(id: journey_to_ignore.id).find_each do |journey|
+      expect(journey.date).to eq(journey.move.date)
+    end
+
+    expect(journey_to_ignore.date).to eq(Date.new(2020, 1, 1))
+  end
+end


### PR DESCRIPTION
This will populate the journey dates with the move date as would happen if the journey had been created at the time.

Depends on #1723 

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3337)