### PR TITLE
P4-4102 change params to query_parameters

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -323,7 +323,7 @@ private
       verb: request.method,
       controller_name: controller_name,
       path: request.path,
-      params: request.params,
+      params: request.query_parameters,
     )
   end
 end


### PR DESCRIPTION
### Jira link

P4-4102

### What?

I have added/removed/altered:

- [ ] altered access log creation to use request.query_parameters instead of request.params

### Why?

I am doing this because:

- params duplicated information stored in other fields

