### PR TITLE
Fix sort order tests on Mac

### DIFF
--- a/spec/requests/api/moves_controller_sorting_spec.rb
+++ b/spec/requests/api/moves_controller_sorting_spec.rb
@@ -17,15 +17,14 @@ RSpec.describe Api::MovesController do
   end
 
   describe 'GET /moves' do
-    # NB sorting should be case-sensitive, i.e. LOCATION1, LOCATION3, location2, location4
-    let(:location1) { create :location, title: 'LOCATION1' }
+    let(:location1) { create :location, title: 'location1' }
     let(:location2) { create :location, title: 'location2' }
-    let(:location3) { create :location, title: 'LOCATION3' }
+    let(:location3) { create :location, title: 'location3' }
     let(:location4) { create :location, title: 'location4' }
 
-    let(:profile1) { create :profile, person: create(:person, last_name: 'PROFILE1') }
+    let(:profile1) { create :profile, person: create(:person, last_name: 'profile1') }
     let(:profile2) { create :profile, person: create(:person, last_name: 'profile2') }
-    let(:profile3) { create :profile, person: create(:person, last_name: 'PROFILE3') }
+    let(:profile3) { create :profile, person: create(:person, last_name: 'profile3') }
     let(:profile4) { create :profile, person: create(:person, last_name: 'profile4') }
 
     let!(:move2) { create :move, :prison_transfer, profile: profile2, to_location: location2 }
@@ -189,7 +188,7 @@ RSpec.describe Api::MovesController do
             let(:sort_params) { { by: 'to_location' } }
 
             it 'sorts by to location' do
-              expect(locations.map(&:title)).to eq(%w[LOCATION1 location2 LOCATION3 location4])
+              expect(locations.map(&:title)).to eq(%w[location1 location2 location3 location4])
             end
           end
 
@@ -197,7 +196,7 @@ RSpec.describe Api::MovesController do
             let(:sort_params) { { by: 'to_location', direction: 'desc' } }
 
             it 'sorts by to location' do
-              expect(locations.map(&:title)).to eq(%w[location4 LOCATION3 location2 LOCATION1])
+              expect(locations.map(&:title)).to eq(%w[location4 location3 location2 location1])
             end
           end
         end
@@ -214,8 +213,8 @@ RSpec.describe Api::MovesController do
           context 'with default direction' do
             let(:sort_params) { { by: 'name' } }
 
-            it 'sorts by last_name (ascending, case sensitive)' do
-              expect(last_names).to eq(%w[PROFILE1 profile2 PROFILE3 profile4])
+            it 'sorts by last_name (ascending)' do
+              expect(last_names).to eq(%w[profile1 profile2 profile3 profile4])
             end
           end
 
@@ -223,7 +222,7 @@ RSpec.describe Api::MovesController do
             let(:sort_params) { { by: 'name', direction: 'desc' } }
 
             it 'sorts by last_name' do
-              expect(last_names).to eq(%w[profile4 PROFILE3 profile2 PROFILE1])
+              expect(last_names).to eq(%w[profile4 profile3 profile2 profile1])
             end
           end
         end

--- a/spec/services/allocations/finder_spec.rb
+++ b/spec/services/allocations/finder_spec.rb
@@ -166,9 +166,9 @@ RSpec.describe Allocations::Finder do
   end
 
   describe 'sorting' do
-    let(:location1) { create :location, title: 'LOCATION1' }
-    let(:location2) { create :location, title: 'Location2' }
-    let(:location3) { create :location, title: 'LOCATION3' }
+    let(:location1) { create :location, title: 'location1' }
+    let(:location2) { create :location, title: 'location2' }
+    let(:location3) { create :location, title: 'location3' }
 
     context 'when by from_location' do
       before do
@@ -181,7 +181,7 @@ RSpec.describe Allocations::Finder do
       let(:sort_params) { { by: :from_location, direction: :asc } }
 
       it 'orders by location title' do
-        expect(allocation_finder.call.map(&:from_location).pluck(:title)).to eql(%w[LOCATION1 Location2 LOCATION3])
+        expect(allocation_finder.call.map(&:from_location).pluck(:title)).to eql(%w[location1 location2 location3])
       end
     end
 
@@ -196,7 +196,7 @@ RSpec.describe Allocations::Finder do
       let(:sort_params) { { by: :to_location, direction: :asc } }
 
       it 'orders by location title' do
-        expect(allocation_finder.call.map(&:to_location).pluck(:title)).to eql(%w[LOCATION1 Location2 LOCATION3])
+        expect(allocation_finder.call.map(&:to_location).pluck(:title)).to eql(%w[location1 location2 location3])
       end
     end
 
@@ -229,9 +229,9 @@ RSpec.describe Allocations::Finder do
 
   describe 'combined filtering and sorting' do
     context 'when filtering by date and sorting by location' do
-      let!(:location1) { create :location, title: 'LOCATION1' }
-      let!(:location2) { create :location, title: 'Location2' }
-      let!(:location3) { create :location, title: 'LOCATION3' }
+      let!(:location1) { create :location, title: 'location1' }
+      let!(:location2) { create :location, title: 'location2' }
+      let!(:location3) { create :location, title: 'location3' }
 
       let(:sort_params) { { by: :to_location, direction: :desc } }
       let(:filter_params) { { date_from: allocation.date.to_s, date_to: (allocation.date + 5.days).to_s, from_locations: from_location.id } }
@@ -244,7 +244,7 @@ RSpec.describe Allocations::Finder do
       end
 
       it 'returns allocations matching date range sorted by location title desc' do
-        expect(allocation_finder.call.map(&:to_location).pluck(:title)).to eql(%w[LOCATION3 Location2 LOCATION1])
+        expect(allocation_finder.call.map(&:to_location).pluck(:title)).to eql(%w[location3 location2 location1])
       end
     end
 

--- a/spec/services/locations/finder_spec.rb
+++ b/spec/services/locations/finder_spec.rb
@@ -141,15 +141,15 @@ RSpec.describe Locations::Finder do
   describe 'sorting' do
     context 'when by title' do
       before do
-        create :location, title: 'LOCATION1'
-        create :location, title: 'Location2'
-        create :location, title: 'LOCATION3'
+        create :location, title: 'location1'
+        create :location, title: 'location2'
+        create :location, title: 'location3'
       end
 
       let(:sort_params) { { by: :title, direction: :asc } }
 
       it 'orders by location title' do
-        expect(location_finder.call.pluck(:title)).to eql(%w[LOCATION1 Location2 LOCATION3]) # NB: case-sensitive order
+        expect(location_finder.call.pluck(:title)).to eql(%w[location1 location2 location3])
       end
     end
 

--- a/spec/services/moves/finder_spec.rb
+++ b/spec/services/moves/finder_spec.rb
@@ -560,10 +560,10 @@ RSpec.describe Moves::Finder do
     end
 
     describe 'sort order' do
-      let(:location1) { create :location, title: 'LOCATION1' }
+      let(:location1) { create :location, title: 'location1' }
       let(:order_params) { { by: :to_location, direction: :asc } }
-      let(:location2) { create :location, title: 'Location2' }
-      let(:location3) { create :location, title: 'LOCATION3' }
+      let(:location2) { create :location, title: 'location2' }
+      let(:location3) { create :location, title: 'location3' }
 
       before do
         create :move, to_location: location1
@@ -572,7 +572,7 @@ RSpec.describe Moves::Finder do
       end
 
       it 'ordered by location' do
-        expect(results.map(&:to_location).pluck(:title)).to eql(%w[LOCATION1 Location2 LOCATION3])
+        expect(results.map(&:to_location).pluck(:title)).to eql(%w[location1 location2 location3])
       end
     end
 


### PR DESCRIPTION
### Jira link

MAP-809

### What?

I have added/removed/altered:

- As we can't reliably test the case-sensitivity in a cross-platform way, let's make the tests case-insensitive so that they pass on both platforms

### Why?

I am doing this because:

- The collation on a Mac is different from on a Linux machine so Postgres will sort things differently and the tests fail on Mac

