### PR TITLE
ci: Build and push the image to quay.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  hmpps: ministryofjustice/hmpps@7.1.0
   slack: circleci/slack@4.12.1
 
 aliases:
@@ -630,6 +631,21 @@ workflows:
             - api_docs
             - rspec_tests
             - linters
+      - hmpps/build_docker:
+          <<: *only_for_deployment
+          requires:
+            - api_docs
+            - rspec_tests
+            - linters
+          name: build_quay
+          image_name: "quay.io/hmpps/hmpps-book-secure-move-api"
+          additional_docker_build_args: >
+            --label build.git.sha=${CIRCLE_SHA1}
+            --label build.git.branch=${CIRCLE_BRANCH}
+            --label build.date=$(date -Is)
+            --build-arg APP_BUILD_DATE=$(date -Is)
+            --build-arg APP_BUILD_TAG=${CIRCLE_BRANCH}
+            --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1}
       - deploy_staging:
           context:
             - hmpps-common-vars


### PR DESCRIPTION
### Jira link

[P4-4193](https://dsdmoj.atlassian.net/browse/P4-4193)

### What?

I have added/removed/altered:

- Push container images to quay.io in addition to ECR

### Why?

I am doing this because:

- We are moving to a more DPS-like build pipeline which will need the image to be in Quay instead of ECR, but for now we will push it to both registries to facilitate a seamless transition


[P4-4193]: https://dsdmoj.atlassian.net/browse/P4-4193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ