### PR TITLE
Upgrade CircleCI Slack orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@4.3.0
+  slack: circleci/slack@4.12.1
 
 aliases:
   - &notify_slack_on_failure


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Upgrade CircleCI Slack orb to hopefully fix the error at the end of production deployments

### Why?

I am doing this because:

- In the hope that it will stop it erroring out when it tries to send the Slack notification after deploying to production

