### PR TITLE
P4-3715 change the index creation to be locking instead of concurrent on updated_at.

### DIFF
--- a/db/migrate/20220608135622_add_index_to_generic_event_updated_at.rb
+++ b/db/migrate/20220608135622_add_index_to_generic_event_updated_at.rb
@@ -1,7 +1,5 @@
 class AddIndexToGenericEventUpdatedAt < ActiveRecord::Migration[6.1]
-  disable_ddl_transaction!
-
   def change
-    add_index :generic_events, :updated_at, algorithm: :concurrently, if_not_exists: true
+    add_index :generic_events, :updated_at, if_not_exists: true
   end
 end


### PR DESCRIPTION
### Jira link

[P4-3717](https://dsdmoj.atlassian.net/browse/P4-3715)

### What?

I have altered:

- the index creation to be locking on the updated_at field.

### Why?

I am doing this because:

We believe the migration is not able to be applied concurrently in a timely fashion due to the volume of data and activity in the events table hence the deployment is failing and the index is not valid.