### PR TITLE
[MAP-480] Fix error in move for_supplier method that was causing 500 errors

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -150,8 +150,7 @@ class Move < VersionedModel
     where(supplier:)
       .or(Move.where(from_location: supplier.locations))
       .or(Move.where(to_location: supplier.locations))
-      .includes(:lodgings)
-      .or(Lodging.where('lodgings.location' => supplier.locations))
+      .or(Move.where(id: Move.joins(:lodgings).where('lodgings.location' => supplier.locations)))
   end
 
   def approve(date:)

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -277,16 +277,21 @@ RSpec.describe Move do
 
     let(:supplier) { create(:supplier) }
     let(:location) { create(:location, suppliers: [supplier]) }
+    let(:location2) { create(:location, suppliers: [supplier]) }
 
     let(:move1) { create(:move, supplier:) }
     let(:move2) { create(:move, to_location: location) }
     let(:move3) { create(:move, from_location: location) }
     let(:move4) { create(:move) }
+    let(:move5) { create(:move) }
+
+    before { create(:lodging, location: location2, move: move5) }
 
     it { is_expected.to include(move1) }
     it { is_expected.to include(move2) }
     it { is_expected.to include(move3) }
     it { is_expected.not_to include(move4) }
+    it { is_expected.to include(move5) }
   end
 
   describe '#reference' do


### PR DESCRIPTION
### Jira link

MAP-480

### What?

I have added/removed/altered:

- Rewrite query in move for_supplier method

### Why?

I am doing this because:

- We were getting 500 error responses when we deployed the app


