### PR TITLE
fix: Splat court case params to be compatible with Ruby 3.x

### DIFF
--- a/app/services/court_hearings/create_in_nomis.rb
+++ b/app/services/court_hearings/create_in_nomis.rb
@@ -19,7 +19,7 @@ module CourtHearings
             comments: hearing.comments,
           }.merge(body_locations),
         }
-        response = NomisClient::CourtHearings.post(body)
+        response = NomisClient::CourtHearings.post(**body)
 
         log_attributes << { response_status: response&.status, response_body: response&.body, request_params: body }
 

--- a/spec/services/court_hearings/create_in_nomis_spec.rb
+++ b/spec/services/court_hearings/create_in_nomis_spec.rb
@@ -26,8 +26,19 @@ RSpec.describe CourtHearings::CreateInNomis do
     let(:booking_id) { 123 }
 
     before do
-      allow(NomisClient::CourtHearings).to receive(:post)
-                                              .and_return(instance_double('OAuth2::Response', status: nomis_response_status, body: { 'id' => 123 }.to_json))
+      allow(NomisClient::CourtHearings)
+        .to receive(:post)
+        .with(**{
+          booking_id:,
+          court_case_id: nomis_case_id,
+          body_params: {
+            'fromPrisonLocation': from_nomis_agency_id,
+            'toCourtLocation': to_nomis_agency_id,
+            'courtHearingDateTime': '2020-04-15T17:36:02',
+            'comments': comments,
+          },
+        })
+        .and_return(instance_double('OAuth2::Response', status: nomis_response_status, body: { 'id' => 123 }.to_json))
       move.person.update!(latest_nomis_booking_id: booking_id)
     end
 


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Splat court case params to be compatible with Ruby 3.x

### Why?

I am doing this because:

- Ruby 3.x release triggered some alerts in sentry, for example: https://ministryofjustice.sentry.io/issues/4558636166/events/d206f6388d9c43d29aab5a8268551914/
