### PR TITLE
chore: Send the same data we send to JPC to the Analytical Platform

### DIFF
--- a/spec/workers/feeds/all_worker_spec.rb
+++ b/spec/workers/feeds/all_worker_spec.rb
@@ -1,16 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Feeds::AllWorker, type: :worker do
-  before do
-    allow(Feeds::FeedWorker).to receive(:perform_async)
+  let(:ap_feed_instance) { instance_double(CloudData::AnalyticalPlatformFeed) }
+  let(:feed_instance) { instance_double(Feeds::Jpc, { call: feed_data }) }
+  let(:feed_data) do
+    {
+      move: 'move_data',
+      journey: 'journey_data',
+      event: 'event_data',
+      profile: 'profile_data',
+      person: 'person_data',
+    }
   end
 
-  it 'calls the FeedWorkers with the specified date' do
-    date = Date.new(2021)
-    described_class.new.perform(date.to_s)
+  before do
+    allow(ap_feed_instance).to receive(:write)
+    allow(CloudData::AnalyticalPlatformFeed).to receive(:new).and_return(ap_feed_instance)
+    allow(Feeds::Jpc).to receive(:new).and_return(feed_instance)
+  end
 
-    described_class.feed_names.each do |feed_name|
-      expect(Feeds::FeedWorker).to have_received(:perform_async).with(feed_name, date)
-    end
+  it 'calls the correct methods' do
+    described_class.new.perform(Date.yesterday.to_s)
+
+    expect(Feeds::Jpc).to have_received(:new).once.with(Date.yesterday.beginning_of_day, Date.yesterday.end_of_day)
+    expect(ap_feed_instance).to have_received(:write).with('move_data', 'moves', Date.yesterday)
+    expect(ap_feed_instance).to have_received(:write).with('journey_data', 'journeys', Date.yesterday)
+    expect(ap_feed_instance).to have_received(:write).with('event_data', 'events', Date.yesterday)
+    expect(ap_feed_instance).to have_received(:write).with('profile_data', 'profiles', Date.yesterday)
+    expect(ap_feed_instance).to have_received(:write).with('person_data', 'people', Date.yesterday)
   end
 end


### PR DESCRIPTION
### Jira link

[MAP-898]

### What?

I have added/removed/altered:

- Send the same data that we send to JPC to the Analytical Platform

### Why?

I am doing this because:

- To make sure they get enough data to build up a full snapshot and not miss any records



[MAP-898]: https://dsdmoj.atlassian.net/browse/MAP-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ