### PR TITLE
P4-3876 - Fix issue with move finder and single active journey lockout moves

### DIFF
--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -144,7 +144,7 @@ module Moves
       Journey
         .not_rejected_or_cancelled
         .where('move_id = moves.id')
-        .where.not('date = moves.date')
+        .where('date != moves.date OR to_location_id != moves.to_location_id')
         .arel.exists
     end
 

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe Moves::Finder do
 
         it { is_expected.to contain_exactly(move) }
       end
+
+      context 'with a single active journey, when journey.to_location is different from move.to_location' do
+        let(:journey) { create(:journey, move: move, date: move.date) }
+        let(:filter_params) { { location_id: [journey.to_location_id] } }
+
+        it { expect(move.to_location).not_to eq(journey.to_location) }
+        it { is_expected.to contain_exactly(move) }
+      end
     end
 
     describe 'by from_location_id' do


### PR DESCRIPTION
### Jira link

P4-3876

### What?

I have added/removed/altered:

- [x] Altered MoveFinder to include journeys which have a different to_location from the move.

### Why?

I am doing this because:

- Currently, when a lockout move only has 1 active journey, the receiving location cannot see the move in their Incoming moves tab.
