### PR TITLE
[MAP-359] Pin Bundler to 2.1.4 as the newest version seems to not work in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ RUN gem update bundler --no-document
 
 # NB: its more efficient not to copy the full app folder until after the gems are installed (reduces unnecessary rebuilds)
 COPY Gemfile Gemfile.lock .ruby-version /app/
-RUN bundle install --jobs 4 --retry 3 \
+
+RUN gem install bundler -v '2.1.4'
+
+RUN bundle _2.1.4_ install --jobs 4 --retry 3 \
      && rm -rf /usr/local/bundle/cache/*.gem \
      && find /usr/local/bundle/gems/ -name "*.c" -delete \
      && find /usr/local/bundle/gems/ -name "*.o" -delete


### PR DESCRIPTION
Pin Bundler to 2.1.4 as 

### Jira link

MAP-359

### What?

I have added/removed/altered:

- Pin Bundler to 2.1.4

### Why?

I am doing this because:

- The newest version seems to not work in Docker - some gems are missing from the multi-stage build


