### PR TITLE
[P4-3998] Include requires_youth_risk_assessment in ProfilesSerializer

### DIFF
--- a/app/serializers/v2/profiles_serializer.rb
+++ b/app/serializers/v2/profiles_serializer.rb
@@ -6,7 +6,7 @@ class V2::ProfilesSerializer
 
   set_type :profiles
 
-  attributes :assessment_answers
+  attributes :requires_youth_risk_assessment, :assessment_answers
 
   belongs_to :category, serializer: CategorySerializer
   belongs_to :person, serializer: ::V2::PersonSerializer

--- a/spec/serializers/v2/profiles_serializer_spec.rb
+++ b/spec/serializers/v2/profiles_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe V2::ProfilesSerializer do
   subject(:serializer) { described_class.new(profile, options) }
 
-  let(:profile) { create(:profile) }
+  let(:profile) { create(:profile, requires_youth_risk_assessment: false) }
   let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
   let(:options) { {} }
 
@@ -14,7 +14,7 @@ RSpec.describe V2::ProfilesSerializer do
       data: {
         id: profile.id,
         type: 'profiles',
-        attributes: { assessment_answers: [] },
+        attributes: { assessment_answers: [], requires_youth_risk_assessment: false },
         relationships: {
           person: {
             data: { id: profile.person.id, type: 'people' },


### PR DESCRIPTION
### Jira link

P4-3998

### What?

I have added/removed/altered:

- [x] Altered ProfilesSerializer to include `requires_youth_risk_assessment`.

### Why?

I am doing this because:

- As part of the incomplete PER work, the frontend requires this field to know which text to show.

