### PR TITLE
MAP-319: Add JPC feed cron jobs

### DIFF
--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -79,9 +79,12 @@ cronJobs:
   - name: token-cleanup
     schedule: "0 1 * * 0"
     command: ["bundle", "exec", "rake", "doorkeeper:db:cleanup"]
-  - name: feeds-job
-    schedule: "0 3 * * *"
+  - name: ap-feeds-job
+    schedule: "30 3 * * *"
     command: ["bundle", "exec", "rake", "feed[all]"]
+  - name: jpc-feeds-job
+    schedule: "0 3 * * *"
+    command: ["bundle", "exec", "rake", "feed[jpc]"]
   - name: metrics
     schedule: "*/30 * * * *"
     command: ["bundle", "exec", "rake", "metrics:export"]

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -65,9 +65,12 @@ cronJobs:
   - name: token-cleanup
     schedule: "0 1 * * 0"
     command: ["bundle", "exec", "rake", "doorkeeper:db:cleanup"]
-  - name: feeds-job
-    schedule: "0 3 * * *"
+  - name: ap-feeds-job
+    schedule: "30 3 * * *"
     command: ["bundle", "exec", "rake", "feed[all]"]
+  - name: jpc-feeds-job
+    schedule: "0 3 * * *"
+    command: ["bundle", "exec", "rake", "feed[jpc]"]
   - name: generate-journeys
     suspend: true
     schedule: "0 10,14 * * *"


### PR DESCRIPTION
### Jira link

MAP-319

### What?

I have added/removed/altered:

- Ad JPC feed cron jobs

### Why?

I am doing this because:

- We want this to run in addition to the analytical platform job
