### PR TITLE
[P4-3998] Include youth_risk_assessment in ProfilesSerializer

### DIFF
--- a/app/serializers/v2/profiles_serializer.rb
+++ b/app/serializers/v2/profiles_serializer.rb
@@ -12,4 +12,5 @@ class V2::ProfilesSerializer
   belongs_to :person, serializer: ::V2::PersonSerializer
 
   has_one_if_included :person_escort_record, serializer: PersonEscortRecordsSerializer
+  has_one_if_included :youth_risk_assessment, serializer: YouthRiskAssessmentsSerializer
 end

--- a/app/serializers/youth_risk_assessments_serializer.rb
+++ b/app/serializers/youth_risk_assessments_serializer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class YouthRiskAssessmentsSerializer
+  include JSONAPI::Serializer
+  include JSONAPI::ConditionalRelationships
+
+  set_type :youth_risk_assessments
+
+  attribute :status do |object|
+    object.status == 'unstarted' ? 'not_started' : object.status
+  end
+end

--- a/spec/serializers/v2/profiles_serializer_spec.rb
+++ b/spec/serializers/v2/profiles_serializer_spec.rb
@@ -85,4 +85,22 @@ RSpec.describe V2::ProfilesSerializer do
       })
     end
   end
+
+  context 'with included youth risk assessment' do
+    let(:options) { { params: { included: %i[youth_risk_assessment] } } }
+    let(:profile) { create(:profile) }
+
+    it 'contains a nil `youth_risk_assessment` relationship if no youth risk assessment present' do
+      expect(result[:data][:relationships][:youth_risk_assessment][:data]).to be_nil
+    end
+
+    it 'contains a`youth_risk_assessment` relationship with youth risk assessment' do
+      youth_risk_assessment = create(:youth_risk_assessment, profile: profile)
+
+      expect(result[:data][:relationships][:youth_risk_assessment][:data]).to eq({
+        id: youth_risk_assessment.id,
+        type: 'youth_risk_assessments',
+      })
+    end
+  end
 end

--- a/spec/serializers/youth_risk_assessments_serializer_spec.rb
+++ b/spec/serializers/youth_risk_assessments_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe YouthRiskAssessmentsSerializer do
+  subject(:serializer) { described_class.new(youth_risk_assessment) }
+
+  let(:youth_risk_assessment) { create(:youth_risk_assessment) }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:expected_result) do
+    {
+      data: {
+        id: youth_risk_assessment.id,
+        type: 'youth_risk_assessments',
+        attributes: {
+          status: 'not_started',
+        },
+      },
+    }
+  end
+
+  it 'contains the expected data' do
+    expect(result).to eq(expected_result)
+  end
+end


### PR DESCRIPTION
### Jira link

P4-3998

### What?

I have added/removed/altered:

- [x] Included YRA in the profiles serializer

### Why?

I am doing this because:

- Frontend needs to know the YRA status to correctly display the incomplete PERs text
