### PR TITLE
fix: Disable DifferentToFromLocationValidator for lockouts

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -96,7 +96,7 @@ class Move < VersionedModel
 
   validates :from_location, presence: true
   validates :to_location, presence: true, unless: -> { prison_recall? || video_remand? }
-  validates_with DifferentToFromLocationValidator
+  validates_with DifferentToFromLocationValidator, unless: -> { generic_events.where(type: 'GenericEvent::MoveLockout').any? }
 
   validates :move_type, inclusion: { in: move_types }
   validates_with Moves::MoveTypeValidator

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -198,6 +198,19 @@ RSpec.describe Move do
     end
   end
 
+  context 'with a lockout move' do
+    subject(:move) { create(:move) }
+
+    before do
+      create(:event_move_lockout, eventable: move)
+    end
+
+    it 'allows identical to and from locations' do
+      move.to_location = move.from_location
+      expect(move).to be_valid
+    end
+  end
+
   context 'when the profile has a prisoner category' do
     it 'prevents an unsupported category from being moved' do
       expect(build(:move, profile: build(:profile, :category_not_supported))).not_to be_valid


### PR DESCRIPTION
The validation on the event allows the same to and from location for lockout moves, but the validation on the move itself also needed relaxing in the same way.

### Jira link

[P4-4128](https://dsdmoj.atlassian.net/browse/P4-4128)

### What?

I have added/removed/altered:

- Relaxed validation for lockout moves to allow identical to and from location

### Why?

I am doing this because:

- GeoAmey were having trouble redirecting moves to the same location


[P4-4128]: https://dsdmoj.atlassian.net/browse/P4-4128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ