### PR TITLE
P4-4102 add body to access log table

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -324,6 +324,7 @@ private
       controller_name: controller_name,
       path: request.path,
       params: request.query_parameters,
+      body: request.body,
     )
   end
 end

--- a/db/migrate/20230323145412_add_body_to_access_logs.rb
+++ b/db/migrate/20230323145412_add_body_to_access_logs.rb
@@ -1,0 +1,11 @@
+class AddBodyToAccessLogs < ActiveRecord::Migration[6.1]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+  def change
+    add_column :access_logs, :body, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_22_161607) do
+ActiveRecord::Schema.define(version: 2023_03_23_145412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2023_03_22_161607) do
     t.string "controller_name"
     t.string "path"
     t.string "params"
+    t.text "body"
     t.index ["client"], name: "index_access_logs_on_client"
     t.index ["controller_name"], name: "index_access_logs_on_controller_name"
   end

--- a/spec/factories/access_logs.rb
+++ b/spec/factories/access_logs.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     controller_name { 'Move' }
     path { '/moves/787595a8-7052-4de5-b991-33a4b4f4bc47/' }
     params { '?include=court_hearings' }
+    body { 'body' }
   end
 
   trait :get do


### PR DESCRIPTION
### Jira link

P4-4102

### What?

I have added/removed/altered:

- [ ] Added a body column to the access log table

### Why?

I am doing this because:

- POST searches without the body don't provide enough information about what is being looked at
-
-

