### PR TITLE
feat: Update person data from NOMIS asynchronously

### DIFF
--- a/app/controllers/api/v2/moves_actions.rb
+++ b/app/controllers/api/v2/moves_actions.rb
@@ -25,12 +25,12 @@ module Api::V2
 
       Rails.logger.info("Move saved with reference [#{move.reference}] - status [#{move.status}]")
 
-      move.person.update_nomis_data if move.person.present?
-
       Notifier.prepare_notifications(topic: move, action_name: 'create')
 
       create_automatic_event!(eventable: move, event_class: GenericEvent::MoveProposed) if move.proposed?
       create_automatic_event!(eventable: move, event_class: GenericEvent::MoveRequested) if move.requested?
+
+      UpdateMoveNomisDataJob.perform_later(move_id: move.id)
 
       PrometheusMetrics.instance.record_move_count
 

--- a/app/jobs/update_move_nomis_data_job.rb
+++ b/app/jobs/update_move_nomis_data_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class UpdateMoveNomisDataJob < ApplicationJob
+  def perform(move_id:)
+    Rails.logger.info("Updating data from NOMIS for move #{move_id}")
+
+    move = Move.find(move_id)
+    return if move.person.nil?
+
+    move.person.update_nomis_data
+
+    Notifier.prepare_notifications(topic: move, action_name: 'update')
+
+    Rails.logger.info("Completed updating data from NOMIS for move #{move_id}")
+  end
+end

--- a/spec/jobs/update_move_nomis_data_job_spec.rb
+++ b/spec/jobs/update_move_nomis_data_job_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UpdateMoveNomisDataJob, type: :job do
+  subject(:perform) do
+    described_class.perform_now(move_id: move_id)
+  end
+
+  let(:move) { create :move }
+  let(:move_id) { move.id }
+
+  before do
+    allow(move.person).to receive(:update_nomis_data) if move.person
+    allow(Move).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
+    allow(Move).to receive(:find).with(move.id).and_return(move)
+    allow(Notifier).to receive(:prepare_notifications)
+  end
+
+  context 'with an associated person' do
+    before { perform }
+
+    it 'updates NOMIS data for the person' do
+      expect(move.person).to have_received(:update_nomis_data)
+    end
+
+    it 'sends an update_move notification' do
+      expect(Notifier)
+        .to have_received(:prepare_notifications)
+        .with(topic: move, action_name: 'update')
+    end
+  end
+
+  context 'without an associated person' do
+    before { perform }
+
+    let(:move) { create(:move, person: nil) }
+
+    it 'does not send an update_move notification' do
+      expect(Notifier).not_to have_received(:prepare_notifications)
+    end
+  end
+
+  context 'when the move is not found' do
+    let(:move_id) { 'bad-id' }
+
+    it 'bubbles up the error' do
+      expect { perform }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context 'when the NOMIS call raises an error' do
+    let(:error) { OAuth2::Error.new(instance_double(OAuth2::Response)) }
+
+    before do
+      allow(move.person)
+        .to receive(:update_nomis_data)
+        .and_raise(error)
+    end
+
+    it 'bubbles up the error' do
+      expect { perform }.to raise_error(error)
+    end
+  end
+end


### PR DESCRIPTION
When a move is created we update the person's image from NOMIS. Sometimes this times out or fails, meaning that a 502 response is returned without JSON data containing the newly created move's ID.

To avoid this, we now queue up a job to update the person's image asynchronously instead, and after that is done we send an update_move notification.

### Jira link

[P4-4122](https://dsdmoj.atlassian.net/browse/P4-4122)

### What?

I have added/removed/altered:

- When a move is created we now update the person's image asynchronously

### Why?

I am doing this because:

- Suppliers are sometimes encountering a 502 response code and not receiving the ID of a move which was created successfully, meaning that they have no reference to the move and are therefore unable to track it or make any updates to it

### Deployment risks (optional)

- Changes the behaviour of the API when creating a move, so we should run this by suppliers before deploying to production



[P4-4122]: https://dsdmoj.atlassian.net/browse/P4-4122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ