### PR TITLE
Add index on journey state and date

### DIFF
--- a/db/migrate/20220329100906_add_index_to_journey_state_and_date.rb
+++ b/db/migrate/20220329100906_add_index_to_journey_state_and_date.rb
@@ -1,0 +1,7 @@
+class AddIndexToJourneyStateAndDate < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :journeys, %i[state date], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_28_100142) do
+ActiveRecord::Schema.define(version: 2022_03_29_100906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -301,6 +301,7 @@ ActiveRecord::Schema.define(version: 2022_03_28_100142) do
     t.index ["move_id", "client_timestamp"], name: "index_journeys_on_move_id_and_client_timestamp"
     t.index ["move_id", "state"], name: "index_journeys_on_move_id_and_state"
     t.index ["move_id"], name: "index_journeys_on_move_id"
+    t.index ["state", "date"], name: "index_journeys_on_state_and_date"
     t.index ["state"], name: "index_journeys_on_state"
     t.index ["supplier_id", "billable"], name: "index_journeys_on_supplier_id_and_billable"
     t.index ["supplier_id", "client_timestamp"], name: "index_journeys_on_supplier_id_and_client_timestamp"


### PR DESCRIPTION
This should hopefully improve the performance of the new moves finder where it looks at journeys as well as moves. The query plan suggests it has to be a scan of the table on these fields, so putting in an index should help that.

```
    ->  Bitmap Heap Scan on journeys journeys_3  (cost=57.85..2531.25 rows=1 width=16) (actual time=0.031..0.032 rows=0 loops=1)
          Recheck Cond: (from_location_id = 'aaa4a8b2-c8b1-4bf4-a6c7-8dd67c666bc1'::uuid)
"          Filter: (((state)::text <> ALL ('{rejected,cancelled}'::text[])) AND (date >= '2022-01-01'::date) AND (date <= '2022-01-01'::date))"
          ->  Bitmap Index Scan on index_journeys_on_from_location_id  (cost=0.00..57.85 rows=723 width=0) (actual time=0.028..0.028 rows=0 loops=1)
                Index Cond: (from_location_id = 'aaa4a8b2-c8b1-4bf4-a6c7-8dd67c666bc1'::uuid)
```