### PR TITLE
fix: Make the moves controller idempotent for create and update

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -3,8 +3,11 @@
 module Api
   class MovesController < ApiController
     include Eventable
+    include Idempotentable
 
     before_action :validate_filter_params, only: %i[index filtered]
+    before_action :validate_idempotency_key, only: %i[create update]
+    around_action :idempotent_action, only: %i[create update]
 
     CSV_INCLUDES = [:from_location, :to_location, { profile: :documents }, { person: %i[gender ethnicity] }].freeze
 

--- a/spec/requests/api/moves_controller_create_spec.rb
+++ b/spec/requests/api/moves_controller_create_spec.rb
@@ -40,8 +40,15 @@ RSpec.describe Api::MovesController do
     end
     let(:supplier) { create(:supplier) }
     let(:access_token) { 'spoofed-token' }
-    let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
     let(:content_type) { ApiController::CONTENT_TYPE }
+
+    let(:headers) do
+      {
+        'Content-Type' => content_type,
+        'Authorization' => "Bearer #{access_token}",
+        'Idempotency-Key' => SecureRandom.uuid,
+      }
+    end
 
     before do
       allow_any_instance_of(PrometheusMetrics).to receive(:record_move_count) # rubocop:disable RSpec/AnyInstance

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Api::MovesController do
       'Accept': 'application/vnd.api+json; version=2',
       'Authorization' => "Bearer #{access_token}",
       'X-Current-User' => 'TEST_USER',
+      'Idempotency-Key' => SecureRandom.uuid,
     }
   end
 

--- a/spec/requests/api/moves_controller_role_access_spec.rb
+++ b/spec/requests/api/moves_controller_role_access_spec.rb
@@ -22,9 +22,16 @@ RSpec.describe Api::MovesController do
   describe 'GET /moves' do
     subject(:get_moves) { get '/api/v1/moves', headers: headers }
 
-    let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{token.token}") }
     let(:schema) { load_yaml_schema('get_moves_responses.yaml') }
     let!(:moves) { create_list(:move, 2, supplier: pentonville_supplier) }
+
+    let(:headers) do
+      {
+        'Content-Type' => content_type,
+        'Authorization' => "Bearer #{token.token}",
+        'Idempotency-Key' => SecureRandom.uuid,
+      }
+    end
 
     before do
       create_list(:move, 2, supplier: birmingham_supplier)
@@ -49,10 +56,17 @@ RSpec.describe Api::MovesController do
   describe 'GET /moves/{move_id}' do
     subject(:get_move) { get "/api/v1/moves/#{move_id}", headers: headers }
 
-    let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{token.token}") }
     let(:schema) { load_yaml_schema('get_move_responses.yaml') }
     let!(:pentonville_move) { create :move, from_location: pentonville, supplier: pentonville_supplier }
     let!(:birmingham_move) { create :move, from_location: birmingham, supplier: birmingham_supplier }
+
+    let(:headers) do
+      {
+        'Content-Type' => content_type,
+        'Authorization' => "Bearer #{token.token}",
+        'Idempotency-Key' => SecureRandom.uuid,
+      }
+    end
 
     before { get_move }
 
@@ -74,7 +88,14 @@ RSpec.describe Api::MovesController do
     subject(:post_moves) { post '/api/v1/moves', params: { data: data }, headers: headers, as: :json }
 
     let(:schema) { load_yaml_schema('post_moves_responses.yaml') }
-    let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{token.token}") }
+
+    let(:headers) do
+      {
+        'Content-Type' => content_type,
+        'Authorization' => "Bearer #{token.token}",
+        'Idempotency-Key' => SecureRandom.uuid,
+      }
+    end
 
     let(:move_attributes) { attributes_for(:move) }
     let!(:person) { create(:person) }
@@ -117,7 +138,14 @@ RSpec.describe Api::MovesController do
   describe 'PATCH /moves/{move_id}' do
     subject(:patch_move) { patch "/api/v1/moves/#{move_id}", params: { data: move_params }, headers: headers, as: :json }
 
-    let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{token.token}") }
+    let(:headers) do
+      {
+        'Content-Type' => content_type,
+        'Authorization' => "Bearer #{token.token}",
+        'Idempotency-Key' => SecureRandom.uuid,
+      }
+    end
+
     let(:schema) { load_yaml_schema('patch_move_responses.yaml') }
 
     let!(:pentonville_move) { create :move, from_location: pentonville, supplier: pentonville_supplier }

--- a/spec/requests/api/moves_controller_sorting_spec.rb
+++ b/spec/requests/api/moves_controller_sorting_spec.rb
@@ -4,10 +4,17 @@ require 'rails_helper'
 
 RSpec.describe Api::MovesController do
   let(:access_token) { 'spoofed-token' }
-  let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization' => "Bearer #{access_token}" } }
   let(:content_type) { ApiController::CONTENT_TYPE }
   let(:response_json) { JSON.parse(response.body) }
   let(:schema) { load_yaml_schema('get_moves_responses.yaml') }
+
+  let(:headers) do
+    {
+      'Content-Type' => content_type,
+      'Authorization' => "Bearer #{access_token}",
+      'Idempotency-Key' => SecureRandom.uuid,
+    }
+  end
 
   describe 'GET /moves' do
     # NB sorting should be case-sensitive, i.e. LOCATION1, LOCATION3, location2, location4

--- a/spec/requests/api/moves_controller_update_cancellation_reason_spec.rb
+++ b/spec/requests/api/moves_controller_update_cancellation_reason_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe Api::MovesController do
   describe 'PATCH /moves/:move_id' do
     let(:supplier) { create(:supplier) }
     let(:access_token) { 'spoofed-token' }
-    let(:headers) { { 'CONTENT_TYPE': content_type, 'Authorization': "Bearer #{access_token}" } }
     let(:content_type) { ApiController::CONTENT_TYPE }
+
+    let(:headers) do
+      {
+        'Content-Type': content_type,
+        'Authorization' => "Bearer #{access_token}",
+        'Idempotency-Key' => SecureRandom.uuid,
+      }
+    end
 
     let(:schema) { load_yaml_schema('patch_move_responses.yaml') }
     let(:from_location_id) { create(:location, suppliers: [supplier]).id }

--- a/spec/requests/api/moves_controller_update_spec.rb
+++ b/spec/requests/api/moves_controller_update_spec.rb
@@ -49,7 +49,14 @@ RSpec.describe Api::MovesController do
     end
 
     context 'when authorized' do
-      let(:headers) { { 'CONTENT_TYPE': content_type }.merge('Authorization' => "Bearer #{access_token}") }
+      let(:headers) do
+        {
+          'Content-Type': content_type,
+          'Authorization' => "Bearer #{access_token}",
+          'Idempotency-Key' => SecureRandom.uuid,
+        }
+      end
+
       let(:access_token) { 'spoofed-token' }
 
       context 'with an existing requested move', :skip_before do

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Api::MovesController do
       'CONTENT_TYPE': content_type,
       'Accept': 'application/vnd.api+json; version=2',
       'Authorization' => "Bearer #{access_token}",
+      'Idempotency-Key' => SecureRandom.uuid,
     }
   end
 


### PR DESCRIPTION
### Jira link

[P4-4131](https://dsdmoj.atlassian.net/browse/P4-4131)

### What?

I have added/removed/altered:

- Implement idempotency for moves controller on create and update

### Why?

I am doing this because:

- This should help suppliers to understand if they have sent a duplicate request and if the original request was processed or not

### Deployment risks (optional)

- This could potentially cause suppliers to receive a 422 response code if they aren't sending an idempotency key header, but we have not detected any requests missing that header
- If suppliers are sending different requests but with the same idempotency key they could start receiving a 409 response code where they weren't before, but we do not anticipate this being an issue if they are using the system correctly



[P4-4131]: https://dsdmoj.atlassian.net/browse/P4-4131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ