### PR TITLE
Catch exception when invalid data is passed to bulk framework response update

### DIFF
--- a/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
@@ -215,6 +215,29 @@ RSpec.describe Api::FrameworkResponsesController do
         end
       end
 
+      context 'when an array is passed in the data array' do
+        let(:bulk_per_params) do
+          {
+            data: [
+              {},
+              {},
+              [],
+            ],
+          }
+        end
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          let(:errors_422) do
+            [
+              {
+                "title": 'Invalid arguments',
+                "detail": 'invalid data type in bulk update array: Array',
+              },
+            ]
+          end
+        end
+      end
+
       context 'with a nested invalid value' do
         let(:framework_response) { create(:collection_response, :multiple_items, assessmentable: person_escort_record) }
         let(:framework_question) { framework_response.framework_question.dependents.first }


### PR DESCRIPTION
### Jira link

P4-3767

### What?

I have added/removed/altered:

- [ ] Added error handling around bulk framework response updates

### Why?

I am doing this because:

- We are currently getting sentry alerts for it and the response to the caller isn't very helpful as it's an unhandled error

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

