### PR TITLE
P4-3888 limiting PER  history to a specific section as perfomance for whole PER is too slow.

### DIFF
--- a/app/controllers/diagnostics_controller.rb
+++ b/app/controllers/diagnostics_controller.rb
@@ -11,7 +11,7 @@ class DiagnosticsController < ApiController
     include_person_details = Rails.env.development? || ENV.fetch('HOSTNAME', 'UNKNOWN') =~ /(-(dev|staging|uat)-)/i
 
     if move.present?
-      render plain: Diagnostics::MoveInspector.new(move, include_person_details: include_person_details).generate, status: :ok
+      render plain: Diagnostics::MoveInspector.new(move, include_person_details: include_person_details, include_per_section_history: params[:include_per_section_history]).generate, status: :ok
     else
       render plain: "Move \"#{params[:id]}\" not found", status: :not_found
     end

--- a/spec/services/diagnostics/move_inspector_spec.rb
+++ b/spec/services/diagnostics/move_inspector_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Diagnostics::MoveInspector do
-  subject { described_class.new(move, include_person_details: include_person_details).generate }
+  subject { described_class.new(move, include_person_details: include_person_details, include_per_section_history: include_per_section_history).generate }
 
   let(:person) { create(:person) }
   let(:profile) { create(:profile, person: person) }
@@ -10,6 +10,7 @@ RSpec.describe Diagnostics::MoveInspector do
   let(:youth_risk_assessment) { create(:youth_risk_assessment, profile: profile, move: move) }
   let(:journey) { create(:journey, move: move) }
   let(:include_person_details) { false }
+  let(:include_per_section_history) { nil }
   let(:journey_event) { create(:event_journey_start, eventable: journey) }
   let(:move_event) { create(:event_move_start, eventable: move) }
   let(:sch) { create(:location, :sch) }
@@ -47,7 +48,7 @@ RSpec.describe Diagnostics::MoveInspector do
     it { is_expected.not_to match(/YOUTH RISK ASSESSMENT/) }
     it { is_expected.not_to match(/id:\s+#{person.id}/) }
     it { is_expected.not_to match(/id:\s+#{profile.id}/) }
-    it { is_expected.not_to match(/PER HISTORY/) }
+    it { is_expected.not_to match(/PER CHANGE HISTORY/) }
   end
 
   context 'when include_person_details=true' do
@@ -60,6 +61,35 @@ RSpec.describe Diagnostics::MoveInspector do
     it { is_expected.to match(/YOUTH RISK ASSESSMENT/) }
     it { is_expected.to match(/id:\s+#{person.id}/) }
     it { is_expected.to match(/id:\s+#{profile.id}/) }
+    it { is_expected.not_to match(/PER CHANGE HISTORY/) }
+  end
+
+  context 'when include_person_details=true and include_per_section_history=the-per-section' do
+    let(:include_person_details) { true }
+    let(:include_per_section_history) { 'the-per-section' }
+
+    it { is_expected.to match(/PERSON/) }
+    it { is_expected.to match(/PROFILE/) }
+    it { is_expected.to match(/ASSESSMENT ANSWERS/) }
+    it { is_expected.to match(/PERSON ESCORT RECORD/) }
+    it { is_expected.to match(/YOUTH RISK ASSESSMENT/) }
+    it { is_expected.to match(/id:\s+#{person.id}/) }
+    it { is_expected.to match(/id:\s+#{profile.id}/) }
     it { is_expected.to match(/PER CHANGE HISTORY/) }
+    it { is_expected.to match(/the-per-section/) }
+  end
+
+  context 'when include_person_details=true and include_per_section_history=" "' do
+    let(:include_person_details) { true }
+    let(:include_per_section_history) { ' ' }
+
+    it { is_expected.to match(/PERSON/) }
+    it { is_expected.to match(/PROFILE/) }
+    it { is_expected.to match(/ASSESSMENT ANSWERS/) }
+    it { is_expected.to match(/PERSON ESCORT RECORD/) }
+    it { is_expected.to match(/YOUTH RISK ASSESSMENT/) }
+    it { is_expected.to match(/id:\s+#{person.id}/) }
+    it { is_expected.to match(/id:\s+#{profile.id}/) }
+    it { is_expected.not_to match(/PER CHANGE HISTORY/) }
   end
 end


### PR DESCRIPTION
[P4-3888](https://dsdmoj.atlassian.net/browse/P4-3888)

### What?

I have limited the amount of information displayed for the PER history to a specific section via the diagnostics endpoints.

### Why?

I am doing this because retrieving the history of the whole PER is too slow at it is timing out.