### PR TITLE
[MAP-1029] Add extradition_capable flag to Locations

### DIFF
--- a/app/controllers/api/reference/locations_controller.rb
+++ b/app/controllers/api/reference/locations_controller.rb
@@ -27,10 +27,23 @@ module Api
         render_json location, serializer: LocationSerializer, include: included_relationships, status:
       end
 
-      PERMITTED_FILTER_PARAMS = %i[location_type nomis_agency_id supplier_id location_id region_id young_offender_institution created_at].freeze
+      PERMITTED_FILTER_PARAMS = %i[
+        location_type
+        nomis_agency_id
+        supplier_id
+        location_id
+        region_id
+        young_offender_institution
+        created_at
+        extradition_capable
+      ].freeze
 
       def filter_params
-        params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h
+        params.fetch(:filter, {}).permit(PERMITTED_FILTER_PARAMS).to_h.tap do |params_hash|
+          if params_hash['extradition_capable']
+            params_hash['extradition_capable'] = ActiveRecord::Type::Boolean.new.deserialize(params_hash['extradition_capable'])
+          end
+        end
       end
 
       def supported_relationships

--- a/app/serializers/locations_serializer.rb
+++ b/app/serializers/locations_serializer.rb
@@ -19,5 +19,6 @@ class LocationsSerializer
              :latitude,
              :longitude,
              :created_at,
-             :disabled_at
+             :disabled_at,
+             :extradition_capable
 end

--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -37,6 +37,7 @@ module Locations
       scope = apply_location_filters(scope)
       scope = apply_region_filters(scope)
       scope = apply_young_offender_institution_filters(scope)
+      scope = apply_extradition_filters(scope)
       apply_created_at_filters(scope)
     end
 
@@ -76,6 +77,11 @@ module Locations
     def apply_young_offender_institution_filters(scope)
       scope = scope.where(young_offender_institution: true) if filter_params[:young_offender_institution].to_s == 'true'
       scope = scope.where(young_offender_institution: false) if filter_params[:young_offender_institution].to_s == 'false'
+      scope
+    end
+
+    def apply_extradition_filters(scope)
+      scope = scope.where(extradition_capable: true) if filter_params.key?(:extradition_capable)
       scope
     end
 

--- a/db/migrate/20240430143853_add_extradition_capable_to_locations.rb
+++ b/db/migrate/20240430143853_add_extradition_capable_to_locations.rb
@@ -1,0 +1,5 @@
+class AddExtraditionCapableToLocations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :locations, :extradition_capable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_18_133654) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_30_143853) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -345,6 +345,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_18_133654) do
     t.string "postcode"
     t.float "latitude"
     t.float "longitude"
+    t.boolean "extradition_capable"
     t.index ["category_id"], name: "index_locations_on_category_id"
     t.index ["location_type"], name: "index_locations_on_location_type"
     t.index ["nomis_agency_id"], name: "index_locations_on_nomis_agency_id"
@@ -646,7 +647,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_18_133654) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.uuid "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -136,4 +136,14 @@ RSpec.describe Location do
       expect(location).to have_received(:geocode).twice
     end
   end
+
+  describe 'extradition_capable' do
+    let(:location) { build(:location) }
+
+    it 'has an extradition_capable field' do
+      location.extradition_capable = true
+      location.save!
+      expect(location.reload.extradition_capable).to eq(true)
+    end
+  end
 end

--- a/spec/requests/api/reference/locations_controller_spec.rb
+++ b/spec/requests/api/reference/locations_controller_spec.rb
@@ -200,6 +200,49 @@ RSpec.describe Api::Reference::LocationsController do
         expect(response_json).to include_json(data: [{ id: location.id }])
       end
     end
+
+    context 'with an extradition_capable location' do
+      before do
+        create(
+          :location,
+          key: 'heathrow_custody_suite',
+          title: 'Heathrow Custody Suite',
+          location_type: 'police',
+          nomis_agency_id: 'HCS',
+          can_upload_documents: false,
+          suppliers: [supplier],
+          extradition_capable: true,
+        )
+      end
+
+      it_behaves_like 'an endpoint that responds with success 200' do
+        before do
+          get '/api/v1/reference/locations', params:, headers:
+        end
+
+        let(:expected_document) do
+          {
+            data: [
+              {
+                type: 'locations',
+                attributes: {
+                  key: 'heathrow_custody_suite',
+                  title: 'Heathrow Custody Suite',
+                  location_type: 'police',
+                  nomis_agency_id: 'HCS',
+                  can_upload_documents: false,
+                  extradition_capable: true,
+                },
+              },
+            ],
+          }
+        end
+
+        it 'returns the correct data' do
+          expect(response_json).to include_json(expected_document)
+        end
+      end
+    end
   end
 
   describe 'GET /api/v1/reference/locations/:id' do

--- a/spec/requests/api/reference/locations_controller_spec.rb
+++ b/spec/requests/api/reference/locations_controller_spec.rb
@@ -173,7 +173,18 @@ RSpec.describe Api::Reference::LocationsController do
       let!(:supplier) { create :supplier }
       let!(:location) { create :location, suppliers: [supplier] }
       let(:created_at) { Date.new(2020, 5, 6) }
-      let(:filters) { { location_type: 'prison', nomis_agency_id: 'PEI', supplier_id: supplier.id, young_offender_institution: nil, created_at: } }
+
+      let(:filters) do
+        {
+          location_type: 'prison',
+          nomis_agency_id: 'PEI',
+          supplier_id: supplier.id,
+          young_offender_institution: nil,
+          created_at:,
+          extradition_capable: false,
+        }
+      end
+
       let(:params) { { filter: filters } }
 
       before do
@@ -191,6 +202,7 @@ RSpec.describe Api::Reference::LocationsController do
             supplier_id: supplier.id,
             young_offender_institution: nil,
             created_at: created_at.to_s,
+            extradition_capable: false,
           },
           active_record_relationships: nil,
         )

--- a/spec/serializers/locations_serializer_spec.rb
+++ b/spec/serializers/locations_serializer_spec.rb
@@ -79,4 +79,8 @@ RSpec.describe LocationsSerializer do
   it 'contains a disabled_at attribute' do
     expect(attributes[:disabled_at]).to eql disabled_at.iso8601
   end
+
+  it 'contains an extradition_capable attribute' do
+    expect(attributes[:extradition_capable]).to be nil
+  end
 end

--- a/spec/services/locations/finder_spec.rb
+++ b/spec/services/locations/finder_spec.rb
@@ -136,6 +136,19 @@ RSpec.describe Locations::Finder do
         expect(location_finder.call.pluck(:title)).to contain_exactly('Non YOI')
       end
     end
+
+    context 'with extradition_capable true' do
+      let(:filter_params) { { extradition_capable: true } }
+
+      before do
+        create(:location, extradition_capable: true, title: 'Extradition Location')
+        create(:location, extradition_capable: false, title: 'Normal Location')
+      end
+
+      it 'returns only extradition locations' do
+        expect(location_finder.call.pluck(:title)).to contain_exactly('Extradition Location')
+      end
+    end
   end
 
   describe 'sorting' do

--- a/swagger/v1/location.yaml
+++ b/swagger/v1/location.yaml
@@ -116,3 +116,9 @@ Location:
           type: boolean
           example: true
           description: A flag to indicate whether this location allows document uploads
+        extradition_capable:
+          oneOf:
+          - type: boolean
+          - type: 'null'
+          example: false
+          description: Indicates that this location can be set as a destination for extradition moves


### PR DESCRIPTION
### Jira link

[MAP-1029]

### What?

I have added/removed/altered:

- Added `extradition_capable` flag to Location model

### Why?

I am doing this because:

- To indicate that a location can be used as a destination for extradition moves

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Database migration required
- Changes an API that is used in production (Serco may experience issues if they are not expecting this field)



[MAP-1029]: https://dsdmoj.atlassian.net/browse/MAP-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ