### PR TITLE
SAR - Throw 403 when missing role

### DIFF
--- a/app/controllers/subject_access_requests_controller.rb
+++ b/app/controllers/subject_access_requests_controller.rb
@@ -29,7 +29,11 @@ private
   # Overrides parent due to endpoint-specific roles
   def verify_token
     unless token.valid_token_with_scope?('read', role: SAR_ROLE)
-      render_error('Valid authorisation token required', 1, 401)
+      if token.valid_token_with_scope?('read', role: '')
+        render_error("Missing role: #{SAR_ROLE}", 1, 403)
+      else
+        render_error('Valid authorisation token required', 1, 401)
+      end
     end
   end
 

--- a/spec/requests/api/subject_access_requests_controller_show_spec.rb
+++ b/spec/requests/api/subject_access_requests_controller_show_spec.rb
@@ -18,14 +18,26 @@ RSpec.describe SubjectAccessRequestsController do
       allow(JwksDecoder).to receive(:decode_token).and_return([token_payload])
     end
 
-    context 'when the token is missing the ROLE_SAR_DATA_ACCESS role' do
+    context 'when the token is invalid' do
+      let(:token_payload) { {} }
+
       before do
-        token_payload['authorities'] = []
         get_sar
       end
 
       it 'returns a response object with status 401' do
         expect(response.status).to eq 401
+      end
+    end
+
+    context 'when the token is missing the ROLE_SAR_DATA_ACCESS role' do
+      before do
+        token_payload['authorities'] = ['']
+        get_sar
+      end
+
+      it 'returns a response object with status 403' do
+        expect(response.status).to eq 403
       end
     end
 


### PR DESCRIPTION
SAR is meant to throw a 403 if the role is missing