### PR TITLE
MAP-340: Let journey take precedence over lodge when filtering

### DIFF
--- a/app/services/moves/finder.rb
+++ b/app/services/moves/finder.rb
@@ -206,12 +206,18 @@ module Moves
 
       if filter_params.key?(:from_location_id)
         scopes << edge_lodging_scope(scope, :from_location_id, 'MIN(lodgings.start_date)')
-        scopes << intermediary_lodgings_scope(scope, :from_location_id, 'end_date')
+
+        intermediary_lodges = intermediary_lodgings_scope(scope, :from_location_id, 'end_date')
+        lodge_journey_collisions = intermediary_lodges.joins(:journeys).where("journeys.date = TO_DATE(lodgings.end_date, 'YYYY-MM-DD')")
+        scopes << intermediary_lodges.where.not(id: Move.from(lodge_journey_collisions))
       end
 
       if filter_params.key?(:to_location_id)
         scopes << edge_lodging_scope(scope, :to_location_id, 'MAX(lodgings.end_date)')
-        scopes << intermediary_lodgings_scope(scope, :to_location_id, 'start_date')
+
+        intermediary_lodges = intermediary_lodgings_scope(scope, :to_location_id, 'start_date')
+        lodge_journey_collisions = intermediary_lodges.joins(:journeys).where("journeys.date = TO_DATE(lodgings.start_date, 'YYYY-MM-DD')")
+        scopes << intermediary_lodges.where.not(id: Move.from(lodge_journey_collisions))
       end
 
       scopes

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -1183,6 +1183,14 @@ RSpec.describe Moves::Finder do
 
           it { is_expected.to be_empty }
         end
+
+        context 'when the journey does not go from location 3' do
+          let(:journey_location) { create(:location) }
+          let!(:journey) { create(:journey, move:, date: '2022-01-05', from_location: journey_location, to_location: lodging3.location) }
+          let(:location) { lodging2.location }
+
+          it { is_expected.to be_empty }
+        end
       end
 
       context 'when incoming' do
@@ -1214,6 +1222,14 @@ RSpec.describe Moves::Finder do
 
         context 'with location 5' do
           let(:location) { move.to_location }
+
+          it { is_expected.to be_empty }
+        end
+
+        context 'when the journey does not go to location 4' do
+          let(:journey_location) { create(:location) }
+          let!(:journey) { create(:journey, move:, date: '2022-01-05', from_location: lodging2.location, to_location: journey_location) }
+          let(:location) { lodging3.location }
 
           it { is_expected.to be_empty }
         end
@@ -1506,6 +1522,114 @@ RSpec.describe Moves::Finder do
           it { is_expected.to contain_exactly(move) }
         end
       end
+    end
+  end
+
+  context 'with different lodging and journey locations' do
+    let(:move) { create(:move, date: '2022-01-01') }
+    let(:lodge_location) { create(:location) }
+    let(:journey_location) { create(:location) }
+
+    before do
+      create(:lodging, move:, start_date: '2022-01-01', end_date: '2022-01-02', location: lodge_location)
+      create(:journey, move:, date: '2022-01-01', from_location: move.from_location, to_location: journey_location)
+      create(:journey, move:, date: '2022-01-02', from_location: journey_location, to_location: move.to_location)
+    end
+
+    context 'and day one, outgoing, start location' do
+      let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', from_location_id: [move.from_location_id] } }
+
+      it { is_expected.to contain_exactly(move) }
+    end
+
+    context 'and day one, outgoing, lodge location' do
+      let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', from_location_id: [lodge_location] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day one, outgoing, journey location' do
+      let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', from_location_id: [journey_location] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day one, outgoing, final location' do
+      let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', from_location_id: [move.to_location_id] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day one, incoming, start location' do
+      let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', to_location_id: [move.from_location_id] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day one, incoming, lodge location' do
+      let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', to_location_id: [lodge_location] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day one, incoming, journey location' do
+      let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', to_location_id: [journey_location] } }
+
+      it { is_expected.to contain_exactly(move) }
+    end
+
+    context 'and day one, incoming, final location' do
+      let(:filter_params) { { date_from: '2022-01-01', date_to: '2022-01-01', to_location_id: [move.to_location_id] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day two, outgoing, start location' do
+      let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', from_location_id: [move.from_location_id] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day two, outgoing, lodge location' do
+      let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', from_location_id: [lodge_location] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day two, outgoing, journey location' do
+      let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', from_location_id: [journey_location] } }
+
+      it { is_expected.to contain_exactly(move) }
+    end
+
+    context 'and day two, outgoing, final location' do
+      let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', from_location_id: [move.to_location_id] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day two, incoming, start location' do
+      let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', to_location_id: [move.from_location_id] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day two, incoming, lodge location' do
+      let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', to_location_id: [lodge_location] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day two, incoming, journey location' do
+      let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', to_location_id: [journey_location] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'and day two, incoming, final location' do
+      let(:filter_params) { { date_from: '2022-01-02', date_to: '2022-01-02', to_location_id: [move.to_location_id] } }
+
+      it { is_expected.to contain_exactly(move) }
     end
   end
 end


### PR DESCRIPTION
### Jira link

MAP-340

### What?

I have added/removed/altered:

- Only show moves on the incoming/outgoing pages relative to the journey, if there is both a lodge and journey

### Why?

I am doing this because:

- If the journey is booked for a different location to the lodge then we assume that the journey is correct and the lodge isn't, as it's more up-to-date

### Deployment risks

- Possible performance impact - we will test for this before going live

