### PR TITLE
chore: Add rake task for requeueing notifications with no delivery attempts

### DIFF
--- a/app/workers/requeue_unsent_notifications_worker.rb
+++ b/app/workers/requeue_unsent_notifications_worker.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RequeueUnsentNotificationsWorker
+  include Sidekiq::Worker
+
+  NOTIFY_JOBS = {
+    NotificationType::EMAIL => NotifyEmailJob,
+    NotificationType::WEBHOOK => NotifyWebhookJob,
+  }.freeze
+
+  def perform
+    Notification.where(
+      delivery_attempts: 0,
+      updated_at: 1.day.ago..1.hour.ago,
+      notification_type_id: [NotificationType::EMAIL, NotificationType::WEBHOOK],
+    ).each do |notification|
+      NOTIFY_JOBS[notification.notification_type_id]
+        .perform_later(notification_id: notification.id, queue_as: :notifications_high)
+    end
+  end
+end

--- a/lib/tasks/requeue_unsent_notifications.rake
+++ b/lib/tasks/requeue_unsent_notifications.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+desc 'Find notifications with no delivery attempts and recreate the job'
+task requeue_unsent_notifications: :environment do
+  RequeueUnsentNotificationsWorker.perform_async
+
+  puts 'The RequeueUnsentNotificationsWorker has been queued.'
+end

--- a/spec/lib/tasks/requeue_unsent_notifications_spec.rb
+++ b/spec/lib/tasks/requeue_unsent_notifications_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Rake::Task['requeue_unsent_notifications'] do
+  before do
+    allow(RequeueUnsentNotificationsWorker).to receive(:perform_async)
+    allow($stdout).to receive(:puts)
+
+    described_class.reenable
+    described_class.invoke
+  end
+
+  it 'queues the RequeueUnsentNotificationsWorker worker' do
+    expect(RequeueUnsentNotificationsWorker).to have_received(:perform_async)
+  end
+
+  it 'logs that it queued the worker' do
+    expect($stdout)
+      .to have_received(:puts)
+      .with('The RequeueUnsentNotificationsWorker has been queued.')
+  end
+end

--- a/spec/workers/requeue_unsent_notifications_worker_spec.rb
+++ b/spec/workers/requeue_unsent_notifications_worker_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe RequeueUnsentNotificationsWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:notification_type) { create(:notification_type, :webhook) }
+  let(:updated_at) { 4.hours.ago }
+
+  let!(:notification) do
+    create(
+      :notification,
+      notification_type: notification_type,
+      updated_at: updated_at,
+      delivery_attempts: delivery_attempts,
+    )
+  end
+
+  let(:notification_job) { NotifyWebhookJob }
+
+  let(:logger) { instance_spy(Logger) }
+
+  before do
+    allow(Rails).to receive(:logger).and_return(logger)
+    allow(notification_job).to receive(:perform_later)
+  end
+
+  shared_examples 'it gets requeued' do
+    it 'runs the notify webhook job' do
+      worker.perform
+
+      expect(notification_job)
+        .to have_received(:perform_later)
+        .with(notification_id: notification.id, queue_as: :notifications_high)
+    end
+  end
+
+  shared_examples 'it does not get requeued' do
+    it 'does not run the notify webhook job' do
+      worker.perform
+
+      expect(NotifyWebhookJob).not_to have_received(:perform_later)
+    end
+  end
+
+  context 'when delivery already attempted' do
+    let(:delivery_attempts) { 1 }
+
+    it_behaves_like 'it does not get requeued'
+  end
+
+  context 'when delivery not attempted' do
+    let(:delivery_attempts) { 0 }
+
+    it_behaves_like 'it gets requeued'
+
+    context 'when created within the last hour' do
+      let(:updated_at) { 1.second.ago }
+
+      it_behaves_like 'it does not get requeued'
+    end
+
+    context 'when created over one day ago' do
+      let(:updated_at) { 2.days.ago }
+
+      it_behaves_like 'it does not get requeued'
+    end
+
+    context 'when email notification' do
+      let(:notification_type) { create(:notification_type, :email) }
+      let(:notification_job) { NotifyEmailJob }
+
+      it_behaves_like 'it gets requeued'
+    end
+  end
+end


### PR DESCRIPTION
Sometimes Sidekiq drops messages. This tasks checks for notifications that were created more than an hour ago (to give Sidekiq a chance to get to them) but less than a day ago (to avoid a torrent of old notifications when we first run this) and retries scheduling the job to send that notification.

[P4-3993]

### Jira link

[P4-3993](https://dsdmoj.atlassian.net/browse/P4-3993)

### What?

I have added/removed/altered:

- Added requeue_unsent_notifications Rake task

### Why?

I am doing this because:

- Sidekiq sometimes drop messages, meaning that suppliers sometimes do not receive notifications about moves. We can check for messages that have had no delivery attempts and recreate the job, to give Sidekiq another chance to pick them up.

[P4-3993]: https://dsdmoj.atlassian.net/browse/P4-3993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ