### PR TITLE
Revert including journeys when finding moves

### DIFF
--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -54,13 +54,14 @@ module Moves
 
     def apply_filters(scope)
       scope = scope.accessible_by(ability)
-      scope = apply_created_at_filters(scope)
+      scope = apply_date_range_filters(scope)
       scope = apply_date_of_birth_filters(scope)
       scope = apply_second_degree_filter(scope, :location_type, joins: :to_location, where: :locations)
+      scope = apply_location_filters(scope)
       scope = apply_allocation_relationship_filters(scope)
       scope = apply_ready_for_transit_filters(scope)
       scope = apply_second_degree_filter(scope, :person_id, joins: :profile, where: :profiles)
-      scope = apply_date_and_location_filters(scope)
+      scope = apply_journey_filters(scope)
       SIMPLE_FIELD_FILTERS.reduce(scope) { |s, filter| apply_filter(s, filter) }
     end
 
@@ -86,7 +87,20 @@ module Moves
         .where(where => { param_name => filter_params[param_name] })
     end
 
-    def apply_created_at_filters(scope)
+    def apply_date_range_filter(scope, field)
+      if filter_params.key?(:date_from) && filter_params.key?(:date_to)
+        scope.where("#{field} BETWEEN ? AND ?", filter_params[:date_from], filter_params[:date_to])
+      elsif filter_params.key?(:date_from)
+        scope.where("#{field} >= ?", filter_params[:date_from])
+      elsif filter_params.key?(:date_to)
+        scope.where("#{field} <= ?", filter_params[:date_to])
+      else
+        scope
+      end
+    end
+
+    def apply_date_range_filters(scope)
+      scope = apply_date_range_filter(scope, 'moves.date')
       scope = scope.where('moves.created_at >= ?', filter_params[:created_at_from]) if filter_params.key?(:created_at_from)
       scope = scope.where('moves.created_at < ?', Date.parse(filter_params[:created_at_to]) + 1) if filter_params.key?(:created_at_to)
       scope
@@ -102,47 +116,14 @@ module Moves
       scope
     end
 
-    def apply_date_range_filter(scope)
-      if filter_params.key?(:date_from) && filter_params.key?(:date_to)
-        scope.where('date BETWEEN ? AND ?', filter_params[:date_from], filter_params[:date_to])
-      elsif filter_params.key?(:date_from)
-        scope.where('date >= ?', filter_params[:date_from])
-      elsif filter_params.key?(:date_to)
-        scope.where('date <= ?', filter_params[:date_to])
-      else
-        scope
-      end
-    end
-
-    def apply_location_filter(scope)
+    def apply_location_filters(scope)
       scope = scope.where(from_location_id: split_params(:from_location_id)) if filter_params.key?(:from_location_id)
       scope = scope.where(to_location_id: split_params(:to_location_id)) if filter_params.key?(:to_location_id)
       scope = scope.where(from_location_id: split_params(:location_id)).or(scope.where(to_location_id: split_params(:location_id))) if filter_params.key?(:location_id)
       scope
     end
 
-    def multi_date_journey_exists_scope
-      Journey
-        .not_rejected_or_cancelled
-        .where('move_id = moves.id')
-        .where.not('date = moves.date')
-        .arel.exists
-    end
-
-    def move_date_location_filters_scope
-      moves_scope = Move.where.not(multi_date_journey_exists_scope)
-      moves_scope = apply_date_range_filter(moves_scope)
-      apply_location_filter(moves_scope)
-    end
-
-    def journey_date_location_filters_scope
-      journey_scope = Journey.not_rejected_or_cancelled.where('move_id = moves.id')
-      journey_scope = apply_date_range_filter(journey_scope)
-      journey_scope = apply_location_filter(journey_scope)
-      Move.where(multi_date_journey_exists_scope).where(journey_scope.arel.exists)
-    end
-
-    def apply_date_and_location_filters(scope)
+    def apply_journey_filters(scope)
       should_apply_filter = filter_params.key?(:from_location_id) ||
         filter_params.key?(:to_location_id) ||
         filter_params.key?(:location_id) ||
@@ -151,7 +132,10 @@ module Moves
 
       return scope unless should_apply_filter
 
-      scope.merge(move_date_location_filters_scope).or(journey_date_location_filters_scope)
+      journey_scope = Journey.not_rejected_or_cancelled.where('move_id = moves.id')
+      journey_scope = apply_location_filters(journey_scope)
+      journey_scope = apply_date_range_filter(journey_scope, 'journeys.date')
+      scope.or(Journey.where(journey_scope.arel.exists))
     end
 
     def apply_allocation_relationship_filters(scope)

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -54,13 +54,6 @@ RSpec.describe Moves::Finder do
 
         it { is_expected.to be_empty }
       end
-
-      context 'with a journey' do
-        let(:journey) { create(:journey, move: move) }
-        let(:filter_params) { { location_id: [journey.to_location_id] } }
-
-        it { is_expected.to contain_exactly(move) }
-      end
     end
 
     describe 'by from_location_id' do
@@ -83,13 +76,6 @@ RSpec.describe Moves::Finder do
         let(:filter_params) { { from_location_id: Random.uuid } }
 
         it { is_expected.to be_empty }
-      end
-
-      context 'with a journey' do
-        let(:journey) { create(:journey, move: move) }
-        let(:filter_params) { { from_location_id: [journey.from_location_id] } }
-
-        it { is_expected.to contain_exactly(move) }
       end
     end
 
@@ -120,13 +106,6 @@ RSpec.describe Moves::Finder do
         let(:filter_params) { { to_location_id: Random.uuid } }
 
         it { is_expected.to be_empty }
-      end
-
-      context 'with a journey' do
-        let(:journey) { create(:journey, move: move) }
-        let(:filter_params) { { to_location_id: [journey.to_location_id] } }
-
-        it { is_expected.to contain_exactly(move) }
       end
     end
 
@@ -182,18 +161,6 @@ RSpec.describe Moves::Finder do
         let(:filter_params) { { date_from: (move.date + 2.days).to_s, date_to: (move.date + 5.days).to_s } }
 
         it { is_expected.to be_empty }
-      end
-
-      context 'with journey dates after move date' do
-        before do
-          create(:journey, move: move, date: move.date + 1.day)
-        end
-
-        let(:filter_params) { { date_from: (move.date + 1.day).to_s, date_to: (move.date + 5.days).to_s } }
-
-        it 'returns moves matching date range' do
-          expect(results).to match_array [move]
-        end
       end
     end
 

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Moves::Finder do
         it { is_expected.to be_empty }
       end
 
-      context 'with a journey on a different day' do
-        let(:journey) { create(:journey, move: move, date: '2022-01-01') }
+      context 'with a journey' do
+        let(:journey) { create(:journey, move: move) }
         let(:filter_params) { { location_id: [journey.to_location_id] } }
 
         it { is_expected.to contain_exactly(move) }
@@ -86,7 +86,7 @@ RSpec.describe Moves::Finder do
       end
 
       context 'with a journey' do
-        let(:journey) { create(:journey, move: move, date: '2022-01-01') }
+        let(:journey) { create(:journey, move: move) }
         let(:filter_params) { { from_location_id: [journey.from_location_id] } }
 
         it { is_expected.to contain_exactly(move) }
@@ -123,90 +123,8 @@ RSpec.describe Moves::Finder do
       end
 
       context 'with a journey' do
-        let(:journey) { create(:journey, move: move, date: '2022-01-01') }
+        let(:journey) { create(:journey, move: move) }
         let(:filter_params) { { to_location_id: [journey.to_location_id] } }
-
-        it { is_expected.to contain_exactly(move) }
-      end
-    end
-
-    context 'with multi-day moves' do
-      let(:move) { create(:move, date: '2022-01-01') }
-      let(:middle_location) { create(:location) }
-
-      before do
-        create(:journey, move: move, date: '2022-01-01', from_location: move.from_location, to_location: middle_location)
-        create(:journey, move: move, date: '2022-01-02', from_location: middle_location, to_location: move.to_location)
-      end
-
-      context 'and day one, outgoing, first location' do
-        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', from_location_id: [move.from_location_id] } }
-
-        it { is_expected.to contain_exactly(move) }
-      end
-
-      context 'and day one, outgoing, second location' do
-        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', from_location_id: [middle_location] } }
-
-        it { is_expected.to be_empty }
-      end
-
-      context 'and day one, outgoing, third location' do
-        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', from_location_id: [move.to_location_id] } }
-
-        it { is_expected.to be_empty }
-      end
-
-      context 'and day one, incoming, first location' do
-        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', to_location_id: [move.from_location_id] } }
-
-        it { is_expected.to be_empty }
-      end
-
-      context 'and day one, incoming, second location' do
-        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', to_location_id: [middle_location] } }
-
-        it { is_expected.to contain_exactly(move) }
-      end
-
-      context 'and day one, incoming, third location' do
-        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', to_location_id: [move.to_location_id] } }
-
-        it { is_expected.to be_empty }
-      end
-
-      context 'and day two, outgoing, first location' do
-        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', from_location_id: [move.from_location_id] } }
-
-        it { is_expected.to be_empty }
-      end
-
-      context 'and day two, outgoing, second location' do
-        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', from_location_id: [middle_location] } }
-
-        it { is_expected.to contain_exactly(move) }
-      end
-
-      context 'and day two, outgoing, third location' do
-        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', from_location_id: [move.to_location_id] } }
-
-        it { is_expected.to be_empty }
-      end
-
-      context 'and day two, incoming, first location' do
-        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', to_location_id: [move.from_location_id] } }
-
-        it { is_expected.to be_empty }
-      end
-
-      context 'and day two, incoming, second location' do
-        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', to_location_id: [middle_location] } }
-
-        it { is_expected.to be_empty }
-      end
-
-      context 'and day two, incoming, third location' do
-        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', to_location_id: [move.to_location_id] } }
 
         it { is_expected.to contain_exactly(move) }
       end


### PR DESCRIPTION
This partially reverts #1793 and #1791 as it's having a performance impact. Hopefully once the indexes have been deployed in #1797 and #1799, we can put this query back without an issue.