### PR TITLE
chore: Always send create_move notification

### DIFF
--- a/app/jobs/prepare_base_notifications_job.rb
+++ b/app/jobs/prepare_base_notifications_job.rb
@@ -73,6 +73,6 @@ private
     return action unless action == 'update_move_status'
 
     create_notification = topic.notifications.find_by(event_type: 'create_move', notification_type_id: type_id)
-    create_notification.nil? ? 'create_move' : 'update_move_status'
+    create_notification.nil? && !topic.cancelled? ? 'create_move' : 'update_move_status'
   end
 end

--- a/app/jobs/prepare_move_notifications_job.rb
+++ b/app/jobs/prepare_move_notifications_job.rb
@@ -10,15 +10,4 @@ private
   def associated_move(topic)
     topic
   end
-
-  def build_notifications(subscription, type_id, topic, action_name)
-    notifications = []
-
-    if %w[update update_status].include?(action_name) &&
-        topic.notifications.where(event_type: 'create_move', notification_type_id: type_id).none?
-      notifications << build_notification(subscription, type_id, topic, 'create')
-    end
-
-    notifications << build_notification(subscription, type_id, topic, action_name)
-  end
 end

--- a/app/jobs/prepare_move_notifications_job.rb
+++ b/app/jobs/prepare_move_notifications_job.rb
@@ -10,4 +10,15 @@ private
   def associated_move(topic)
     topic
   end
+
+  def build_notifications(subscription, type_id, topic, action_name)
+    notifications = []
+
+    if %w[update update_status].include?(action_name) &&
+        topic.notifications.where(event_type: 'create_move', notification_type_id: type_id).none?
+      notifications << build_notification(subscription, type_id, topic, 'create')
+    end
+
+    notifications << build_notification(subscription, type_id, topic, action_name)
+  end
 end

--- a/spec/jobs/prepare_generic_event_notifications_job_spec.rb
+++ b/spec/jobs/prepare_generic_event_notifications_job_spec.rb
@@ -40,8 +40,10 @@ RSpec.describe PrepareGenericEventNotificationsJob, type: :job do
     it 'schedules NotifyWebhookJob' do
       perform
 
-      expect(NotifyWebhookJob).to have_received(:perform_later)
-                                    .with(notification_id: Notification.webhooks.last.id, queue_as: :some_queue_name)
+      expect(NotifyWebhookJob)
+        .to have_received(:perform_later)
+        .once
+        .with(notification_id: Notification.webhooks.last.id, queue_as: :some_queue_name)
     end
 
     it 'does not schedule a NotifyEmailJob' do

--- a/spec/jobs/prepare_move_notifications_job_spec.rb
+++ b/spec/jobs/prepare_move_notifications_job_spec.rb
@@ -117,7 +117,38 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
     context 'when a create_move notification has already been sent' do
       before do
         subscription.notifications.create!(
-          notification_type_id: :webhook, topic: move, event_type: 'create_move'
+          notification_type_id: :webhook, topic: move, event_type: 'create_move',
+        )
+      end
+
+      it 'sends the notification as update_move_status' do
+        perform
+        expect(Notification.webhooks.order(:created_at).last.event_type).to eq('update_move_status')
+      end
+    end
+  end
+
+  context 'when cancelling a move' do
+    let(:action_name) { 'update_status' }
+
+    before { move.cancel!(cancellation_reason: Move::CANCELLATION_REASON_OTHER) }
+
+    it_behaves_like 'it creates a webhook notification record'
+    it_behaves_like 'it creates an email notification record'
+    it_behaves_like 'it schedules NotifyWebhookJob'
+    it_behaves_like 'it schedules NotifyEmailJob'
+
+    context 'when a create_move notification has not already been sent' do
+      it 'sends the notification as update_move_status' do
+        perform
+        expect(Notification.webhooks.order(:created_at).last.event_type).to eq('update_move_status')
+      end
+    end
+
+    context 'when a create_move notification has already been sent' do
+      before do
+        subscription.notifications.create!(
+          notification_type_id: :webhook, topic: move, event_type: 'create_move',
         )
       end
 

--- a/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_escort_record_notifications_job_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe PreparePersonEscortRecordNotificationsJob, type: :job do
 
     it 'schedules NotifyWebhookJob' do
       perform
-      expect(NotifyWebhookJob).to have_received(:perform_later).with(notification_id: Notification.webhooks.last.id, queue_as: :some_queue_name)
+      expect(NotifyWebhookJob).to have_received(:perform_later).once.with(notification_id: Notification.webhooks.last.id, queue_as: :some_queue_name)
     end
 
     it 'schedules NotifyEmailJob' do
       perform
-      expect(NotifyEmailJob).to have_received(:perform_later).with(notification_id: Notification.emails.last.id, queue_as: :some_queue_name)
+      expect(NotifyEmailJob).to have_received(:perform_later).once.with(notification_id: Notification.emails.last.id, queue_as: :some_queue_name)
     end
   end
 end

--- a/spec/jobs/prepare_person_notifications_job_spec.rb
+++ b/spec/jobs/prepare_person_notifications_job_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe PreparePersonNotificationsJob, type: :job do
   end
 
   shared_examples 'it calls PrepareMoveNotificationsJob for the related moves' do
-    it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move_today.id, action_name: action_name, queue_as: :notifications_high) }
-    it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move_next_week.id, action_name: action_name, queue_as: :notifications_low) }
+    it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).once.with(topic_id: move_today.id, action_name: action_name, queue_as: :notifications_high) }
+    it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).once.with(topic_id: move_next_week.id, action_name: action_name, queue_as: :notifications_low) }
     it { expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name, queue_as: :notifications_medium) }
   end
 

--- a/spec/jobs/prepare_profile_notifications_job_spec.rb
+++ b/spec/jobs/prepare_profile_notifications_job_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe PrepareProfileNotificationsJob, type: :job do
   end
 
   shared_examples 'it calls PrepareMoveNotificationsJob for the related moves' do
-    it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move_today.id, action_name: action_name, queue_as: :notifications_high) }
-    it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).with(topic_id: move_next_week.id, action_name: action_name, queue_as: :notifications_low) }
+    it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).once.with(topic_id: move_today.id, action_name: action_name, queue_as: :notifications_high) }
+    it { expect(PrepareMoveNotificationsJob).to have_received(:perform_now).once.with(topic_id: move_next_week.id, action_name: action_name, queue_as: :notifications_low) }
     it { expect(PrepareMoveNotificationsJob).not_to have_received(:perform_now).with(topic_id: other_move.id, action_name: action_name, queue_as: :notifications_medium) }
   end
 

--- a/spec/jobs/prepare_youth_risk_assessment_notifications_job_spec.rb
+++ b/spec/jobs/prepare_youth_risk_assessment_notifications_job_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe PrepareYouthRiskAssessmentNotificationsJob, type: :job do
 
     it 'schedules NotifyWebhookJob' do
       perform
-      expect(NotifyWebhookJob).to have_received(:perform_later).with(notification_id: Notification.webhooks.last.id, queue_as: :some_queue_name)
+      expect(NotifyWebhookJob).to have_received(:perform_later).once.with(notification_id: Notification.webhooks.last.id, queue_as: :some_queue_name)
     end
 
     it 'does not schedule a NotifyEmailJob' do

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe Api::MovesController do
           context 'when the supplier has a webhook subscription', :skip_before do
             let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
             let!(:notification_type_webhook) { create(:notification_type, :webhook) }
-            let(:notification) { subscription.notifications.last }
+            let(:notification) { subscription.notifications.order(:created_at).last }
             let(:faraday_client) do
               class_double(
                 Faraday,
@@ -431,7 +431,7 @@ RSpec.describe Api::MovesController do
           context 'when the supplier has an email subscription', :skip_before do
             let!(:subscription) { create(:subscription, :no_callback_url, supplier: supplier) }
             let!(:notification_type_email) { create(:notification_type, :email) }
-            let(:notification) { subscription.notifications.last }
+            let(:notification) { subscription.notifications.order(:created_at).last }
             let(:notify_response) do
               instance_double(
                 ActionMailer::MessageDelivery,
@@ -471,7 +471,7 @@ RSpec.describe Api::MovesController do
             # NB: updates to existing moves should trigger a webhook notification
             let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
             let!(:notification_type_webhook) { create(:notification_type, :webhook) }
-            let(:notification) { subscription.notifications.last }
+            let(:notification) { subscription.notifications.order(:created_at).last }
             let(:faraday_client) do
               class_double(
                 Faraday,
@@ -509,7 +509,7 @@ RSpec.describe Api::MovesController do
           context 'when the supplier has an email subscription', :skip_before do
             # NB: updates to existing moves should trigger an email notification
             let!(:subscription) { create(:subscription, :no_callback_url, supplier: supplier) }
-            let(:notification) { subscription.notifications.last }
+            let(:notification) { subscription.notifications.order(:created_at).last }
             let(:notify_response) do
               instance_double(
                 ActionMailer::MessageDelivery,
@@ -540,8 +540,8 @@ RSpec.describe Api::MovesController do
               end
             end
 
-            it 'creates an email notification' do
-              expect(subscription.notifications.count).to be 1
+            it 'creates email notifications for create and update' do
+              expect(subscription.notifications.count).to be 2
             end
           end
         end

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -540,8 +540,8 @@ RSpec.describe Api::MovesController do
               end
             end
 
-            it 'creates email notifications for create and update' do
-              expect(subscription.notifications.count).to be 2
+            it 'creates an email notification' do
+              expect(subscription.notifications.count).to be 1
             end
           end
         end

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe Api::MovesController do
         end
 
         it 'creates email notifications for create and update' do
-          expect(subscription.notifications.count).to be 2
+          expect(subscription.notifications.count).to be 1
         end
       end
     end

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe Api::MovesController do
 
       context 'when the supplier has a webhook subscription' do
         let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
-        let(:notification) { subscription.notifications.last }
+        let(:notification) { subscription.notifications.order(:created_at).last }
         let(:faraday_client) do
           class_double(
             Faraday,
@@ -298,7 +298,7 @@ RSpec.describe Api::MovesController do
 
       context 'when the supplier has an email subscription' do
         let!(:subscription) { create(:subscription, :no_callback_url, supplier: supplier) }
-        let(:notification) { subscription.notifications.last }
+        let(:notification) { subscription.notifications.order(:created_at).last }
         let(:notify_response) do
           instance_double(
             ActionMailer::MessageDelivery,
@@ -346,7 +346,7 @@ RSpec.describe Api::MovesController do
         # NB: updates to existing moves should trigger a webhook notification
         let!(:subscription) { create(:subscription, :no_email_address, supplier: supplier) }
         let!(:notification_type_webhook) { create(:notification_type, :webhook) }
-        let(:notification) { subscription.notifications.last }
+        let(:notification) { subscription.notifications.order(:created_at).last }
         let(:faraday_client) do
           class_double(
             Faraday,
@@ -384,7 +384,7 @@ RSpec.describe Api::MovesController do
       context 'when the supplier has an email subscription' do
         # NB: updates to existing moves should trigger an email notification
         let!(:subscription) { create(:subscription, :no_callback_url, supplier: supplier) }
-        let(:notification) { subscription.notifications.last }
+        let(:notification) { subscription.notifications.order(:created_at).last }
         let(:notify_response) do
           instance_double(
             ActionMailer::MessageDelivery,
@@ -415,8 +415,8 @@ RSpec.describe Api::MovesController do
           end
         end
 
-        it 'creates an email notification' do
-          expect(subscription.notifications.count).to be 1
+        it 'creates email notifications for create and update' do
+          expect(subscription.notifications.count).to be 2
         end
       end
     end


### PR DESCRIPTION
We don't send notifications if the move has not yet been approved. This means that sometimes there is no create_move notification. We have decided to always send this notification at the point when we start sending notifications to the subscriber, so at that point we create one and send it if it doesn't yet exist.

### Jira link

[P4-4118](https://dsdmoj.atlassian.net/browse/P4-4118)

### What?

I have added/removed/altered:

- create_move notifications are now always sent out before any others

### Why?

I am doing this because:

- Serco asked for it

### Have you? (optional)

- [ ] Updated API docs if necessary

### Deployment risks (optional)

- We need to liaise with the suppliers to make sure this is what they want and that it won't break anything



[P4-4118]: https://dsdmoj.atlassian.net/browse/P4-4118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ