### PR TITLE
Add lockout events

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -57,6 +57,7 @@ class GenericEvent < ApplicationRecord
     MoveReject
     MoveRequested
     MoveStart
+    PerConcealed
     PerConfirmation
     PerCourtAllDocumentationProvidedToSupplier
     PerCourtAssignCellInCustody
@@ -72,6 +73,7 @@ class GenericEvent < ApplicationRecord
     PerCourtTakeFromCustodyToDock
     PerCourtTakeToSeeVisitors
     PerCourtTask
+    PerEscape
     PerGeneric
     PerHandover
     PerMedicalAid
@@ -79,6 +81,9 @@ class GenericEvent < ApplicationRecord
     PerMedicalMentalHealth
     PerPrisonerWelfare
     PerPropertyChange
+    PerSelfHarm
+    PerViolentDangerous
+    PerWeapons
     PersonMoveAssault
     PersonMoveBookedIntoReceivingEstablishment
     PersonMoveDeathInCustody

--- a/app/models/generic_event/per_concealed.rb
+++ b/app/models/generic_event/per_concealed.rb
@@ -1,0 +1,4 @@
+class GenericEvent
+  class PerConcealed < PerIncident
+  end
+end

--- a/app/models/generic_event/per_escape.rb
+++ b/app/models/generic_event/per_escape.rb
@@ -1,0 +1,4 @@
+class GenericEvent
+  class PerEscape < PerIncident
+  end
+end

--- a/app/models/generic_event/per_incident.rb
+++ b/app/models/generic_event/per_incident.rb
@@ -1,0 +1,21 @@
+class GenericEvent
+  class PerIncident < GenericEvent
+    LOCATION_ATTRIBUTE_KEY = :location_id
+
+    def event_classification
+      :incident
+    end
+
+    def self.inherited(child)
+      child.details_attributes :supplier_personnel_number, :police_personnel_number
+      child.relationship_attributes location_id: :locations
+      child.eventable_types 'PersonEscortRecord'
+
+      child.include PersonnelNumberValidations
+      child.include LocationFeed
+      child.include LocationValidations
+
+      super
+    end
+  end
+end

--- a/app/models/generic_event/per_self_harm.rb
+++ b/app/models/generic_event/per_self_harm.rb
@@ -1,0 +1,4 @@
+class GenericEvent
+  class PerSelfHarm < PerIncident
+  end
+end

--- a/app/models/generic_event/per_violent_dangerous.rb
+++ b/app/models/generic_event/per_violent_dangerous.rb
@@ -1,0 +1,4 @@
+class GenericEvent
+  class PerViolentDangerous < PerIncident
+  end
+end

--- a/app/models/generic_event/per_weapons.rb
+++ b/app/models/generic_event/per_weapons.rb
@@ -1,0 +1,4 @@
+class GenericEvent
+  class PerWeapons < PerIncident
+  end
+end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -22,6 +22,17 @@ FactoryBot.define do
     end
   end
 
+  factory :per_incident, parent: :generic_event do
+    eventable { association(:person_escort_record) }
+    classification { 'incident' }
+    details do
+      {
+        location_id: create(:location).id,
+        supplier_personnel_number: SecureRandom.uuid,
+      }
+    end
+  end
+
   factory :medical, parent: :generic_event do
     eventable { association(:person_escort_record) }
     classification { 'medical' }
@@ -378,6 +389,9 @@ FactoryBot.define do
     eventable { association(:journey) }
   end
 
+  factory :event_per_concealed, parent: :per_incident, class: 'GenericEvent::PerConcealed' do
+  end
+
   factory :event_per_court_cell_share_risk_assessment, parent: :generic_event, class: 'GenericEvent::PerCourtCellShareRiskAssessment' do
     eventable { association(:person_escort_record) }
     details do
@@ -521,6 +535,9 @@ FactoryBot.define do
     end
   end
 
+  factory :event_per_escape, parent: :per_incident, class: 'GenericEvent::PerEscape' do
+  end
+
   factory :event_per_generic, parent: :generic_event, class: 'GenericEvent::PerGeneric' do
     eventable { association(:person_escort_record) }
   end
@@ -563,6 +580,15 @@ FactoryBot.define do
 
   factory :event_per_handover, parent: :generic_event, class: 'GenericEvent::PerHandover' do
     eventable { association(:person_escort_record, :confirmed) }
+  end
+
+  factory :event_per_self_harm, parent: :per_incident, class: 'GenericEvent::PerSelfHarm' do
+  end
+
+  factory :event_per_violent_dangerous, parent: :per_incident, class: 'GenericEvent::PerViolentDangerous' do
+  end
+
+  factory :event_per_weapons, parent: :per_incident, class: 'GenericEvent::PerWeapons' do
   end
 
   factory :event_person_move_assault, parent: :incident, class: 'GenericEvent::PersonMoveAssault' do

--- a/spec/models/generic_event/per_concealed_spec.rb
+++ b/spec/models/generic_event/per_concealed_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::PerConcealed do
+  subject(:generic_event) { build(:event_per_concealed) }
+
+  it_behaves_like 'an event about a PER incident'
+end

--- a/spec/models/generic_event/per_escape_spec.rb
+++ b/spec/models/generic_event/per_escape_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::PerEscape do
+  subject(:generic_event) { build(:event_per_escape) }
+
+  it_behaves_like 'an event about a PER incident'
+end

--- a/spec/models/generic_event/per_incident_spec.rb
+++ b/spec/models/generic_event/per_incident_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::PerIncident, type: :model do
+  let(:event) { described_class.new }
+
+  describe '#event_type' do
+    subject(:event_type) { event.event_type }
+
+    it { is_expected.to eq('PerIncident') }
+  end
+
+  describe '#event_classification' do
+    subject(:event_classification) { event.event_classification }
+
+    it { is_expected.to eq(:incident) }
+
+    context 'when event has nil classification' do
+      let(:event) { create(:event_per_violent_dangerous, classification: nil) }
+
+      it { is_expected.to eq(:incident) }
+    end
+  end
+end

--- a/spec/models/generic_event/per_self_harm_spec.rb
+++ b/spec/models/generic_event/per_self_harm_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::PerSelfHarm do
+  subject(:generic_event) { build(:event_per_self_harm) }
+
+  it_behaves_like 'an event about a PER incident'
+end

--- a/spec/models/generic_event/per_violent_dangerous_spec.rb
+++ b/spec/models/generic_event/per_violent_dangerous_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::PerViolentDangerous do
+  subject(:generic_event) { build(:event_per_violent_dangerous) }
+
+  it_behaves_like 'an event about a PER incident'
+end

--- a/spec/models/generic_event/per_weapons_spec.rb
+++ b/spec/models/generic_event/per_weapons_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::PerWeapons do
+  subject(:generic_event) { build(:event_per_weapons) }
+
+  it_behaves_like 'an event about a PER incident'
+end

--- a/spec/models/generic_event_spec.rb
+++ b/spec/models/generic_event_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe GenericEvent, type: :model do
         .sub('app/models/generic_event/', '')
         .sub('.rb', '')
         .camelcase
-    } - %w[Incident Medical Notification]
+    } - %w[Incident Medical Notification PerIncident]
 
     expect(described_class::STI_CLASSES).to match_array(expected_sti_classes)
   end

--- a/spec/support/an_event_about_a_per_incident.rb
+++ b/spec/support/an_event_about_a_per_incident.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples 'an event about a PER incident' do
+  it_behaves_like 'an event with details', :supplier_personnel_number, :police_personnel_number
+  it_behaves_like 'an event with relationships', location_id: :locations
+  it_behaves_like 'an event with eventable types', 'PersonEscortRecord'
+  it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
+
+  it { is_expected.to validate_presence_of(:supplier_personnel_number) }
+end


### PR DESCRIPTION
These will be used in lockouts and overnight lodges to record any changes to the PER which would be appropriate for the second leg of any move. Specifically, while in police custody, these might be recorded by police personnel.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3335)