### PR TITLE
Add index to the updated_at field on the generic_events table.

### DIFF
--- a/db/migrate/20220608135622_add_index_to_generic_event_updated_at.rb
+++ b/db/migrate/20220608135622_add_index_to_generic_event_updated_at.rb
@@ -1,0 +1,7 @@
+class AddIndexToGenericEventUpdatedAt < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :generic_events, :updated_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_29_100906) do
+ActiveRecord::Schema.define(version: 2022_06_08_135622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -275,6 +275,7 @@ ActiveRecord::Schema.define(version: 2022_03_29_100906) do
     t.index ["occurred_at"], name: "index_generic_events_on_occurred_at"
     t.index ["recorded_at"], name: "index_generic_events_on_recorded_at"
     t.index ["supplier_id"], name: "index_generic_events_on_supplier_id"
+    t.index ["updated_at"], name: "index_generic_events_on_updated_at"
   end
 
   create_table "identifier_types", id: :string, force: :cascade do |t|


### PR DESCRIPTION
We are experiencing slow queries for the events feed. Adding an index to the updated at should help reduce the query times.

### Jira link

[P4-3715](https://dsdmoj.atlassian.net/browse/P4-3715)

### What?

I have added:

Index to the update_at field on the generic_events table.

### Why?

I am doing this because:

We are experiencing very slow times for the reporting feeds.

