### PR TITLE
[P4-3948] Change proposed journey dates when move date is changed

### DIFF
--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -984,4 +984,25 @@ RSpec.describe Move do
       expect(move.expected_collection_time).to eq('2019-06-17T10:20:30+01:00')
     end
   end
+
+  describe '#update_proposed_journey_dates' do
+    let(:journey1) { create(:journey, :proposed, client_timestamp: Time.zone.now - 1.day, vehicle: { id: '12345', registration: 'AB12 CDE' }) }
+    let(:journey2) { create(:journey, :in_progress, client_timestamp: Time.zone.now - 2.days, vehicle: { id: '6789', registration: 'CD12 ABC' }) }
+    let(:journey3) { create(:journey, :proposed, date: Time.zone.today + 1, client_timestamp: Time.zone.now - 1.day, vehicle: { id: '123443', registration: 'AB16 CDE' }) }
+    let(:move) { create(:move, date: Time.zone.today, journeys: [journey1, journey2, journey3]) }
+
+    it 'updates the date of proposed moves' do
+      expect(journey1.date).to eq(Time.zone.today)
+      expect(journey2.date).to eq(Time.zone.today)
+      expect(journey3.date).to eq(Time.zone.today + 1)
+      expect(move.date).to eq(Time.zone.today)
+
+      move.date = Time.zone.today + 6
+      move.save!
+
+      expect(journey1.date).to eq(Time.zone.today + 6)
+      expect(journey2.date).to eq(Time.zone.today)
+      expect(journey3.date).to eq(Time.zone.today + 7)
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

P4-3948

### What?

I have added/removed/altered:

- [x] Altered moves to update their proposed journey dates when the move date is changed.

### Why?

I am doing this because:

- Currently, if a move has a proposed journey and the move date is changed, the date doesn't update in the frontend, because it displays the journey's date.
