### PR TITLE
[MAP-26] Allow non-string args for Sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,2 @@
+# Sidekiq >= 7 throws an error for non-string args by default
+Sidekiq.strict_args!(false)


### PR DESCRIPTION
### Jira link

MAP-26

### What?

I have added/removed/altered:

- Disable strict args in Sidekiq

### Why?

I am doing this because:

- Sidekiq >= 7 throws an error for complex args. We pass in dates which seems to work OK so it seems simpler to just disable the error.


