### PR TITLE
Add GenericEvent::PerPropertyChange

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -78,6 +78,7 @@ class GenericEvent < ApplicationRecord
     PerMedicalDrugsAlcohol
     PerMedicalMentalHealth
     PerPrisonerWelfare
+    PerPropertyChange
     PersonMoveAssault
     PersonMoveBookedIntoReceivingEstablishment
     PersonMoveDeathInCustody

--- a/app/models/generic_event/per_property_change.rb
+++ b/app/models/generic_event/per_property_change.rb
@@ -1,0 +1,5 @@
+class GenericEvent
+  class PerPropertyChange < GenericEvent
+    include PersonEscortRecordEventValidations
+  end
+end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -548,6 +548,10 @@ FactoryBot.define do
     end
   end
 
+  factory :event_per_property_change, parent: :generic_event, class: 'GenericEvent::PerPropertyChange' do
+    eventable { association(:person_escort_record) }
+  end
+
   factory :event_per_confirmation, parent: :generic_event, class: 'GenericEvent::PerConfirmation' do
     eventable { association(:person_escort_record, :confirmed, confirmed_at: '2021-01-01') }
     details do

--- a/spec/models/generic_event/per_property_change_spec.rb
+++ b/spec/models/generic_event/per_property_change_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::PerPropertyChange do
+  subject(:generic_event) { build(:event_per_property_change) }
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
+end

--- a/spec/requests/api/generic_events_controller_create_person_escort_record_events_spec.rb
+++ b/spec/requests/api/generic_events_controller_create_person_escort_record_events_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Api::GenericEventsController do
   it_behaves_like 'a generic event endpoint', 'PerCourtTakeToSeeVisitors'
   it_behaves_like 'a generic event endpoint', 'PerCourtTask'
   it_behaves_like 'a generic event endpoint', 'PerGeneric'
+  it_behaves_like 'a generic event endpoint', 'PerPropertyChange'
   it_behaves_like 'a generic event endpoint', 'PerHandover'
   it_behaves_like 'a generic event endpoint', 'PerMedicalAid'
   it_behaves_like 'a generic event endpoint', 'PerPrisonerWelfare'


### PR DESCRIPTION
This is to represent a change to the property of a person being moved after a move has started (and therefore the PER is locked in). We'll be using this event as a way of making amendments to the PER.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3335)