### PR TITLE
Refactor move incident events

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -321,7 +321,9 @@ class Move < VersionedModel
   end
 
   def important_events
-    incident_events + (profile&.person_escort_record&.important_events || [])
+    all_events_for_timeline
+      .where(classification: %w[medical incident])
+      .or(GenericEvent.where(type: [GenericEvent::PerPropertyChange].map(&:name)))
   end
 
   def vehicle_registration

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -323,7 +323,7 @@ class Move < VersionedModel
   def important_events
     all_events_for_timeline
       .where(classification: %w[medical incident])
-      .or(GenericEvent.where(type: [GenericEvent::PerPropertyChange].map(&:name)))
+      .or(GenericEvent.where(type: [GenericEvent::PerPropertyChange, GenericEvent::MoveLodgingEnd].map(&:name)))
   end
 
   def vehicle_registration

--- a/app/models/person_escort_record.rb
+++ b/app/models/person_escort_record.rb
@@ -12,10 +12,6 @@ class PersonEscortRecord < VersionedModel
     'person-escort-record'
   end
 
-  def important_events
-    medical_events + incident_events + GenericEvent::PerPropertyChange.where(eventable: self)
-  end
-
 private
 
   def previous_assessment

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -820,9 +820,7 @@ RSpec.describe Move do
     let(:move) { create(:move, profile: create(:profile, :with_person_escort_record)) }
 
     context 'when there are no events' do
-      it 'returns an empty Array' do
-        expect(important_events).to eq([])
-      end
+      it { is_expected.to be_empty }
     end
 
     context 'when there are move incident events' do
@@ -830,9 +828,7 @@ RSpec.describe Move do
 
       before { create(:event_move_approve, eventable: move) }
 
-      it 'returns correct events' do
-        expect(important_events.pluck(:id)).to eq([important_event.id])
-      end
+      it { is_expected.to match_array([important_event]) }
     end
 
     context 'when there are PER medical events' do
@@ -841,9 +837,7 @@ RSpec.describe Move do
 
       before { create(:event_per_prisoner_welfare, eventable: person_escort_record) }
 
-      it 'returns correct events' do
-        expect(important_events.pluck(:id)).to eq([important_event.id])
-      end
+      it { is_expected.to match_array([important_event]) }
     end
 
     context 'when there are move incident and PER medical events' do
@@ -851,9 +845,14 @@ RSpec.describe Move do
       let!(:first_event) { create(:event_person_move_assault, eventable: move) }
       let!(:second_event) { create(:event_per_medical_aid, eventable: person_escort_record) }
 
-      it 'returns correct events' do
-        expect(important_events.pluck(:id)).to eq([first_event.id, second_event.id])
-      end
+      it { is_expected.to match_array([first_event, second_event]) }
+    end
+
+    context 'when there are PER property change events' do
+      let(:person_escort_record) { move.profile.person_escort_record }
+      let!(:important_event) { create(:event_per_property_change, eventable: person_escort_record) }
+
+      it { is_expected.to match_array([important_event]) }
     end
   end
 

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -854,6 +854,12 @@ RSpec.describe Move do
 
       it { is_expected.to match_array([important_event]) }
     end
+
+    context 'when there are lodging end events' do
+      let!(:important_event) { create(:event_move_lodging_end, eventable: move) }
+
+      it { is_expected.to match_array([important_event]) }
+    end
   end
 
   describe '#vehicle_registration' do

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -175,23 +175,6 @@ RSpec.describe PersonEscortRecord do
     it { is_expected.to include(GenericEvent::PerEscape.first) }
   end
 
-  describe '#important_events' do
-    subject(:important_events) { per.important_events }
-
-    let(:per) { create(:person_escort_record) }
-
-    before do
-      create(:event_per_escape, eventable: per)
-      create(:event_per_medical_aid, eventable: per)
-      create(:event_per_property_change, eventable: per)
-    end
-
-    it { is_expected.not_to be_empty }
-    it { is_expected.to include(GenericEvent::PerEscape.first) }
-    it { is_expected.to include(GenericEvent::PerMedicalAid.first) }
-    it { is_expected.to include(GenericEvent::PerPropertyChange.first) }
-  end
-
   describe '#responded_by' do
     subject(:responded_by) { per.responded_by }
 


### PR DESCRIPTION
This refactors the move incident events to simplify the code, reduce the number of queries to the database and improves the tests.

Closes #1821 

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3346)