### PR TITLE
Expose the is_lockout field to the move serializer

### DIFF
--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -21,7 +21,8 @@ module V2
                :rejection_reason,
                :status,
                :time_due,
-               :updated_at
+               :updated_at,
+               :is_lockout
 
     belongs_to :from_location,          serializer: LocationSerializer
     belongs_to :prison_transfer_reason, serializer: PrisonTransferReasonSerializer

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe V2::MoveSerializer do
             status: 'requested',
             time_due: move.time_due.iso8601,
             updated_at: move.updated_at.iso8601,
+            is_lockout: false,
           },
           relationships: {
             profile: { data: { id: move.profile.id, type: 'profiles' } },

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe V2::MovesSerializer do
             status: 'requested',
             time_due: move.time_due.iso8601,
             updated_at: move.updated_at.iso8601,
+            is_lockout: false,
           },
           relationships: {
             profile: { data: { id: move.profile_id, type: 'profiles' } },


### PR DESCRIPTION
Expose the is_lockout field to the moves serializer, so we can check if a specific move is locked out. This is so we can show this on the frontend ticket: [P4-3342](https://dsdmoj.atlassian.net/browse/P4-3342)