### PR TITLE
feat: Add more env vars for reporting jobs

### DIFF
--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -67,10 +67,14 @@ sidekiq:
       book-a-secure-move-api-iam:
         ATHENA_ACCESS_KEY_ID: access_key_id
         ATHENA_SECRET_ACCESS_KEY: secret_access_key
+        S3_REPORTING_BUCKET_NAME: bucket_name
       hmpps-book-secure-move-api-production-gps-data-secrets:
         SLACK_WEBHOOK: webhook
       hmpps-book-secure-move-api-secrets-production:
         GOVUK_NOTIFY_API_KEY: govuk_notify_api_key
+      book-a-secure-move-reporting-s3-bucket:
+        S3_REPORTING_ACCESS_KEY_ID: access_key_id
+        S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
 
 cronJobs:
   - name: token-cleanup


### PR DESCRIPTION
### Jira link

MAP-26

### What?

I have added/removed/altered:

- Added more env vars for Sidekiq jobs

### Why?

I am doing this because:

- Reporting jobs were still missing some vars

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [x] Added any new environment variables to the [Helm chart](https://github.com/ministryofjustice/hmpps-book-secure-move-api/tree/main/helm_deploy)


