### PR TITLE
fix: Add missing environment variable for reports

### DIFF
--- a/helm_deploy/hmpps-book-secure-move-api/values.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/values.yaml
@@ -54,6 +54,7 @@ sidekiq:
       GOVUK_NOTIFY_ENABLED: "TRUE"
       GOVUK_NOTIFY_MOVE_TEMPLATE_ID: "8f2e5473-15f2-4db8-a2de-153f26a0524c"
       GOVUK_NOTIFY_PER_TEMPLATE_ID: "e2aa6021-d0a7-475f-afce-68b49ec9c2c6"
+      GOVUK_NOTIFY_REPORT_TEMPLATE_ID: "aa5fbe87-e530-495e-8135-fcd237893be9"
 
 dashboards:
   enabled: false


### PR DESCRIPTION
### Jira link

MAP-26

### What?

I have added/removed/altered:

- Added missing env var for reports

### Why?

I am doing this because:

- Because Sentry alerted us to an error

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [x] Added any new environment variables to the [Helm chart](https://github.com/ministryofjustice/hmpps-book-secure-move-api/tree/main/helm_deploy)

