### PR TITLE
P4-3715 changing migration for updated_at on generic_events to only create if it doesn't exist.

### DIFF
--- a/db/migrate/20220608135622_add_index_to_generic_event_updated_at.rb
+++ b/db/migrate/20220608135622_add_index_to_generic_event_updated_at.rb
@@ -2,6 +2,6 @@ class AddIndexToGenericEventUpdatedAt < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   def change
-    add_index :generic_events, :updated_at, algorithm: :concurrently
+    add_index :generic_events, :updated_at, algorithm: :concurrently, if_not_exists: true
   end
 end


### PR DESCRIPTION
Updating index migration to only create if the index does not already exist.

**Jira link**

[P4-3715](https://dsdmoj.atlassian.net/browse/P4-3715)
What?

**I have added:**

Index to the update_at field on the generic_events table.
Why?

I am doing this because:

We are experiencing very slow times for the reporting feeds.