### PR TITLE
Capture error when requesting webhook

### DIFF
--- a/app/jobs/notify_webhook_job.rb
+++ b/app/jobs/notify_webhook_job.rb
@@ -34,6 +34,8 @@ private
     unless response.success?
       raise NotificationFailedResponseError, "Non-success status received from #{subscription.callback_url}.\nStatus: #{response.status}, Reason: #{response.reason_phrase}, Response body: '#{response.body}'"
     end
+  rescue Faraday::ConnectionFailed
+    raise NotificationFailedResponseError, "Connection failed to #{subscription.callback_url}."
   rescue Faraday::TimeoutError
     raise NotificationFailedResponseError, "Timeout received from #{subscription.callback_url}."
   end


### PR DESCRIPTION
This follows on from https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1753 to capture another kind of error we get and group it into the notification failed error.

This should prevent issues like https://sentry.io/organizations/ministryofjustice/issues/3066627844/ being recorded as separate events in Sentry.