### PR TITLE
Add unique index to lodgings

### DIFF
--- a/app/models/generic_event/move_overnight_lodge.rb
+++ b/app/models/generic_event/move_overnight_lodge.rb
@@ -25,14 +25,16 @@ class GenericEvent
     end
 
     def trigger(dry_run: false)
-      unless dry_run
-        Lodging.create!(
-          move_id: eventable_id,
-          location_id: location_id,
-          start_date: start_date,
-          end_date: end_date,
-        )
-      end
+      return if dry_run
+
+      Lodging.create!(
+        move_id: eventable_id,
+        location_id: location_id,
+        start_date: start_date,
+        end_date: end_date,
+      )
+    rescue ActiveRecord::RecordNotUnique
+      # do nothing
     end
 
   private

--- a/db/migrate/20230808150500_add_unique_index_to_lodgings.rb
+++ b/db/migrate/20230808150500_add_unique_index_to_lodgings.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToLodgings < ActiveRecord::Migration[6.1]
+  def change
+    add_index :lodgings, [:start_date, :move_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_02_145421) do
+ActiveRecord::Schema.define(version: 2023_08_08_150500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -372,6 +372,7 @@ ActiveRecord::Schema.define(version: 2023_08_02_145421) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["location_id"], name: "index_lodgings_on_location_id"
     t.index ["move_id"], name: "index_lodgings_on_move_id"
+    t.index ["start_date", "move_id"], name: "index_lodgings_on_start_date_and_move_id", unique: true
   end
 
   create_table "moves", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
### Jira link

MAP-84

### What?

I have added/removed/altered:

- [x] Added a unique index against Lodging start_date and move_id

### Why?

I am doing this because:

- It will stop duplicate lodgings from being created

