### PR TITLE
Add Dependabot auto-merge from frontend

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,16 @@
+name: Dependabot Auto Merge PR
+
+on:
+  pull_request:
+  
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor # includes patch updates as well!
+          github-token: ${{ secrets.DEPENDABOT_AUTO_MERGE_TOKEN }}


### PR DESCRIPTION
This will automatically merge minor/patch dependabot dependency upgrades once they pass all merge criteria, to reduce the amount of open PRs.