### PR TITLE
Add lodgings into supplier move accessibility check

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,7 +10,8 @@ class Ability
       can :manage, Move, Move.for_supplier(application.owner) do |move|
         move.supplier == application.owner ||
           move.from_location&.suppliers&.include?(application.owner) ||
-          move.to_location&.suppliers&.include?(application.owner)
+          move.to_location&.suppliers&.include?(application.owner) ||
+          move.lodgings.any? { |lodging| lodging.location.suppliers.include?(application.owner) }
       end
 
       can :manage, Journey, supplier_id: application.owner_id

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -149,6 +149,8 @@ class Move < VersionedModel
     where(supplier:)
       .or(Move.where(from_location: supplier.locations))
       .or(Move.where(to_location: supplier.locations))
+      .includes(:lodgings)
+      .or(Lodging.where('lodgings.location' => supplier.locations))
   end
 
   def approve(date:)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe Ability, type: :model do
       end
     end
 
-    context 'as supplier A' do
+    context 'with supplier A' do
       let(:supplier) { supplier_a }
 
       include_examples 'move is accessible'
     end
 
-    context 'as supplier B' do
+    context 'with supplier B' do
       let(:supplier) { supplier_b }
 
       include_examples 'move is accessible'
@@ -60,7 +60,7 @@ RSpec.describe Ability, type: :model do
       location_b = create(:location, suppliers: [supplier_a])
       lodge_location = create(:location, suppliers: [supplier_b])
       move = create(:move, from_location: location_a, to_location: location_b)
-      create(:lodging, move: move, location: lodge_location)
+      create(:lodging, move:, location: lodge_location)
 
       move
     end
@@ -75,13 +75,13 @@ RSpec.describe Ability, type: :model do
       end
     end
 
-    context 'as supplier A' do
+    context 'with supplier A' do
       let(:supplier) { supplier_a }
 
       include_examples 'move is accessible'
     end
 
-    context 'as supplier B' do
+    context 'with supplier B' do
       let(:supplier) { supplier_b }
 
       include_examples 'move is accessible'

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -4,7 +4,7 @@ require 'cancan/matchers'
 RSpec.describe Ability, type: :model do
   subject(:ability) { described_class.new(application) }
 
-  context 'when application is owned the supplier of the move' do
+  context 'when application.owner is the supplier of the move' do
     let(:owner_supplier) { create :supplier }
     let(:another_supplier) { create :supplier }
     let(:application) { Doorkeeper::Application.create(name: 'test', owner: owner_supplier) }
@@ -12,7 +12,7 @@ RSpec.describe Ability, type: :model do
     it { is_expected.to be_able_to(:manage, Move.new(supplier: owner_supplier)) }
   end
 
-  context 'when application is NOT owned the supplier of the move' do
+  context 'when application.owner is NOT the supplier of the move' do
     let(:owner_supplier) { create :supplier }
     let(:another_supplier) { create :supplier }
     let(:application) { Doorkeeper::Application.create(name: 'test', owner: owner_supplier) }
@@ -20,7 +20,7 @@ RSpec.describe Ability, type: :model do
     it { is_expected.not_to be_able_to(:manage, Move.new(supplier: another_supplier)) }
   end
 
-  context 'when application is owned by cross-supplier move' do
+  context 'when there is a cross-supplier move' do
     let(:supplier_a) { create :supplier }
     let(:supplier_b) { create :supplier }
     let(:move) do
@@ -39,13 +39,49 @@ RSpec.describe Ability, type: :model do
       end
     end
 
-    context 'and as supplier A' do
+    context 'as supplier A' do
       let(:supplier) { supplier_a }
 
       include_examples 'move is accessible'
     end
 
-    context 'and as supplier B' do
+    context 'as supplier B' do
+      let(:supplier) { supplier_b }
+
+      include_examples 'move is accessible'
+    end
+  end
+
+  context 'when there is a move with cross-supplier lodging' do
+    let(:supplier_a) { create :supplier }
+    let(:supplier_b) { create :supplier }
+    let(:move) do
+      location_a = create(:location, suppliers: [supplier_a])
+      location_b = create(:location, suppliers: [supplier_a])
+      lodge_location = create(:location, suppliers: [supplier_b])
+      move = create(:move, from_location: location_a, to_location: location_b)
+      create(:lodging, move: move, location: lodge_location)
+
+      move
+    end
+
+    shared_examples 'move is accessible' do
+      let(:application) { Doorkeeper::Application.create(name: 'test', owner: supplier) }
+
+      it { is_expected.to be_able_to(:manage, move) }
+
+      it 'finds the move when queried' do
+        expect(Move.accessible_by(ability)).to eq([move])
+      end
+    end
+
+    context 'as supplier A' do
+      let(:supplier) { supplier_a }
+
+      include_examples 'move is accessible'
+    end
+
+    context 'as supplier B' do
       let(:supplier) { supplier_b }
 
       include_examples 'move is accessible'


### PR DESCRIPTION
### Jira link

MAP-334

### What?

I have added/removed/altered:

- [x] Altered the move permission logic to allow suppliers to edit moves that have lodges at their locations

### Why?

I am doing this because:

- It was fed back to us after demoing the lodgings work to suppliers

