### PR TITLE
P4-3888 - Swap from bulk updates so that PaperTrail::Versions are made

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ erd.pdf
 # Ignore local data directory for docker-compose
 .data
 spec/wiremock/wiremock-standalone.jar
+
+# Ignore out dir
+out

--- a/app/services/framework_responses/bulk_updater.rb
+++ b/app/services/framework_responses/bulk_updater.rb
@@ -52,11 +52,11 @@ module FrameworkResponses
     end
 
     def apply_bulk_response_changes(updated_responses)
-      # Bulk update all modified response values
-      FrameworkResponse.import(updated_responses, validate: false, on_duplicate_key_update: { conflict_target: [:id], columns: %i[value_text value_json responded responded_by responded_at] })
-
-      # Update associated flags for all modified response values
-      updated_responses.each(&:rebuild_flags!)
+      updated_responses.each do |response|
+        response.save!
+        # Update associated flags for the modified response values
+        response.rebuild_flags!
+      end
 
       # Clear dependent values for all modified response values
       FrameworkResponse.clear_dependent_values_and_flags!(updated_responses)

--- a/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
+++ b/spec/requests/api/framework_responses_controller_bulk_update_spec.rb
@@ -72,6 +72,11 @@ RSpec.describe Api::FrameworkResponsesController do
         expect(framework_response.reload.responded_by).to eq('TEST_USER')
       end
 
+      it 'creates PaperTrail::Versions' do
+        expect(framework_response.reload.versions.map(&:event)).to match_array(%w[create update])
+        expect(other_framework_response.reload.versions.map(&:event)).to match_array(%w[create update])
+      end
+
       it 'returns the responded at timestamp' do
         expect(framework_response.reload.responded_at).to eq(recorded_timestamp)
       end
@@ -148,6 +153,7 @@ RSpec.describe Api::FrameworkResponsesController do
             multiple_items_response => multiple_items_value,
           }.each do |response, expected_value|
             expect(response.reload.value).to eq(expected_value)
+            expect(response.versions.map(&:event)).to match_array(%w[create update])
           end
         end
       end

--- a/spec/requests/api/person_escort_records_controller_create_spec.rb
+++ b/spec/requests/api/person_escort_records_controller_create_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe Api::PersonEscortRecordsController do
       it 'returns the correct data' do
         expect(response_json).to include_json(data: data)
       end
+
+      it 'creates a PaperTrail::Version for the response' do
+        expect(FrameworkResponse.last.versions.map(&:event)).to eq(%w[create])
+      end
     end
 
     context 'when prefilling from previous person escort record' do

--- a/spec/services/framework_responses/bulk_updater_spec.rb
+++ b/spec/services/framework_responses/bulk_updater_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe FrameworkResponses::BulkUpdater do
       it 'raises an error if transaction fails twice' do
         per = create(:person_escort_record)
         response = create(:string_response, assessmentable: per, value: nil)
-        allow(FrameworkResponse).to receive(:import).and_raise(ActiveRecord::PreparedStatementCacheExpired).twice
+        allow(FrameworkResponse).to receive(:clear_dependent_values_and_flags!).and_raise(ActiveRecord::PreparedStatementCacheExpired).twice
 
         expect { described_class.new(assessment: per, response_values_hash: { response.id => 'Yes' }).call }.to raise_error(ActiveRecord::PreparedStatementCacheExpired)
       end
@@ -118,7 +118,7 @@ RSpec.describe FrameworkResponses::BulkUpdater do
 
         # Allow update to fail first time, and second time to complete transaction
         return_values = [:raise, true]
-        allow(FrameworkResponse).to receive(:import).twice do
+        allow(FrameworkResponse).to receive(:clear_dependent_values_and_flags!).twice do
           return_value = return_values.shift
           return_value == :raise ? raise(ActiveRecord::PreparedStatementCacheExpired) : response.update!(value: 'Yes')
         end


### PR DESCRIPTION
### Jira link

P4-3888

### What?

I have added/removed/altered:

- [x] Changed bulk update and the PER controller to not use ActiveRecord bulk updates

### Why?

I am doing this because:

- Bulk updates skip before/after actions, which means that PaperTrail::Versions were not being created.
