### PR TITLE
Refresh allocation status when cancelling a move

### DIFF
--- a/app/controllers/api/allocation_events_controller.rb
+++ b/app/controllers/api/allocation_events_controller.rb
@@ -31,11 +31,7 @@ module Api
     end
 
     def cancel_move_params
-      cancel_params.tap do |params|
-        # NB: we should always provide the reason other for the cancelled underlying moves regardless
-        # of the reason chosen for cancelling the allocation
-        params[:attributes][:cancellation_reason] = Move::CANCELLATION_REASON_OTHER
-      end
+      cancel_params.deep_merge(attributes: { cancellation_reason: Move::CANCELLATION_REASON_OTHER })
     end
 
     def cancellation_details

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -300,6 +300,8 @@ class Move < VersionedModel
 
       save! # save before notifying
 
+      allocation&.refresh_status_and_moves_count!
+
       Notifier.prepare_notifications(topic: self, action_name: action_name)
       true
     else

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -710,6 +710,20 @@ RSpec.describe Move do
         expect(move.reload.status).to eq('in_transit')
       end
 
+      context 'with an allocation' do
+        subject(:move) { create(:move, allocation: allocation) }
+
+        let(:allocation) { create(:allocation) }
+
+        before { allow(allocation).to receive(:refresh_status_and_moves_count!) }
+
+        it 'updates the allocation' do
+          move.handle_event_run
+
+          expect(allocation).to have_received(:refresh_status_and_moves_count!)
+        end
+      end
+
       it 'triggers a move notification' do
         move.handle_event_run
 


### PR DESCRIPTION
Cancelling a move can affect the status of an allocation as only moves which are not cancelled are used to determine the status. Without this, you can end up in a state where an allocation is left unfilled if the one of the moves ends up being cancelled before the other moves start.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3563)