### PR TITLE
Fix issue with PerCompletion backfill without completed_at

### DIFF
--- a/lib/tasks/backfill_per_completion.rake
+++ b/lib/tasks/backfill_per_completion.rake
@@ -3,7 +3,7 @@
 namespace :backfill do
   desc 'Backfill PerCompletion events'
   task per_completion: :environment do
-    PersonEscortRecord.where(status: %i[completed confirmed]).find_in_batches.each do |batch|
+    PersonEscortRecord.where.not(completed_at: nil).find_in_batches.each do |batch|
       batch.each do |per|
         next if per.generic_events.where(type: 'GenericEvent::PerCompletion').present?
 


### PR DESCRIPTION
The backfill task from the previous PR was failing in staging because somehow, some completed PERs didn't have a completed_at set.