### PR TITLE
chore: Add logging to RequeueUnsentNotificationsWorker

### DIFF
--- a/app/workers/requeue_unsent_notifications_worker.rb
+++ b/app/workers/requeue_unsent_notifications_worker.rb
@@ -14,8 +14,13 @@ class RequeueUnsentNotificationsWorker
       updated_at: 1.day.ago..1.hour.ago,
       notification_type_id: [NotificationType::EMAIL, NotificationType::WEBHOOK],
     ).each do |notification|
-      NOTIFY_JOBS[notification.notification_type_id]
-        .perform_later(notification_id: notification.id, queue_as: :notifications_high)
+      notify_job = NOTIFY_JOBS[notification.notification_type_id]
+      notify_job.perform_later(notification_id: notification.id, queue_as: :notifications_high)
+
+      Rails.logger.info(
+        "[RequeueUnsentNotificationsWorker] #{notify_job} recreated for " \
+        "Notification ID #{notification.id}",
+      )
     end
   end
 end

--- a/spec/workers/requeue_unsent_notifications_worker_spec.rb
+++ b/spec/workers/requeue_unsent_notifications_worker_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe RequeueUnsentNotificationsWorker, type: :worker do
         .to have_received(:perform_later)
         .with(notification_id: notification.id, queue_as: :notifications_high)
     end
+
+    it 'logs that the job was recreated' do
+      worker.perform
+
+      expect(logger).to have_received(:info).with(
+        "[RequeueUnsentNotificationsWorker] #{notification_job} recreated for " \
+        "Notification ID #{notification.id}",
+      )
+    end
   end
 
   shared_examples 'it does not get requeued' do


### PR DESCRIPTION
### Jira link

[P4-3993](https://dsdmoj.atlassian.net/browse/P4-3993)

### What?

I have added/removed/altered:

- Added logging to the RequeueUnsentNotificationsWorker

### Why?

I am doing this because:

- It will help with debugging and enable us to verify that the worker is doing what it said it would do



[P4-3993]: https://dsdmoj.atlassian.net/browse/P4-3993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ