### PR TITLE
Add framework response author information to serializers

### DIFF
--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -166,4 +166,8 @@ module FrameworkAssessmentable
 
     move.requested? || move.booked?
   end
+
+  def responded_by
+    framework_responses.pluck(:responded_by).sort.uniq
+  end
 end

--- a/app/serializers/framework_response_serializer.rb
+++ b/app/serializers/framework_response_serializer.rb
@@ -11,7 +11,7 @@ class FrameworkResponseSerializer
   has_many_if_included :flags, serializer: FrameworkFlagSerializer, &:framework_flags
   has_many_if_included :nomis_mappings, serializer: FrameworkNomisMappingSerializer, &:framework_nomis_mappings
 
-  attributes :value, :responded, :prefilled, :value_type
+  attributes :value, :responded, :prefilled, :value_type, :responded_by, :responded_at
 
   SUPPORTED_RELATIONSHIPS = %w[
     assessment

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -191,4 +191,17 @@ RSpec.describe PersonEscortRecord do
     it { is_expected.to include(GenericEvent::PerMedicalAid.first) }
     it { is_expected.to include(GenericEvent::PerPropertyChange.first) }
   end
+
+  describe '#responded_by' do
+    subject(:responded_by) { per.responded_by }
+
+    let(:per) { create(:person_escort_record) }
+
+    before do
+      create(:string_response, assessmentable: per, responded_by: 'ABC')
+      create(:string_response, assessmentable: per, responded_by: 'DEF')
+    end
+
+    it { is_expected.to match_array(%w[ABC DEF]) }
+  end
 end

--- a/spec/serializers/framework_response_serializer_spec.rb
+++ b/spec/serializers/framework_response_serializer_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe FrameworkResponseSerializer do
     expect(result[:data][:attributes][:prefilled]).to eq(framework_response.prefilled)
   end
 
+  it 'contains a `responded_by` attribute' do
+    expect(result[:data][:attributes][:responded_by]).to eq(framework_response.responded_by)
+  end
+
+  it 'contains a `responded_at` attribute' do
+    expect(result[:data][:attributes][:responded_at]).to eq(framework_response.responded_at)
+  end
+
   it 'contains a `assessment` relationship' do
     expect(result[:data][:relationships][:assessment][:data]).to eq(
       id: framework_response.assessmentable.id,


### PR DESCRIPTION
This adds the information of who completed a framework response to the API so it can be accessible by the frontend.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3574)