### PR TITLE
Support multiple handovers

### DIFF
--- a/app/models/generic_event/per_handover.rb
+++ b/app/models/generic_event/per_handover.rb
@@ -1,5 +1,9 @@
-class GenericEvent
-  class PerHandover < GenericEvent
-    eventable_types 'PersonEscortRecord'
-  end
+class GenericEvent::PerHandover < GenericEvent
+  LOCATION_ATTRIBUTE_KEY = :location_id
+
+  relationship_attributes location_id: :locations
+  eventable_types 'PersonEscortRecord'
+
+  include LocationValidations
+  include LocationFeed
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -326,8 +326,15 @@ class Move < VersionedModel
 
     events = GenericEvent.where(eventable_type: eventable_types, eventable_id: eventable_ids)
 
+    medical_or_incident_events = events.where(classification: %w[medical incident])
+    other_events = events.where(type: [
+      GenericEvent::PerPropertyChange,
+      GenericEvent::MoveLodgingEnd,
+      GenericEvent::PerHandover,
+    ].map(&:name))
+
     # This is more performant that doing an `OR` in SQL as the query planner gets confused by the lack of an index for the type column
-    events.where(classification: %w[medical incident]) + events.where(type: [GenericEvent::PerPropertyChange, GenericEvent::MoveLodgingEnd].map(&:name))
+    medical_or_incident_events + other_events
   end
 
   def vehicle_registration

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -574,15 +574,12 @@ FactoryBot.define do
 
   factory :event_per_confirmation, parent: :generic_event, class: 'GenericEvent::PerConfirmation' do
     eventable { association(:person_escort_record, :confirmed, confirmed_at: '2021-01-01') }
-    details do
-      {
-        confirmed_at: '2021-01-01',
-      }
-    end
+    details { { confirmed_at: '2021-01-01' } }
   end
 
   factory :event_per_handover, parent: :generic_event, class: 'GenericEvent::PerHandover' do
     eventable { association(:person_escort_record, :confirmed) }
+    details { { location_id: create(:location).id } }
   end
 
   factory :event_per_self_harm, parent: :per_incident, class: 'GenericEvent::PerSelfHarm' do

--- a/spec/models/generic_event/per_handover_spec.rb
+++ b/spec/models/generic_event/per_handover_spec.rb
@@ -4,4 +4,8 @@ RSpec.describe GenericEvent::PerHandover do
   subject(:generic_event) { build(:event_per_handover) }
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
+
+  it_behaves_like 'an event with relationships', location_id: :locations
+  it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -855,6 +855,13 @@ RSpec.describe Move do
       it { is_expected.to match_array([important_event]) }
     end
 
+    context 'when there are PER handover events' do
+      let(:person_escort_record) { move.profile.person_escort_record }
+      let!(:important_event) { create(:event_per_handover, eventable: person_escort_record) }
+
+      it { is_expected.to match_array([important_event]) }
+    end
+
     context 'when there are lodging end events' do
       let!(:important_event) { create(:event_move_lodging_end, eventable: move) }
 


### PR DESCRIPTION
For lockouts and overnight lodges, we know there will be at least two PER handovers. Once when the move starts on the first day (handover from location to supplier) and once on the second day (handover from police custody to supplier).

To better support this behaviour, I've added locations to the PER handover event so we know where the handover occurred, and ensured that the handover events are returned in the important events for a PER, allowing us to render these on the frontend in the details tab. The location should appear in the `handover_details` as a `location_id` field.

The ability to record multiple PER handover events is already implemented, it happens if automatically if you update the handover details on a PER, each time an event is created.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3584)