### PR TITLE
Add numbers to journeys

### DIFF
--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -91,4 +91,8 @@ class Journey < ApplicationRecord
   def handle_event_run(dry_run: false)
     save! if changed? && valid? && !dry_run
   end
+
+  def number
+    @number ||= (move.journeys.default_order.pluck(:id).index(id) + 1)
+  end
 end

--- a/app/serializers/journeys_serializer.rb
+++ b/app/serializers/journeys_serializer.rb
@@ -5,7 +5,7 @@ class JourneysSerializer
 
   set_type :journeys
 
-  attributes :state, :billable, :vehicle, :date
+  attributes :state, :billable, :vehicle, :date, :number
   attribute :timestamp, &:client_timestamp
 
   has_one :from_location, serializer: LocationsSerializer

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -204,4 +204,15 @@ RSpec.describe Journey, type: :model do
       end
     end
   end
+
+  describe '#number' do
+    let(:move) { create(:move) }
+    let(:journey_1) { create(:journey, move: move, client_timestamp: Date.new(2020, 1, 1)) }
+    let(:journey_2) { create(:journey, move: move, client_timestamp: Date.new(2020, 1, 2)) }
+
+    it 'has the correct journey number' do
+      expect(journey_1.number).to eq(1)
+      expect(journey_2.number).to eq(2)
+    end
+  end
 end

--- a/spec/serializers/journeys_serializer_spec.rb
+++ b/spec/serializers/journeys_serializer_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe JourneysSerializer do
     expect(result[:data][:relationships][:to_location]).to eql(data: { id: journey.to_location.id, type: 'locations' })
   end
 
+  it 'contains a number property' do
+    expect(result[:data][:attributes][:number]).to be 1
+  end
+
   describe 'included relationships' do
     let(:adapter_options) do
       {


### PR DESCRIPTION
This adds a number field to journeys which represents the human-readable index of the journey.

It's [a bit awkward to implement this in an efficient way (i.e. including it within the `SELECT` of the query)](https://stackoverflow.com/a/18751290) so I've left it as a separate query for now. I don't anticipate this being a problem as most moves only have one or two journeys, so it's not an extreme `N+1` problem, but we can monitor this when we release it.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3345)