### PR TITLE
[MAP-1038] Add FlightDetails model and controller

### DIFF
--- a/app/controllers/api/flight_details_controller.rb
+++ b/app/controllers/api/flight_details_controller.rb
@@ -1,0 +1,63 @@
+module Api
+  class FlightDetailsController < ApiController
+    before_action :set_flight_details, only: %i[index update]
+
+    PERMITTED_NEW_PARAMS = [
+      :type,
+      {
+        attributes: %i[flight_number flight_time],
+        relationships: [{ move: {} }],
+      },
+    ].freeze
+
+    PERMITTED_UPDATE_PARAMS = [:type, { attributes: %i[flight_number flight_time] }].freeze
+
+    def index
+      render_flight_details(@flight_details, :ok)
+    end
+
+    def create
+      @flight_details = FlightDetails.new(new_flight_details_attributes)
+
+      @flight_details.save!
+
+      render_flight_details(@flight_details, :created)
+    end
+
+    def update
+      @flight_details.update!(update_flight_details_attributes)
+
+      render_flight_details(@flight_details, :ok)
+    end
+
+  private
+
+    def set_flight_details
+      @flight_details = FlightDetails.find_by!(move:)
+    end
+
+    def new_flight_details_params
+      params.require(:data).permit(PERMITTED_NEW_PARAMS)
+    end
+
+    def new_flight_details_attributes
+      @new_flight_details_attributes ||= new_flight_details_params.to_h[:attributes].merge!(move:)
+    end
+
+    def update_flight_details_params
+      params.require(:data).permit(PERMITTED_UPDATE_PARAMS)
+    end
+
+    def update_flight_details_attributes
+      @update_flight_details_attributes ||= update_flight_details_params.to_h[:attributes]
+    end
+
+    def move
+      @move ||= Move.accessible_by(current_ability).find(params.require(:move_id))
+    end
+
+    def render_flight_details(flight_details, status)
+      render_json flight_details, serializer: FlightDetailsSerializer, include: included_relationships, status:
+    end
+  end
+end

--- a/app/models/flight_details.rb
+++ b/app/models/flight_details.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class FlightDetails < ApplicationRecord
+  belongs_to :move
+
+  validates :flight_number, presence: true
+  validates :flight_time, presence: true
+
+  validates_each :flight_time do |record, attr, value|
+    Date.iso8601(value)
+  rescue ArgumentError
+    record.errors.add(attr, 'must be formatted as a valid ISO-8601 date')
+  end
+end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -84,6 +84,7 @@ class Move < VersionedModel
   has_one :person, through: :profile
   has_one :person_escort_record
   has_one :youth_risk_assessment
+  has_one :flight_details
 
   belongs_to :prison_transfer_reason, optional: true
   belongs_to :allocation, inverse_of: :moves, optional: true

--- a/app/serializers/flight_details_serializer.rb
+++ b/app/serializers/flight_details_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class FlightDetailsSerializer
+  include JSONAPI::Serializer
+
+  set_type :flight_details
+
+  attributes :flight_number,
+             :flight_time
+
+  belongs_to :move, serializer: MoveSerializer
+
+  SUPPORTED_RELATIONSHIPS = %w[
+    move
+  ].freeze
+end

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -41,6 +41,8 @@ module V2
     belongs_to :allocation, serializer: AllocationSerializer
     belongs_to :original_move, serializer: V2::MoveSerializer
 
+    has_one_if_included :flight_details, serializer: FlightDetailsSerializer
+
     SUPPORTED_RELATIONSHIPS = %w[
       profile.documents
       profile.category
@@ -83,6 +85,7 @@ module V2
       journeys.to_location
       lodgings
       lodgings.location
+      flight_details
     ].freeze
 
     INCLUDED_FIELDS = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Rails.application.routes.draw do
         end
       end
 
+      resources :flight_details, only: %i[index create update]
+
       member do
         post 'accept', controller: 'move_events'
         post 'approve', controller: 'move_events'

--- a/db/migrate/20240502112955_create_flight_details.rb
+++ b/db/migrate/20240502112955_create_flight_details.rb
@@ -1,0 +1,11 @@
+class CreateFlightDetails < ActiveRecord::Migration[7.0]
+  def change
+    create_table :flight_details, id: :uuid do |t|
+      t.string :flight_number, null: false
+      t.string :flight_time, null: false
+      t.references :move, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_30_143853) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_02_112955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -142,6 +142,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_30_143853) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "nomis_code"
     t.datetime "disabled_at", precision: nil
+  end
+
+  create_table "flight_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "flight_number", null: false
+    t.string "flight_time", null: false
+    t.uuid "move_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["move_id"], name: "index_flight_details_on_move_id"
   end
 
   create_table "flipper_features", force: :cascade do |t|
@@ -682,6 +691,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_30_143853) do
   add_foreign_key "allocations", "locations", column: "to_location_id", name: "fk_rails_allocations_to_location_id"
   add_foreign_key "court_hearings", "moves"
   add_foreign_key "documents", "moves"
+  add_foreign_key "flight_details", "moves"
   add_foreign_key "framework_flags", "framework_questions"
   add_foreign_key "framework_questions", "frameworks"
   add_foreign_key "framework_responses", "framework_questions"

--- a/spec/factories/flight_details.rb
+++ b/spec/factories/flight_details.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :flight_details do
+    association(:move, factory: :move)
+    flight_number { 'BA0001' }
+    flight_time { '2024-01-01T12:00:00' }
+  end
+end

--- a/spec/models/flight_details_spec.rb
+++ b/spec/models/flight_details_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlightDetails do
+  subject(:flight_details) { build(:flight_details, flight_time:) }
+
+  let(:flight_time) { '2024-01-01T12:00:00Z' }
+
+  it { is_expected.to belong_to(:move) }
+
+  it { is_expected.to validate_presence_of(:flight_number) }
+  it { is_expected.to validate_presence_of(:flight_time) }
+
+  context 'when the flight_time format is not an iso8601 date' do
+    let(:flight_time) { '2024/01/01' }
+
+    it { is_expected.to be_invalid }
+  end
+end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Move do
   it { is_expected.to have_many(:notification_events) }
   it { is_expected.to have_one(:person_escort_record) }
   it { is_expected.to have_one(:youth_risk_assessment) }
+  it { is_expected.to have_one(:flight_details) }
 
   it { is_expected.to validate_presence_of(:from_location) }
   it { is_expected.to validate_presence_of(:date) }

--- a/spec/requests/api/flight_details_controller_create_spec.rb
+++ b/spec/requests/api/flight_details_controller_create_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::FlightDetailsController do
+  describe 'POST /moves/:move_id/flight_details' do
+    subject(:do_post) do
+      post "/api/moves/#{move_id}/flight_details", params:, headers:, as: :json
+    end
+
+    let(:headers) do
+      {
+        'CONTENT_TYPE': content_type,
+        'Accept': 'application/vnd.api+json; version=2',
+        'Authorization' => "Bearer #{access_token}",
+        'X-Current-User' => 'TEST_USER',
+        'Idempotency-Key' => SecureRandom.uuid,
+      }
+    end
+
+    let(:response_json) { JSON.parse(response.body) }
+    let(:schema) { load_yaml_schema('post_moves_responses.yaml', version: 'v2') }
+    let(:supplier) { create(:supplier) }
+    let(:access_token) { 'spoofed-token' }
+    let(:content_type) { ApiController::CONTENT_TYPE }
+    let(:move) { create(:move, supplier:) }
+    let(:move_id) { move.id }
+    let(:flight_number) { 'BA0123' }
+    let(:flight_time) { '2020-05-04' }
+
+    let(:params) do
+      {
+        data: {
+          type: 'flight_details',
+          attributes: {
+            flight_number:,
+            flight_time:,
+          },
+          relationships: {
+            move: {
+              data: {
+                id: move_id,
+                type: 'moves',
+              },
+            },
+          },
+        },
+      }
+    end
+
+    context 'when successful' do
+      let(:data) do
+        {
+          id: FlightDetails.last.id,
+          type: 'flight_details',
+          attributes: {
+            flight_number:,
+            flight_time:,
+          },
+          relationships: {
+            move: {
+              data: {
+                id: move.id,
+                type: 'moves',
+              },
+            },
+          },
+        }
+      end
+
+      let(:schema) { load_yaml_schema('post_flight_details_responses.yaml') }
+
+      it_behaves_like 'an endpoint that responds with success 201' do
+        before { do_post }
+      end
+
+      it 'returns the correct data' do
+        do_post
+        expect(response_json).to include_json(data:)
+      end
+
+      it 'creates the flight details in the DB' do
+        do_post
+        expect(move.flight_details.attributes.symbolize_keys.slice(:flight_number, :flight_time, :move_id)).to eq({
+          flight_number:,
+          flight_time:,
+          move_id:,
+        })
+      end
+    end
+
+    context 'when unsuccessful' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+
+      context 'with an invalid flight time' do
+        let(:flight_time) { '9999-A1-02' }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          before { do_post }
+
+          let(:errors_422) do
+            [
+              {
+                'title' => 'Unprocessable entity',
+                'detail' => 'Flight time must be formatted as a valid iso-8601 date',
+              },
+            ]
+          end
+        end
+      end
+
+      context 'with a bad request' do
+        let(:params) { nil }
+
+        it_behaves_like 'an endpoint that responds with error 400' do
+          before { do_post }
+        end
+      end
+
+      context 'when the move_id is not found' do
+        let(:move_id) { 'foo-bar' }
+        let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
+
+        it_behaves_like 'an endpoint that responds with error 404' do
+          before do
+            do_post
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/flight_details_controller_index_spec.rb
+++ b/spec/requests/api/flight_details_controller_index_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::FlightDetailsController do
+  describe 'GET /moves/:move_id/flight_details' do
+    subject(:do_get) do
+      get "/api/moves/#{move_id}/flight_details", headers:, as: :json
+    end
+
+    let(:headers) do
+      {
+        'CONTENT_TYPE': content_type,
+        'Accept': 'application/vnd.api+json; version=2',
+        'Authorization' => "Bearer #{access_token}",
+        'X-Current-User' => 'TEST_USER',
+        'Idempotency-Key' => SecureRandom.uuid,
+      }
+    end
+
+    let(:response_json) { JSON.parse(response.body) }
+    let(:schema) { load_yaml_schema('post_moves_responses.yaml', version: 'v2') }
+    let(:supplier) { create(:supplier) }
+    let(:access_token) { 'spoofed-token' }
+    let(:content_type) { ApiController::CONTENT_TYPE }
+    let(:move) { create(:move, supplier:) }
+    let(:move_id) { move.id }
+    let(:flight_number) { 'BA0123' }
+    let(:flight_time) { '2024-01-01' }
+
+    context 'when flight details exist' do
+      let!(:flight_details) { create(:flight_details, flight_number:, flight_time:, move:) }
+
+      let(:data) do
+        {
+          id: flight_details.id,
+          type: 'flight_details',
+          attributes: {
+            flight_number:,
+            flight_time:,
+          },
+          relationships: {
+            move: {
+              data: {
+                id: move.id,
+                type: 'moves',
+              },
+            },
+          },
+        }
+      end
+
+      let(:schema) { load_yaml_schema('get_flight_details_responses.yaml') }
+
+      it_behaves_like 'an endpoint that responds with success 200' do
+        before { do_get }
+      end
+
+      it 'returns the correct data' do
+        do_get
+        expect(response_json).to include_json(data:)
+      end
+
+      it 'updates the flight number in the database' do
+        do_get
+        expect(flight_details.reload.flight_number).to eq(flight_number)
+      end
+
+      describe 'with included move' do
+        let(:params) do
+          { include: 'move' }
+        end
+
+        it 'includes the requested includes in the response' do
+          do_get
+          pp response_json
+          returned_types = response_json['data']['relationships']
+          expect(returned_types).to eq({
+            'move' => {
+              'data' => {
+                'id' => move_id,
+                'type' => 'moves',
+              },
+            },
+          })
+        end
+      end
+    end
+
+    context 'when unsuccessful' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+
+      context 'when the move_id is not found' do
+        let(:move_id) { 'foo-bar' }
+        let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
+
+        it_behaves_like 'an endpoint that responds with error 404' do
+          before do
+            do_get
+          end
+        end
+      end
+
+      context 'when there are no flight details associated with the move' do
+        let(:detail_404) { "Couldn't find FlightDetails with [WHERE \"flight_details\".\"move_id\" = $1]" }
+
+        it_behaves_like 'an endpoint that responds with error 404' do
+          before do
+            do_get
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/flight_details_controller_update_spec.rb
+++ b/spec/requests/api/flight_details_controller_update_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::FlightDetailsController do
+  describe 'PATCH /moves/:move_id/flight_details/:flight_details_id' do
+    subject(:do_patch) do
+      patch "/api/moves/#{move_id}/flight_details/#{flight_details.id}", params:, headers:, as: :json
+    end
+
+    let(:headers) do
+      {
+        'CONTENT_TYPE': content_type,
+        'Accept': 'application/vnd.api+json; version=2',
+        'Authorization' => "Bearer #{access_token}",
+        'X-Current-User' => 'TEST_USER',
+        'Idempotency-Key' => SecureRandom.uuid,
+      }
+    end
+
+    let(:response_json) { JSON.parse(response.body) }
+    let(:schema) { load_yaml_schema('post_moves_responses.yaml', version: 'v2') }
+    let(:supplier) { create(:supplier) }
+    let(:access_token) { 'spoofed-token' }
+    let(:content_type) { ApiController::CONTENT_TYPE }
+    let(:move) { create(:move, supplier:) }
+    let(:move_id) { move.id }
+    let(:flight_number) { 'BA0123' }
+    let(:flight_time) { '2024-01-01' }
+    let(:flight_details) { create(:flight_details, flight_number: 'AA0234', flight_time: '2024-01-01', move:) }
+
+    let(:params) do
+      {
+        data: {
+          type: 'flight_details',
+          attributes: {
+            flight_number:,
+            flight_time:,
+          },
+          relationships: {
+            move: {
+              data: {
+                id: move_id,
+                type: 'moves',
+              },
+            },
+          },
+        },
+      }
+    end
+
+    context 'when successful' do
+      let(:data) do
+        {
+          id: flight_details.id,
+          type: 'flight_details',
+          attributes: {
+            flight_number:,
+            flight_time:,
+          },
+          relationships: {
+            move: {
+              data: {
+                id: move.id,
+                type: 'moves',
+              },
+            },
+          },
+        }
+      end
+
+      let(:schema) { load_yaml_schema('patch_flight_details_responses.yaml') }
+
+      it_behaves_like 'an endpoint that responds with success 200' do
+        before { do_patch }
+      end
+
+      it 'returns the correct data' do
+        do_patch
+        expect(response_json).to include_json(data:)
+      end
+
+      it 'updates the flight number in the database' do
+        do_patch
+        expect(flight_details.reload.flight_number).to eq(flight_number)
+      end
+    end
+
+    context 'when unsuccessful' do
+      let(:schema) { load_yaml_schema('error_responses.yaml') }
+
+      context 'with an invalid flight time' do
+        let(:flight_time) { '9999-A1-02' }
+
+        it_behaves_like 'an endpoint that responds with error 422' do
+          before { do_patch }
+
+          let(:errors_422) do
+            [
+              {
+                'title' => 'Unprocessable entity',
+                'detail' => 'Flight time must be formatted as a valid iso-8601 date',
+              },
+            ]
+          end
+        end
+      end
+
+      context 'with a bad request' do
+        let(:params) { nil }
+
+        it_behaves_like 'an endpoint that responds with error 400' do
+          before { do_patch }
+        end
+      end
+
+      context 'when the move_id is not found' do
+        let(:move_id) { 'foo-bar' }
+        let(:detail_404) { "Couldn't find Move with 'id'=foo-bar" }
+
+        it_behaves_like 'an endpoint that responds with error 404' do
+          before do
+            do_patch
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/flight_details_serializer_spec.rb
+++ b/spec/serializers/flight_details_serializer_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlightDetailsSerializer do
+  subject(:serializer) { described_class.new(flight_details, adapter_options) }
+
+  let(:flight_details) { create :flight_details }
+  let(:result) { JSON.parse(serializer.serializable_hash.to_json).deep_symbolize_keys }
+  let(:adapter_options) { {} }
+
+  it 'contains a type property' do
+    expect(result[:data][:type]).to eql 'flight_details'
+  end
+
+  it 'contains an `id` property' do
+    expect(result[:data][:id]).to eql flight_details.id
+  end
+
+  it 'contains a `flight_number` property' do
+    expect(result[:data][:attributes][:flight_number]).to eql 'BA0001'
+  end
+
+  it 'contains an `flight_time` property' do
+    expect(result[:data][:attributes][:flight_time]).to eql '2024-01-01T12:00:00'
+  end
+
+  it 'contains a `move` relationship' do
+    expect(result[:data][:relationships][:move]).to eql(data: { id: flight_details.move.id, type: 'moves' })
+  end
+
+  describe 'included relationships' do
+    let(:adapter_options) do
+      {
+        include: %w[move],
+      }
+    end
+
+    let(:expected_json) do
+      [
+        {
+          id: flight_details.move_id,
+          type: 'moves',
+          attributes: { reference: flight_details.move.reference },
+        },
+      ]
+    end
+
+    it 'contains an included move' do
+      expect(result[:included]).to(include_json(expected_json))
+    end
+  end
+end

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe V2::MoveSerializer do
         profile: create(:profile, :with_documents),
         supplier: create(:supplier),
         lodgings: create_list(:lodging, 1),
+        flight_details: create(:flight_details),
       )
     end
 
@@ -71,7 +72,7 @@ RSpec.describe V2::MoveSerializer do
 
     it 'contains all included relationships' do
       expect(result[:included].map { |r| r[:type] }.uniq)
-        .to match_array(%w[people ethnicities genders locations profiles moves documents prison_transfer_reasons court_hearings suppliers lodgings])
+        .to match_array(%w[people ethnicities genders locations profiles moves documents prison_transfer_reasons court_hearings suppliers lodgings flight_details])
     end
 
     # TODO: Remove me when we're done with location suppliers - this is used to distinguish between them

--- a/swagger/v1/flight_details.yaml
+++ b/swagger/v1/flight_details.yaml
@@ -1,0 +1,31 @@
+FlightDetails:
+  type: object
+  required:
+  - type
+  - attributes
+  properties:
+    id:
+      type: string
+      format: uuid
+      example: 7cc9c528-3301-4d69-f200-69e964ce1ed8
+      description: The unique identifier (UUID) of this object
+    type:
+      type: string
+      example: flight_details
+      enum:
+      - flight_details
+      description: The type of this object - always `flight_details`
+    attributes:
+      type: object
+      properties:
+        flight_number:
+          type: string
+        flight_time:
+          type: string
+          format: date
+    relationships:
+      type: object
+      properties:
+        move:
+          $ref: move_reference.yaml#/MoveReference
+          description: The Move associated with these FlightDetails

--- a/swagger/v1/get_flight_details_responses.yaml
+++ b/swagger/v1/get_flight_details_responses.yaml
@@ -1,0 +1,12 @@
+'200':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: flight_details.yaml#/FlightDetails
+    included:
+      type: array
+      items:
+        anyOf:
+        - $ref: move.yaml#/Move

--- a/swagger/v1/patch_flight_details_responses.yaml
+++ b/swagger/v1/patch_flight_details_responses.yaml
@@ -1,0 +1,12 @@
+'200':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: flight_details.yaml#/FlightDetails
+    included:
+      type: array
+      items:
+        anyOf:
+        - $ref: move.yaml#/Move

--- a/swagger/v1/post_flight_details_responses.yaml
+++ b/swagger/v1/post_flight_details_responses.yaml
@@ -1,0 +1,12 @@
+'201':
+  type: object
+  required:
+  - data
+  properties:
+    data:
+      $ref: flight_details.yaml#/FlightDetails
+    included:
+      type: array
+      items:
+        anyOf:
+        - $ref: move.yaml#/Move


### PR DESCRIPTION
### Jira link

[MAP-1038]

### What?

I have added/removed/altered:

- Add FlightDetails model and controller
- FlightDetails can also be included when retrieving a move

### Why?

I am doing this because:

- We need to be able to create and view the flight details in the frontend

### Have you? (optional)

- [ ] Updated API docs if necessary - _we have not added the controller actions to the API docs yet_

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production



[MAP-1038]: https://dsdmoj.atlassian.net/browse/MAP-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAP-1038]: https://dsdmoj.atlassian.net/browse/MAP-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ