### PR TITLE
Add support for events from notifications

### DIFF
--- a/app/controllers/api/generic_events_controller.rb
+++ b/app/controllers/api/generic_events_controller.rb
@@ -17,6 +17,10 @@ module Api
       event = event_type.constantize.create!(event_attributes)
       run_event_logs
 
+      unless doorkeeper_application_owner.is_a?(Supplier)
+        Notifier.prepare_notifications(topic: event, action_name: 'create_event')
+      end
+
       render_json event, serializer: event.class.serializer, status: :created
     end
 

--- a/app/jobs/prepare_generic_event_notifications_job.rb
+++ b/app/jobs/prepare_generic_event_notifications_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PrepareGenericEventNotificationsJob < PrepareBaseNotificationsJob
+private
+
+  def find_topic(topic_id)
+    GenericEvent.find(topic_id)
+  end
+
+  def associated_move(topic)
+    topic.move
+  end
+end

--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -133,6 +133,10 @@ class GenericEvent < ApplicationRecord
     :default
   end
 
+  def move
+    @move ||= eventable.is_a?(Move) ? eventable : eventable.try(:move)
+  end
+
   # Default trigger behaviour for all events is to do nothing
   def trigger(*); end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -47,4 +47,35 @@ class Notification < ApplicationRecord
       MoveMailer
     end
   end
+
+  def generic_event_id
+    @generic_event_id ||= topic.is_a?(GenericEvent) ? topic.id : nil
+  end
+
+  def move_id
+    @move_id ||= begin
+      return topic.id if topic.is_a?(Move)
+      return topic.eventable.id if topic.is_a?(GenericEvent) && topic.eventable.is_a?(Move)
+
+      nil
+    end
+  end
+
+  def person_escort_record_id
+    @person_escort_record_id ||= begin
+      return topic.id if topic.is_a?(PersonEscortRecord)
+      return topic.eventable.id if topic.is_a?(GenericEvent) && topic.eventable.is_a?(PersonEscortRecord)
+
+      nil
+    end
+  end
+
+  def youth_risk_assessment_id
+    @youth_risk_assessment_id ||= begin
+      return topic.id if topic.is_a?(YouthRiskAssessment)
+      return topic.eventable.id if topic.is_a?(GenericEvent) && topic.eventable.is_a?(YouthRiskAssessment)
+
+      nil
+    end
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -55,7 +55,7 @@ class Notification < ApplicationRecord
   def move_id
     @move_id ||= begin
       return topic.id if topic.is_a?(Move)
-      return topic.eventable.id if topic.is_a?(GenericEvent) && topic.eventable.is_a?(Move)
+      return topic.move.id if topic.is_a?(GenericEvent)
 
       nil
     end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -21,5 +21,5 @@ class NotificationSerializer
     self: ->(object) { Rails.application.routes.url_helpers.api_youth_risk_assessment_url(object.youth_risk_assessment_id) },
   }
 
-  belongs_to :generic_event, if: ->(object) { object.generic_event_id }
+  belongs_to :event, id_method_name: :generic_event_id, serializer: GenericEventSerializer, if: ->(object) { object.generic_event_id }
 end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -9,15 +9,17 @@ class NotificationSerializer
 
   attribute :timestamp, &:created_at
 
-  belongs_to :move, id_method_name: :topic_id, if: proc { |object| object.topic.is_a?(Move) }, links: {
-    self: ->(object) { Rails.application.routes.url_helpers.api_move_url(object.topic.id) },
+  belongs_to :move, if: ->(object) { object.move_id }, links: {
+    self: ->(object) { Rails.application.routes.url_helpers.api_move_url(object.move_id) },
   }
 
-  belongs_to :person_escort_record, id_method_name: :topic_id, if: proc { |object| object.topic.is_a?(PersonEscortRecord) }, links: {
-    self: ->(object) { Rails.application.routes.url_helpers.api_person_escort_record_url(object.topic.id) },
+  belongs_to :person_escort_record, if: ->(object) { object.person_escort_record_id }, links: {
+    self: ->(object) { Rails.application.routes.url_helpers.api_person_escort_record_url(object.person_escort_record_id) },
   }
 
-  belongs_to :youth_risk_assessment, id_method_name: :topic_id, if: proc { |object| object.topic.is_a?(YouthRiskAssessment) }, links: {
-    self: ->(object) { Rails.application.routes.url_helpers.api_youth_risk_assessment_url(object.topic.id) },
+  belongs_to :youth_risk_assessment, if: ->(object) { object.youth_risk_assessment_id }, links: {
+    self: ->(object) { Rails.application.routes.url_helpers.api_youth_risk_assessment_url(object.youth_risk_assessment_id) },
   }
+
+  belongs_to :generic_event, if: ->(object) { object.generic_event_id }
 end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -5,6 +5,8 @@ class Notifier
 
   def self.prepare_notifications(topic:, action_name:)
     case topic
+    when GenericEvent
+      PrepareGenericEventNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, send_emails: false, queue_as: move_queue_priority(topic.move))
     when Move
       PrepareMoveNotificationsJob.perform_later(topic_id: topic.id, action_name: action_name, queue_as: move_queue_priority(topic))
     when Person

--- a/spec/jobs/prepare_generic_event_notifications_job_spec.rb
+++ b/spec/jobs/prepare_generic_event_notifications_job_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PrepareGenericEventNotificationsJob, type: :job do
+  subject(:perform) do
+    described_class.perform_now(
+      topic_id: generic_event.id,
+      action_name: 'create_generic_event',
+      queue_as: :some_queue_name,
+      send_webhooks: true,
+      send_emails: false,
+      only_supplier_id: nil,
+    )
+  end
+
+  let(:subscription) { create :subscription }
+  let(:supplier) { create :supplier, name: 'test', subscriptions: [subscription] }
+  let(:location) { create :location, suppliers: [supplier] }
+  let(:move) { create :move, from_location: location, supplier: supplier }
+  let(:per) { create :person_escort_record, move: move }
+  let(:generic_event) { create :event_per_generic, eventable: per }
+
+  before do
+    create(:notification_type, :webhook)
+
+    allow(NotifyWebhookJob).to receive(:perform_later)
+    allow(NotifyEmailJob).to receive(:perform_later)
+  end
+
+  context 'when notifying about a generic event' do
+    it 'creates a webhook notification record' do
+      expect { perform }.to change(Notification.webhooks, :count).by(1)
+    end
+
+    it 'does not create an email notification record' do
+      expect { perform }.not_to change(Notification.emails, :count)
+    end
+
+    it 'schedules NotifyWebhookJob' do
+      perform
+
+      expect(NotifyWebhookJob).to have_received(:perform_later)
+                                    .with(notification_id: Notification.webhooks.last.id, queue_as: :some_queue_name)
+    end
+
+    it 'does not schedule a NotifyEmailJob' do
+      perform
+
+      expect(NotifyEmailJob).not_to have_received(:perform_later)
+    end
+  end
+end

--- a/spec/jobs/prepare_generic_event_notifications_job_spec.rb
+++ b/spec/jobs/prepare_generic_event_notifications_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PrepareGenericEventNotificationsJob, type: :job do
   subject(:perform) do
     described_class.perform_now(
       topic_id: generic_event.id,
-      action_name: 'create_generic_event',
+      action_name: 'create_event',
       queue_as: :some_queue_name,
       send_webhooks: true,
       send_emails: false,

--- a/spec/serializers/notification_serializer_spec.rb
+++ b/spec/serializers/notification_serializer_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe NotificationSerializer do
       let(:notification) { create(:notification, topic: generic_event) }
 
       it 'contains generic_event relationship data' do
-        expect(result[:data][:relationships][:generic_event][:data]).to eql(id: generic_event.id, type: 'events')
+        expect(result[:data][:relationships][:event][:data]).to eql(id: generic_event.id, type: 'events')
       end
 
       it 'contains person_escort_record relationship data' do

--- a/spec/serializers/notification_serializer_spec.rb
+++ b/spec/serializers/notification_serializer_spec.rb
@@ -76,7 +76,25 @@ RSpec.describe NotificationSerializer do
       end
     end
 
-    context 'when topic is not a Move, PersonEscortRecord or YouthRiskAssessment' do
+    context 'when topic is a GenericEvent' do
+      let(:per) { create(:person_escort_record) }
+      let(:generic_event) { create(:event_per_generic, eventable: per) }
+      let(:notification) { create(:notification, topic: generic_event) }
+
+      it 'contains generic_event relationship data' do
+        expect(result[:data][:relationships][:generic_event][:data]).to eql(id: generic_event.id, type: 'events')
+      end
+
+      it 'contains person_escort_record relationship data' do
+        expect(result[:data][:relationships][:person_escort_record][:data]).to eql(id: per.id, type: 'person_escort_records')
+      end
+
+      it 'contains person_escort_record relationship links' do
+        expect(result[:data][:relationships][:person_escort_record][:links]).to eql(self: "http://localhost:4000/api/v1/person_escort_records/#{per.id}")
+      end
+    end
+
+    context 'when topic is not a Move, GenericEvent, PersonEscortRecord or YouthRiskAssessment' do
       let(:allocation) { create(:allocation) }
       let(:notification) { create(:notification, topic: allocation) }
 

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Notifier do
   context 'when scheduled with a generic_event' do
     let(:move) { create(:move, date: Time.zone.tomorrow) }
     let(:topic) { create(:event_person_move_assault, eventable: move) }
-    let(:action_name) { 'create_generic_event' }
+    let(:action_name) { 'create_event' }
 
     it 'queues a job' do
       expect(PrepareGenericEventNotificationsJob)

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe Notifier do
     clear_performed_jobs
   end
 
+  context 'when scheduled with a generic_event' do
+    let(:move) { create(:move, date: Time.zone.tomorrow) }
+    let(:topic) { create(:event_person_move_assault, eventable: move) }
+    let(:action_name) { 'create_generic_event' }
+
+    it 'queues a job' do
+      expect(PrepareGenericEventNotificationsJob)
+        .to have_been_enqueued
+        .with(topic_id: topic.id, action_name: action_name, send_emails: false, queue_as: :notifications_medium)
+    end
+  end
+
   context 'when scheduled with a move for today' do
     let(:topic) { create(:move, date: Time.zone.today) }
 


### PR DESCRIPTION
This makes it possible to send out notifications for the creation of events. Specifically, we're adding this functionality to support lockouts and overnight lodgings, where we want police users to add events and to let the suppliers know.

This won't go live as I'll disable these notifications until the suppliers are ready to handle them using: 
https://github.com/ministryofjustice/hmpps-book-secure-move-api/blob/0f69b45111b8b5d831f5cfe1439280161c28f885/app/jobs/prepare_base_notifications_job.rb#L50

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3427)