### PR TITLE
Mark PYI as a youth offender institution

### DIFF
--- a/app/services/locations/updater.rb
+++ b/app/services/locations/updater.rb
@@ -2,7 +2,7 @@
 
 module Locations
   class Updater
-    YOI_NOMIS_AGENCIES = %w[WYI WNI CKI PRI FMI FYI].freeze
+    YOI_NOMIS_AGENCIES = %w[WYI WNI CKI PYI FMI FYI].freeze
 
     def self.call
       Location.transaction do


### PR DESCRIPTION
In #1743 we updated the reference data for HMP Parc (as it's youth side is being split up in to a separate location) but this was not updated as it should have been.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3032)