### PR TITLE
[MAP-84] Add index on from_location and to_location to moves

### DIFF
--- a/db/migrate/20230802145421_add_location_indexes_to_moves.rb
+++ b/db/migrate/20230802145421_add_location_indexes_to_moves.rb
@@ -1,0 +1,8 @@
+class AddLocationIndexesToMoves < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :moves, :from_location_id, algorithm: :concurrently
+    add_index :moves, :to_location_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_07_133106) do
+ActiveRecord::Schema.define(version: 2023_08_02_145421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -404,9 +404,11 @@ ActiveRecord::Schema.define(version: 2023_07_07_133106) do
     t.index ["allocation_id"], name: "index_moves_on_allocation_id"
     t.index ["created_at"], name: "index_moves_on_created_at"
     t.index ["date"], name: "index_moves_on_date"
+    t.index ["from_location_id"], name: "index_moves_on_from_location_id"
     t.index ["prison_transfer_reason_id"], name: "index_moves_on_prison_transfer_reason_id"
     t.index ["reference"], name: "index_moves_on_reference", unique: true
     t.index ["supplier_id"], name: "index_moves_on_supplier_id"
+    t.index ["to_location_id"], name: "index_moves_on_to_location_id"
     t.index ["updated_at"], name: "index_moves_on_updated_at"
   end
 


### PR DESCRIPTION
### Jira link

MAP-84

### What?

I have added/removed/altered:

- Add index on from_location and to_location to moves

### Why?

I am doing this because:

- Filtering by to_location and from_location has become an order of magnitude slower since adding the lodgings table and adding the related SQL clauses to the moves finder, so we are adding some indexes to see if that helps.


