### PR TITLE
chore: Improve logging - direct calls to logger include request info

### DIFF
--- a/app/controllers/api/court_hearings_controller.rb
+++ b/app/controllers/api/court_hearings_controller.rb
@@ -3,18 +3,18 @@ module Api
     def create
       court_hearing = CourtHearing.create!(court_hearings_attributes)
 
-      Rails.logger.info("Received court hearing #{request.body.read}")
+      log_with_request(:info, "Received court hearing #{request.body.read}")
 
       request.body.rewind
 
-      Rails.logger.info("Created a court hearing #{court_hearing.attributes.to_json}")
+      log_with_request(:info, "Created a court hearing #{court_hearing.attributes.to_json}")
 
       if should_save_in_nomis?
         log_attributes = CourtHearings::CreateInNomis.call(move, move.court_hearings)
 
-        Rails.logger.info("Tried to save a court hearing to nomis #{log_attributes.to_json}")
+        log_with_request(:info, "Tried to save a court hearing to nomis #{log_attributes.to_json}")
       else
-        Rails.logger.info("Did not save to nomis #{court_hearing.attributes.to_json}")
+        log_with_request(:info, "Did not save to nomis #{court_hearing.attributes.to_json}")
       end
 
       render_json court_hearing, serializer: CourtHearingSerializer, status: :created

--- a/app/controllers/api/v1/moves_actions.rb
+++ b/app/controllers/api/v1/moves_actions.rb
@@ -20,7 +20,7 @@ module Api::V1
       authorize!(:create, move)
       move.save!
 
-      Rails.logger.info("V1 Move creation started - #{move.reference} #{move.status}")
+      log_with_request(:info, "V1 Move creation started - #{move.reference} #{move.status}")
 
       move.person.update_nomis_data if move.person.present?
 
@@ -28,7 +28,7 @@ module Api::V1
 
       PrometheusMetrics.instance.record_move_count
 
-      Rails.logger.info("V1 Move creation finished - #{move.reference}")
+      log_with_request(:info, "V1 Move creation finished - #{move.reference}")
 
       render_move(move, :created)
     end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -304,6 +304,10 @@ private
   def append_info_to_payload(payload)
     super
 
+    enrich_payload!(payload)
+  end
+
+  def enrich_payload!(payload)
     payload[:remote_ip] = request.remote_ip
     payload[:request_id] = request.request_id
     payload[:transaction_id] = request.headers['X-Transaction-Id']
@@ -312,6 +316,12 @@ private
     payload[:client_name] = current_user&.name
     payload[:supplier_name] = doorkeeper_application_owner&.name || 'none'
     payload[:api_version] = api_version || DEFAULT_API_VERSION
+  end
+
+  def log_with_request(severity, message)
+    payload = { msg: message, severity: severity }
+    enrich_payload!(payload)
+    Rails.logger.public_send(severity, payload.to_json)
   end
 
   def write_access_log


### PR DESCRIPTION
Improve log messages to include request details

### Jira link

[P4-4100](https://dsdmoj.atlassian.net/browse/P4-4100)

### What?

I have added/removed/altered:

- Log messages created while a request is being processed now contain the same extra fields that the Rails access logs contain

### Why?

I am doing this because:

- This will make it easier to see all logs associated with a request as we can search for the request_id in Kibana


