### PR TITLE
[P4-3910] Add new endpoint: GET /events/:event_id

### DIFF
--- a/app/controllers/api/generic_events_controller.rb
+++ b/app/controllers/api/generic_events_controller.rb
@@ -21,10 +21,24 @@ module Api
         Notifier.prepare_notifications(topic: event, action_name: 'create_event')
       end
 
-      render_json event, serializer: event.class.serializer, status: :created
+      render_event(event, :created)
+    end
+
+    def show
+      render_event(event, :ok)
     end
 
   private
+
+    def render_event(event, status)
+      render_json event, serializer: event.class.serializer, status: status
+    end
+
+    def event
+      @event ||= GenericEvent
+                  .includes(active_record_relationships)
+                  .find(params[:id])
+    end
 
     def event_attributes
       {}.tap do |attributes|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   namespace :api do
     filter :versioned_path
 
-    resources :events, only: %i[create], controller: 'generic_events'
+    resources :events, only: %i[create show], controller: 'generic_events'
 
     resources :allocations, only: %i[create index show] do
       collection { post 'filtered' }

--- a/spec/requests/api/generic_events_controller_show_spec.rb
+++ b/spec/requests/api/generic_events_controller_show_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::GenericEventsController do
+  subject { create(:event_move_collection_by_escort) }
+
+  let(:response_json) { JSON.parse(response.body) }
+  let(:schema) { load_yaml_schema('get_event_responses.yaml', version: 'v2') }
+  let(:access_token) { 'spoofed-token' }
+  let(:content_type) { ApiController::CONTENT_TYPE }
+
+  let(:resource_to_json) do
+    JSON.parse(GenericEventSerializer.new(subject).serializable_hash.to_json)
+  end
+
+  let(:headers) do
+    {
+      'CONTENT_TYPE': content_type,
+      'Accept': 'application/vnd.api+json; version=2',
+      'Authorization' => "Bearer #{access_token}",
+      'X-Current-User' => 'TEST_USER',
+    }
+  end
+
+  describe 'GET /events/:id' do
+    it 'returns serialized data' do
+      do_get
+      expect(response_json).to eq resource_to_json
+    end
+
+    it_behaves_like 'an endpoint that responds with success 200' do
+      before { do_get }
+    end
+  end
+
+  def do_get
+    get "/api/events/#{subject.id}", headers: headers, as: :json
+  end
+end

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -799,3 +799,57 @@
             application/vnd.api+json:
               schema:
                 "$ref": "../v2/post_event_responses.yaml#/422"
+  "/events/{event_id}":
+    get:
+      summary: Returns the details of an event
+      tags:
+        - Events
+      consumes:
+        - application/vnd.api+json
+      parameters:
+        - "$ref": "../v2/accept_type_parameter.yaml#/Accept"
+        - name: event_id
+          in: path
+          description: The ID of the event
+          schema:
+            type: string
+          format: uuid
+          example: 00525ecb-7316-492a-aae2-f69334b2a155
+          required: true
+      responses:
+        "200":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/get_event_responses.yaml#/200"
+        "400":
+          description: bad request
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/get_event_responses.yaml#/400"
+        "401":
+          description: unauthorized
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/get_event_responses.yaml#/401"
+        "404":
+          description: resource not found
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/get_event_responses.yaml#/404"
+        "415":
+          description: invalid media type
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/get_event_responses.yaml#/415"
+        "422":
+          description: unprocessable entity
+          content:
+            application/vnd.api+json:
+              schema:
+                "$ref": "../v2/get_event_responses.yaml#/422"

--- a/swagger/v2/get_event_responses.yaml
+++ b/swagger/v2/get_event_responses.yaml
@@ -1,0 +1,52 @@
+"200":
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      $ref: "../v2/event.yaml#/EventResponseBody"
+"400":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/BadRequest"
+"401":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/NotAuthorisedError"
+"404":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/ResourceNotFound"
+"415":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/UnsupportedMediaType"
+"422":
+  type: object
+  required:
+    - errors
+  properties:
+    errors:
+      type: array
+      items:
+        $ref: "../v1/errors.yaml#/UnprocessableEntity"


### PR DESCRIPTION
### Jira link

P4-3910

### What?

I have added/removed/altered:

- [x] Added new endpoint: GET /events/:event_id

### Why?

I am doing this because:

- Currently, when an event is added via BaSM frontend, we send a notification to the suppliers containing the event id, but they have no way of directly getting the event details from us.

### Have you? (optional)

- [x] Updated API docs if necessary	
