### PR TITLE
P4-3888 - lock diagnostic PII behind a scope

### DIFF
--- a/app/controllers/diagnostics_controller.rb
+++ b/app/controllers/diagnostics_controller.rb
@@ -7,8 +7,7 @@ class DiagnosticsController < ApiController
 
   def move
     move = Move.accessible_by(current_ability).find_by(id: params[:id]) || Move.accessible_by(current_ability).find_by(reference: params[:id])
-    # NB: personal details should only be available on localhost, dev, staging and uat; not on pre-prod or production
-    include_person_details = Rails.env.development? || ENV.fetch('HOSTNAME', 'UNKNOWN') =~ /(-(dev|staging|uat)-)/i
+    include_person_details = doorkeeper_token.acceptable?(:'diagnostics.pii')
     include_per_history = params[:include_per_history] == 'true'
 
     if move.present?

--- a/app/services/diagnostics/move_inspector.rb
+++ b/app/services/diagnostics/move_inspector.rb
@@ -195,11 +195,11 @@ class Diagnostics::MoveInspector
       @output << "(no journeys recorded)\n"
     end
 
-    if (include_person_details || include_per_history) && move.profile&.person_escort_record.present?
-      per_inspector = Diagnostics::PerInspector.new(move.profile.person_escort_record)
-    end
-
     if include_person_details
+      if move.profile&.person_escort_record.present?
+        per_inspector = Diagnostics::PerInspector.new(move.profile.person_escort_record)
+      end
+
       @output << <<~PERSONDETAILS
 
         PERSON
@@ -277,22 +277,20 @@ class Diagnostics::MoveInspector
         ENDPEREVENTS
 
         @output << per_inspector.events
+
+        if include_per_history
+          @output << <<~ENDPERHISTORY
+
+            PERSON ESCORT RECORD HISTORY
+            ----------------------------
+          ENDPERHISTORY
+
+          @output << per_inspector.history
+        end
       else
         @output << "(no person escort record recorded)\n"
       end
-    end
 
-    if include_per_history && per_inspector.present?
-      @output << <<~ENDPERHISTORY
-
-        PERSON ESCORT RECORD HISTORY
-        ----------------------------
-      ENDPERHISTORY
-
-      @output << per_inspector.history
-    end
-
-    if include_person_details
       @output << <<~ENDPER
 
         YOUTH RISK ASSESSMENT

--- a/app/services/diagnostics/per_inspector.rb
+++ b/app/services/diagnostics/per_inspector.rb
@@ -1,5 +1,5 @@
 class Diagnostics::PerInspector
-  attr_reader :per
+  attr_reader :per, :include_per_history
 
   def initialize(per)
     @per = per
@@ -42,7 +42,7 @@ class Diagnostics::PerInspector
   def history
     per.framework_responses.group_by(&:section).map { |section, responses|
       "START OF SECTION:\t#{section}\n" <<
-        responses.map { |r| response_history(r) }.join("\n") <<
+        responses.map { |r| response_history(r) }.select(&:present?).join("\n") <<
         "END OF SECTION:\t#{section}\n"
     }.join("\n")
   end

--- a/spec/services/diagnostics/move_inspector_spec.rb
+++ b/spec/services/diagnostics/move_inspector_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe Diagnostics::MoveInspector do
     it { is_expected.not_to match(/id:\s+#{person.id}/) }
     it { is_expected.not_to match(/id:\s+#{profile.id}/) }
     it { is_expected.not_to match(/PERSON ESCORT RECORD HISTORY/) }
+
+    context 'when include_per_history=true' do
+      let(:include_per_history) { true }
+
+      it { is_expected.not_to match(/PERSON ESCORT RECORD HISTORY/) }
+    end
   end
 
   context 'when include_person_details=true' do
@@ -63,11 +69,11 @@ RSpec.describe Diagnostics::MoveInspector do
     it { is_expected.to match(/id:\s+#{profile.id}/) }
 
     it { is_expected.not_to match(/PERSON ESCORT RECORD HISTORY/) }
-  end
 
-  context 'when include_per_history=true' do
-    let(:include_per_history) { true }
+    context 'when include_per_history=true' do
+      let(:include_per_history) { true }
 
-    it { is_expected.to match(/PERSON ESCORT RECORD HISTORY/) }
+      it { is_expected.to match(/PERSON ESCORT RECORD HISTORY/) }
+    end
   end
 end


### PR DESCRIPTION
Previously, PII was only available in non-production environments, this change makes it so that applications with the `diagnostics.pii` scope (will only be internal) can view the PII.