### PR TITLE
[P4-3862] Fix move date being reverted to original date

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -150,8 +150,9 @@ class Move < VersionedModel
   end
 
   def approve(date:)
+    return unless state_machine.approve
+
     assign_attributes(date: date) if date.present?
-    state_machine.approve
   end
 
   def approve!(args)


### PR DESCRIPTION
### Jira link

P4-3862

### What?

I have added/removed/altered:

- [x] Altered move.approve to only change the date of the move if the state_machine.approve returns true (state changed)

### Why?

I am doing this because:

- We have allowed users to change move dates, but as soon as any other event is added, the move date reverts back to the original date.

