### PR TITLE
Add notify_unnotified_moves job

### DIFF
--- a/app/workers/notify_unnotified_moves_worker.rb
+++ b/app/workers/notify_unnotified_moves_worker.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class NotifyUnnotifiedMovesWorker
+  include Sidekiq::Worker
+
+  def perform
+    Move.where(date: Time.zone.today..Time.zone.tomorrow)
+        .where.not(status: %w[proposed cancelled])
+        .reject { |m| m.notifications.map(&:event_type).include?('create_move') }
+        .each do |move|
+      unless move.generic_events.pluck(:type).include?('GenericEvent::MoveRequested')
+        Rails.logger.info("[NotifyUnnotifiedMovesWorker] Creating MoveRequested event for move #{move.reference}")
+        create_requested_event(move)
+        Rails.logger.info("[NotifyUnnotifiedMovesWorker] Created MoveRequested event for move #{move.reference}")
+      end
+
+      Rails.logger.info("[NotifyUnnotifiedMovesWorker] Creating move_create Notification for move #{move.reference}")
+      Notifier.prepare_notifications(topic: move, action_name: 'create')
+      Rails.logger.info("[NotifyUnnotifiedMovesWorker] Created move_create Notification for move #{move.reference}")
+    end
+  end
+
+private
+
+  def create_requested_event(move)
+    GenericEvent::MoveRequested.create!(
+      eventable: move,
+      occurred_at: move.created_at,
+      recorded_at: Time.zone.now,
+      notes: 'Automatically generated event',
+      details: {},
+    )
+  end
+end

--- a/lib/tasks/gps_data_report.rake
+++ b/lib/tasks/gps_data_report.rake
@@ -4,5 +4,5 @@ desc 'Posts a report of the past weeks GPS data to slack'
 task gps_data_report: :environment do
   GPSReportWorker.perform_async
 
-  puts 'The GPS data report worker been queued.'
+  puts 'The GPS data report worker has been queued.'
 end

--- a/lib/tasks/notify_unnotified_moves.rake
+++ b/lib/tasks/notify_unnotified_moves.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+desc "Sends create_move notifications for Moves that don't have them"
+task notify_unnotified_moves: :environment do
+  NotifyUnnotifiedMovesWorker.perform_async
+
+  puts 'The NotifyUnnotifiedMovesWorker has been queued.'
+end


### PR DESCRIPTION
This job will create create_move notifications for moves without them.

Every hour a query will run, looking for moves in BaSM that:
1. are requested for the next two days
2. are not in the proposed or cancelled state
3. have no notifications
For any moves returned, a move requested event and a create move notification will then be generated.
