### PR TITLE
P4-4102 Store request body as json

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -324,7 +324,7 @@ private
       controller_name: controller_name,
       path: request.path,
       params: request.query_parameters,
-      body: request.body.string,
+      body: request.body.as_json,
     )
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -324,7 +324,7 @@ private
       controller_name: controller_name,
       path: request.path,
       params: request.query_parameters,
-      body: request.body,
+      body: request.body.string,
     )
   end
 end

--- a/db/migrate/20230323145412_add_body_to_access_logs.rb
+++ b/db/migrate/20230323145412_add_body_to_access_logs.rb
@@ -1,11 +1,6 @@
 class AddBodyToAccessLogs < ActiveRecord::Migration[6.1]
 
-  # The largest text column available in all supported RDBMS is
-  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
-  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
-  # when serializing very large objects, `text` might not be big enough.
-  TEXT_BYTES = 1_073_741_823
   def change
-    add_column :access_logs, :body, :text, limit: TEXT_BYTES
+    add_column :access_logs, :body, :json
   end
 end


### PR DESCRIPTION
### Jira link

P4-4102

### What?

I have added/removed/altered:

- as_json the request.body for access log table

### Why?

I am doing this because:

- Currently we get an object reference
-
-

