### PR TITLE
Add PerUpdated event

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -84,6 +84,7 @@ class GenericEvent < ApplicationRecord
     PerPrisonerWelfare
     PerPropertyChange
     PerSelfHarm
+    PerUpdated
     PerViolentDangerous
     PerWeapons
     PersonMoveAssault

--- a/app/models/generic_event/per_updated.rb
+++ b/app/models/generic_event/per_updated.rb
@@ -1,0 +1,6 @@
+class GenericEvent
+  class PerUpdated < GenericEvent
+    details_attributes :responded_by, :section
+    eventable_types 'PersonEscortRecord'
+  end
+end

--- a/app/state_machines/framework_assessment_state_machine.rb
+++ b/app/state_machines/framework_assessment_state_machine.rb
@@ -25,6 +25,13 @@ class FrameworkAssessmentStateMachine < FiniteMachine::Definition
             details: { completed_at: Time.zone.now },
           )
         end
+      elsif target.is_a?(PersonEscortRecord)
+        response = target.framework_responses.order(updated_at: :asc).last
+        target.generic_events << GenericEvent::PerUpdated.new(
+          occurred_at: Time.zone.now,
+          recorded_at: Time.zone.now,
+          details: { responded_by: response.responded_by, section: response.section },
+        )
       end
     end
   end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -579,7 +579,7 @@ FactoryBot.define do
 
   factory :event_per_completion, parent: :generic_event, class: 'GenericEvent::PerCompletion' do
     eventable { association(:person_escort_record, :completed, completed_at: '2021-01-01') }
-    details { { completed_at: '2021-01-01', responded_by: {'risk-information' => ['TEST_USER']} } }
+    details { { completed_at: '2021-01-01', responded_by: { 'risk-information' => %w[TEST_USER] } } }
   end
 
   factory :event_per_updated, parent: :generic_event, class: 'GenericEvent::PerUpdated' do

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -579,7 +579,12 @@ FactoryBot.define do
 
   factory :event_per_completion, parent: :generic_event, class: 'GenericEvent::PerCompletion' do
     eventable { association(:person_escort_record, :completed, completed_at: '2021-01-01') }
-    details { { completed_at: '2021-01-01' } }
+    details { { completed_at: '2021-01-01', responded_by: {'risk-information' => ['TEST_USER']} } }
+  end
+
+  factory :event_per_updated, parent: :generic_event, class: 'GenericEvent::PerUpdated' do
+    eventable { association(:person_escort_record, :completed, completed_at: '2021-01-01') }
+    details { { section: 'risk-information', responded_by: 'TEST_USER' } }
   end
 
   factory :event_per_handover, parent: :generic_event, class: 'GenericEvent::PerHandover' do

--- a/spec/models/generic_event/per_completion_spec.rb
+++ b/spec/models/generic_event/per_completion_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe GenericEvent::PerCompletion do
-  subject(:generic_event) { build(:event_per_confirmation) }
+  subject(:generic_event) { build(:event_per_completion) }
 
   it_behaves_like 'an event with details', :completed_at, :responded_by
 
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
-  it { is_expected.to validate_presence_of(:confirmed_at) }
+  it { is_expected.to validate_presence_of(:completed_at) }
 end

--- a/spec/models/generic_event/per_updated_spec.rb
+++ b/spec/models/generic_event/per_updated_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::PerUpdated do
+  subject(:generic_event) { build(:event_per_updated) }
+
+  it_behaves_like 'an event with details', :section, :responded_by
+
+  it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
+end

--- a/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe Api::FrameworkResponsesController do
         expect(person_escort_record.reload.status).to eq('completed')
       end
 
+      it 'creates a PerCompletion event' do
+        expect(person_escort_record.generic_events.pluck(:type)).to include('GenericEvent::PerCompletion')
+      end
+
       it 'attaches flags to the responses' do
         expect(framework_response.framework_flags).to contain_exactly(flag)
         expect(other_framework_response.framework_flags).to contain_exactly(other_flag)
@@ -326,11 +330,11 @@ RSpec.describe Api::FrameworkResponsesController do
         instance_double(
           ActionMailer::MessageDelivery,
           deliver_now!:
-          instance_double(
-            Mail::Message,
-            govuk_notify_response:
-            instance_double(Notifications::Client::ResponseNotification, id: SecureRandom.uuid),
-          ),
+            instance_double(
+              Mail::Message,
+              govuk_notify_response:
+                instance_double(Notifications::Client::ResponseNotification, id: SecureRandom.uuid),
+            ),
         )
       end
 
@@ -346,20 +350,20 @@ RSpec.describe Api::FrameworkResponsesController do
         notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
 
         expect(notification).to have_attributes(
-          topic: person_escort_record,
-          notification_type: notification_type_webhook,
-          event_type: 'amend_person_escort_record',
-        )
+                                  topic: person_escort_record,
+                                  notification_type: notification_type_webhook,
+                                  event_type: 'amend_person_escort_record',
+                                )
       end
 
       it 'creates an email notification' do
         notification = subscription.notifications.find_by(notification_type: notification_type_email)
 
         expect(notification).to have_attributes(
-          topic: person_escort_record,
-          notification_type: notification_type_email,
-          event_type: 'amend_person_escort_record',
-        )
+                                  topic: person_escort_record,
+                                  notification_type: notification_type_email,
+                                  event_type: 'amend_person_escort_record',
+                                )
       end
 
       context 'when the assessment was not previously completed' do
@@ -369,10 +373,10 @@ RSpec.describe Api::FrameworkResponsesController do
           notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
 
           expect(notification).to have_attributes(
-            topic: person_escort_record,
-            notification_type: notification_type_webhook,
-            event_type: 'complete_person_escort_record',
-          )
+                                    topic: person_escort_record,
+                                    notification_type: notification_type_webhook,
+                                    event_type: 'complete_person_escort_record',
+                                  )
         end
 
         it 'does not create an email notification' do

--- a/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
@@ -350,20 +350,20 @@ RSpec.describe Api::FrameworkResponsesController do
         notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
 
         expect(notification).to have_attributes(
-                                  topic: person_escort_record,
-                                  notification_type: notification_type_webhook,
-                                  event_type: 'amend_person_escort_record',
-                                )
+          topic: person_escort_record,
+          notification_type: notification_type_webhook,
+          event_type: 'amend_person_escort_record',
+        )
       end
 
       it 'creates an email notification' do
         notification = subscription.notifications.find_by(notification_type: notification_type_email)
 
         expect(notification).to have_attributes(
-                                  topic: person_escort_record,
-                                  notification_type: notification_type_email,
-                                  event_type: 'amend_person_escort_record',
-                                )
+          topic: person_escort_record,
+          notification_type: notification_type_email,
+          event_type: 'amend_person_escort_record',
+        )
       end
 
       context 'when the assessment was not previously completed' do
@@ -373,10 +373,10 @@ RSpec.describe Api::FrameworkResponsesController do
           notification = subscription.notifications.find_by(notification_type: notification_type_webhook)
 
           expect(notification).to have_attributes(
-                                    topic: person_escort_record,
-                                    notification_type: notification_type_webhook,
-                                    event_type: 'complete_person_escort_record',
-                                  )
+            topic: person_escort_record,
+            notification_type: notification_type_webhook,
+            event_type: 'complete_person_escort_record',
+          )
         end
 
         it 'does not create an email notification' do

--- a/spec/requests/api/framework_responses_controller_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_update_spec.rb
@@ -316,6 +316,15 @@ RSpec.describe Api::FrameworkResponsesController do
         it_behaves_like 'an endpoint that responds with error 403'
       end
 
+      context 'when assessment completed' do
+        let(:assessment) { create(:person_escort_record, :completed) }
+        let(:framework_response) { create(:string_response, assessmentable: assessment) }
+
+        it 'creates a PerUpdated event' do
+          expect(assessment.generic_events.pluck(:type)).to include('GenericEvent::PerUpdated')
+        end
+      end
+
       context 'when the framework_response_id is not found' do
         let(:framework_response_id) { 'foo-bar' }
         let(:detail_404) { "Couldn't find FrameworkResponse with 'id'=foo-bar" }


### PR DESCRIPTION
### Jira link

P4-3577

### What?

I have added/removed/altered:

- [x] Added the PerUpdated event, it is automatically added when a PER is updated after being completed.

### Why?

I am doing this because:

- It's helpful to see which users updated which sections of the PER.
