### PR TITLE
MAP-21 Add Approved premises move type

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -58,6 +58,7 @@ class Move < VersionedModel
     prison_remand: 'prison_remand',
     prison_transfer: 'prison_transfer',
     video_remand: 'video_remand',
+    approved_premises: 'approved_premises'
   }
 
   CANCELLATION_REASONS = [

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -58,7 +58,7 @@ class Move < VersionedModel
     prison_remand: 'prison_remand',
     prison_transfer: 'prison_transfer',
     video_remand: 'video_remand',
-    approved_premises: 'approved_premises'
+    approved_premises: 'approved_premises',
   }
 
   CANCELLATION_REASONS = [

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -34,6 +34,13 @@ FactoryBot.define do
       # This is already the default
     end
 
+    trait :approved_premises do
+      sequence(:key) { |x| "ap_#{x}" }
+      title { "#{Faker::Address.city} Approved Premises" }
+      location_type { Location::LOCATION_TYPE_APPROVED_PREMISES }
+      nomis_agency_id { 'GUIAP' }
+    end
+
     trait :court do
       sequence(:key) { |x| "court_#{x}" }
       title { "#{Faker::Address.city} Crown Court" }

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -454,6 +454,25 @@ RSpec.describe Api::MovesController do
       end
     end
 
+    context 'with explicit AP `move_type`' do
+      let(:move_attributes) { attributes_for(:move, move_type: 'approved_premises') }
+      let(:to_location) { create :location, :approved_premises, suppliers: [supplier] }
+
+      it_behaves_like 'an endpoint that responds with success 201' do
+        before { do_post }
+      end
+
+      it 'creates a move' do
+        expect { do_post }.to change(Move, :count).by(1)
+      end
+
+      it 'sets the move_type to `approved_premises`' do
+        do_post
+
+        expect(response_json.dig('data', 'attributes', 'move_type')).to eq 'approved_premises'
+      end
+    end
+
     context 'with a profile relationship' do
       let(:profile) { create(:profile) }
       let(:data) do

--- a/swagger/v1/move_type_attribute.yaml
+++ b/swagger/v1/move_type_attribute.yaml
@@ -9,4 +9,5 @@ MoveType:
     - prison_remand
     - prison_transfer
     - video_remand
+    - approved_premises
   description: Indicates the type of move, e.g. prison transfer or court appearance


### PR DESCRIPTION
### Jira link

[MAP-21](https://dsdmoj.atlassian.net/browse/MAP-21)

### What?

I have added/removed/altered:

- [ ] Added move type: approved_premises
- [ ] Removed baz

### Why?

I am doing this because:

- Requested addition
-
-

### Have you? (optional)

- [x] Updated API docs if necessary	


### Deployment risks (optional)

- Changes an api that is used in production



[MAP-21]: https://dsdmoj.atlassian.net/browse/MAP-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ