### PR TITLE
MAP-531 Monthly incomplete PER report

### DIFF
--- a/reports/monthly-per/duplicates_per_month.sql
+++ b/reports/monthly-per/duplicates_per_month.sql
@@ -1,0 +1,125 @@
+select l.title as from_loc,
+t.title as to_loc,
+	m.date,
+	m.reference,
+	person.first_names,
+	person.last_name,
+	getstatus(risk.status) as risk,
+	getstatus(offence.status) as offence,
+	getstatus(health.status) as health,
+	getstatus(property.status) as property,
+	m.status as move_status,
+	COALESCE(per.status, 'No PER') as per_status,
+	m.allocation_id as allocation,
+	COALESCE(s.name, 'BaSM Frontend') as created_by,
+	'https://bookasecuremove.service.justice.gov.uk/move/' || m.id as url
+	from moves m 
+	left join profiles pro on m.profile_id = pro.id
+	left join person_escort_records per on pro.id = per.profile_id
+	left join people person on  pro.person_id = person.id
+	left join locations l on  m.from_location_id = l.id
+		left join locations t on  m.to_location_id = t.id
+	left outer join versions v on v.item_id = m.id and v.item_type = 'Move' and v.event = 'create'
+	left outer join suppliers s on v.supplier_id = s.id
+	left join (
+		select profile_id, section.key, section.status from person_escort_records, jsonb_to_recordset(person_escort_records.section_progress) as section(key text, status text)
+	    where section.key = 'offence-information'
+		and profile_id in (
+			select pro.id from moves m
+			left join profiles pro on m.profile_id = pro.id
+			left join person_escort_records per on pro.id = per.profile_id
+			left join people person on  pro.person_id = person.id
+			where m.date between '2023-12-01' and '2024-01-01'
+		)
+	) as offence 
+	on offence.profile_id = pro.id
+
+	left join (
+		select profile_id, section.key, section.status from person_escort_records, jsonb_to_recordset(person_escort_records.section_progress) as section(key text, status text)
+		where section.key = 'property-information'
+		and profile_id in (
+			select pro.id from moves m
+			left join profiles pro on m.profile_id = pro.id
+			left join person_escort_records per on pro.id = per.profile_id
+			left join people person on  pro.person_id = person.id
+			where m.date between '2023-12-01' and '2024-01-01'
+		)
+	) as property 
+	on property.profile_id = pro.id
+	
+	left join (
+			select profile_id, section.key, section.status from person_escort_records, jsonb_to_recordset(person_escort_records.section_progress) as section(key text, status text)
+			where section.key = 'risk-information'
+			and profile_id in (
+			select pro.id from moves m
+			left join profiles pro on m.profile_id = pro.id
+			left join person_escort_records per on pro.id = per.profile_id
+			left join people person on  pro.person_id = person.id
+			where m.date between '2023-12-01' and '2024-01-01'
+	)
+	) as risk 
+	on risk.profile_id = pro.id
+	
+	left join (
+			select profile_id, section.key, section.status from person_escort_records, jsonb_to_recordset(person_escort_records.section_progress) as section(key text, status text)
+			where section.key = 'health-information'
+			and profile_id in (
+			select pro.id from moves m
+			left join profiles pro on m.profile_id = pro.id
+			left join person_escort_records per on pro.id = per.profile_id
+			left join people person on  pro.person_id = person.id
+			where m.date between '2023-12-01' and '2024-01-01'
+	)
+	) as health 
+	on health.profile_id = pro.id
+	
+join (		
+select distinct(first_names, last_name, date), first_names, last_name, date from (
+select m.date,
+	upper(person.first_names) as first_names,
+	upper(person.last_name) as last_name
+	from moves m 
+	left join profiles pro on m.profile_id = pro.id
+	left join person_escort_records per on pro.id = per.profile_id
+	left join people person on  pro.person_id = person.id
+	left join (
+		select m.id, 'true' as dupe 
+		from (
+			select  i.date, i.first_names, i.last_name, i.from_location_id from (
+				select count(*) as occ,
+				m.date,
+				upper(ps.last_name) as last_name,
+				upper(ps.first_names) as first_names,
+				m.from_location_id
+				from moves m
+				join profiles p on m.profile_id = p.id
+				join people ps on p.person_id = ps.id
+				and m.date between '2023-12-01' and '2024-01-01'
+				group by m.date,
+				upper(ps.last_name),
+				upper(ps.first_names),
+				
+				m.from_location_id
+			) as i
+
+			where i.occ > 1
+
+			) as j
+
+			join people ps on j.last_name = upper(ps.last_name) and j.first_names = upper(ps.first_names)
+			join profiles p on p.person_id = ps.id
+			join moves m on m.date = j.date and m.profile_id = p.id
+	) as dupe
+	on dupe.id = m.id	
+	where m.date between '2023-12-01' and '2024-01-01'
+	and m.status = 'completed'
+	and (per.id is null or per.status not in ('completed', 'confirmed'))
+	and dupe.dupe = 'true'
+   ) as dupe_people ) as dupes
+	on dupes.last_name = upper(person.last_name) and dupes.first_names= upper(person.first_names) and m.date = dupes.date
+
+	where m.date between '2023-12-01' and '2024-01-01'
+	
+	order by date, last_name, first_names, move_status, per_status
+	
+

--- a/reports/monthly-per/incompletePerStatus.sql
+++ b/reports/monthly-per/incompletePerStatus.sql
@@ -1,0 +1,102 @@
+CREATE EXTENSION IF NOT EXISTS tablefunc;
+    create or replace function getstatus(varchar) RETURNS integer
+AS $$
+BEGIN        
+
+	if $1 = 'completed' then
+	   return 1;
+	elsif $1 = 'not_started' then
+	   return -1;
+	elsif $1 = 'in_progress' then
+	   return 0;
+	else
+	   return null;
+	end if;
+END;
+$$ LANGUAGE plpgsql;
+
+
+select l.title as from_loc,
+t.title as to_loc,
+COALESCE(s.name, 'BaSM Frontend') as created_by,
+m.status,
+	m.date,
+	m.reference,
+	person.first_names,
+	person.last_name,
+	getstatus(info."risk-information") as risk,
+	getstatus(info."offence-information") as offence,
+	getstatus(info."health-information") as health,
+	getstatus(info."property-information") as property,
+	dupe.dupe as dupe,
+	CASE
+		WHEN s.name is not null and l.location_type = 'court' then 'true'
+		ELSE null
+	END as supplier_from_court,
+	m.allocation_id as allocation,
+	'https://bookasecuremove.service.justice.gov.uk/move/' || m.id as url
+	from moves m 
+	left join profiles pro on m.profile_id = pro.id
+	left join person_escort_records per on pro.id = per.profile_id
+	left join people person on  pro.person_id = person.id
+	left join locations l on  m.from_location_id = l.id
+	left join locations t on  m.to_location_id = t.id
+	left outer join versions v on v.item_id = m.id and v.item_type = 'Move' and v.event = 'create'
+	left outer join suppliers s on v.supplier_id = s.id
+	left join (
+select *
+FROM crosstab('
+		select profile_id, section.key, section.status from person_escort_records, jsonb_to_recordset(person_escort_records.section_progress) as section(key text, status text)
+		
+		where profile_id in (
+			select pro.id from moves m
+			left join profiles pro on m.profile_id = pro.id
+			left join person_escort_records per on pro.id = per.profile_id
+			left join people person on  pro.person_id = person.id
+			where m.date between ''2024-03-01'' and ''2024-04-01''
+			and m.status = ''completed''
+			and (per.id is null or per.status not in (''completed'', ''confirmed''))
+		)') as ct (profile_id uuid,
+				"property-information" text,
+				"offence-information" text,
+				"health-information" text,
+				"risk-information" text)
+    ) as info
+	on info.profile_id = pro.id
+	
+	left join (
+		select m.id, m.from_location_id, 'true' as dupe 
+		from (
+			select  i.date, i.first_names, i.last_name, i.from_location_id from (
+				select count(*) as occ,
+				m.date,
+				upper(ps.last_name) as last_name,
+				upper(ps.first_names) as first_names,
+				m.from_location_id
+				from moves m
+				join profiles p on m.profile_id = p.id
+				join people ps on p.person_id = ps.id
+				and m.date between '2024-03-01' and '2024-04-01'
+				group by m.date,
+				upper(ps.last_name),
+				upper(ps.first_names),
+				
+				m.from_location_id
+			) as i
+
+			where i.occ > 1
+
+			) as j
+
+			join people ps on j.last_name = upper(ps.last_name) and j.first_names = upper(ps.first_names)
+			join profiles p on p.person_id = ps.id
+			join moves m on m.date = j.date and m.profile_id = p.id and m.from_location_id = j.from_location_id
+	) as dupe
+	on dupe.id = m.id and dupe.from_location_id = m.from_location_id
+	
+	
+	where m.date between '2024-03-01' and '2024-04-01'
+	and m.status = 'completed'
+	and (per.id is null or per.status not in ('completed', 'confirmed'))
+	--and v.supplier_id is null
+	order by from_loc, date

--- a/reports/monthly-per/per_stats.sql
+++ b/reports/monthly-per/per_stats.sql
@@ -1,0 +1,28 @@
+SELECT 
+	lf.title,
+	count(L.flid) as completed_moves,
+	NULLIF(count(L.flid) filter (where L.per_status in ('completed', 'confirmed')),0) as completed_per,
+	NULLIF(count(L.flid) filter (where L.pro_requires_yra = 'true'),0) as needs_yra,
+	NULLIF(count(L.flid) filter (where (L.pro_requires_yra = 'true') and (L.yra_id is null or L.yra_status not in ('completed', 'confirmed'))),0) as incomplete_yra,
+	NULLIF(count(L.flid) filter (where L.per_id is null),0) as no_per,
+	NULLIF(count(L.flid) filter (where L.per_status = 'unstarted'),0) as unstarted_per,
+	NULLIF(count(L.flid) filter (where L.per_status = 'in_progress'),0) as in_progress_pers,
+	NULLIF(round(((count(L.flid) filter (where (per_id is null or per_status not in ('completed', 'confirmed'))))::decimal / count(L.flid)::decimal), 3),0) as pc_incomplete
+FROM (
+	select 
+		m.from_location_id as flid,
+		per.status as per_status,
+		per.id as per_id,
+		pro.requires_youth_risk_assessment as pro_requires_yra,
+		yra.id as yra_id,
+		yra.status as yra_status
+	from moves m 
+	left join profiles pro on m.profile_id = pro.id
+	left join person_escort_records per on pro.id = per.profile_id
+	left join youth_risk_assessments yra on pro.id = yra.profile_id
+	left outer join versions v on v.item_id = m.id and v.item_type = 'Move' and v.event = 'create'
+	where m.date between '2024-03-01' and '2024-04-01'
+	and m.status = 'completed') as L
+left join locations lf on L.flid = lf.id 
+group by lf.title
+order by pc_incomplete desc NULLS LAST, (count(L.flid) filter (where (per_id is null or per_status not in ('completed', 'confirmed')))) desc NULLS LAST


### PR DESCRIPTION
### Jira link

MAP-531

### What?

I have added/removed/altered:

- [ ] Added updated SQL scripts that produce tabs for the monthly incomplete PER report.

### Why?

I am doing this because:

- Users reports an issues with a mismatch in numbers between tabs. This was a misunderstanding, however during investigation found that duplicates were being produced in the "Section Progress" tab. This has been fixed.
- Users wanted the ability to filter "Section Progress" tab for moves made by suppliers from court. 
- Efficiency improvements to SQL queries. 
- The scripts will be used in k8s automation of report production and sending. 

