### PR TITLE
Check if event trigger is a dry run to remove false positive sentry logging

### DIFF
--- a/app/models/generic_event/journey_admit_to_reception.rb
+++ b/app/models/generic_event/journey_admit_to_reception.rb
@@ -9,8 +9,8 @@ class GenericEvent
     include LocationValidations
     include LocationFeed
 
-    def trigger(*)
-      if vehicle_reg.blank?
+    def trigger(dry_run: false)
+      if vehicle_reg.blank? && !dry_run
         Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
       end
     end

--- a/app/models/generic_event/journey_arrive_at_outer_gate.rb
+++ b/app/models/generic_event/journey_arrive_at_outer_gate.rb
@@ -9,8 +9,8 @@ class GenericEvent
     include LocationValidations
     include LocationFeed
 
-    def trigger(*)
-      if vehicle_reg.blank?
+    def trigger(dry_run: false)
+      if vehicle_reg.blank? && !dry_run
         Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
       end
     end

--- a/app/models/generic_event/journey_exit_through_outer_gate.rb
+++ b/app/models/generic_event/journey_exit_through_outer_gate.rb
@@ -9,8 +9,8 @@ class GenericEvent
     include LocationValidations
     include LocationFeed
 
-    def trigger(*)
-      if vehicle_reg.blank?
+    def trigger(dry_run: false)
+      if vehicle_reg.blank? && !dry_run
         Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
       end
     end

--- a/app/models/generic_event/journey_person_leave_vehicle.rb
+++ b/app/models/generic_event/journey_person_leave_vehicle.rb
@@ -3,8 +3,8 @@ class GenericEvent
     details_attributes :vehicle_reg
     eventable_types 'Journey'
 
-    def trigger(*)
-      if vehicle_reg.blank?
+    def trigger(dry_run: false)
+      if vehicle_reg.blank? && !dry_run
         Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
       end
     end

--- a/app/models/generic_event/journey_ready_to_exit.rb
+++ b/app/models/generic_event/journey_ready_to_exit.rb
@@ -9,8 +9,8 @@ class GenericEvent
     include LocationValidations
     include LocationFeed
 
-    def trigger(*)
-      if vehicle_reg.blank?
+    def trigger(dry_run: false)
+      if vehicle_reg.blank? && !dry_run
         Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
       end
     end


### PR DESCRIPTION
### Jira link

P4-3769

### What?

I have added/removed/altered:

- [x] Removed vehicle_reg logging for dry run events

### Why?

I am doing this because:

- We are getting false positive alerts in Sentry

