### PR TITLE
MAP-293: Add `incomplete_per` as a cancellation reason for moves

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -67,6 +67,7 @@ class Move < VersionedModel
     CANCELLATION_REASON_CANCELLED_BY_PMU = 'cancelled_by_pmu',
     CANCELLATION_REASON_REJECTED = 'rejected',
     CANCELLATION_REASON_DATABASE_CORRECTION = 'database_correction',
+    CANCELLATION_REASON_INCOMPLETE_PER = 'incomplete_per',
     CANCELLATION_REASON_OTHER = 'other',
   ].freeze
 

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Move do
             supplier_declined_to_move
             cancelled_by_pmu
             rejected
+            incomplete_per
             other
           ])
       }

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -721,6 +721,7 @@
                 - supplier_declined_to_move
                 - cancelled_by_pmu
                 - rejected
+                - incomplete_per
                 - other
         - name: filter[rejection_reason]
           in: query

--- a/spec/swagger/swagger_doc_v2.yaml
+++ b/spec/swagger/swagger_doc_v2.yaml
@@ -397,6 +397,7 @@
                 - supplier_declined_to_move
                 - cancelled_by_pmu
                 - rejected
+                - incomplete_per
                 - other
         - name: filter[rejection_reason]
           in: query

--- a/swagger/v1/move.yaml
+++ b/swagger/v1/move.yaml
@@ -100,6 +100,7 @@ Move:
             - supplier_declined_to_move
             - cancelled_by_pmu
             - rejected
+            - incomplete_per
             - other
           - type: 'null'
           description: Reason the move has been cancelled

--- a/swagger/v1/move_cancellation_reason_attribute.yaml
+++ b/swagger/v1/move_cancellation_reason_attribute.yaml
@@ -6,5 +6,6 @@ MoveCancellationReason:
   - supplier_declined_to_move
   - cancelled_by_pmu
   - rejected
+  - incomplete_per
   - other
   description: The reason the move has been cancelled

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -105,6 +105,7 @@ Move:
                 - supplier_declined_to_move
                 - cancelled_by_pmu
                 - rejected
+                - incomplete_per
                 - other
             - type: "null"
           description: Reason the move has been cancelled

--- a/swagger/v2/patch_move.yaml
+++ b/swagger/v2/patch_move.yaml
@@ -98,6 +98,7 @@ Move:
                 - supplier_declined_to_move
                 - cancelled_by_pmu
                 - rejected
+                - incomplete_per
                 - other
             - type: "null"
           description: Reason the move has been cancelled


### PR DESCRIPTION
### Jira link

MAP-293

### What?

I have added/removed/altered:

- Added incomplete_per as a cancellation reason for moves

### Why?

I am doing this because:

- Suppliers have been asked by PECS to reject moves with an incomplete PER, but they want it to be clear why they have cancelled the move so that they are not penalised for unnecessary cancellations

### Have you? (optional)

- [x] Updated API docs if necessary	


