### PR TITLE
fix: Restore old feeds in addition to still providing new AP feeds

### DIFF
--- a/app/lib/cloud_data/analytical_platform_feed.rb
+++ b/app/lib/cloud_data/analytical_platform_feed.rb
@@ -1,0 +1,36 @@
+module CloudData
+  class AnalyticalPlatformFeed
+    DATABASE_NAME = 'feeds_report'.freeze
+
+    def initialize(bucket_name = ENV['S3_AP_BUCKET_NAME'])
+      client = Aws::S3::Client.new(
+        access_key_id: ENV['S3_AP_ACCESS_KEY_ID'],
+        secret_access_key: ENV['S3_AP_SECRET_ACCESS_KEY'],
+      )
+      @s3 = Aws::S3::Resource.new(client: client)
+      @bucket = @s3.bucket(bucket_name)
+    end
+
+    def write(content, table, report_date = Time.zone.yesterday)
+      path = full_path(report_date, table)
+
+      obj = bucket.object(path)
+      obj.put(acl: 'bucket-owner-full-control', body: content, server_side_encryption: 'AES256')
+
+      path
+    end
+
+  private
+
+    attr_reader :bucket
+
+    def full_path(report_date, table)
+      "#{ENV.fetch('S3_AP_PROJECT_PATH')}/" \
+      'data/' \
+      "database_name=#{DATABASE_NAME}/" \
+      "table_name=#{table}/" \
+      "extraction_timestamp=#{report_date.strftime('%Y%m%d%H%M%SZ')}/" \
+      "#{report_date.strftime('%Y-%m-%d')}-#{table}.jsonl"
+    end
+  end
+end

--- a/app/workers/feeds/feed_worker.rb
+++ b/app/workers/feeds/feed_worker.rb
@@ -10,7 +10,8 @@ class Feeds::FeedWorker
     time_since = TimeSince.new
 
     feed = "Feeds::#{feed_name.titleize}".constantize.new(date.beginning_of_day, date.end_of_day).call
-    CloudData::ReportsFeed.new.write(feed, feed_name.pluralize, date)
+    CloudData::ReportsFeed.new.write(feed, "#{feed_name.pluralize}.jsonl", date)
+    CloudData::AnalyticalPlatformFeed.new.write(feed, feed_name.pluralize, date)
 
     Sidekiq.logger.info("Generated #{feed_name} feed in #{time_since.get} seconds")
   end

--- a/app/workers/gps_report_worker.rb
+++ b/app/workers/gps_report_worker.rb
@@ -63,7 +63,7 @@ private
   end
 
   def full_path(supplier_name)
-    "#{ENV.fetch('S3_REPORTING_PROJECT_PATH')}/" \
+    "#{ENV.fetch('S3_AP_PROJECT_PATH')}/" \
     'data/' \
     "database_name=#{DATABASE_NAME}/" \
     "table_name=gps_reports_#{supplier_name}/" \
@@ -75,11 +75,11 @@ private
     return @bucket if @bucket.present?
 
     client = Aws::S3::Client.new(
-      access_key_id: ENV['S3_REPORTING_ACCESS_KEY_ID'],
-      secret_access_key: ENV['S3_REPORTING_SECRET_ACCESS_KEY'],
+      access_key_id: ENV['S3_AP_ACCESS_KEY_ID'],
+      secret_access_key: ENV['S3_AP_SECRET_ACCESS_KEY'],
     )
     s3 = Aws::S3::Resource.new(client: client)
-    @bucket = s3.bucket(ENV['S3_REPORTING_BUCKET_NAME'])
+    @bucket = s3.bucket(ENV['S3_AP_BUCKET_NAME'])
   end
 
   def generate_block(supplier, results)

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -18,8 +18,8 @@ generic-service:
   env:
     DISABLE_WEBHOOK_CREATE_EVENT_GEOAMEY: "true"
     DISABLE_WEBHOOK_CREATE_EVENT_SERCO: "true"
-    S3_REPORTING_BUCKET_NAME: moj-reg-prod
-    S3_REPORTING_PROJECT_PATH: landing/hmpps-book-secure-move-api-prod
+    S3_AP_BUCKET_NAME: moj-reg-prod
+    S3_AP_PROJECT_PATH: landing/hmpps-book-secure-move-api-prod
     SENTRY_ENVIRONMENT: "production"
     SERVE_API_DOCS: "false"
     SERVER_FQDN: "api.bookasecuremove.service.justice.gov.uk"
@@ -48,13 +48,17 @@ generic-service:
     rds-instance-hmpps-book-secure-move-api-production:
       DATABASE_URL: url
     book-a-secure-move-ap-user:
-      S3_REPORTING_ACCESS_KEY_ID: access_key_id
-      S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
+      S3_AP_ACCESS_KEY_ID: access_key_id
+      S3_AP_SECRET_ACCESS_KEY: secret_access_key
     book-a-secure-move-documents-s3-bucket:
       S3_BUCKET_ARN: bucket_arn
       S3_BUCKET_NAME: bucket_name
     book-a-secure-move-metrics-s3-bucket:
       S3_METRICS_BUCKET_NAME: bucket_name
+    book-a-secure-move-reporting-s3-bucket:
+      S3_REPORTING_BUCKET_NAME: bucket_name
+      S3_REPORTING_ACCESS_KEY_ID: access_key_id
+      S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
     elasticache-hmpps-book-secure-move-api-production:
       REDIS_URL: url
 

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -14,8 +14,8 @@ generic-service:
       - hmpps-book-secure-move-api-staging.apps.cloud-platform.service.justice.gov.uk
 
   env:
-    S3_REPORTING_BUCKET_NAME: moj-reg-dev
-    S3_REPORTING_PROJECT_PATH: landing/hmpps-book-secure-move-api-dev
+    S3_AP_BUCKET_NAME: moj-reg-dev
+    S3_AP_PROJECT_PATH: landing/hmpps-book-secure-move-api-dev
     SENTRY_ENVIRONMENT: "staging"
     SERVER_FQDN: "hmpps-book-secure-move-api-staging.apps.cloud-platform.service.justice.gov.uk"
     WEB_CONCURRENCY: "3"
@@ -43,13 +43,17 @@ generic-service:
     rds-instance-hmpps-book-secure-move-api-staging:
       DATABASE_URL: url
     book-a-secure-move-ap-user:
-      S3_REPORTING_ACCESS_KEY_ID: access_key_id
-      S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
+      S3_AP_ACCESS_KEY_ID: access_key_id
+      S3_AP_SECRET_ACCESS_KEY: secret_access_key
     book-a-secure-move-documents-s3-bucket:
       S3_BUCKET_ARN: bucket_arn
       S3_BUCKET_NAME: bucket_name
     book-a-secure-move-metrics-s3-bucket:
       S3_METRICS_BUCKET_NAME: bucket_name
+    book-a-secure-move-reporting-s3-bucket:
+      S3_REPORTING_BUCKET_NAME: bucket_name
+      S3_REPORTING_ACCESS_KEY_ID: access_key_id
+      S3_REPORTING_SECRET_ACCESS_KEY: secret_access_key
     elasticache-hmpps-book-secure-move-api-staging:
       REDIS_URL: url
 

--- a/spec/lib/cloud_data/analytical_platform_feed_spec.rb
+++ b/spec/lib/cloud_data/analytical_platform_feed_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe CloudData::AnalyticalPlatformFeed do
+  let(:s3_client) do
+    Aws::S3::Client.new(
+      access_key_id: s3_id,
+      secret_access_key: s3_key,
+      stub_responses: true,
+    )
+  end
+
+  let(:full_path) do
+    'landing/hmpps-book-secure-move-api/data/' \
+    'database_name=feeds_report/' \
+    'table_name=moves/' \
+    'extraction_timestamp=20200129000000Z/' \
+    '2020-01-29-moves.jsonl'
+  end
+
+  let(:table) { 'moves' }
+  let(:content) { 'some content' }
+  let(:bucket_name) { 'bucket_name' }
+  let(:s3_id) { 'my_id' }
+  let(:s3_key) { 'token123' }
+
+  before do
+    allow(Aws::S3::Client).to receive(:new).with(
+      access_key_id: s3_id,
+      secret_access_key: s3_key,
+    ).and_return(s3_client)
+
+    Timecop.freeze(Time.zone.local(2020, 1, 30))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  around do |example|
+    ClimateControl.modify(
+      'S3_AP_ACCESS_KEY_ID' => s3_id,
+      'S3_AP_SECRET_ACCESS_KEY' => s3_key,
+      'S3_AP_PROJECT_PATH' => 'landing/hmpps-book-secure-move-api',
+    ) do
+      example.run
+    end
+  end
+
+  it 'writes a file on S3 and return the full_name' do
+    full_name = described_class.new(bucket_name)
+                    .write(content, table)
+
+    expect(full_name).to eq(full_path)
+  end
+
+  it 'calls the S3 SDK with the correct data' do
+    described_class.new(bucket_name).write(content, table)
+
+    expect(s3_client.api_requests.first.slice(:operation_name, :params)).to eq({
+      operation_name: :put_object,
+      params: {
+        acl: 'bucket-owner-full-control',
+        body: content,
+        bucket: bucket_name,
+        key: full_path,
+        server_side_encryption: 'AES256',
+      },
+    })
+  end
+
+  context 'when a report date is specified' do
+    let(:report_date) { Date.new(2020, 1, 15) }
+
+    it 'creates a file and names it based on the report date' do
+      full_name = described_class.new(bucket_name)
+                                 .write(content, table, report_date)
+
+      expect(full_name).to eq(
+        'landing/hmpps-book-secure-move-api/data/' \
+        'database_name=feeds_report/' \
+        'table_name=moves/' \
+        'extraction_timestamp=20200115000000Z/' \
+        '2020-01-15-moves.jsonl',
+      )
+    end
+  end
+end

--- a/spec/lib/cloud_data/reports_feed_spec.rb
+++ b/spec/lib/cloud_data/reports_feed_spec.rb
@@ -1,34 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CloudData::ReportsFeed do
-  let(:s3_client) do
-    Aws::S3::Client.new(
-      access_key_id: s3_id,
-      secret_access_key: s3_key,
-      stub_responses: true,
-    )
-  end
-
-  let(:full_path) do
-    'landing/hmpps-book-secure-move-api/data/' \
-    'database_name=feeds_report/' \
-    'table_name=moves/' \
-    'extraction_timestamp=20200129000000Z/' \
-    '2020-01-29-moves.jsonl'
-  end
-
-  let(:table) { 'moves' }
-  let(:content) { 'some content' }
-  let(:bucket_name) { 'bucket_name' }
-  let(:s3_id) { 'my_id' }
-  let(:s3_key) { 'token123' }
-
   before do
-    allow(Aws::S3::Client).to receive(:new).with(
-      access_key_id: s3_id,
-      secret_access_key: s3_key,
-    ).and_return(s3_client)
-
+    Aws.config.update(stub_responses: true) # rubocop:disable Rails/SaveBang
     Timecop.freeze(Time.zone.local(2020, 1, 30))
   end
 
@@ -36,52 +10,21 @@ RSpec.describe CloudData::ReportsFeed do
     Timecop.return
   end
 
-  around do |example|
-    ClimateControl.modify(
-      'S3_REPORTING_ACCESS_KEY_ID' => s3_id,
-      'S3_REPORTING_SECRET_ACCESS_KEY' => s3_key,
-      'S3_REPORTING_PROJECT_PATH' => 'landing/hmpps-book-secure-move-api',
-    ) do
-      example.run
-    end
-  end
-
   it 'writes a file on S3 and return the full_name' do
-    full_name = described_class.new(bucket_name)
-                    .write(content, table)
+    full_name = described_class.new('bucket_name')
+                    .write('some content', 'report.json')
 
-    expect(full_name).to eq(full_path)
-  end
-
-  it 'calls the S3 SDK with the correct data' do
-    described_class.new(bucket_name).write(content, table)
-
-    expect(s3_client.api_requests.first.slice(:operation_name, :params)).to eq({
-      operation_name: :put_object,
-      params: {
-        acl: 'bucket-owner-full-control',
-        body: content,
-        bucket: bucket_name,
-        key: full_path,
-        server_side_encryption: 'AES256',
-      },
-    })
+    expect(full_name).to eq('2020/01/29/2020-01-29-report.json')
   end
 
   context 'when a report date is specified' do
     let(:report_date) { Date.new(2020, 1, 15) }
 
-    it 'creates a file and names it based on the report date' do
-      full_name = described_class.new(bucket_name)
-                                 .write(content, table, report_date)
+    it 'creates a file and names it base on the report date ' do
+      full_name = described_class.new('bucket_name')
+                                 .write('some content', 'report.json', report_date)
 
-      expect(full_name).to eq(
-        'landing/hmpps-book-secure-move-api/data/' \
-        'database_name=feeds_report/' \
-        'table_name=moves/' \
-        'extraction_timestamp=20200115000000Z/' \
-        '2020-01-15-moves.jsonl',
-      )
+      expect(full_name).to eq('2020/01/15/2020-01-15-report.json')
     end
   end
 end

--- a/spec/workers/feeds/feed_worker_spec.rb
+++ b/spec/workers/feeds/feed_worker_spec.rb
@@ -2,11 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Feeds::FeedWorker, type: :worker do
   let(:reports_feed_instance) { instance_double(CloudData::ReportsFeed) }
+  let(:ap_feed_instance) { instance_double(CloudData::AnalyticalPlatformFeed) }
   let(:feed_instance) { instance_double(Feeds::Event, { call: 'feed_data' }) }
 
   before do
     allow(reports_feed_instance).to receive(:write)
+    allow(ap_feed_instance).to receive(:write)
     allow(CloudData::ReportsFeed).to receive(:new).and_return(reports_feed_instance)
+    allow(CloudData::AnalyticalPlatformFeed).to receive(:new).and_return(ap_feed_instance)
   end
 
   Feeds::AllWorker.feed_names.each do |feed_name|
@@ -21,7 +24,8 @@ RSpec.describe Feeds::FeedWorker, type: :worker do
         described_class.new.perform(feed_name, Date.yesterday.to_s)
 
         expect(feed_class).to have_received(:new).once.with(Date.yesterday.beginning_of_day, Date.yesterday.end_of_day)
-        expect(reports_feed_instance).to have_received(:write).once.with('feed_data', feed_name.pluralize, Date.yesterday)
+        expect(reports_feed_instance).to have_received(:write).once.with('feed_data', "#{feed_name.pluralize}.jsonl", Date.yesterday)
+        expect(ap_feed_instance).to have_received(:write).once.with('feed_data', feed_name.pluralize, Date.yesterday)
       end
     end
   end

--- a/spec/workers/gps_report_worker_spec.rb
+++ b/spec/workers/gps_report_worker_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe GPSReportWorker, type: :worker do
   around do |example|
     Timecop.freeze('2021-01-02 00:00:00')
     ClimateControl.modify(
-      'S3_REPORTING_ACCESS_KEY_ID' => s3_id,
-      'S3_REPORTING_BUCKET_NAME' => 'moj-reg-dev',
-      'S3_REPORTING_SECRET_ACCESS_KEY' => s3_key,
-      'S3_REPORTING_PROJECT_PATH' => 'landing/hmpps-book-secure-move-api',
+      'S3_AP_ACCESS_KEY_ID' => s3_id,
+      'S3_AP_BUCKET_NAME' => 'moj-reg-dev',
+      'S3_AP_SECRET_ACCESS_KEY' => s3_key,
+      'S3_AP_PROJECT_PATH' => 'landing/hmpps-book-secure-move-api',
     ) do
       example.run
     end


### PR DESCRIPTION
### Jira link

MAP-149

### What?

I have added/removed/altered:

- The feeds still need to go into the old bucket because JPC needs to read them. Output these in addition to the new analytical platform feeds.

### Why?

I am doing this because:

- This got accidentally disabled when we did the analytical platform changes

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [x] Added any new environment variables to the [Helm chart](https://github.com/ministryofjustice/hmpps-book-secure-move-api/tree/main/helm_deploy)


