### PR TITLE
fix: Get timeline events using correct method

### DIFF
--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -62,6 +62,6 @@ module V2
     belongs_to :allocation, serializer: AllocationSerializer
 
     has_many_if_included :important_events, serializer: ImportantEventsSerializer, &:important_events
-    has_many_if_included :timeline_events, serializer: TimelineEventsSerializer, &:timeline_events
+    has_many_if_included :timeline_events, serializer: TimelineEventsSerializer, &:all_events_for_timeline
   end
 end

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -140,4 +140,21 @@ RSpec.describe V2::MovesSerializer do
       expect(meta).to be_empty
     end
   end
+
+  context 'with lodge event' do
+    let!(:event) { create(:event_move_overnight_lodge, eventable: move) }
+    let(:includes) { %i[timeline_events] }
+    let(:options) { { include: includes, params: { included: includes } } }
+    let(:included_event) { result[:included].find { |include| include[:id] == event.id } }
+
+    it 'contains a list of timeline_events' do
+      expect(result[:data][:relationships]).to include(
+        { timeline_events: { data: [{ id: event.id, type: 'events' }] } },
+      )
+    end
+
+    it 'contains the included timeline event' do
+      expect(included_event).to be_present
+    end
+  end
 end

--- a/swagger/v2/moves_include_parameter.yaml
+++ b/swagger/v2/moves_include_parameter.yaml
@@ -18,4 +18,5 @@ MovesIncludeParameter:
       - supplier
       - to_location
       - important_events
+      - timeline_events
   example: from_location


### PR DESCRIPTION
### Jira link

[P4-4147](https://dsdmoj.atlassian.net/browse/P4-4147)

### What?

I have added/removed/altered:

- [x] Fixed timeline_events in moves serializer

### Why?

I am doing this because:

- It was causing a 500 server error




[P4-4147]: https://dsdmoj.atlassian.net/browse/P4-4147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ