### PR TITLE
Expand important events for PERs

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -316,7 +316,7 @@ class Move < VersionedModel
   end
 
   def important_events
-    incident_events + (profile&.person_escort_record&.medical_events || [])
+    incident_events + (profile&.person_escort_record&.important_events || [])
   end
 
   def vehicle_registration

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -12,6 +12,10 @@ class PersonEscortRecord < VersionedModel
     'person-escort-record'
   end
 
+  def important_events
+    medical_events + incident_events + GenericEvent::PerPropertyChange.where(eventable: self)
+  end
+
 private
 
   def previous_assessment

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -5,7 +5,8 @@ class PersonEscortRecord < VersionedModel
   # To support legacy PERs without a move, allow the association to be optional
   belongs_to :move, optional: true
 
-  has_many :medical_events, -> { where classification: :medical }, as: :eventable, class_name: 'GenericEvent'
+  has_many :medical_events, -> { where(classification: :medical) }, as: :eventable, class_name: 'GenericEvent'
+  has_many :incident_events, -> { where(classification: :incident) }, as: :eventable, class_name: 'GenericEvent'
 
   def self.framework_name
     'person-escort-record'

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -152,4 +152,26 @@ RSpec.describe PersonEscortRecord do
   end
 
   it_behaves_like 'a framework assessment', :person_escort_record, described_class
+
+  describe '#medical_events' do
+    subject(:medical_events) { per.medical_events }
+
+    let(:per) { create(:person_escort_record) }
+
+    before { create(:event_per_medical_aid, eventable: per) }
+
+    it { is_expected.not_to be_empty }
+    it { is_expected.to include(GenericEvent::PerMedicalAid.first) }
+  end
+
+  describe '#incident_events' do
+    subject(:incident_events) { per.incident_events }
+
+    let(:per) { create(:person_escort_record) }
+
+    before { create(:event_per_escape, eventable: per) }
+
+    it { is_expected.not_to be_empty }
+    it { is_expected.to include(GenericEvent::PerEscape.first) }
+  end
 end

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -174,4 +174,21 @@ RSpec.describe PersonEscortRecord do
     it { is_expected.not_to be_empty }
     it { is_expected.to include(GenericEvent::PerEscape.first) }
   end
+
+  describe '#important_events' do
+    subject(:important_events) { per.important_events }
+
+    let(:per) { create(:person_escort_record) }
+
+    before do
+      create(:event_per_escape, eventable: per)
+      create(:event_per_medical_aid, eventable: per)
+      create(:event_per_property_change, eventable: per)
+    end
+
+    it { is_expected.not_to be_empty }
+    it { is_expected.to include(GenericEvent::PerEscape.first) }
+    it { is_expected.to include(GenericEvent::PerMedicalAid.first) }
+    it { is_expected.to include(GenericEvent::PerPropertyChange.first) }
+  end
 end


### PR DESCRIPTION
This expands which events are considered important in the context of a PER. This is necessary as we'd like to start displaying PER incidents and property change events on the move detail page which is populated from the `important_events`.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3519)