### PR TITLE
Reduce Sentry Transaction Sampling from 10% to 1%

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -23,6 +23,6 @@ Sentry.init do |config|
     transaction_context = sampling_context[:transaction_context]
     transaction_name = transaction_context[:name]
 
-    transaction_name.in?(EXCLUDE_PATHS) ? 0.0 : 0.1
+    transaction_name.in?(EXCLUDE_PATHS) ? 0.0 : 0.01
   end
 end


### PR DESCRIPTION
### Jira link

NA

### What?

I have added/removed/altered:

- [ ] Altered Sentry Transaction Sampling from 10% to 1%


### Why?

I am doing this because:

- hmpps-book-a-secure-move-api currently consumes ~10% of the overall MoJ quota. This change will reduce the consumption to ~1%. Reducing the risk of reaching capacity and losing access to Sentry features.

### Have you? (optional)

NA

### Deployment risks (optional)

- Low risk, only affects Transaction Sampling Rates in Sentry

