### PR TITLE
MAP-957: Stop updating cancelled lodgings

### DIFF
--- a/app/controllers/api/lodgings_controller.rb
+++ b/app/controllers/api/lodgings_controller.rb
@@ -110,14 +110,14 @@ module Api
   private
 
     def update_future_lodgings(details)
-      return if details[:end_date].blank? || move.lodgings.count < 2
+      return if details[:end_date].blank? || move.lodgings.not_cancelled.count < 2
 
       start_date = Date.parse(lodging.start_date)
       old_length = Date.parse(lodging.end_date) - start_date
       new_length = Date.parse(update_lodging_attributes[:end_date]) - start_date
       length_difference = new_length - old_length
 
-      move.lodgings.each do |l|
+      move.lodgings.not_cancelled.each do |l|
         l_start_date = Date.parse(l.start_date)
         next if start_date >= l_start_date
 

--- a/spec/requests/api/lodgings_controller_update_spec.rb
+++ b/spec/requests/api/lodgings_controller_update_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe Api::LodgingsController do
       end
 
       context 'with other lodgings' do
+        let!(:cancelled_lodging) { create(:lodging, move:, location:, start_date: '2020-05-05', end_date: '2020-05-06', status: :cancelled) }
         let!(:lodging2) { create(:lodging, move:, location:, start_date: '2020-05-03', end_date: '2020-05-04') }
         let!(:lodging3) { create(:lodging, move:, location:, start_date: '2020-05-05', end_date: '2020-05-06') }
         let!(:lodging4) { create(:lodging, move:, location:, start_date: '2020-05-06', end_date: '2020-05-08') }
@@ -124,6 +125,14 @@ RSpec.describe Api::LodgingsController do
           expect(lodging2.reload.attributes).to include({
             'start_date' => '2020-05-03',
             'end_date' => '2020-05-04',
+          })
+        end
+
+        it 'does not update the cancelled lodging' do
+          do_patch
+          expect(cancelled_lodging.reload.attributes).to include({
+            'start_date' => '2020-05-05',
+            'end_date' => '2020-05-06',
           })
         end
 


### PR DESCRIPTION
### Jira link

MAP-957

### What?

I have added/removed/altered:

- [x] Altered Lodgings so that cancelled lodgings are no longer updated when a lodging has it's length changed

### Why?

I am doing this because:

- Cancelled lodgings shouldn't be updated
