### PR TITLE
MAP-319: Fix JPC feed

### DIFF
--- a/app/workers/feeds/jpc_worker.rb
+++ b/app/workers/feeds/jpc_worker.rb
@@ -11,7 +11,7 @@ class Feeds::JpcWorker
 
     feeds = Feeds::Jpc.new(date.beginning_of_day, date.end_of_day).call
     feeds.each do |feed_name, feed_data|
-      CloudData::ReportsFeed.new.write(feed_data, "#{feed_name.pluralize}.jsonl", date)
+      CloudData::ReportsFeed.new.write(feed_data, "#{feed_name.to_s.pluralize}.jsonl", date)
     end
 
     Sidekiq.logger.info("Generated JPC feed in #{time_since.get} seconds")

--- a/spec/workers/feeds/feed_worker_spec.rb
+++ b/spec/workers/feeds/feed_worker_spec.rb
@@ -1,14 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Feeds::FeedWorker, type: :worker do
-  let(:reports_feed_instance) { instance_double(CloudData::ReportsFeed) }
   let(:ap_feed_instance) { instance_double(CloudData::AnalyticalPlatformFeed) }
   let(:feed_instance) { instance_double(Feeds::Event, { call: 'feed_data' }) }
 
   before do
-    allow(reports_feed_instance).to receive(:write)
     allow(ap_feed_instance).to receive(:write)
-    allow(CloudData::ReportsFeed).to receive(:new).and_return(reports_feed_instance)
     allow(CloudData::AnalyticalPlatformFeed).to receive(:new).and_return(ap_feed_instance)
   end
 

--- a/spec/workers/feeds/jpc_worker_spec.rb
+++ b/spec/workers/feeds/jpc_worker_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Feeds::JpcWorker, type: :worker do
+  let(:reports_feed_instance) { instance_double(CloudData::ReportsFeed) }
+  let(:feed_instance) { instance_double(Feeds::Jpc, { call: feed_data }) }
+  let(:feed_data) do
+    {
+      move: 'move_data',
+      journey: 'journey_data',
+      event: 'event_data',
+      profile: 'profile_data',
+      person: 'person_data',
+    }
+  end
+
+  before do
+    allow(reports_feed_instance).to receive(:write)
+    allow(CloudData::ReportsFeed).to receive(:new).and_return(reports_feed_instance)
+    allow(Feeds::Jpc).to receive(:new).and_return(feed_instance)
+  end
+
+  it 'calls the correct methods' do
+    described_class.new.perform(Date.yesterday.to_s)
+
+    expect(Feeds::Jpc).to have_received(:new).once.with(Date.yesterday.beginning_of_day, Date.yesterday.end_of_day)
+    expect(reports_feed_instance).to have_received(:write).with('move_data', 'moves.jsonl', Date.yesterday)
+    expect(reports_feed_instance).to have_received(:write).with('journey_data', 'journeys.jsonl', Date.yesterday)
+    expect(reports_feed_instance).to have_received(:write).with('event_data', 'events.jsonl', Date.yesterday)
+    expect(reports_feed_instance).to have_received(:write).with('profile_data', 'profiles.jsonl', Date.yesterday)
+    expect(reports_feed_instance).to have_received(:write).with('person_data', 'people.jsonl', Date.yesterday)
+  end
+end


### PR DESCRIPTION
### Jira link

MAP-319

### What?

I have added/removed/altered:

- Call to_s before formatting JPC feed names

### Why?

I am doing this because:

- It was failing with an error


