### PR TITLE
Revert "Bump doorkeeper from 5.5.4 to 5.6.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     discard (1.2.1)
       activerecord (>= 4.2, < 8)
     docile (1.3.4)
-    doorkeeper (5.6.0)
+    doorkeeper (5.5.4)
       railties (>= 5)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-api#1953

This version of doorkeeper is throwing an error when no scopes are specified