### PR TITLE
feat: Send notify_move notification to cross-deck supplier

### DIFF
--- a/app/jobs/prepare_lodging_notifications_job.rb
+++ b/app/jobs/prepare_lodging_notifications_job.rb
@@ -11,7 +11,7 @@ private
     topic.move
   end
 
-  def event_type(action_name, topic, _)
+  def event_type(action_name, topic, _, _)
     "#{action_name}_#{topic.class.name&.underscore}"
   end
 end

--- a/app/models/generic_event/move_redirect.rb
+++ b/app/models/generic_event/move_redirect.rb
@@ -33,6 +33,10 @@ class GenericEvent
       if !was_cross_deck && eventable.cross_deck?
         Notifier.prepare_notifications(topic: eventable, action_name: 'notify')
       end
+
+      if was_cross_deck && !eventable.cross_deck?
+        Notifier.prepare_notifications(topic: eventable, action_name: 'disregard')
+      end
     end
   end
 end

--- a/app/models/generic_event/move_redirect.rb
+++ b/app/models/generic_event/move_redirect.rb
@@ -25,8 +25,14 @@ class GenericEvent
     delegate :generic_events, to: :eventable
 
     def trigger(*)
+      was_cross_deck = eventable.cross_deck?
+
       eventable.to_location = to_location
       eventable.move_type = move_type if move_type.present?
+
+      if !was_cross_deck && eventable.cross_deck?
+        Notifier.prepare_notifications(topic: eventable, action_name: 'notify')
+      end
     end
   end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -382,6 +382,10 @@ class Move < VersionedModel
     generic_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime' }.max_by(&:occurred_at)&.expected_at
   end
 
+  def cross_deck?
+    from_location&.suppliers != to_location&.suppliers
+  end
+
 private
 
   def date_to_after_date_from

--- a/spec/jobs/prepare_move_notifications_job_spec.rb
+++ b/spec/jobs/prepare_move_notifications_job_spec.rb
@@ -240,6 +240,23 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
     end
   end
 
+  context 'when explicitly notifying a cross-deck move' do
+    let(:action_name) { 'notify' }
+    let!(:initial_supplier) { create(:supplier) }
+    let!(:receiving_supplier) { create(:supplier) }
+    let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
+    let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
+    let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
+    let(:move) { create :move, from_location: location, to_location:, supplier: }
+
+    it 'sends the notify_move notification only to the receiving supplier' do
+      perform
+      expect(Notification.webhooks.order(:created_at).pluck(:subscription_id, :event_type)).to contain_exactly(
+        [subscription2.id, 'notify_move'],
+      )
+    end
+  end
+
   context 'when confirming a person escort record' do
     let(:action_name) { 'confirm_person_escort_record' }
 

--- a/spec/jobs/prepare_move_notifications_job_spec.rb
+++ b/spec/jobs/prepare_move_notifications_job_spec.rb
@@ -97,6 +97,87 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
       it_behaves_like 'it schedules NotifyEmailJob'
       it_behaves_like 'it does not schedule NotifyWebhookJob'
     end
+
+    context 'when it is a cross-deck move' do
+      let!(:initial_supplier) { create(:supplier) }
+      let!(:receiving_supplier) { create(:supplier) }
+      let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
+      let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
+      let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
+      let(:move) { create :move, from_location: location, to_location:, supplier: }
+
+      it 'sends the create_move and notify_move notifications to the respective suppliers' do
+        perform
+        expect(Notification.webhooks.order(:created_at).pluck(:subscription_id, :event_type)).to contain_exactly(
+          [subscription.id, 'create_move'],
+          [subscription2.id, 'notify_move'],
+        )
+      end
+    end
+  end
+
+  context 'when updating a move' do
+    let(:action_name) { 'update' }
+
+    context 'when a subscription has both a webhook and email addresses' do
+      it_behaves_like 'it creates a webhook notification record'
+      it_behaves_like 'it creates an email notification record'
+      it_behaves_like 'it schedules NotifyWebhookJob'
+      it_behaves_like 'it schedules NotifyEmailJob'
+    end
+
+    context 'when a subscription has no email addresses' do
+      let(:subscription) { create :subscription, :no_email_address }
+
+      it_behaves_like 'it creates a webhook notification record'
+      it_behaves_like 'it does not create an email notification record'
+      it_behaves_like 'it schedules NotifyWebhookJob'
+      it_behaves_like 'it does not schedule NotifyEmailJob'
+    end
+
+    context 'when a subscription has no webhook' do
+      let(:subscription) { create :subscription, :no_callback_url }
+
+      it_behaves_like 'it does not create a webhook notification record'
+      it_behaves_like 'it creates an email notification record'
+      it_behaves_like 'it schedules NotifyEmailJob'
+      it_behaves_like 'it does not schedule NotifyWebhookJob'
+    end
+
+    context 'when it is updated to become a cross-deck move' do
+      let!(:initial_supplier) { create(:supplier) }
+      let!(:receiving_supplier) { create(:supplier) }
+      let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
+      let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
+      let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
+      let(:move) { create :move, from_location: location, to_location:, supplier: }
+
+      it 'sends the update_move and notify_move notifications to the respective suppliers' do
+        perform
+        expect(Notification.webhooks.order(:created_at).pluck(:subscription_id, :event_type)).to contain_exactly(
+          [subscription.id, 'update_move'],
+          [subscription2.id, 'notify_move'],
+        )
+      end
+    end
+
+    context 'when it is a cross-deck move that has already been notified' do
+      let!(:initial_supplier) { create(:supplier) }
+      let!(:receiving_supplier) { create(:supplier) }
+      let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
+      let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
+      let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
+      let(:move) { create :move, from_location: location, to_location:, supplier: }
+      let!(:existing_notify_move) { create(:notification, event_type: 'notify_move', topic: move, subscription: subscription2) }
+
+      it 'sends the update_move notifications to both suppliers' do
+        perform
+        expect(Notification.webhooks.order(:created_at).last(2).pluck(:subscription_id, :event_type)).to contain_exactly(
+          [subscription.id, 'update_move'],
+          [subscription2.id, 'update_move'],
+        )
+      end
+    end
   end
 
   context 'when updating move status' do

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -129,9 +129,10 @@ RSpec.describe GenericEvent::MoveRedirect do
 
       let(:departing_supplier) { create(:supplier) }
       let(:receiving_supplier) { create(:supplier) }
+      let(:from_location) { create(:location, :court, suppliers: [departing_supplier]) }
       let(:old_to_location) { create(:location, :court, suppliers: [departing_supplier]) }
       let(:new_to_location) { create(:location, :court, suppliers: [receiving_supplier]) }
-      let(:eventable) { build(:move, move_type: 'prison_transfer') }
+      let(:eventable) { build(:move, move_type: 'court_appearance', from_location:, to_location: old_to_location) }
       let(:details) { { reason: 'other', to_location_id: new_to_location.id } }
 
       before { allow(Notifier).to receive(:prepare_notifications) }
@@ -139,6 +140,25 @@ RSpec.describe GenericEvent::MoveRedirect do
       it 'sends a notify_move notification to the receiving supplier' do
         generic_event.trigger
         expect(Notifier).to have_received(:prepare_notifications).with(topic: eventable, action_name: 'notify')
+      end
+    end
+
+    context 'when it ceases to be a cross-deck move' do
+      subject(:generic_event) { build(:event_move_redirect, details:, eventable:) }
+
+      let(:departing_supplier) { create(:supplier) }
+      let(:receiving_supplier) { create(:supplier) }
+      let(:from_location) { create(:location, :court, suppliers: [departing_supplier]) }
+      let(:old_to_location) { create(:location, :court, suppliers: [receiving_supplier]) }
+      let(:new_to_location) { create(:location, :court, suppliers: [departing_supplier]) }
+      let(:eventable) { build(:move, move_type: 'court_appearance', from_location:, to_location: old_to_location) }
+      let(:details) { { reason: 'other', to_location_id: new_to_location.id } }
+
+      before { allow(Notifier).to receive(:prepare_notifications) }
+
+      it 'sends a disregard_move notification to the receiving supplier' do
+        generic_event.trigger
+        expect(Notifier).to have_received(:prepare_notifications).with(topic: eventable, action_name: 'disregard')
       end
     end
   end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -1049,4 +1049,20 @@ RSpec.describe Move do
       expect(journey3.date).to eq(Time.zone.today + 7)
     end
   end
+
+  describe '#cross_deck?' do
+    let(:move) { create(:move) }
+
+    it { expect(move.cross_deck?).to be false }
+
+    context 'when the origin and destination suppliers are different' do
+      let!(:supplier1) { create(:supplier) }
+      let!(:supplier2) { create(:supplier) }
+      let!(:from_location) { create(:location, suppliers: [supplier1]) }
+      let!(:to_location) { create(:location, :court, suppliers: [supplier2]) }
+      let(:move) { create(:move, from_location:, to_location:) }
+
+      it { expect(move.cross_deck?).to be true }
+    end
+  end
 end

--- a/spec/requests/api/allocations_controller_update_spec.rb
+++ b/spec/requests/api/allocations_controller_update_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Api::AllocationsController do
       it 'creates notifications for each move' do
         perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
           expect { patch_allocations }
-            .to change { subscription.notifications.where(event_type: 'update_move').count }
+            .to change { subscription.notifications.count }
             .by(2)
         end
       end

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -730,6 +730,59 @@ RSpec.describe Api::MovesController do
         before { do_post }
       end
     end
+
+    context 'when it is a cross-deck move' do
+      before do
+        create(:notification_type, :webhook)
+        allow(Faraday).to receive(:new).and_return(faraday_client)
+      end
+
+      let!(:receiving_supplier) { create(:supplier) }
+      let!(:subscription) { create(:subscription, :no_email_address, supplier: another_supplier) }
+      let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
+      let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
+
+      let(:faraday_client) do
+        class_double(
+          Faraday,
+          headers: {},
+          post: instance_double(Faraday::Response, success?: true, status: 202),
+        )
+      end
+
+      let(:expected_notification_attributes) do
+        {
+          'topic_id' => move.id,
+          'topic_type' => 'Move',
+          'delivery_attempts' => 1,
+          'delivery_attempted_at' => be_within(5.seconds).of(Time.zone.now),
+          'delivered_at' => be_within(5.seconds).of(Time.zone.now),
+          'discarded_at' => nil,
+          'response_id' => nil,
+          'notification_type_id' => 'webhook',
+        }
+      end
+
+      it 'notifies the initial supplier' do
+        perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
+          do_post
+        end
+
+        expect(subscription.notifications.last.attributes).to include_json(
+          expected_notification_attributes.merge({ 'event_type' => 'create_move' }),
+        )
+      end
+
+      it 'notifies the receiving supplier' do
+        perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
+          do_post
+        end
+
+        expect(subscription2.notifications.last.attributes).to include_json(
+          expected_notification_attributes.merge({ 'event_type' => 'notify_move' }),
+        )
+      end
+    end
   end
 
   def do_post


### PR DESCRIPTION
### Jira link

[MAP-322]

### What?

I have added/removed/altered:

- Where the receiving location is operated by another supplier, we now send them a `notify_move` notification at the same time as we send the departing supplier a `create_move` notification
- Any subsequent `update_move` notifications will go to both suppliers
- A `MoveRedirect` which results in the move becoming cross-deck will also result in a `notify_move` notification being sent to the receiving supplier
- A `MoveRedirect` which results in the move ceasing to be cross-deck will result in a `disregard_move` notification being sent to any supplier that previously received a `notify_move` notification

### Why?

I am doing this because:

- So that the receiving supplier can add it to their systems to be ready for when they take over the move

[MAP-322]: https://dsdmoj.atlassian.net/browse/MAP-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ