### PR TITLE
Modified daily-IPT report SQL query to add cancellation reasons

### DIFF
--- a/helm_deploy/hmpps-book-secure-move-api/templates/reports/daily-ipt/01-daily-ipt-config.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/reports/daily-ipt/01-daily-ipt-config.yaml
@@ -22,7 +22,8 @@ data:
                     completed_moves, 
                     cancelled_moves, 
                     nomis_ids_comp as offenders_booked_or_moved, 
-                    nomis_ids_can  as offenders_cancelled 
+                    nomis_ids_can  as offenders_cancelled,
+                    nomis_ids_can_reasons  as cancelled_move_reasons
     from (SELECT from_loc, 
                  to_loc, 
                  allocation_id, 
@@ -74,7 +75,8 @@ data:
                                            ELSE m.allocation_id
                                            END                                                          as join_id,
                                        string_agg(nomis_id, ';') filter (where m.status <> 'cancelled') as nomis_ids_comp,
-                                       string_agg(nomis_id, ';') filter (where m.status = 'cancelled')  as nomis_ids_can
+                                       string_agg(nomis_id, ';') filter (where m.status = 'cancelled')  as nomis_ids_can,
+                                       string_agg(CONCAT_WS(' - ', cancellation_reason, cancellation_reason_comment), ';') filter (where m.status = 'cancelled')  as nomis_ids_can_reasons
                        from moves as m
                                 LEFT JOIN profiles pro on m.profile_id = pro.id
                                 LEFT JOIN (select id, coalesce(prison_number, nomis_prison_number) as nomis_id

--- a/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-cancelled-court-moves/01-weekly-cancelled-court-moves-config.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-cancelled-court-moves/01-weekly-cancelled-court-moves-config.yaml
@@ -5,8 +5,8 @@ kind: ConfigMap
 metadata:
   name: {{ $fullName }}
 data:
-  from-date: "1 day ago"
-  to-date: "7 days"
+  from-date: "7 days ago"
+  to-date: "1 day ago"
   subject: "BaSM Cancelled Court Moves Report [TODAY_DATE]"
   body: "BaSM Cancelled Court Moves report for yesterday ([FROM_DATE_FULL]) to [TO_DATE_FULL] is available at the link below."
   filename: "basm-cancelled-court-moves-report-[TODAY_DATE]"

--- a/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-cancelled-moves/01-weekly-cancelled-moves-config.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-cancelled-moves/01-weekly-cancelled-moves-config.yaml
@@ -5,8 +5,8 @@ kind: ConfigMap
 metadata:
   name: {{ $fullName }}
 data:
-  from-date: "1 day ago"
-  to-date: "7 days"
+  from-date: "7 days ago"
+  to-date: "1 day ago"
   subject: "BaSM Cancelled Moves Report [TODAY_DATE]"
   body: "BaSM Cancelled moves report for yesterday ([FROM_DATE_FULL]) to [TO_DATE_FULL] is available at the link below."
   filename: "basm-cancelled-moves-report-[TODAY_DATE]"


### PR DESCRIPTION
### Jira link

MAP-975

### What?

I have added/removed/altered:

- [ ] Modified SQL query for the daily IPT report to include move cancellation reasons
- [ ] Fixed dates in weekly reports

### Why?

I am doing this because:

- Users want to be able to see reasons for moves being cancelled.