### PR TITLE
Refactor notification webhook job

### DIFF
--- a/app/jobs/notify_webhook_job.rb
+++ b/app/jobs/notify_webhook_job.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
-# This job is responsible for sending the notification to the supplier's webhook endpoint
 class NotifyWebhookJob < ApplicationJob
   include QueueDeterminer
 
   def perform(notification_id:, **_)
     notification = Notification.webhooks.kept.includes(:subscription).find(notification_id)
+
     subscription = notification.subscription
     return unless subscription.enabled?
 
-    # just return if the notification has been already delivered
     return if notification.delivered_at.present?
 
     begin
@@ -27,7 +26,6 @@ class NotifyWebhookJob < ApplicationJob
         delivery_attempts: notification.delivery_attempts.succ,
         delivery_attempted_at: Time.zone.now,
       )
-      # TODO: in the future, consider suggesting that the webhook endpoint could return a UUID in the response, which we could store in notification.response_id ?
     rescue StandardError => e
       notification.update!(
         delivery_attempts: notification.delivery_attempts.succ,


### PR DESCRIPTION
This refactors the notification webhook job to make it easier to read and maintain. I've also slightly changed the error reporting logic so that timeout errors are grouped with other kinds of `NotificationFailedResponseError` errors in Sentry.