### PR TITLE
ci: Delete dev environment from build config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,13 +155,6 @@ aliases:
       branches:
         only:
           - main
-  - &only_main_and_create_dev
-    filters:
-      branches:
-        only:
-          - main
-          - dev-auth-from-docs
-          - /.*-deploydev/
   - &only_for_deployment
     filters:
       tags:
@@ -637,12 +630,6 @@ workflows:
             - api_docs
             - rspec_tests
             - linters
-      - deploy_dev:
-          context:
-            - hmpps-common-vars
-          <<: *only_main_and_create_dev
-          requires:
-            - build_image
       - deploy_staging:
           context:
             - hmpps-common-vars


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Removed dev deploy step in build config

### Why?

I am doing this because:

- The environment has been scrapped because we don't use it, and it was causing the build to fail on main


