### PR TITLE
Revert "Update assessment status based on required questions"

### DIFF
--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -140,7 +140,7 @@ module FrameworkAssessmentable
 
   def required_responses
     @required_responses ||= framework_responses.includes(:framework_question, :parent).select do |framework_response|
-      framework_response.parent ? framework_response.parent.option_selected?(framework_response.framework_question.dependent_value) : framework_response.framework_question.required
+      framework_response.parent ? framework_response.parent.option_selected?(framework_response.framework_question.dependent_value) : framework_response
     end
   end
 

--- a/spec/factories/framework_assessment.rb
+++ b/spec/factories/framework_assessment.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
     trait :with_responses do
       after(:create) do |assessment|
-        create_list(:framework_question, 2, framework: assessment.framework, required: true)
+        create_list(:framework_question, 2, framework: assessment.framework)
         assessment.framework_questions.each do |question|
           create(
             :string_response,

--- a/spec/factories/framework_question.rb
+++ b/spec/factories/framework_question.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     section { %w[offence-information health-information risk-information].sample }
     question_type { 'radio' }
     options { %w[Yes No] }
-    required { false }
 
     trait :text do
       question_type { 'text' }

--- a/spec/factories/framework_response.rb
+++ b/spec/factories/framework_response.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :framework_response do
-    association(:framework_question, required: true)
+    association(:framework_question)
     association(:assessmentable, factory: :person_escort_record)
     value_type { framework_question.response_type }
     section { framework_question.section }

--- a/spec/models/framework_response/string_spec.rb
+++ b/spec/models/framework_response/string_spec.rb
@@ -58,14 +58,13 @@ RSpec.describe FrameworkResponse::String do
 
     context 'when question not required' do
       it 'does not validate presence of value when value is nil with options' do
-        question = create(:framework_question, required: false)
-        response = create(:string_response, value: nil, framework_question: question)
+        response = create(:string_response, value: nil)
 
         expect(response).to be_valid
       end
 
       it 'does not validate presence of value when value is nil with no options' do
-        question = create(:framework_question, :text, required: false)
+        question = create(:framework_question, :text)
         response = create(:string_response, value: nil, framework_question: question)
 
         expect(response).to be_valid

--- a/spec/models/framework_response_spec.rb
+++ b/spec/models/framework_response_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe FrameworkResponse do
       end
 
       it 'updates person escort record progress' do
-        question = create(:framework_question, section: 'risk-information', required: true)
+        question = create(:framework_question, section: 'risk-information')
         response = create(:string_response, value: nil, framework_question: question)
         response.update_with_flags!(new_value: 'Yes')
 
@@ -470,7 +470,7 @@ RSpec.describe FrameworkResponse do
 
     it 'sets the responded value to true on update with value' do
       response = create(:string_response, value: 'Yes')
-      response.update!(value: 'No')
+      response.update!(value: nil)
 
       expect(response.responded).to be(true)
     end

--- a/spec/requests/api/person_escort_records_controller_show_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_show_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::PersonEscortRecordsController do
     include_context 'with supplier with spoofed access token'
 
     let(:response_json) { JSON.parse(response.body) }
-    let(:framework_question) { build(:framework_question, section: 'risk-information', required: true) }
+    let(:framework_question) { build(:framework_question, section: 'risk-information') }
     let(:flag) { build(:framework_flag, framework_question: framework_question) }
     let(:framework) { create(:framework, framework_questions: [framework_question]) }
     let(:person_escort_record) do

--- a/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
+++ b/spec/requests/api/youth_risk_assessments_controller_show_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::YouthRiskAssessmentsController do
     include_context 'with supplier with spoofed access token'
 
     let(:response_json) { JSON.parse(response.body) }
-    let(:framework_question) { build(:framework_question, section: 'risk-information', required: true) }
+    let(:framework_question) { build(:framework_question, section: 'risk-information') }
     let(:flag) { build(:framework_flag, framework_question: framework_question) }
     let(:framework) { create(:framework, framework_questions: [framework_question]) }
     let(:youth_risk_assessment) do

--- a/spec/serializers/framework_assessment_serializer_spec.rb
+++ b/spec/serializers/framework_assessment_serializer_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe FrameworkAssessmentSerializer do
 
   describe 'meta' do
     it 'includes section progress' do
-      question = create(:framework_question, framework: assessment.framework, section: 'risk-information', required: true)
+      question = create(:framework_question, framework: assessment.framework, section: 'risk-information')
       create(:string_response, value: nil, framework_question: question, assessmentable: assessment)
       assessment.update_status_and_progress!
 

--- a/spec/serializers/person_escort_records_serializer_spec.rb
+++ b/spec/serializers/person_escort_records_serializer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe PersonEscortRecordsSerializer do
 
   describe 'meta' do
     it 'includes section progress' do
-      question = create(:framework_question, framework: person_escort_record.framework, section: 'risk-information', required: true)
+      question = create(:framework_question, framework: person_escort_record.framework, section: 'risk-information')
       create(:string_response, value: nil, framework_question: question, assessmentable: person_escort_record)
       person_escort_record.update_status_and_progress!
 

--- a/spec/services/framework_responses/bulk_updater_spec.rb
+++ b/spec/services/framework_responses/bulk_updater_spec.rb
@@ -171,8 +171,8 @@ RSpec.describe FrameworkResponses::BulkUpdater do
 
     it 'updates person escort record progress' do
       per = create(:person_escort_record)
-      question1 = create(:framework_question, section: 'risk-information', required: true)
-      question2 = create(:framework_question, section: 'health-information', required: true)
+      question1 = create(:framework_question, section: 'risk-information')
+      question2 = create(:framework_question, section: 'health-information')
       response1 = create(:string_response, value: nil, assessmentable: per, framework_question: question1)
       create(:string_response, value: nil, assessmentable: per, framework_question: question2)
       described_class.new(assessment: per, response_values_hash: { response1.id => 'Yes' }).call

--- a/spec/support/a_framework_assessment.rb
+++ b/spec/support/a_framework_assessment.rb
@@ -423,8 +423,8 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
 
     it 'returns a section as `not_started` if all responded values are false' do
       assessment = create(assessment_type)
-      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, required: true)
-      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, required: true)
+      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false)
+      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false)
 
       expect(assessment.calculate_section_progress).to contain_exactly(
         {
@@ -436,8 +436,8 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
 
     it 'returns a section as `in_progress` if some responded values are true' do
       assessment = create(assessment_type)
-      create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, required: true)
-      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, required: true)
+      create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true)
+      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false)
 
       expect(assessment.calculate_section_progress).to contain_exactly(
         {
@@ -450,14 +450,14 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
     it 'returns a section as `in_progress` if not all required dependent responses responded' do
       assessment = create(assessment_type)
       # Non dependent Responses
-      create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, required: true)
-      parent_response = create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, required: true)
+      create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true)
+      parent_response = create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true)
       # Dependent responses on parent_response
-      child_response = create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, parent: parent_response, dependent_value: 'Yes', parent_question: parent_response.framework_question, required: true)
-      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, parent: parent_response, dependent_value: 'No', parent_question: parent_response.framework_question, required: true)
+      child_response = create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, parent: parent_response, dependent_value: 'Yes', parent_question: parent_response.framework_question)
+      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, parent: parent_response, dependent_value: 'No', parent_question: parent_response.framework_question)
       # Dependent responses on child_response
-      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, parent: child_response, dependent_value: 'Yes', parent_question: child_response.framework_question, required: true)
-      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, parent: child_response, dependent_value: 'No', parent_question: child_response.framework_question, required: true)
+      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, parent: child_response, dependent_value: 'Yes', parent_question: child_response.framework_question)
+      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, parent: child_response, dependent_value: 'No', parent_question: child_response.framework_question)
 
       expect(assessment.calculate_section_progress).to contain_exactly(
         {
@@ -469,8 +469,8 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
 
     it 'returns a section as `completed` if all responded values are true' do
       assessment = create(assessment_type)
-      create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, required: true)
-      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: true, required: true)
+      create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true)
+      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: true)
 
       expect(assessment.calculate_section_progress).to contain_exactly(
         {
@@ -484,14 +484,14 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
       assessment = create(assessment_type)
 
       # Non dependent Responses
-      create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, required: true)
-      parent_response = create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, required: true)
+      create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true)
+      parent_response = create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true)
       # Dependent responses on parent_response
-      child_response = create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, parent: parent_response, dependent_value: 'Yes', parent_question: parent_response.framework_question, required: true)
-      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, parent: parent_response, dependent_value: 'No', parent_question: parent_response.framework_question, required: true)
+      child_response = create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, parent: parent_response, dependent_value: 'Yes', parent_question: parent_response.framework_question)
+      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, parent: parent_response, dependent_value: 'No', parent_question: parent_response.framework_question)
       # Dependent responses on child_response
-      create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, parent: child_response, dependent_value: 'Yes', parent_question: child_response.framework_question, required: true)
-      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, parent: child_response, dependent_value: 'No', parent_question: child_response.framework_question, required: true)
+      create_response(assessmentable: assessment, section: 'risk', value: 'Yes', responded: true, parent: child_response, dependent_value: 'Yes', parent_question: child_response.framework_question)
+      create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, parent: child_response, dependent_value: 'No', parent_question: child_response.framework_question)
 
       expect(assessment.calculate_section_progress).to contain_exactly(
         {
@@ -503,7 +503,7 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
 
     it 'returns a section as `not_started` if all responded values are false even if prefilled' do
       assessment = create(assessment_type, :prefilled)
-      create_response(assessmentable: assessment, section: 'risk', value: 'No', responded: false, prefilled: true, required: true)
+      create_response(assessmentable: assessment, section: 'risk', value: 'No', responded: false, prefilled: true)
 
       expect(assessment.calculate_section_progress).to contain_exactly(
         {
@@ -515,7 +515,7 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
 
     it 'allows for custom framework responses to be passed in' do
       assessment = create(assessment_type)
-      response = create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false, required: true)
+      response = create_response(assessmentable: assessment, section: 'risk', value: nil, responded: false)
 
       expect(assessment.calculate_section_progress(responses: [response])).to contain_exactly(
         {
@@ -538,8 +538,8 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
 
     it 'sets initial progress to sections' do
       assessment = create(assessment_type)
-      question1 = create(:framework_question, section: 'risk-information', required: true)
-      question2 = create(:framework_question, section: 'health-information', required: true)
+      question1 = create(:framework_question, section: 'risk-information')
+      question2 = create(:framework_question, section: 'health-information')
       create(:string_response, value: nil, assessmentable: assessment, framework_question: question1)
       create(:string_response, value: nil, assessmentable: assessment, framework_question: question2)
       assessment.update_status_and_progress!
@@ -561,8 +561,8 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
 
     it 'updates progress to sections in progress' do
       assessment = create(assessment_type)
-      question1 = create(:framework_question, section: 'risk-information', required: true)
-      question2 = create(:framework_question, section: 'risk-information', required: true)
+      question1 = create(:framework_question, section: 'risk-information')
+      question2 = create(:framework_question, section: 'risk-information')
       create(:string_response, responded: true, assessmentable: assessment, framework_question: question1)
       create(:string_response, value: nil, responded: false, assessmentable: assessment, framework_question: question2)
       assessment.update_status_and_progress!
@@ -592,8 +592,8 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
 
     it 'updates progress to sections completed' do
       assessment = create(assessment_type)
-      question1 = create(:framework_question, section: 'risk-information', required: true)
-      question2 = create(:framework_question, section: 'health-information', required: true)
+      question1 = create(:framework_question, section: 'risk-information')
+      question2 = create(:framework_question, section: 'health-information')
       create(:string_response, responded: true, assessmentable: assessment, framework_question: question1)
       create(:string_response, responded: true, assessmentable: assessment, framework_question: question2)
       assessment.update_status_and_progress!
@@ -779,7 +779,7 @@ RSpec.shared_examples 'a framework assessment' do |assessment_type, assessment_c
   end
 
   def create_response(options = {})
-    question = create(:framework_question, framework: options[:assessmentable].framework, section: options[:section], dependent_value: options[:dependent_value], parent: options[:parent_question], required: options[:required])
+    question = create(:framework_question, framework: options[:assessmentable].framework, section: options[:section], dependent_value: options[:dependent_value], parent: options[:parent_question])
     create(:string_response, value: options[:value], framework_question: question, assessmentable: options[:assessmentable], responded: options[:responded], parent: options[:parent])
   end
 end


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-api#1814

This is causing an issue with the Youth Risk Assessments (https://sentry.io/organizations/ministryofjustice/issues/3183417988/?referrer=slack)