### PR TITLE
[MAP-929] Fix create_lodging notifications

### DIFF
--- a/spec/requests/api/lodgings_controller_create_spec.rb
+++ b/spec/requests/api/lodgings_controller_create_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe Api::LodgingsController do
       }
     end
 
+    before do
+      allow(Notifier).to receive(:prepare_notifications)
+    end
+
     context 'when successful' do
       let(:data) do
         {
@@ -89,6 +93,13 @@ RSpec.describe Api::LodgingsController do
       it 'sets the created by on the GenericEvent' do
         do_post
         expect(GenericEvent.last.created_by).to eq('TEST_USER')
+      end
+
+      it 'sends a notification' do
+        do_post
+        expect(Notifier)
+          .to have_received(:prepare_notifications)
+          .with(topic: Lodging.find_by!(start_date: '2020-05-04'), action_name: 'create')
       end
     end
 


### PR DESCRIPTION
### Jira link

MAP-929

### What?

I have added/removed/altered:

- Send create_lodging notifications properly

### Why?

I am doing this because:

- It was trying to create a notification from the controller itself rather than from the newly created lodging, so the notifications were never created


