### PR TITLE
[P4-3937] Temporarily allow Moves within an Allocation to have their dates changed

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -117,7 +117,10 @@ class Move < VersionedModel
 
   validate :date_to_after_date_from
   validate :validate_prisoner_category
-  validate :validate_date_change_allocation, on: :update
+
+  # Commented out for now, will return as part of P4-3938
+  #
+  # validate :validate_date_change_allocation, on: :update
 
   before_validation :set_reference
   before_validation :set_move_type
@@ -408,9 +411,11 @@ private
     end
   end
 
-  def validate_date_change_allocation
-    if date_changed? && allocation
-      errors.add(:date, :cant_change_allocation, message: 'cannot be changed as move is part of an allocation')
-    end
-  end
+  # Commented out for now, will return as part of P4-3938
+  #
+  # def validate_date_change_allocation
+  #   if date_changed? && allocation
+  #     errors.add(:date, :cant_change_allocation, message: 'cannot be changed as move is part of an allocation')
+  #   end
+  # end
 end

--- a/spec/services/moves/updater_spec.rb
+++ b/spec/services/moves/updater_spec.rb
@@ -69,9 +69,17 @@ RSpec.describe Moves::Updater do
       let(:allocation) { create :allocation, moves_count: 5 }
       let(:move) { create :move, :requested, allocation: allocation }
 
-      it 'fails to update the date' do
-        expect { updater.call }.to raise_error(ActiveRecord::RecordInvalid, /cannot be changed as move is part of an allocation/)
+      # Remove as part of P4-3938
+      it 'sets `date_changed` to `true`' do
+        updater.call
+        expect(updater.date_changed).to be true
       end
+
+      # Commented out for now, will return as part of P4-3938
+      #
+      # it 'fails to update the date' do
+      #   expect { updater.call }.to raise_error(ActiveRecord::RecordInvalid, /cannot be changed as move is part of an allocation/)
+      # end
     end
 
     context 'when status is not updated' do


### PR DESCRIPTION

### Jira link

P4-3937

### What?

I have added/removed/altered:

- [x] Removed the validation that disallowed allocation moves to have their dates changed

### Why?

I am doing this because:

- This is a temporary fix to allow the dates of allocation moves to be changed, in the future this will be re-added and the date of the allocation will be able to be changed as a whole.
