### PR TITLE
P4 3947 upgrade postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,7 @@ references:
       command: |
         echo "Loading wiremock mappings..."
         find spec/wiremock/prison-api/mappings/*.json -exec curl --request POST --url http://localhost:8888/__admin/mappings/ --header 'content-type: application/json' --data-binary "@{}" \;
+        curl http://localhost:8888/__admin/mappings/
   _notify_sentry_release: &notify_sentry_release
     run:
       name: Create release and notify Sentry of deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,7 @@ references:
 executors:
   basic-executor:
     docker:
-      - image: cimg/base:2020.06
+      - image: cimg/base:2022.11
 
   cloud-platform-executor:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,8 +220,8 @@ references:
       name: Load mappings into wiremock
       command: |
         echo "Loading wiremock mappings..."
-        find spec/wiremock/prison-api/mappings/*.json -exec curl -vv  --request POST --url http://localhost:8888/__admin/mappings/ --header 'content-type: application/json' --data-binary "@{}" \;
-        curl -vv http://localhost:8888/__admin/mappings/ 
+        find spec/wiremock/prison-api/mappings/*.json -exec curl -vv  --request POST --url http://localhost:8888/__admin/mappings --header 'content-type: application/json' --data-binary "@{}" \;
+        curl -vv http://localhost:8888/__admin/mappings 
         echo "Done"
   _notify_sentry_release: &notify_sentry_release
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,8 @@ references:
       command: |
         echo "Loading wiremock mappings..."
         find spec/wiremock/prison-api/mappings/*.json -exec curl --request POST --url http://localhost:8888/__admin/mappings/ --header 'content-type: application/json' --data-binary "@{}" \;
-        curl http://localhost:8888/__admin/mappings/
+        curl http://localhost:8888/__admin/mappings/ 
+        echo "Done"
   _notify_sentry_release: &notify_sentry_release
     run:
       name: Create release and notify Sentry of deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ references:
       name: Load mappings into wiremock
       command: |
         echo "Loading wiremock mappings..."
-        find spec/wiremock/prison-api/mappings/*.json -exec curl --request POST --url http://localhost:8888/__admin/mappings/ --header 'content-type: application/json' --data-binary "@{}" \;
+        find spec/wiremock/prison-api/mappings/*.json -exec curl -vv  --request POST --url http://localhost:8888/__admin/mappings/ --header 'content-type: application/json' --data-binary "@{}" \;
         curl -vv http://localhost:8888/__admin/mappings/ 
         echo "Done"
   _notify_sentry_release: &notify_sentry_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ references:
       command: |
         echo "Loading wiremock mappings..."
         find spec/wiremock/prison-api/mappings/*.json -exec curl --request POST --url http://localhost:8888/__admin/mappings/ --header 'content-type: application/json' --data-binary "@{}" \;
-        curl http://localhost:8888/__admin/mappings/ 
+        curl -vv http://localhost:8888/__admin/mappings/ 
         echo "Done"
   _notify_sentry_release: &notify_sentry_release
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,12 +273,12 @@ executors:
           EXTERNAL_URL: mocked_in_tests
           ENCRYPTOR_SALT: "2EREZ8Xub/vt0ya1ZM6YKUwIMN72MbmqeWMq7KS4BV8oSJJc27rDpZYmA6AQGYcS"
           EXTERNAL_WIREMOCK: "true"
-      - image: circleci/postgres:10-alpine-ram
+      - image: cimg/postgres:12.11
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: hmpps-book-secure-move-api
           LANG: C.utf8
-      - image: rodolpheche/wiremock:2.27.1-alpine
+      - image: wiremock/wiremock:2.32.0-alpine
         command: --port 8888
 
 commands:

--- a/spec/requests/api/moves_controller_sorting_spec.rb
+++ b/spec/requests/api/moves_controller_sorting_spec.rb
@@ -182,8 +182,7 @@ RSpec.describe Api::MovesController do
             let(:sort_params) { { by: 'to_location' } }
 
             it 'sorts by to location' do
-              # NB: this is a case-sensitive order. If this test fails, check the database collation: it should be UTF-8, not en_US.
-              expect(locations.map(&:title)).to eq(%w[LOCATION1 LOCATION3 location2 location4])
+              expect(locations.map(&:title)).to eq(%w[LOCATION1 location2 LOCATION3 location4])
             end
           end
 
@@ -191,8 +190,7 @@ RSpec.describe Api::MovesController do
             let(:sort_params) { { by: 'to_location', direction: 'desc' } }
 
             it 'sorts by to location' do
-              # NB: this is a case-sensitive order. If this test fails, check the database collation: it should be UTF-8, not en_US.
-              expect(locations.map(&:title)).to eq(%w[location4 location2 LOCATION3 LOCATION1])
+              expect(locations.map(&:title)).to eq(%w[location4 LOCATION3 location2 LOCATION1])
             end
           end
         end
@@ -210,15 +208,15 @@ RSpec.describe Api::MovesController do
             let(:sort_params) { { by: 'name' } }
 
             it 'sorts by last_name (ascending, case sensitive)' do
-              expect(last_names).to eq(%w[PROFILE1 PROFILE3 profile2 profile4])
+              expect(last_names).to eq(%w[PROFILE1 profile2 PROFILE3 profile4])
             end
           end
 
           context 'with reverse direction' do
             let(:sort_params) { { by: 'name', direction: 'desc' } }
 
-            it 'sorts by last_name (descending, case sensitive)' do
-              expect(last_names).to eq(%w[profile4 profile2 PROFILE3 PROFILE1])
+            it 'sorts by last_name' do
+              expect(last_names).to eq(%w[profile4 PROFILE3 profile2 PROFILE1])
             end
           end
         end

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -180,8 +180,8 @@ RSpec.describe Allocations::Finder do
 
       let(:sort_params) { { by: :from_location, direction: :asc } }
 
-      it 'orders by location title (case-sensitive)' do
-        expect(allocation_finder.call.map(&:from_location).pluck(:title)).to eql(%w[LOCATION1 LOCATION3 Location2])
+      it 'orders by location title' do
+        expect(allocation_finder.call.map(&:from_location).pluck(:title)).to eql(%w[LOCATION1 Location2 LOCATION3])
       end
     end
 
@@ -195,8 +195,8 @@ RSpec.describe Allocations::Finder do
 
       let(:sort_params) { { by: :to_location, direction: :asc } }
 
-      it 'orders by location title (case-sensitive)' do
-        expect(allocation_finder.call.map(&:to_location).pluck(:title)).to eql(%w[LOCATION1 LOCATION3 Location2])
+      it 'orders by location title' do
+        expect(allocation_finder.call.map(&:to_location).pluck(:title)).to eql(%w[LOCATION1 Location2 LOCATION3])
       end
     end
 
@@ -243,8 +243,8 @@ RSpec.describe Allocations::Finder do
         create :allocation, :with_moves, date: allocation.date + 5.days, from_location: from_location, to_location: location3
       end
 
-      it 'returns allocations matching date range sorted by location title (case-sensitive)' do
-        expect(allocation_finder.call.map(&:to_location).pluck(:title)).to eql(%w[Location2 LOCATION3 LOCATION1])
+      it 'returns allocations matching date range sorted by location title desc' do
+        expect(allocation_finder.call.map(&:to_location).pluck(:title)).to eql(%w[LOCATION3 Location2 LOCATION1])
       end
     end
 

--- a/spec/services/locations/finder_spec.rb
+++ b/spec/services/locations/finder_spec.rb
@@ -148,8 +148,8 @@ RSpec.describe Locations::Finder do
 
       let(:sort_params) { { by: :title, direction: :asc } }
 
-      it 'orders by location title (case-sensitive)' do
-        expect(location_finder.call.pluck(:title)).to eql(%w[LOCATION1 LOCATION3 Location2]) # NB: case-sensitive order
+      it 'orders by location title' do
+        expect(location_finder.call.pluck(:title)).to eql(%w[LOCATION1 Location2 LOCATION3]) # NB: case-sensitive order
       end
     end
 

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -571,8 +571,8 @@ RSpec.describe Moves::Finder do
         create :move, to_location: location3
       end
 
-      it 'ordered by location (case-sensitive)' do
-        expect(results.map(&:to_location).pluck(:title)).to eql(%w[LOCATION1 LOCATION3 Location2]) # NB: case-sensitive order
+      it 'ordered by location' do
+        expect(results.map(&:to_location).pluck(:title)).to eql(%w[LOCATION1 Location2 LOCATION3])
       end
     end
 


### PR DESCRIPTION
### Jira link

P4-3947

### What?

I have altered:

- Wiremock, postgres and base image versions in ci pipeline

### Why?

I am doing this because:

- Postgres 10 support is being removed, update is required


### Deployment risks (optional)

- Doesn't change code but until DBs in cloud platform are upgraded, ci and deployed applications will be running against differing versions of postgres

