### PR TITLE
chore: Disable feeds checker

### DIFF
--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -84,24 +84,6 @@ cronJobs:
   - name: feeds-job
     schedule: "0 3 * * *"
     command: ["bundle", "exec", "rake", "feed[all]"]
-  - name: feeds-checker
-    schedule: "0 7 * * *"
-    command: ["/bin/bash"]
-    args: ["/feeds/runme.sh"]
-    volumeMounts:
-      - name: script
-        mountPath: "/feeds"
-    volumes:
-      - name: script
-        configMap:
-          name: hmpps-book-secure-move-api-feeds-checker-script
-    overrideValues:
-      env:
-        AWS_DEFAULT_REGION: "eu-west-2"
-      namespace_secrets:
-        hmpps-book-secure-move-api-production-feeds-secrets:
-          INFO_SLACKWEBHOOK: book-secure-move-feeds-webhook
-          ALERT_SLACKWEBHOOK: alerts-book-a-secure-move-webhook
   - name: metrics
     schedule: "*/30 * * * *"
     command: ["bundle", "exec", "rake", "metrics:export"]

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -72,24 +72,6 @@ cronJobs:
   - name: feeds-job
     schedule: "0 3 * * *"
     command: ["bundle", "exec", "rake", "feed[all]"]
-  - name: feeds-checker
-    schedule: "0 7 * * *"
-    command: ["/bin/bash"]
-    args: ["/feeds/runme.sh"]
-    volumeMounts:
-      - name: script
-        mountPath: "/feeds"
-    volumes:
-      - name: script
-        configMap:
-          name: hmpps-book-secure-move-api-feeds-checker-script
-    overrideValues:
-      env:
-        AWS_DEFAULT_REGION: "eu-west-2"
-      namespace_secrets:
-        hmpps-book-secure-move-api-staging-feeds-secrets:
-          INFO_SLACKWEBHOOK: book-secure-move-feeds-webhook
-          ALERT_SLACKWEBHOOK: alerts-book-a-secure-move-webhook
   - name: generate-journeys
     suspend: true
     schedule: "0 10,14 * * *"


### PR DESCRIPTION
### Jira link

MAP-19

### What?

I have added/removed/altered:

- Disable feeds checker

### Why?

I am doing this because:

- Unfortunately the feeds checker won't work with the new reporting bucket, as we only have `put` permissions. We will have to rework it if we want to continue verifying the reporting.


