### PR TITLE
MAP-958: Assign the correct dates to future lodging LodgingUpdate events

### DIFF
--- a/app/controllers/api/lodgings_controller.rb
+++ b/app/controllers/api/lodgings_controller.rb
@@ -121,9 +121,16 @@ module Api
         l_start_date = Date.parse(l.start_date)
         next if start_date >= l_start_date
 
-        l.update!(start_date: l_start_date + length_difference.days, end_date: Date.parse(l.end_date) + length_difference.days)
+        l_details = {
+          old_start_date: l.start_date,
+          start_date: l_start_date + length_difference.days,
+          old_end_date: l.end_date,
+          end_date: Date.parse(l.end_date) + length_difference.days,
+        }
 
-        create_automatic_event!(eventable: l, event_class: GenericEvent::LodgingUpdate, details:)
+        l.update!(l_details.slice(:start_date, :end_date))
+
+        create_automatic_event!(eventable: l, event_class: GenericEvent::LodgingUpdate, details: l_details)
 
         Notifier.prepare_notifications(topic: l, action_name: 'update')
       end

--- a/spec/requests/api/lodgings_controller_update_spec.rb
+++ b/spec/requests/api/lodgings_controller_update_spec.rb
@@ -153,8 +153,30 @@ RSpec.describe Api::LodgingsController do
         end
 
         it 'adds an event for each' do
+          update_event_count = GenericEvent::LodgingUpdate.count
           do_patch
-          expect(GenericEvent.order(:created_at).last(3).pluck(:eventable_id)).to eq([lodging3.id, lodging4.id, lodging.id])
+          expect(GenericEvent::LodgingUpdate.count).to eq(update_event_count + 3)
+
+          lodging3_event, lodging4_event, lodging_event = *GenericEvent::LodgingUpdate.order(:created_at).last(3)
+
+          expect(lodging3_event.details).to eq({
+            'old_start_date' => '2020-05-05',
+            'start_date' => '2020-05-06',
+            'old_end_date' => '2020-05-06',
+            'end_date' => '2020-05-07',
+          })
+
+          expect(lodging4_event.details).to eq({
+            'old_start_date' => '2020-05-06',
+            'start_date' => '2020-05-07',
+            'old_end_date' => '2020-05-08',
+            'end_date' => '2020-05-09',
+          })
+
+          expect(lodging_event.details).to eq({
+            'old_end_date' => '2020-05-05',
+            'end_date' => '2020-05-06',
+          })
         end
 
         it 'sends notifications for the other lodgings' do


### PR DESCRIPTION
### Jira link

MAP-958

### What?

I have added/removed/altered:

- [x] Altered the dates that are being set on LodgingUpdate events for future lodgings

### Why?

I am doing this because:

- The dates that were being assigned previously were incorrect

