### PR TITLE
Handle optional locations in event feed

### DIFF
--- a/app/models/concerns/location_feed.rb
+++ b/app/models/concerns/location_feed.rb
@@ -5,7 +5,7 @@ module LocationFeed
       location_method = location_key.sub('_id', '')
       prefix = location_key == 'location_id' ? nil : location_key.sub('_location_id', '')
 
-      updated_location = public_send(location_method).for_feed(prefix: prefix)
+      updated_location = public_send(location_method)&.for_feed(prefix: prefix) || { location_method => nil }
 
       common_feed_attributes['details'].merge!(updated_location)
       common_feed_attributes['details'].delete(location_key)

--- a/spec/support/an_event_with_a_location_in_the_feed.rb
+++ b/spec/support/an_event_with_a_location_in_the_feed.rb
@@ -2,31 +2,48 @@
 
 RSpec.shared_examples 'an event with a location in the feed' do |location_id_key|
   describe '#for_feed' do
-    before do
-      generic_event.details[location_id_key] = location.id
-    end
+    subject(:for_feed) { generic_event.for_feed }
 
-    let(:location) { create(:location) }
+    before { generic_event.details[location_id_key] = location&.id }
 
-    let(:expected_json) do
-      location_key = location_id_key.to_s.sub('_id', '')
-      location_type_key = "#{location_key}_type"
+    let(:location_key) { location_id_key.to_s.sub('_id', '') }
+    let(:location_type_key) { "#{location_key}_type" }
 
+    let(:common_expected_json) do
       {
         'id' => generic_event.id,
         'type' => generic_event.type.sub('GenericEvent::', ''),
         'notes' => 'Flibble',
         'eventable_id' => generic_event.eventable_id,
         'eventable_type' => generic_event.eventable_type,
-        'details' => {
-          location_key => location.nomis_agency_id,
-          location_type_key => location.location_type,
-        },
       }
     end
 
-    it 'generates a feed document' do
-      expect(generic_event.for_feed).to include_json(expected_json)
+    context 'when location is present' do
+      let(:location) { create(:location) }
+
+      let(:expected_json) do
+        common_expected_json.merge({
+          'details' => {
+            location_key => location.nomis_agency_id,
+            location_type_key => location.location_type,
+          },
+        })
+      end
+
+      it { is_expected.to include_json(expected_json) }
+    end
+
+    context 'when location is nil' do
+      let(:location) { nil }
+
+      let(:expected_json) do
+        common_expected_json.merge({
+          'details' => { location_key => nil },
+        })
+      end
+
+      it { is_expected.to include_json(expected_json) }
     end
   end
 end


### PR DESCRIPTION
Some events, notable the PerHandover event, will have an optional location. This is currently not supported when it tries to export the feed for the events, and so we get an exception raised.

[Sentry Issue](https://sentry.io/organizations/ministryofjustice/issues/3231300738/)