### PR TITLE
Filter on journey information efficiently

### DIFF
--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -61,6 +61,7 @@ module Moves
       scope = apply_allocation_relationship_filters(scope)
       scope = apply_ready_for_transit_filters(scope)
       scope = apply_second_degree_filter(scope, :person_id, joins: :profile, where: :profiles)
+      scope = apply_journey_filters(scope)
       SIMPLE_FIELD_FILTERS.reduce(scope) { |s, filter| apply_filter(s, filter) }
     end
 
@@ -100,15 +101,8 @@ module Moves
 
     def apply_date_range_filters(scope)
       scope = apply_date_range_filter(scope, 'moves.date')
-
-      if filter_params.key?(:date_from) || filter_params.key?(:date_to)
-        journey_scope = apply_date_range_filter(Journey.not_rejected_or_cancelled.where('move_id = moves.id'), 'journeys.date')
-        scope = scope.or(Journey.where(journey_scope.arel.exists))
-      end
-
       scope = scope.where('moves.created_at >= ?', filter_params[:created_at_from]) if filter_params.key?(:created_at_from)
       scope = scope.where('moves.created_at < ?', Date.parse(filter_params[:created_at_to]) + 1) if filter_params.key?(:created_at_to)
-
       scope
     end
 
@@ -122,22 +116,26 @@ module Moves
       scope
     end
 
-    def apply_location_filter(scope)
+    def apply_location_filters(scope)
       scope = scope.where(from_location_id: split_params(:from_location_id)) if filter_params.key?(:from_location_id)
       scope = scope.where(to_location_id: split_params(:to_location_id)) if filter_params.key?(:to_location_id)
       scope = scope.where(from_location_id: split_params(:location_id)).or(scope.where(to_location_id: split_params(:location_id))) if filter_params.key?(:location_id)
       scope
     end
 
-    def apply_location_filters(scope)
-      scope = apply_location_filter(scope)
+    def apply_journey_filters(scope)
+      should_apply_filter = filter_params.key?(:from_location_id) ||
+        filter_params.key?(:to_location_id) ||
+        filter_params.key?(:location_id) ||
+        filter_params.key?(:date_from) ||
+        filter_params.key?(:date_to)
 
-      if filter_params.key?(:from_location_id) || filter_params.key?(:to_location_id) || filter_params.key?(:location_id)
-        journey_scope = apply_location_filter(Journey.not_rejected_or_cancelled.where('move_id = moves.id'))
-        scope = scope.or(Journey.where(journey_scope.arel.exists))
-      end
+      return scope unless should_apply_filter
 
-      scope
+      journey_scope = Journey.not_rejected_or_cancelled.where('move_id = moves.id')
+      journey_scope = apply_location_filters(journey_scope)
+      journey_scope = apply_date_range_filter(journey_scope, 'journeys.date')
+      scope.or(Journey.where(journey_scope.arel.exists))
     end
 
     def apply_allocation_relationship_filters(scope)

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -86,12 +86,29 @@ module Moves
         .where(where => { param_name => filter_params[param_name] })
     end
 
+    def apply_date_range_filter(scope, field)
+      if filter_params.key?(:date_from) && filter_params.key?(:date_to)
+        scope.where("#{field} BETWEEN ? AND ?", filter_params[:date_from], filter_params[:date_to])
+      elsif filter_params.key?(:date_from)
+        scope.where("#{field} >= ?", filter_params[:date_from])
+      elsif filter_params.key?(:date_to)
+        scope.where("#{field} <= ?", filter_params[:date_to])
+      else
+        scope
+      end
+    end
+
     def apply_date_range_filters(scope)
-      scope = scope.where('moves.date >= ?', filter_params[:date_from]) if filter_params.key?(:date_from)
-      scope = scope.where('moves.date <= ?', filter_params[:date_to]) if filter_params.key?(:date_to)
-      # created_at is a date/time, so inclusive filtering has to be subtly different
+      scope = apply_date_range_filter(scope, 'moves.date')
+
+      if filter_params.key?(:date_from) || filter_params.key?(:date_to)
+        journey_scope = apply_date_range_filter(Journey.not_rejected_or_cancelled.where('move_id = moves.id'), 'journeys.date')
+        scope = scope.or(Journey.where(journey_scope.arel.exists))
+      end
+
       scope = scope.where('moves.created_at >= ?', filter_params[:created_at_from]) if filter_params.key?(:created_at_from)
       scope = scope.where('moves.created_at < ?', Date.parse(filter_params[:created_at_to]) + 1) if filter_params.key?(:created_at_to)
+
       scope
     end
 
@@ -105,10 +122,21 @@ module Moves
       scope
     end
 
-    def apply_location_filters(scope)
+    def apply_location_filter(scope)
       scope = scope.where(from_location_id: split_params(:from_location_id)) if filter_params.key?(:from_location_id)
       scope = scope.where(to_location_id: split_params(:to_location_id)) if filter_params.key?(:to_location_id)
       scope = scope.where(from_location_id: split_params(:location_id)).or(scope.where(to_location_id: split_params(:location_id))) if filter_params.key?(:location_id)
+      scope
+    end
+
+    def apply_location_filters(scope)
+      scope = apply_location_filter(scope)
+
+      if filter_params.key?(:from_location_id) || filter_params.key?(:to_location_id) || filter_params.key?(:location_id)
+        journey_scope = apply_location_filter(Journey.not_rejected_or_cancelled.where('move_id = moves.id'))
+        scope = scope.or(Journey.where(journey_scope.arel.exists))
+      end
+
       scope
     end
 

--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -54,14 +54,13 @@ module Moves
 
     def apply_filters(scope)
       scope = scope.accessible_by(ability)
-      scope = apply_date_range_filters(scope)
+      scope = apply_created_at_filters(scope)
       scope = apply_date_of_birth_filters(scope)
       scope = apply_second_degree_filter(scope, :location_type, joins: :to_location, where: :locations)
-      scope = apply_location_filters(scope)
       scope = apply_allocation_relationship_filters(scope)
       scope = apply_ready_for_transit_filters(scope)
       scope = apply_second_degree_filter(scope, :person_id, joins: :profile, where: :profiles)
-      scope = apply_journey_filters(scope)
+      scope = apply_date_and_location_filters(scope)
       SIMPLE_FIELD_FILTERS.reduce(scope) { |s, filter| apply_filter(s, filter) }
     end
 
@@ -87,20 +86,7 @@ module Moves
         .where(where => { param_name => filter_params[param_name] })
     end
 
-    def apply_date_range_filter(scope, field)
-      if filter_params.key?(:date_from) && filter_params.key?(:date_to)
-        scope.where("#{field} BETWEEN ? AND ?", filter_params[:date_from], filter_params[:date_to])
-      elsif filter_params.key?(:date_from)
-        scope.where("#{field} >= ?", filter_params[:date_from])
-      elsif filter_params.key?(:date_to)
-        scope.where("#{field} <= ?", filter_params[:date_to])
-      else
-        scope
-      end
-    end
-
-    def apply_date_range_filters(scope)
-      scope = apply_date_range_filter(scope, 'moves.date')
+    def apply_created_at_filters(scope)
       scope = scope.where('moves.created_at >= ?', filter_params[:created_at_from]) if filter_params.key?(:created_at_from)
       scope = scope.where('moves.created_at < ?', Date.parse(filter_params[:created_at_to]) + 1) if filter_params.key?(:created_at_to)
       scope
@@ -116,14 +102,47 @@ module Moves
       scope
     end
 
-    def apply_location_filters(scope)
+    def apply_date_range_filter(scope)
+      if filter_params.key?(:date_from) && filter_params.key?(:date_to)
+        scope.where('date BETWEEN ? AND ?', filter_params[:date_from], filter_params[:date_to])
+      elsif filter_params.key?(:date_from)
+        scope.where('date >= ?', filter_params[:date_from])
+      elsif filter_params.key?(:date_to)
+        scope.where('date <= ?', filter_params[:date_to])
+      else
+        scope
+      end
+    end
+
+    def apply_location_filter(scope)
       scope = scope.where(from_location_id: split_params(:from_location_id)) if filter_params.key?(:from_location_id)
       scope = scope.where(to_location_id: split_params(:to_location_id)) if filter_params.key?(:to_location_id)
       scope = scope.where(from_location_id: split_params(:location_id)).or(scope.where(to_location_id: split_params(:location_id))) if filter_params.key?(:location_id)
       scope
     end
 
-    def apply_journey_filters(scope)
+    def multi_date_journey_exists_scope
+      Journey
+        .not_rejected_or_cancelled
+        .where('move_id = moves.id')
+        .where.not('date = moves.date')
+        .arel.exists
+    end
+
+    def move_date_location_filters_scope
+      moves_scope = Move.where.not(multi_date_journey_exists_scope)
+      moves_scope = apply_date_range_filter(moves_scope)
+      apply_location_filter(moves_scope)
+    end
+
+    def journey_date_location_filters_scope
+      journey_scope = Journey.not_rejected_or_cancelled.where('move_id = moves.id')
+      journey_scope = apply_date_range_filter(journey_scope)
+      journey_scope = apply_location_filter(journey_scope)
+      Move.where(multi_date_journey_exists_scope).where(journey_scope.arel.exists)
+    end
+
+    def apply_date_and_location_filters(scope)
       should_apply_filter = filter_params.key?(:from_location_id) ||
         filter_params.key?(:to_location_id) ||
         filter_params.key?(:location_id) ||
@@ -132,10 +151,7 @@ module Moves
 
       return scope unless should_apply_filter
 
-      journey_scope = Journey.not_rejected_or_cancelled.where('move_id = moves.id')
-      journey_scope = apply_location_filters(journey_scope)
-      journey_scope = apply_date_range_filter(journey_scope, 'journeys.date')
-      scope.or(Journey.where(journey_scope.arel.exists))
+      scope.merge(move_date_location_filters_scope).or(journey_date_location_filters_scope)
     end
 
     def apply_allocation_relationship_filters(scope)

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Moves::Finder do
         it { is_expected.to be_empty }
       end
 
-      context 'with a journey' do
-        let(:journey) { create(:journey, move: move) }
+      context 'with a journey on a different day' do
+        let(:journey) { create(:journey, move: move, date: '2022-01-01') }
         let(:filter_params) { { location_id: [journey.to_location_id] } }
 
         it { is_expected.to contain_exactly(move) }
@@ -86,7 +86,7 @@ RSpec.describe Moves::Finder do
       end
 
       context 'with a journey' do
-        let(:journey) { create(:journey, move: move) }
+        let(:journey) { create(:journey, move: move, date: '2022-01-01') }
         let(:filter_params) { { from_location_id: [journey.from_location_id] } }
 
         it { is_expected.to contain_exactly(move) }
@@ -123,8 +123,90 @@ RSpec.describe Moves::Finder do
       end
 
       context 'with a journey' do
-        let(:journey) { create(:journey, move: move) }
+        let(:journey) { create(:journey, move: move, date: '2022-01-01') }
         let(:filter_params) { { to_location_id: [journey.to_location_id] } }
+
+        it { is_expected.to contain_exactly(move) }
+      end
+    end
+
+    context 'with multi-day moves' do
+      let(:move) { create(:move, date: '2022-01-01') }
+      let(:middle_location) { create(:location) }
+
+      before do
+        create(:journey, move: move, date: '2022-01-01', from_location: move.from_location, to_location: middle_location)
+        create(:journey, move: move, date: '2022-01-02', from_location: middle_location, to_location: move.to_location)
+      end
+
+      context 'and day one, outgoing, first location' do
+        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', from_location_id: [move.from_location_id] } }
+
+        it { is_expected.to contain_exactly(move) }
+      end
+
+      context 'and day one, outgoing, second location' do
+        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', from_location_id: [middle_location] } }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'and day one, outgoing, third location' do
+        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', from_location_id: [move.to_location_id] } }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'and day one, incoming, first location' do
+        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', to_location_id: [move.from_location_id] } }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'and day one, incoming, second location' do
+        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', to_location_id: [middle_location] } }
+
+        it { is_expected.to contain_exactly(move) }
+      end
+
+      context 'and day one, incoming, third location' do
+        let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', to_location_id: [move.to_location_id] } }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'and day two, outgoing, first location' do
+        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', from_location_id: [move.from_location_id] } }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'and day two, outgoing, second location' do
+        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', from_location_id: [middle_location] } }
+
+        it { is_expected.to contain_exactly(move) }
+      end
+
+      context 'and day two, outgoing, third location' do
+        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', from_location_id: [move.to_location_id] } }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'and day two, incoming, first location' do
+        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', to_location_id: [move.from_location_id] } }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'and day two, incoming, second location' do
+        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', to_location_id: [middle_location] } }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'and day two, incoming, third location' do
+        let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', to_location_id: [move.to_location_id] } }
 
         it { is_expected.to contain_exactly(move) }
       end

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -54,6 +54,13 @@ RSpec.describe Moves::Finder do
 
         it { is_expected.to be_empty }
       end
+
+      context 'with a journey' do
+        let(:journey) { create(:journey, move: move) }
+        let(:filter_params) { { location_id: [journey.to_location_id] } }
+
+        it { is_expected.to contain_exactly(move) }
+      end
     end
 
     describe 'by from_location_id' do
@@ -76,6 +83,13 @@ RSpec.describe Moves::Finder do
         let(:filter_params) { { from_location_id: Random.uuid } }
 
         it { is_expected.to be_empty }
+      end
+
+      context 'with a journey' do
+        let(:journey) { create(:journey, move: move) }
+        let(:filter_params) { { from_location_id: [journey.from_location_id] } }
+
+        it { is_expected.to contain_exactly(move) }
       end
     end
 
@@ -106,6 +120,13 @@ RSpec.describe Moves::Finder do
         let(:filter_params) { { to_location_id: Random.uuid } }
 
         it { is_expected.to be_empty }
+      end
+
+      context 'with a journey' do
+        let(:journey) { create(:journey, move: move) }
+        let(:filter_params) { { to_location_id: [journey.to_location_id] } }
+
+        it { is_expected.to contain_exactly(move) }
       end
     end
 
@@ -161,6 +182,18 @@ RSpec.describe Moves::Finder do
         let(:filter_params) { { date_from: (move.date + 2.days).to_s, date_to: (move.date + 5.days).to_s } }
 
         it { is_expected.to be_empty }
+      end
+
+      context 'with journey dates after move date' do
+        before do
+          create(:journey, move: move, date: move.date + 1.day)
+        end
+
+        let(:filter_params) { { date_from: (move.date + 1.day).to_s, date_to: (move.date + 5.days).to_s } }
+
+        it 'returns moves matching date range' do
+          expect(results).to match_array [move]
+        end
       end
     end
 


### PR DESCRIPTION
This brings back the functionality that was reverted in #1800 but with an optimised query making use of the `UNION` operator. This ensures the query planner is able to generate a better query rather than doing a sequential scan on the moves table, it can rely on in indexes.

To actually generate the `UNION` query in Rails, I've followed the code used from [this article](https://joshfrankel.me/blog/a-journey-into-writing-union-queries-with-active-record/) as it's not built in to ActiveRecord. The query is a little odd as it uses an `id IN (...)`, but that's more of a quirk of how it works in ActiveRecord and doesn't introduce any major slowdowns. I've concluded that it's better to keep the query in Ruby rather than dropping down to SQL, than to produce the most optimal query.

I'm confident this could be optimised further, perhaps by doing the `UNION` earlier in the filters, but I think for now this is good enough.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3339)

## Old query

<details>
  <summary>Click to expand</summary>

```sql
    SELECT
        *     
    FROM
        moves     
    WHERE
        (
            NOT (EXISTS(                               SELECT
                *                               
            FROM
                journeys                               
            WHERE
                state NOT IN ('rejected', 'cancelled')                                 
                AND move_id = moves.id                                 
                AND NOT date = moves.date                           ))                       
            AND date BETWEEN '2022-01-01' AND '2022-01-01'                       
            AND from_location_id = 'aaa4a8b2-c8b1-4bf4-a6c7-8dd67c666bc1'                    
            OR EXISTS(
                SELECT
                    *                               
                FROM
                    journeys                               
                WHERE
                    state NOT IN (
                        'rejected', 'cancelled'
                    )                                 
                    AND move_id = moves.id                                 
                    AND NOT date = moves.date                           
            )                   
            AND EXISTS(
                SELECT
                    *                               
                FROM
                    journeys                               
                WHERE
                    state NOT IN (
                        'rejected', 'cancelled'
                    )                                 
                    AND move_id = moves.id                                 
                    AND date BETWEEN '2022-01-01' AND '2022-01-01'                                 
                    AND from_location_id = 'aaa4a8b2-c8b1-4bf4-a6c7-8dd67c666bc1'                           
            )               
        );
```
</details>

## Old query plan

<details>
  <summary>Click to expand</summary>

```
Seq Scan on moves  (cost=0.00..24512724.04 rows=241374 width=323) (actual time=25227.717..25227.720 rows=0 loops=1)
  Filter: (((NOT (SubPlan 1)) AND (date >= '2022-01-01'::date) AND (date <= '2022-01-01'::date) AND (from_location_id = 'aaa4a8b2-c8b1-4bf4-a6c7-8dd67c666bc1'::uuid)) OR ((SubPlan 2) AND (alternatives: SubPlan 3 or hashed SubPlan 4)))
  Rows Removed by Filter: 956514
  SubPlan 1
    ->  Index Scan using index_journeys_on_move_id_and_client_timestamp on journeys  (cost=0.42..8.45 rows=1 width=0) (actual time=0.022..0.022 rows=0 loops=956514)
          Index Cond: (move_id = moves.id)
          Filter: (((state)::text <> ALL ('{rejected,cancelled}'::text[])) AND (date <> moves.date))
          Rows Removed by Filter: 1
  SubPlan 2
    ->  Index Scan using index_journeys_on_move_id_and_client_timestamp on journeys journeys_1  (cost=0.42..8.45 rows=1 width=0) (actual time=0.002..0.002 rows=0 loops=956514)
          Index Cond: (move_id = moves.id)
          Filter: (((state)::text <> ALL ('{rejected,cancelled}'::text[])) AND (date <> moves.date))
          Rows Removed by Filter: 1
  SubPlan 3
    ->  Index Scan using index_journeys_on_date on journeys journeys_2  (cost=0.42..8.45 rows=1 width=0) (never executed)
          Index Cond: ((date >= '2022-01-01'::date) AND (date <= '2022-01-01'::date))
          Filter: (((state)::text <> ALL ('{rejected,cancelled}'::text[])) AND (move_id = moves.id) AND (from_location_id = 'aaa4a8b2-c8b1-4bf4-a6c7-8dd67c666bc1'::uuid))
  SubPlan 4
    ->  Index Scan using index_journeys_on_date on journeys journeys_3  (cost=0.42..8.45 rows=1 width=16) (actual time=317.856..317.856 rows=0 loops=1)
          Index Cond: ((date >= '2022-01-01'::date) AND (date <= '2022-01-01'::date))
          Filter: (((state)::text <> ALL ('{rejected,cancelled}'::text[])) AND (from_location_id = 'aaa4a8b2-c8b1-4bf4-a6c7-8dd67c666bc1'::uuid))
          Rows Removed by Filter: 475
Planning time: 1.297 ms
Execution time: 25227.794 ms
```
</details>

## New query

<details>
  <summary>Click to expand</summary>

```sql
    SELECT
        "moves".* 
    FROM
        "moves" 
    WHERE
        "moves"."id" IN (
            SELECT
                "moves"."id" 
            FROM
                ((SELECT
                    "moves".* 
                FROM
                    "moves" 
                WHERE
                    NOT (EXISTS (SELECT
                        "journeys".* 
                    FROM
                        "journeys" 
                    WHERE
                        "journeys"."state" NOT IN ('rejected', 'cancelled') 
                        AND (move_id = moves.id) 
                        AND NOT (date = moves.date))) 
                    AND (
                        date BETWEEN '2022-01-01' AND '2022-01-01'
                    ) 
                    AND "moves"."from_location_id" = '58acecc0-661c-4141-9c42-882af6843e1b'
                ) 
            UNION
            (
                SELECT
                    "moves".* 
                FROM
                    "moves" 
                WHERE
                    EXISTS (
                        SELECT
                            "journeys".* 
                        FROM
                            "journeys" 
                        WHERE
                            "journeys"."state" NOT IN (
                                'rejected', 'cancelled'
                            ) 
                            AND (
                                move_id = moves.id
                            ) 
                            AND NOT (date = moves.date)
                    ) 
                    AND EXISTS (
                        SELECT
                            "journeys".* 
                        FROM
                            "journeys" 
                        WHERE
                            "journeys"."state" NOT IN (
                                'rejected', 'cancelled'
                            ) 
                            AND (
                                move_id = moves.id
                            ) 
                            AND (
                                date BETWEEN '2022-01-01' AND '2022-01-01'
                            ) 
                            AND "journeys"."from_location_id" = '58acecc0-661c-4141-9c42-882af6843e1b'
                    )
                )
            ) moves
    ) 
```
</details>

## New query plan

<details>
  <summary>Click to expand</summary>

```
Sort  (cost=35.17..35.23 rows=24 width=323) (actual time=0.975..0.980 rows=0 loops=1)
  Sort Key: moves.date DESC
  Sort Method: quicksort  Memory: 25kB
  ->  Append  (cost=0.85..34.62 rows=24 width=323) (actual time=0.960..0.963 rows=0 loops=1)
        ->  Nested Loop Anti Join  (cost=0.85..16.91 rows=1 width=323) (actual time=0.398..0.399 rows=0 loops=1)
              ->  Index Scan using index_moves_on_date on moves  (cost=0.42..8.45 rows=1 width=323) (actual time=0.396..0.397 rows=0 loops=1)
                    Index Cond: ((date >= '2022-01-01'::date) AND (date <= '2022-01-01'::date))
                    Filter: (from_location_id = 'aaa4a8b2-c8b1-4bf4-a6c7-8dd67c666bc1'::uuid)
                    Rows Removed by Filter: 447
              ->  Index Scan using index_journeys_on_move_id_and_client_timestamp on journeys  (cost=0.42..8.45 rows=1 width=20) (never executed)
                    Index Cond: (move_id = moves.id)
                    Filter: (((state)::text <> ALL ('{rejected,cancelled}'::text[])) AND (date <> moves.date))
        ->  Nested Loop Semi Join  (cost=9.30..17.47 rows=23 width=323) (actual time=0.561..0.563 rows=0 loops=1)
              ->  Nested Loop  (cost=8.88..16.91 rows=1 width=339) (actual time=0.560..0.562 rows=0 loops=1)
                    ->  HashAggregate  (cost=8.45..8.46 rows=1 width=16) (actual time=0.560..0.560 rows=0 loops=1)
                          Group Key: journeys_2.move_id
                          ->  Index Scan using index_journeys_on_date on journeys journeys_2  (cost=0.42..8.45 rows=1 width=16) (actual time=0.558..0.558 rows=0 loops=1)
                                Index Cond: ((date >= '2022-01-01'::date) AND (date <= '2022-01-01'::date))
                                Filter: (((state)::text <> ALL ('{rejected,cancelled}'::text[])) AND (from_location_id = 'aaa4a8b2-c8b1-4bf4-a6c7-8dd67c666bc1'::uuid))
                                Rows Removed by Filter: 475
                    ->  Index Scan using moves_pkey on moves moves_1  (cost=0.42..8.44 rows=1 width=323) (never executed)
                          Index Cond: (id = journeys_2.move_id)
              ->  Index Scan using index_journeys_on_move_id on journeys journeys_1  (cost=0.42..0.56 rows=1 width=20) (never executed)
                    Index Cond: (move_id = moves_1.id)
                    Filter: (((state)::text <> ALL ('{rejected,cancelled}'::text[])) AND (date <> moves_1.date))
Planning time: 1.378 ms
Execution time: 1.107 ms
```
</details>