### PR TITLE
Add responded_by to PerConfirmation event details

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -57,6 +57,8 @@ class ApiController < ApplicationController
 private
 
   def set_sentry_transaction_id
+    return unless Sentry.initialized?
+
     Sentry.set_tags(transaction_id: request.headers['X-Transaction-Id'])
   end
 

--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -167,7 +167,12 @@ module FrameworkAssessmentable
     move.requested? || move.booked?
   end
 
-  def responded_by
-    framework_responses.pluck(:responded_by).sort.uniq
+  def responded_by(before_datetime = Time.zone.now)
+    framework_responses.where(created_at: Time.zone.at(0)..before_datetime).each_with_object({}) do |framework_response, hash|
+      hash[framework_response.section] ||= []
+      next if hash[framework_response.section].include?(framework_response.responded_by)
+
+      hash[framework_response.section] << framework_response.responded_by
+    end
   end
 end

--- a/app/models/concerns/framework_assessmentable.rb
+++ b/app/models/concerns/framework_assessmentable.rb
@@ -168,7 +168,7 @@ module FrameworkAssessmentable
   end
 
   def responded_by(before_datetime = Time.zone.now)
-    framework_responses.where(created_at: Time.zone.at(0)..before_datetime).each_with_object({}) do |framework_response, hash|
+    framework_responses.order(:created_at).where(created_at: Time.zone.at(0)..before_datetime).each_with_object({}) do |framework_response, hash|
       hash[framework_response.section] ||= []
       next if hash[framework_response.section].include?(framework_response.responded_by)
 

--- a/app/models/generic_event/per_confirmation.rb
+++ b/app/models/generic_event/per_confirmation.rb
@@ -1,8 +1,12 @@
 class GenericEvent
   class PerConfirmation < GenericEvent
-    details_attributes :confirmed_at
+    details_attributes :confirmed_at, :responded_by
     eventable_types 'PersonEscortRecord'
 
     validates :confirmed_at, presence: true
+
+    before_create do
+      self.responded_by = eventable.responded_by
+    end
   end
 end

--- a/lib/tasks/populate_per_confirmation_with_responded_by.rake
+++ b/lib/tasks/populate_per_confirmation_with_responded_by.rake
@@ -1,6 +1,4 @@
-GITHUB_FRAMEWORK_URI = 'https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git'.freeze
-GITHUB_FRAMEWORK_NAME = 'hmpps-book-secure-move-frameworks'.freeze
-FRAMEWORK_TEMP_PATH = Rails.root.join('tmp/checkout').freeze
+# frozen_string_literal: true
 
 namespace :per_confirmation do
   desc 'Populate PerConfirmation events with responded_by'

--- a/lib/tasks/populate_per_confirmation_with_responded_by.rake
+++ b/lib/tasks/populate_per_confirmation_with_responded_by.rake
@@ -1,0 +1,18 @@
+GITHUB_FRAMEWORK_URI = 'https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git'.freeze
+GITHUB_FRAMEWORK_NAME = 'hmpps-book-secure-move-frameworks'.freeze
+FRAMEWORK_TEMP_PATH = Rails.root.join('tmp/checkout').freeze
+
+namespace :per_confirmation do
+  desc 'Populate PerConfirmation events with responded_by'
+  task populate_responded_by: :environment do
+    GenericEvent::PerConfirmation.find_in_batches.each do |batch|
+      batch.each do |event|
+        next unless event.responded_by.nil?
+        next if event.eventable.blank?
+
+        event.responded_by = event.eventable.responded_by(event.created_at)
+        event.save!
+      end
+    end
+  end
+end

--- a/spec/models/generic_event/per_confirmation_spec.rb
+++ b/spec/models/generic_event/per_confirmation_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe GenericEvent::PerConfirmation do
   subject(:generic_event) { build(:event_per_confirmation) }
 
-  it_behaves_like 'an event with details', :confirmed_at
+  it_behaves_like 'an event with details', :confirmed_at, :responded_by
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
   it { is_expected.to validate_presence_of(:confirmed_at) }

--- a/spec/models/person_escort_record_spec.rb
+++ b/spec/models/person_escort_record_spec.rb
@@ -178,13 +178,15 @@ RSpec.describe PersonEscortRecord do
   describe '#responded_by' do
     subject(:responded_by) { per.responded_by }
 
-    let(:per) { create(:person_escort_record) }
+    let(:framework) { create(:framework) }
+    let(:alert_code) { create(:framework_nomis_code, code: 'VI', code_type: 'alert') }
+    let(:question) { create(:framework_question, framework: framework, framework_nomis_codes: [alert_code]) }
+    let(:response1) { create(:string_response, section: 'section1', framework_question: question, responded_by: 'TEST_USER') }
+    let(:response2) { create(:string_response, section: 'section1', framework_question: question, responded_by: 'TEST_USER') }
+    let(:response3) { create(:string_response, section: 'section1', framework_question: question, responded_by: 'OTHER_TEST_USER') }
+    let(:response4) { create(:string_response, section: 'section2', framework_question: question, responded_by: 'OTHER_TEST_USER') }
+    let(:per) { create(:person_escort_record, framework_responses: [response1, response2, response3, response4]) }
 
-    before do
-      create(:string_response, assessmentable: per, responded_by: 'ABC')
-      create(:string_response, assessmentable: per, responded_by: 'DEF')
-    end
-
-    it { is_expected.to match_array(%w[ABC DEF]) }
+    it { is_expected.to eq({ 'section1' => %w[TEST_USER OTHER_TEST_USER], 'section2' => %w[OTHER_TEST_USER] }) }
   end
 end


### PR DESCRIPTION
This is the API side of this work, there is still frontend work to do, but I'm releasing this so that I can complete the frontend work more easily.

### Jira link

P4-3575

### What?

I have added/removed/altered:

- [ ] Added `responded_by` field to PerConfirmation events.

### Why?

I am doing this because:

- It will allow the frontend to display the authors of PERs.

