### PR TITLE
Revert "P4-3715 change the index creation to be locking instead of concurrent on updated_at."

### DIFF
--- a/db/migrate/20220608135622_add_index_to_generic_event_updated_at.rb
+++ b/db/migrate/20220608135622_add_index_to_generic_event_updated_at.rb
@@ -1,5 +1,7 @@
 class AddIndexToGenericEventUpdatedAt < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
   def change
-    add_index :generic_events, :updated_at, if_not_exists: true
+    add_index :generic_events, :updated_at, algorithm: :concurrently, if_not_exists: true
   end
 end


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-api#1863