### PR TITLE
Move ENCRYPTOR_SALT env var to secret

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,7 +14,6 @@ generic-service:
       - hmpps-book-secure-move-api-preprod.apps.cloud-platform.service.justice.gov.uk
 
   env:
-    ENCRYPTOR_SALT: '\xA7\xFD\xD1\xEAfu*hk\xE8\xD4Gi\xF0@:\xD1\x0Ew\xEC\xB7\xCF\xF4\xD9\xB3\xA9,\x8D\a,\x19\xEC'
     SENTRY_ENVIRONMENT: "preprod"
     SERVE_API_DOCS: "false"
     SERVER_FQDN: "hmpps-book-secure-move-api-preprod.apps.cloud-platform.service.justice.gov.uk"
@@ -37,6 +36,7 @@ generic-service:
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key
+      ENCRYPTOR_SALT: encryptor_salt
     rds-instance-hmpps-book-secure-move-api-preprod:
       DATABASE_URL: url
     book-a-secure-move-documents-s3-bucket:

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -18,7 +18,6 @@ generic-service:
   env:
     DISABLE_WEBHOOK_CREATE_EVENT_GEOAMEY: "true"
     DISABLE_WEBHOOK_CREATE_EVENT_SERCO: "true"
-    ENCRYPTOR_SALT: '+\xCC[#\xF7\x14\x98^\x0F\xCC\x9A\xA4\x16\xE3\x9E\xF2W8\xE6\x059\xFD\xB0\x1F.OK\x91\x85*(A'
     S3_REPORTING_BUCKET_NAME: moj-reg-prod
     S3_REPORTING_PROJECT_PATH: landing/hmpps-book-secure-move-api-prod
     SENTRY_ENVIRONMENT: "production"
@@ -45,6 +44,7 @@ generic-service:
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key
       PER_QUALITY_REPORT_RECIPIENTS: per_quality_report_recipients
+      ENCRYPTOR_SALT: encryptor_salt
     rds-instance-hmpps-book-secure-move-api-production:
       DATABASE_URL: url
     book-a-secure-move-ap-user:

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -16,7 +16,6 @@ generic-service:
       - hmpps-book-secure-move-api-staging.apps.cloud-platform.service.justice.gov.uk
 
   env:
-    ENCRYPTOR_SALT: ':D\xCD\xF4\xCE&v\x9C\xA6\xBC3`~\xCEDA\vn\xDD\xF5S1\x9B\xDD~4\xF6\xBE\x0FY\xECl'
     S3_REPORTING_BUCKET_NAME: moj-reg-dev
     S3_REPORTING_PROJECT_PATH: landing/hmpps-book-secure-move-api-dev
     SENTRY_ENVIRONMENT: "staging"
@@ -42,6 +41,7 @@ generic-service:
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key
+      ENCRYPTOR_SALT: encryptor_salt
     rds-instance-hmpps-book-secure-move-api-staging:
       DATABASE_URL: url
     book-a-secure-move-ap-user:

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -15,7 +15,6 @@ generic-service:
       - hmpps-book-secure-move-api-uat.apps.cloud-platform.service.justice.gov.uk
 
   env:
-    ENCRYPTOR_SALT: '5xZMNA+9m9gTblE6omRvG0vAXu+vy2K+KIn7wBPrt3uMYjalx0zyq43X7UiHtr3U'
     SENTRY_ENVIRONMENT: "uat"
     SERVER_FQDN: "hmpps-book-secure-move-api-uat.apps.cloud-platform.service.justice.gov.uk"
 
@@ -38,6 +37,7 @@ generic-service:
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key
+      ENCRYPTOR_SALT: encryptor_salt
     rds-instance-hmpps-book-secure-move-api-uat:
       DATABASE_URL: url
     book-a-secure-move-documents-s3-bucket:


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Move ENCRYPTOR_SALT env var to secret

### Why?

I am doing this because:

- It's binary and it will confuse the k8s CLI less if it's base64 encoded

