### PR TITLE
[MAP-147] Use IRSA for AWS S3 access

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,14 +11,6 @@
       "description": "Secret salt value for encryption/decryption",
       "required": true
     },
-    "S3_ACCESS_KEY_ID": {
-      "description": "Public access key for AWS S3 storage",
-      "required": true
-    },
-    "S3_SECRET_ACCESS_KEY": {
-      "description": "Private secrete access key for AWS S3 storage",
-      "required": true
-    },
     "S3_REPORTING_BUCKET_NAME": {
       "description": "Name of the storage bucket to use on AWS S3",
       "required": true

--- a/app/lib/cloud_data/metrics_feed.rb
+++ b/app/lib/cloud_data/metrics_feed.rb
@@ -3,11 +3,7 @@ module CloudData
     attr_reader :bucket
 
     def initialize(bucket, client = nil)
-      @client = client || Aws::S3::Client.new(
-        region: ENV['S3_METRICS_REGION'],
-        access_key_id: ENV['S3_METRICS_ACCESS_KEY_ID'],
-        secret_access_key: ENV['S3_METRICS_SECRET_ACCESS_KEY'],
-      )
+      @client = client || Aws::S3::Client.new(region: ENV['S3_METRICS_REGION'])
       @bucket = bucket
     end
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,5 @@ local:
 
 amazon:
   service: S3
-  access_key_id: <%= ENV['S3_ACCESS_KEY_ID'] %>
-  secret_access_key: <%= ENV['S3_SECRET_ACCESS_KEY'] %>
   region: 'eu-west-2'
   bucket: <%= ENV['S3_BUCKET_NAME'] %>

--- a/helm_deploy/hmpps-book-secure-move-api/templates/cron_jobs.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/cron_jobs.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       template:
         spec:
+          serviceAccountName: book-a-secure-move-api
           containers:
             - name: {{ .name }}
               image: "{{ $genericService.image.repository }}:{{ $genericService.image.tag | default $.Chart.AppVersion }}"

--- a/helm_deploy/hmpps-book-secure-move-api/templates/deployment_sidekiq.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/deployment_sidekiq.yaml
@@ -27,6 +27,7 @@ spec:
         app: "{{ include "generic-service.fullname" . }}-sidekiq"
         tier: sidekiq
     spec:
+      serviceAccountName: book-a-secure-move-api
       containers:
         - name: sidekiq
           image: "{{ $genericService.image.repository }}:{{ $genericService.image.tag | default .Chart.AppVersion }}"

--- a/helm_deploy/hmpps-book-secure-move-api/templates/migration_job.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/migration_job.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       name: {{ $fullName }}
     spec:
+      serviceAccountName: book-a-secure-move-api
       containers:
         - name: migration
           image: "{{ $genericService.image.repository }}:{{ $genericService.image.tag | default $.Chart.AppVersion }}"

--- a/helm_deploy/hmpps-book-secure-move-api/values.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/values.yaml
@@ -3,6 +3,7 @@ buildEnv: unknown_environment # override per environment
 
 generic-service:
   nameOverride: hmpps-book-secure-move-api
+  serviceAccountName: book-a-secure-move-api
 
   replicaCount: 4
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -40,13 +40,9 @@ generic-service:
     rds-instance-hmpps-book-secure-move-api-preprod:
       DATABASE_URL: url
     book-a-secure-move-documents-s3-bucket:
-      S3_ACCESS_KEY_ID: access_key_id
-      S3_SECRET_ACCESS_KEY: secret_access_key
       S3_BUCKET_ARN: bucket_arn
       S3_BUCKET_NAME: bucket_name
     book-a-secure-move-metrics-s3-bucket:
-      S3_METRICS_ACCESS_KEY_ID: access_key_id
-      S3_METRICS_SECRET_ACCESS_KEY: secret_access_key
       S3_METRICS_BUCKET_NAME: bucket_name
     elasticache-hmpps-book-secure-move-api-preprod:
       REDIS_URL: url

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -51,13 +51,9 @@ generic-service:
       S3_REPORTING_ACCESS_KEY_ID: access_key_id
       S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
     book-a-secure-move-documents-s3-bucket:
-      S3_ACCESS_KEY_ID: access_key_id
-      S3_SECRET_ACCESS_KEY: secret_access_key
       S3_BUCKET_ARN: bucket_arn
       S3_BUCKET_NAME: bucket_name
     book-a-secure-move-metrics-s3-bucket:
-      S3_METRICS_ACCESS_KEY_ID: access_key_id
-      S3_METRICS_SECRET_ACCESS_KEY: secret_access_key
       S3_METRICS_BUCKET_NAME: bucket_name
     elasticache-hmpps-book-secure-move-api-production:
       REDIS_URL: url
@@ -92,8 +88,6 @@ cronJobs:
         S3_METRICS_REGION: "eu-west-2"
       namespace_secrets:
         book-a-secure-move-metrics-s3-bucket:
-          S3_METRICS_ACCESS_KEY_ID: access_key_id
-          S3_METRICS_SECRET_ACCESS_KEY: secret_access_key
           S3_METRICS_BUCKET_NAME: bucket_name
   - name: gps-data
     schedule: "0 5 * * 4"

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -6,8 +6,6 @@ buildEnv: staging
 generic-service:
   replicaCount: 4
 
-  serviceAccountName: book-a-secure-move-api
-
   ingress:
     annotations:
       external-dns.alpha.kubernetes.io/set-identifier: hmpps-book-secure-move-api-v1-2-hmpps-book-secure-move-api-staging-green
@@ -48,13 +46,9 @@ generic-service:
       S3_REPORTING_ACCESS_KEY_ID: access_key_id
       S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
     book-a-secure-move-documents-s3-bucket:
-      S3_ACCESS_KEY_ID: access_key_id
-      S3_SECRET_ACCESS_KEY: secret_access_key
       S3_BUCKET_ARN: bucket_arn
       S3_BUCKET_NAME: bucket_name
     book-a-secure-move-metrics-s3-bucket:
-      S3_METRICS_ACCESS_KEY_ID: access_key_id
-      S3_METRICS_SECRET_ACCESS_KEY: secret_access_key
       S3_METRICS_BUCKET_NAME: bucket_name
     elasticache-hmpps-book-secure-move-api-staging:
       REDIS_URL: url
@@ -88,6 +82,4 @@ cronJobs:
         S3_METRICS_REGION: "eu-west-2"
       namespace_secrets:
         book-a-secure-move-metrics-s3-bucket:
-          S3_METRICS_ACCESS_KEY_ID: access_key_id
-          S3_METRICS_SECRET_ACCESS_KEY: secret_access_key
           S3_METRICS_BUCKET_NAME: bucket_name

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -41,13 +41,9 @@ generic-service:
     rds-instance-hmpps-book-secure-move-api-uat:
       DATABASE_URL: url
     book-a-secure-move-documents-s3-bucket:
-      S3_ACCESS_KEY_ID: access_key_id
-      S3_SECRET_ACCESS_KEY: secret_access_key
       S3_BUCKET_ARN: bucket_arn
       S3_BUCKET_NAME: bucket_name
     book-a-secure-move-metrics-s3-bucket:
-      S3_METRICS_ACCESS_KEY_ID: access_key_id
-      S3_METRICS_SECRET_ACCESS_KEY: secret_access_key
       S3_METRICS_BUCKET_NAME: bucket_name
     elasticache-hmpps-book-secure-move-api-uat:
       REDIS_URL: url
@@ -70,6 +66,4 @@ cronJobs:
         S3_METRICS_REGION: "eu-west-2"
       namespace_secrets:
         book-a-secure-move-metrics-s3-bucket:
-          S3_METRICS_ACCESS_KEY_ID: access_key_id
-          S3_METRICS_SECRET_ACCESS_KEY: secret_access_key
           S3_METRICS_BUCKET_NAME: bucket_name


### PR DESCRIPTION
### Jira link

MAP-147

### What?

I have added/removed/altered:

- Use IRSA for AWS S3 access

### Why?

I am doing this because:

- The Cloud Platform team are disabling long-lived credentials on 4th Sept 2023

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [x] Added any new environment variables to the [Helm chart](https://github.com/ministryofjustice/hmpps-book-secure-move-api/tree/main/helm_deploy)


