### PR TITLE
Fix frontend error with occurredAt.split

### DIFF
--- a/app/serializers/important_events_serializer.rb
+++ b/app/serializers/important_events_serializer.rb
@@ -5,5 +5,5 @@ class ImportantEventsSerializer
 
   set_type :events
 
-  attributes :event_type, :classification
+  attributes :occurred_at, :event_type, :classification
 end

--- a/spec/serializers/important_events_serializer_spec.rb
+++ b/spec/serializers/important_events_serializer_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe ImportantEventsSerializer do
     expect(result_data[:id]).to eql event.id
   end
 
+  it 'contains an occurred_at attribute' do
+    expect(attributes[:occurred_at]).to eql event.occurred_at.iso8601
+  end
+
   it 'contains an event_type attribute' do
     expect(attributes[:event_type]).to eql 'PersonMoveAssault'
   end


### PR DESCRIPTION
### Jira link

P4-3967

### What?

I have added/removed/altered:

- [x] Added occurred_at to the ImportantEventsSerializer

### Why?

I am doing this because:

- The frontend needs access to event occurred_at to ensure that PerHandovers are correctly displayed
