### PR TITLE
Bring alloction move requested events in line with single move request, supplier does not need populating for these events

### DIFF
--- a/app/services/allocations/creator.rb
+++ b/app/services/allocations/creator.rb
@@ -45,7 +45,7 @@ module Allocations
             recorded_at: now,
             notes: 'Automatically generated for allocation',
             created_by: created_by,
-            supplier: supplier,
+            supplier: nil,
           )
         end
       end

--- a/spec/services/allocations/creator_spec.rb
+++ b/spec/services/allocations/creator_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Allocations::Creator do
         eventable_type: 'Move',
         notes: 'Automatically generated for allocation',
         created_by: 'Iama Requestor',
-        supplier_id: supplier.id,
+        supplier_id: nil,
       )
     end
 


### PR DESCRIPTION
### Jira link

[P4-3705](https://dsdmoj.atlassian.net/browse/P4-3705)

### What?

I have altered:

-  The creation of Allocation moves move requested events.

### Why?

I am doing this because:

- This is to bring inline with move requested events for standard move creation so the UI logic for the events is the same.
