### PR TITLE
ci: Make migration job name unique per release

### DIFF
--- a/helm_deploy/hmpps-book-secure-move-api/templates/migration_job.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/migration_job.yaml
@@ -1,9 +1,10 @@
 {{- $genericService := index .Values "generic-service" -}}
+{{- $hash := toJson .Values | sha256sum | trunc 7 -}}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  {{- $fullName := printf "%s-%s" (include "generic-service.fullname" $) "migration" | trunc 52 }}
+  {{- $fullName := printf "%s-%s-%s" (include "generic-service.fullname" $) "migration" $hash | trunc 52 }}
   name: {{ $fullName }}
   labels:
     app: {{ $fullName }}


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Make migration job name unique per release

### Why?

- When the migration pre-hook fails it hangs around, and Helm doesn't want to overwrite it when we rerun the job, so it fails again. Adding a hash generated from the values should make the name unique per release.

