### PR TITLE
fix: Update reporting bucket config

### DIFF
--- a/helm_deploy/hmpps-book-secure-move-api/values.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/values.yaml
@@ -38,7 +38,6 @@ generic-service:
     PROMETHEUS_METRICS: "on"
     RAILS_LOG_TO_STDOUT: "true"
     RAILS_MAX_THREADS: "5"
-    S3_REPORTING_PROJECT_PATH: landing/hmpps-book-secure-move-api
     SERVE_API_DOCS: "true"
     SIDEKIQ_PROCESSES: "3"
 

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -19,6 +19,8 @@ generic-service:
     DISABLE_WEBHOOK_CREATE_EVENT_GEOAMEY: "true"
     DISABLE_WEBHOOK_CREATE_EVENT_SERCO: "true"
     ENCRYPTOR_SALT: '+\xCC[#\xF7\x14\x98^\x0F\xCC\x9A\xA4\x16\xE3\x9E\xF2W8\xE6\x059\xFD\xB0\x1F.OK\x91\x85*(A'
+    S3_REPORTING_BUCKET_NAME: moj-reg-prod
+    S3_REPORTING_PROJECT_PATH: landing/hmpps-book-secure-move-api-prod
     SENTRY_ENVIRONMENT: "production"
     SERVE_API_DOCS: "false"
     SERVER_FQDN: "api.bookasecuremove.service.justice.gov.uk"
@@ -45,6 +47,9 @@ generic-service:
       PER_QUALITY_REPORT_RECIPIENTS: per_quality_report_recipients
     rds-instance-hmpps-book-secure-move-api-production:
       DATABASE_URL: url
+    book-a-secure-move-ap-user:
+      S3_REPORTING_ACCESS_KEY_ID: access_key_id
+      S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
     book-a-secure-move-documents-s3-bucket:
       S3_ACCESS_KEY_ID: access_key_id
       S3_SECRET_ACCESS_KEY: secret_access_key
@@ -71,10 +76,6 @@ sidekiq:
         SLACK_WEBHOOK: webhook
       hmpps-book-secure-move-api-secrets-production:
         GOVUK_NOTIFY_API_KEY: govuk_notify_api_key
-      book-a-secure-move-reporting-s3-bucket:
-        S3_REPORTING_BUCKET_NAME: bucket_name
-        S3_REPORTING_ACCESS_KEY_ID: access_key_id
-        S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
 
 cronJobs:
   - name: token-cleanup
@@ -98,10 +99,6 @@ cronJobs:
       env:
         AWS_DEFAULT_REGION: "eu-west-2"
       namespace_secrets:
-        book-a-secure-move-reporting-s3-bucket:
-          AWS_ACCESS_KEY_ID: access_key_id
-          AWS_SECRET_ACCESS_KEY: secret_access_key
-          S3_REPORTING_BUCKET_NAME: bucket_name
         hmpps-book-secure-move-api-production-feeds-secrets:
           INFO_SLACKWEBHOOK: book-secure-move-feeds-webhook
           ALERT_SLACKWEBHOOK: alerts-book-a-secure-move-webhook

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -17,6 +17,8 @@ generic-service:
 
   env:
     ENCRYPTOR_SALT: ':D\xCD\xF4\xCE&v\x9C\xA6\xBC3`~\xCEDA\vn\xDD\xF5S1\x9B\xDD~4\xF6\xBE\x0FY\xECl'
+    S3_REPORTING_BUCKET_NAME: moj-reg-dev
+    S3_REPORTING_PROJECT_PATH: landing/hmpps-book-secure-move-api-dev
     SENTRY_ENVIRONMENT: "staging"
     SERVER_FQDN: "hmpps-book-secure-move-api-staging.apps.cloud-platform.service.justice.gov.uk"
     WEB_CONCURRENCY: "3"
@@ -42,6 +44,9 @@ generic-service:
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key
     rds-instance-hmpps-book-secure-move-api-staging:
       DATABASE_URL: url
+    book-a-secure-move-ap-user:
+      S3_REPORTING_ACCESS_KEY_ID: access_key_id
+      S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
     book-a-secure-move-documents-s3-bucket:
       S3_ACCESS_KEY_ID: access_key_id
       S3_SECRET_ACCESS_KEY: secret_access_key
@@ -57,10 +62,6 @@ generic-service:
 sidekiq:
   overrideValues:
     namespace_secrets:
-      book-a-secure-move-reporting-s3-bucket:
-        S3_REPORTING_BUCKET_NAME: bucket_name
-        S3_REPORTING_ACCESS_KEY_ID: access_key_id
-        S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
       hmpps-book-secure-move-api-secrets-staging:
         GOVUK_NOTIFY_API_KEY: govuk_notify_api_key
 
@@ -86,10 +87,6 @@ cronJobs:
       env:
         AWS_DEFAULT_REGION: "eu-west-2"
       namespace_secrets:
-        book-a-secure-move-reporting-s3-bucket:
-          AWS_ACCESS_KEY_ID: access_key_id
-          AWS_SECRET_ACCESS_KEY: secret_access_key
-          S3_REPORTING_BUCKET_NAME: bucket_name
         hmpps-book-secure-move-api-staging-feeds-secrets:
           INFO_SLACKWEBHOOK: book-secure-move-feeds-webhook
           ALERT_SLACKWEBHOOK: alerts-book-a-secure-move-webhook
@@ -101,11 +98,6 @@ cronJobs:
       env:
         AWS_DEFAULT_REGION: "eu-west-2"
         ELASTIC_APM_ENABLED: "false"
-      namespace_secrets:
-        book-a-secure-move-reporting-s3-bucket:
-          AWS_ACCESS_KEY_ID: access_key_id
-          AWS_SECRET_ACCESS_KEY: secret_access_key
-          S3_REPORTING_BUCKET_NAME: bucket_name
   - name: metrics
     schedule: "*/30 * * * *"
     command: ["bundle", "exec", "rake", "metrics:export"]


### PR DESCRIPTION
### Jira link

MAP-19

### What?

I have added/removed/altered:

- Update reporting bucket config

### Why?

I am doing this because:

- Because Terraform has created new secrets for us to use

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [x] Added any new environment variables to the [Helm chart](https://github.com/ministryofjustice/hmpps-book-secure-move-api/tree/main/helm_deploy)

