### PR TITLE
[MAP-26] Generate swagger docs during container build

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The rake task needs to be run manually to see up to date documentation in local 
 to the `spec/swagger` files. Changes to other files under `swagger/vN` should be automatically picked up by reloading the Swagger UI page.
 
 The task generates output files in `swagger/vN/swagger.yaml` - these are not tracked in git as they can be generated as needed and are
-automatically created as part of the Circle CI build pipeline. Documentation can be downloaded via Swagger UI and imported into a REST
+automatically created as part of the container image build. Documentation can be downloaded via Swagger UI and imported into a REST
 client such as Insomnia or Postman for easier manual API testing.
 
 ### Database schema

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Jira link
 
-P4-<TODO>
+MAP-<TODO>
 
 ### What?
 
@@ -20,7 +20,7 @@ I am doing this because:
 ### Have you? (optional)
 
 - [ ] Updated API docs if necessary	
-- [ ] Added environment variables to [deployment repository](https://github.com/ministryofjustice/hmpps-book-secure-move-api-deploy)
+- [ ] Added any new environment variables to the [Helm chart](https://github.com/ministryofjustice/hmpps-book-secure-move-api/tree/main/helm_deploy)
 
 ### Deployment risks (optional)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,7 +45,7 @@ require 'rspec/rails'
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin
-  ActiveRecord::Migration.maintain_test_schema!
+  ActiveRecord::Migration.maintain_test_schema! unless ENV['SKIP_MAINTAIN_TEST_SCHEMA']
 rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1


### PR DESCRIPTION
### Jira link

[MAP-26]

### What?

I have added/removed/altered:

- Build Swagger docs during container build

### Why?

I am doing this because:

- We are no longer in direct control of the container build step, so this is the easiest way to make sure the API docs are in the image

[MAP-26]: https://dsdmoj.atlassian.net/browse/MAP-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ