### PR TITLE
Prevent allocation moves date being updated

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -115,6 +115,7 @@ class Move < VersionedModel
 
   validate :date_to_after_date_from
   validate :validate_prisoner_category
+  validate :validate_date_change_allocation, on: :update
 
   before_validation :set_reference
   before_validation :set_move_type
@@ -386,6 +387,12 @@ private
   def validate_prisoner_category
     if profile&.category&.move_supported == false
       errors.add(:profile, :unsupported_prisoner_category, message: "person is a category '#{profile.category.key}' prisoner and cannot be moved using this service")
+    end
+  end
+
+  def validate_date_change_allocation
+    if date_changed? && allocation
+      errors.add(:date, :cant_change_allocation, message: 'cannot be changed as move is part of an allocation')
     end
   end
 end


### PR DESCRIPTION
We currently don't allow the date of an allocation to be modified after it's been created, but the date of the moves can be changed. This can cause a mismatch between the allocation and the moves which leads to the allocation not appearing in the right place in the frontend.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3585)