### PR TITLE
Allow fault_classification to be nil if the supplier_id is nil

### DIFF
--- a/app/models/generic_event/incident.rb
+++ b/app/models/generic_event/incident.rb
@@ -21,7 +21,7 @@ class GenericEvent
       child.include LocationFeed
 
       child.validates :reported_at, iso_date_time: true
-      child.validates :fault_classification, presence: true, inclusion: { in: child.fault_classifications }
+      child.validates :fault_classification, presence: true, if: -> { supplier_id.present? }, inclusion: { in: child.fault_classifications }
 
       super
     end

--- a/spec/models/generic_event/incident_spec.rb
+++ b/spec/models/generic_event/incident_spec.rb
@@ -19,5 +19,13 @@ RSpec.describe GenericEvent::Incident, type: :model do
 
       it { is_expected.to eq(:incident) }
     end
+
+    describe 'when a supplier_id is nil' do
+      context 'when we allow fault_classification to be nil' do
+        let(:event) { create(:event_person_move_used_force, supplier_id: nil, fault_classification: nil) }
+
+        it { is_expected.to eq(:incident) }
+      end
+    end
   end
 end

--- a/spec/support/an_event_about_an_incident.rb
+++ b/spec/support/an_event_about_an_incident.rb
@@ -12,10 +12,21 @@ RSpec.shared_examples 'an event about an incident' do
       investigation
     ]
   end
+  
+  context 'with a supplier' do
+    let(:supplier) { create(:supplier) }
 
-  it { is_expected.to validate_presence_of(:supplier_personnel_numbers) }
-  it { is_expected.to validate_inclusion_of(:fault_classification).in_array(fault_classifications) }
-  it { is_expected.to validate_presence_of(:fault_classification) }
+    before { generic_event.update(supplier: supplier) }
+
+    it { is_expected.to validate_inclusion_of(:fault_classification).in_array(fault_classifications) }
+    it { is_expected.to validate_presence_of(:fault_classification) }
+  end
+
+  context 'without a supplier' do
+    before { generic_event.update(supplier: nil) }
+
+    it { is_expected.not_to validate_presence_of(:fault_classification) }
+  end
 
   context 'when reported_at is not a valid iso8601 date' do
     before do


### PR DESCRIPTION
We now allow the `fault_classification` to be nil if the `supplier_id` is not provided, this has been done as in the frontend we allow a user to submit events via a form. 

Previous to this we would have had to provide a `fault_classification` attribute with some data, which would have had to be hard coded. 