### PR TITLE
feat: Add recall_date field to moves [P4-3970]

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -73,6 +73,7 @@ module Api
       profile_id
       person_id
       reference
+      recall_date
     ].freeze
 
     PERMITTED_FILTERED_PARAMS = [

--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -82,6 +82,7 @@ module Api::V2
           move_type
           date_from
           date_to
+          recall_date
         ],
         relationships: {} },
     ].freeze

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -22,6 +22,7 @@ class Move < VersionedModel
     date_to
     allocation_id
     rejection_reason
+    recall_date
   ].freeze
 
   include StateMachineable
@@ -117,6 +118,8 @@ class Move < VersionedModel
 
   validate :date_to_after_date_from
   validate :validate_prisoner_category
+
+  validates :recall_date, date: true
 
   # Commented out for now, will return as part of P4-3938
   #

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -22,7 +22,8 @@ module V2
                :status,
                :time_due,
                :updated_at,
-               :is_lockout
+               :is_lockout,
+               :recall_date
 
     belongs_to :from_location,          serializer: LocationSerializer
     belongs_to :prison_transfer_reason, serializer: PrisonTransferReasonSerializer

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -20,7 +20,8 @@ module V2
                 :status,
                 :time_due,
                 :updated_at,
-                :is_lockout
+                :is_lockout,
+                :recall_date
 
     set_type :moves
 

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if record.public_send("#{attribute}_before_type_cast").blank?
+
+    unless value.acts_like?(:date)
+      record.errors.add(attribute, :invalid)
+    end
+  end
+end

--- a/db/migrate/20230119131112_add_recall_date_to_moves.rb
+++ b/db/migrate/20230119131112_add_recall_date_to_moves.rb
@@ -1,0 +1,5 @@
+class AddRecallDateToMoves < ActiveRecord::Migration[6.1]
+  def change
+    add_column :moves, :recall_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_08_135622) do
+ActiveRecord::Schema.define(version: 2023_01_19_131112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -372,6 +372,7 @@ ActiveRecord::Schema.define(version: 2022_06_08_135622) do
     t.uuid "original_move_id"
     t.uuid "supplier_id"
     t.boolean "is_lockout", default: false
+    t.date "recall_date"
     t.index ["allocation_id"], name: "index_moves_on_allocation_id"
     t.index ["created_at"], name: "index_moves_on_created_at"
     t.index ["date"], name: "index_moves_on_date"

--- a/spec/factories/move.rb
+++ b/spec/factories/move.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     additional_information { 'some more info about the move that the supplier might need to know' }
     sequence(:created_at) { |n| Time.zone.now - n.minutes }
     sequence(:date_from) { |n| Time.zone.today - n.days }
+    recall_date { Time.zone.now - 1.day }
 
     association(:supplier)
 

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -175,6 +175,18 @@ RSpec.describe Move do
     expect(build(:move, date_from: '2020-03-04', date_to: '2020-03-04')).to be_valid
   end
 
+  it 'allows a valid date for recall_date' do
+    expect(build(:move, recall_date: '2023-01-05')).to be_valid
+  end
+
+  it 'allows a nil date for recall_date' do
+    expect(build(:move, recall_date: nil)).to be_valid
+  end
+
+  it 'does not allow an invalid date for recall_date' do
+    expect(build(:move, recall_date: 'not a date')).not_to be_valid
+  end
+
   context 'when the from_location and to_location are the same' do
     subject(:move) { build(:move, to_location: location, from_location: location) }
 

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Api::MovesController do
         status: status,
         additional_information: 'some more info',
         move_type: 'court_appearance',
+        recall_date: '2023-01-02',
       }
     end
 
@@ -171,6 +172,12 @@ RSpec.describe Api::MovesController do
       do_post
 
       expect(response_json.dig('data', 'attributes', 'additional_information')).to match 'some more info'
+    end
+
+    it 'sets the recall_date' do
+      do_post
+
+      expect(response_json.dig('data', 'attributes', 'recall_date')).to match '2023-01-02'
     end
 
     context 'when the supplier has a webhook subscription' do

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Api::MovesController do
     let(:profile) { create(:profile) }
     let(:date_from) { Date.yesterday }
     let(:date_to) { Date.tomorrow }
+    let(:recall_date) { Date.new(2023, 1, 2) }
 
     let(:move_params) do
       {
@@ -44,6 +45,7 @@ RSpec.describe Api::MovesController do
           move_agreed_by: 'Fred Bloggs',
           date_from: date_from,
           date_to: date_to,
+          recall_date: recall_date,
         },
       }
     end
@@ -58,6 +60,7 @@ RSpec.describe Api::MovesController do
         'date_to' => date_to,
         'move_agreed' => true,
         'move_agreed_by' => 'Fred Bloggs',
+        'recall_date' => recall_date,
         'status' => 'requested',
       }
     end

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe V2::MoveSerializer do
             time_due: move.time_due.iso8601,
             updated_at: move.updated_at.iso8601,
             is_lockout: false,
+            recall_date: move.recall_date.iso8601,
           },
           relationships: {
             profile: { data: { id: move.profile.id, type: 'profiles' } },

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe V2::MovesSerializer do
             time_due: move.time_due.iso8601,
             updated_at: move.updated_at.iso8601,
             is_lockout: false,
+            recall_date: move.recall_date.iso8601,
           },
           relationships: {
             profile: { data: { id: move.profile_id, type: 'profiles' } },

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -115,6 +115,13 @@ Move:
           description:
             In case 'other' is chosen as cancellation_reason, further details
             can be specified
+        recall_date:
+          oneOf:
+            - type: string
+              format: date
+            - type: "null"
+          example: "2023-01-02"
+          description: Date of return to Police custody (prison recall moves only)
     relationships:
       type: object
       required:

--- a/swagger/v2/patch_move.yaml
+++ b/swagger/v2/patch_move.yaml
@@ -108,6 +108,13 @@ Move:
           description:
             In case 'other' is chosen as cancellation_reason, further details
             can be specified
+        recall_date:
+          oneOf:
+            - type: string
+              format: date
+            - type: "null"
+          example: "2023-01-02"
+          description: Date of return to Police custody (prison recall moves only)
     relationships:
       type: object
       properties:


### PR DESCRIPTION
Add recall date field to moves.

### Jira link

[P4-P4-3970](https://dsdmoj.atlassian.net/browse/P4-3970)

### What?

I have added/removed/altered:

- Added recall_date field to Move model

### Why?

I am doing this because:

- This field is being moved to the booking form instead of the PER. Only police are able to provide this information, and it's easier to restrict access to sections of the booking form than the PER.

### Have you? (optional)

- [x] Updated API docs if necessary	
- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)

### Deployment risks (optional)

- The code expects the recall_date column to exist in the moves table so the migrations should be run prior to deployment
- Changes an API that is used in production - suppliers need to be kept informed

