### PR TITLE
[MAP-1035] Add `extradition` move type

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -59,6 +59,7 @@ class Move < VersionedModel
     prison_transfer: 'prison_transfer',
     video_remand: 'video_remand',
     approved_premises: 'approved_premises',
+    extradition: 'extradition',
   }
 
   CANCELLATION_REASONS = [
@@ -124,6 +125,13 @@ class Move < VersionedModel
   validate :validate_date_change_allocation, on: :update, unless: -> { validation_context == :update_allocation }
 
   validates :recall_date, date: true
+
+  validates :move_type,
+            exclusion: {
+              in: %w[extradition],
+              message: '%{value} is only valid if extradition_capable is true for destination location',
+            },
+            unless: -> { to_location&.extradition_capable }
 
   before_validation :set_reference
   before_validation :set_move_type

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -188,6 +188,16 @@ RSpec.describe Move do
     expect(build(:move, recall_date: 'not a date')).not_to be_valid
   end
 
+  it 'allows a move_type of `extradition` if the `to_location` is permitted' do
+    to_location = build(:location, extradition_capable: true)
+    expect(build(:move, move_type: 'extradition', to_location:)).to be_valid
+  end
+
+  it 'does not allow a move_type of `extradition` if the `to_location` is not permitted' do
+    to_location = build(:location, extradition_capable: nil)
+    expect(build(:move, move_type: 'extradition', to_location:)).not_to be_valid
+  end
+
   context 'when the from_location and to_location are the same' do
     subject(:move) { build(:move, to_location: location, from_location: location) }
 

--- a/swagger/v1/move_type_attribute.yaml
+++ b/swagger/v1/move_type_attribute.yaml
@@ -10,4 +10,5 @@ MoveType:
     - prison_transfer
     - video_remand
     - approved_premises
+    - extradition
   description: Indicates the type of move, e.g. prison transfer or court appearance


### PR DESCRIPTION
### Jira link

[MAP-1035]

### What?

I have added/removed/altered:

- Added `extradition` move type, which is only allowed if `extradition_capable` is true for `to_location`.

### Why?

I am doing this because:

- To allow extradition moves to be created

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production



[MAP-1035]: https://dsdmoj.atlassian.net/browse/MAP-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ