### PR TITLE
Add is_lockout field to move object and trigger change when lockout occurs

### DIFF
--- a/app/models/generic_event/move_lockout.rb
+++ b/app/models/generic_event/move_lockout.rb
@@ -10,6 +10,10 @@ class GenericEvent
     include LocationValidations
     include LocationFeed
 
+    def trigger(*)
+      eventable.is_lockout = true
+    end
+
     enum reason: {
       unachievable_ptr_request: 'unachievable_ptr_request', # (PECS - police only)
       no_space: 'no_space', # (PECS)

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -19,7 +19,8 @@ module V2
                 :rejection_reason,
                 :status,
                 :time_due,
-                :updated_at
+                :updated_at,
+                :is_lockout
 
     set_type :moves
 

--- a/db/migrate/20220328100142_add_column_is_lockout_to_moves.rb
+++ b/db/migrate/20220328100142_add_column_is_lockout_to_moves.rb
@@ -1,0 +1,5 @@
+class AddColumnIsLockoutToMoves < ActiveRecord::Migration[6.1]
+  def change
+    add_column :moves, :is_lockout, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_28_093153) do
+ActiveRecord::Schema.define(version: 2022_03_28_100142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -369,6 +369,7 @@ ActiveRecord::Schema.define(version: 2022_03_28_093153) do
     t.string "rejection_reason"
     t.uuid "original_move_id"
     t.uuid "supplier_id"
+    t.boolean "is_lockout", default: false
     t.index ["allocation_id"], name: "index_moves_on_allocation_id"
     t.index ["created_at"], name: "index_moves_on_created_at"
     t.index ["date"], name: "index_moves_on_date"

--- a/spec/acceptance/generic_events/runner_spec.rb
+++ b/spec/acceptance/generic_events/runner_spec.rb
@@ -310,14 +310,15 @@ RSpec.describe GenericEvents::Runner do
     end
 
     context 'when event_name=lockout' do
-      # NB: lockout events have should have no effect on a move, they are purely for auditing
       before { create(:event_move_lockout, eventable: move) }
+
+      it 'does update the moves is_lockout value' do
+        expect { runner.call }.to change(move, :is_lockout).to(true)
+      end
 
       it 'does not update the move status' do
         expect { runner.call }.not_to change(move, :status).from('requested')
       end
-
-      it_behaves_like 'it does not call the Notifier'
     end
 
     context 'when the move record fails to save' do

--- a/spec/requests/api/move_events_controller_lockout_spec.rb
+++ b/spec/requests/api/move_events_controller_lockout_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Api::MoveEventsController do
 
       describe 'webhook and email notifications' do
         it 'calls the notifier when updating a person' do
-          expect(Notifier).not_to have_received(:prepare_notifications)
+          expect(Notifier).to have_received(:prepare_notifications)
         end
       end
     end


### PR DESCRIPTION
### Jira link

[P4-3340](https://dsdmoj.atlassian.net/browse/P4-3340)

### What?

Added the `is_lockout` field to the move model, as well as trigger an update to the `is_lockout` field whenever a lockout occurs

### Why?

I am doing this because: This allows the frontend to receive this specific field without the need for us to pull in more data than we need into the frontend

