### PR TITLE
Map 1040 - Add court columns to incomplete per report

### DIFF
--- a/reports/monthly-incomplete-per/01-config.yaml
+++ b/reports/monthly-incomplete-per/01-config.yaml
@@ -160,10 +160,14 @@ data:
     getstatus(info."health-information") as health,
     getstatus(info."property-information") as property,
     dupe.dupe as dupe,
-    CASE
-    WHEN s.name is not null and l.location_type = 'court' then 'true'
-    ELSE null
-    END as supplier_from_court,
+	  CASE
+		WHEN l.location_type = 'court' then 'true'
+		ELSE null
+	  END as from_location_court,
+	  CASE
+		WHEN t.location_type = 'court' then 'true'
+		ELSE null
+	  END as to_location_court,
     m.allocation_id as allocation,
     'https://bookasecuremove.service.justice.gov.uk/move/' || m.id as url
     from moves m

--- a/reports/monthly-per/incompletePerStatus.sql
+++ b/reports/monthly-per/incompletePerStatus.sql
@@ -30,9 +30,13 @@ m.status,
 	getstatus(info."property-information") as property,
 	dupe.dupe as dupe,
 	CASE
-		WHEN s.name is not null and l.location_type = 'court' then 'true'
+		WHEN l.location_type = 'court' then 'true'
 		ELSE null
-	END as supplier_from_court,
+	END as from_location_court,
+	CASE
+		WHEN t.location_type = 'court' then 'true'
+		ELSE null
+	END as to_location_court,
 	m.allocation_id as allocation,
 	'https://bookasecuremove.service.justice.gov.uk/move/' || m.id as url
 	from moves m 


### PR DESCRIPTION
### Jira link

MAP-1040

### What?

I have added/removed/altered:

- [ ] Added columns "from_location_court" and "to_location_court" to per status tab or monthly incomplete per report.
- [ ] Removed "supplier_from_court" column.

### Why?

I am doing this because:

- Users want to be able to see and filter moves that include court locations.
- "supplier_from_court" column no longer required as users can filter the same conditions using a combination of the "created_by" and "from_location_court" columns.