### PR TITLE
Revert "feat: Send notify_move notification to cross-deck supplier (#2266)"

### DIFF
--- a/app/jobs/prepare_base_notifications_job.rb
+++ b/app/jobs/prepare_base_notifications_job.rb
@@ -7,13 +7,15 @@ class PrepareBaseNotificationsJob < ApplicationJob
     topic = find_topic(topic_id)
     move = associated_move(topic)
 
-    subscriptions(move, action_name:, only_supplier_id:).find_each do |subscription|
+    subscriptions(move, only_supplier_id:).find_each do |subscription|
       if send_webhooks && subscription.callback_url.present? && should_webhook?(subscription, move, action_name)
-        build_and_send_notifications(subscription, NotificationType::WEBHOOK, topic, action_name, queue_as)
+        notification = build_notification(subscription, NotificationType::WEBHOOK, topic, action_name)
+        NotifyWebhookJob.perform_later(notification_id: notification.id, queue_as:)
       end
 
       if send_emails && subscription.email_address.present? && should_email?(move)
-        build_and_send_notifications(subscription, NotificationType::EMAIL, topic, action_name, queue_as)
+        notification = build_notification(subscription, NotificationType::EMAIL, topic, action_name)
+        NotifyEmailJob.perform_later(notification_id: notification.id, queue_as:)
       end
     end
   end
@@ -28,36 +30,20 @@ private
     raise NotImplementedError
   end
 
-  def subscriptions(move, action_name:, only_supplier_id: nil)
-    # only cross-deck suppliers get `notify` or `disregard` notifications
-    case action_name
-    when 'notify'
-      return Subscription.kept.enabled.where(supplier: move.to_location&.suppliers || [])
-    when 'disregard'
-      notified_sub_ids = Notification.where(topic: move, event_type: 'notify_move').pluck(:subscription_id)
-      return Subscription.kept.enabled.where(id: notified_sub_ids)
-    end
-
-    suppliers = [move.supplier || move.suppliers].flatten
-
-    if move.cross_deck?
-      suppliers += move.to_location&.suppliers || []
-    end
-
-    suppliers = suppliers.uniq.filter do |supplier|
+  def subscriptions(move, only_supplier_id: nil)
+    suppliers = [move.supplier || move.suppliers].flatten.filter do |supplier|
       only_supplier_id.nil? || only_supplier_id == supplier.id
     end
 
     Subscription.kept.enabled.where(supplier: suppliers)
   end
 
-  def build_and_send_notifications(subscription, type_id, topic, action_name, queue_as)
-    notification = subscription.notifications.create!(
+  def build_notification(subscription, type_id, topic, action_name)
+    subscription.notifications.create!(
       notification_type_id: type_id,
       topic:,
-      event_type: event_type(action_name, topic, type_id, subscription),
+      event_type: event_type(action_name, topic, type_id),
     )
-    notify_job(type_id).perform_later(notification_id: notification.id, queue_as:)
   end
 
   def should_webhook?(subscription, move, action_name)
@@ -76,40 +62,17 @@ private
     move.current? && VALID_EMAIL_STATUSES.include?(move.status)
   end
 
-  def event_type(action_name, topic, type_id, subscription)
+  def event_type(action_name, topic, type_id)
     action = {
       'create' => 'create_move',
       'update' => 'update_move',
       'update_status' => 'update_move_status',
       'destroy' => 'destroy_move',
-      'notify' => 'notify_move',
-      'disregard' => 'disregard_move',
     }.fetch(action_name, action_name)
 
-    # make sure we send a create_move notification if we haven't sent one yet
-    if action == 'update_move_status'
-      create_notification = topic.notifications.find_by(event_type: 'create_move', notification_type_id: type_id)
-      action = 'create_move' if create_notification.nil? && !topic.cancelled?
-    end
+    return action unless action == 'update_move_status'
 
-    # send create notification as `notify_move` if we are notifying a cross-deck supplier
-    if action == 'create_move' && !topic.from_location.suppliers.include?(subscription.supplier)
-      action = 'notify_move'
-    end
-
-    # make sure we send a notify_move notification if we haven't sent one yet for a cross-deck supplier
-    if action == 'update_move' && !topic.from_location.suppliers.include?(subscription.supplier)
-      notify_notification = topic.notifications.find_by(event_type: 'notify_move', notification_type_id: type_id)
-      action = 'notify_move' if notify_notification.nil? && !topic.cancelled?
-    end
-
-    action
-  end
-
-  def notify_job(type_id)
-    {
-      NotificationType::WEBHOOK => NotifyWebhookJob,
-      NotificationType::EMAIL => NotifyEmailJob,
-    }[type_id]
+    create_notification = topic.notifications.find_by(event_type: 'create_move', notification_type_id: type_id)
+    create_notification.nil? && !topic.cancelled? ? 'create_move' : 'update_move_status'
   end
 end

--- a/app/jobs/prepare_lodging_notifications_job.rb
+++ b/app/jobs/prepare_lodging_notifications_job.rb
@@ -11,7 +11,7 @@ private
     topic.move
   end
 
-  def event_type(action_name, topic, _, _)
+  def event_type(action_name, topic, _)
     "#{action_name}_#{topic.class.name&.underscore}"
   end
 end

--- a/app/models/generic_event/move_redirect.rb
+++ b/app/models/generic_event/move_redirect.rb
@@ -25,18 +25,8 @@ class GenericEvent
     delegate :generic_events, to: :eventable
 
     def trigger(*)
-      was_cross_deck = eventable.cross_deck?
-
       eventable.to_location = to_location
       eventable.move_type = move_type if move_type.present?
-
-      if !was_cross_deck && eventable.cross_deck?
-        Notifier.prepare_notifications(topic: eventable, action_name: 'notify')
-      end
-
-      if was_cross_deck && !eventable.cross_deck?
-        Notifier.prepare_notifications(topic: eventable, action_name: 'disregard')
-      end
     end
   end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -382,10 +382,6 @@ class Move < VersionedModel
     generic_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime' }.max_by(&:occurred_at)&.expected_at
   end
 
-  def cross_deck?
-    from_location&.suppliers != to_location&.suppliers
-  end
-
 private
 
   def date_to_after_date_from

--- a/spec/jobs/prepare_move_notifications_job_spec.rb
+++ b/spec/jobs/prepare_move_notifications_job_spec.rb
@@ -97,87 +97,6 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
       it_behaves_like 'it schedules NotifyEmailJob'
       it_behaves_like 'it does not schedule NotifyWebhookJob'
     end
-
-    context 'when it is a cross-deck move' do
-      let!(:initial_supplier) { create(:supplier) }
-      let!(:receiving_supplier) { create(:supplier) }
-      let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
-      let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
-      let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
-      let(:move) { create :move, from_location: location, to_location:, supplier: }
-
-      it 'sends the create_move and notify_move notifications to the respective suppliers' do
-        perform
-        expect(Notification.webhooks.order(:created_at).pluck(:subscription_id, :event_type)).to contain_exactly(
-          [subscription.id, 'create_move'],
-          [subscription2.id, 'notify_move'],
-        )
-      end
-    end
-  end
-
-  context 'when updating a move' do
-    let(:action_name) { 'update' }
-
-    context 'when a subscription has both a webhook and email addresses' do
-      it_behaves_like 'it creates a webhook notification record'
-      it_behaves_like 'it creates an email notification record'
-      it_behaves_like 'it schedules NotifyWebhookJob'
-      it_behaves_like 'it schedules NotifyEmailJob'
-    end
-
-    context 'when a subscription has no email addresses' do
-      let(:subscription) { create :subscription, :no_email_address }
-
-      it_behaves_like 'it creates a webhook notification record'
-      it_behaves_like 'it does not create an email notification record'
-      it_behaves_like 'it schedules NotifyWebhookJob'
-      it_behaves_like 'it does not schedule NotifyEmailJob'
-    end
-
-    context 'when a subscription has no webhook' do
-      let(:subscription) { create :subscription, :no_callback_url }
-
-      it_behaves_like 'it does not create a webhook notification record'
-      it_behaves_like 'it creates an email notification record'
-      it_behaves_like 'it schedules NotifyEmailJob'
-      it_behaves_like 'it does not schedule NotifyWebhookJob'
-    end
-
-    context 'when it is updated to become a cross-deck move' do
-      let!(:initial_supplier) { create(:supplier) }
-      let!(:receiving_supplier) { create(:supplier) }
-      let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
-      let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
-      let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
-      let(:move) { create :move, from_location: location, to_location:, supplier: }
-
-      it 'sends the update_move and notify_move notifications to the respective suppliers' do
-        perform
-        expect(Notification.webhooks.order(:created_at).pluck(:subscription_id, :event_type)).to contain_exactly(
-          [subscription.id, 'update_move'],
-          [subscription2.id, 'notify_move'],
-        )
-      end
-    end
-
-    context 'when it is a cross-deck move that has already been notified' do
-      let!(:initial_supplier) { create(:supplier) }
-      let!(:receiving_supplier) { create(:supplier) }
-      let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
-      let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
-      let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
-      let(:move) { create :move, from_location: location, to_location:, supplier: }
-      let!(:existing_notify_move) { create(:notification, event_type: 'notify_move', topic: move, subscription: subscription2) }
-
-      it 'sends the update_move notifications to both suppliers' do
-        perform
-        expect(Notification.webhooks.order(:created_at).last(2).pluck(:subscription_id, :event_type)).to contain_exactly(
-          [subscription.id, 'update_move'],
-          [subscription2.id, 'update_move'],
-        )
-      end
-    end
   end
 
   context 'when updating move status' do
@@ -237,40 +156,6 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
         perform
         expect(Notification.webhooks.order(:created_at).last.event_type).to eq('update_move_status')
       end
-    end
-  end
-
-  context 'when explicitly notifying a cross-deck move' do
-    let(:action_name) { 'notify' }
-    let!(:initial_supplier) { create(:supplier) }
-    let!(:receiving_supplier) { create(:supplier) }
-    let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
-    let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
-    let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
-    let(:move) { create :move, from_location: location, to_location:, supplier: }
-
-    it 'sends the notify_move notification only to the receiving supplier' do
-      perform
-      expect(Notification.webhooks.order(:created_at).pluck(:subscription_id, :event_type)).to contain_exactly(
-        [subscription2.id, 'notify_move'],
-      )
-    end
-  end
-
-  context 'when explicitly notifying that a move is no longer cross-deck' do
-    let(:action_name) { 'disregard' }
-    let!(:initial_supplier) { create(:supplier) }
-    let!(:receiving_supplier) { create(:supplier) }
-    let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
-    let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
-    let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
-    let(:move) { create :move, from_location: location, to_location:, supplier: }
-    let!(:notification) { create(:notification, :webhook, event_type: 'notify_move', subscription: subscription2, topic: move) }
-
-    it 'sends the disregard_move notification only to the supplier who received the notify_move' do
-      perform
-      expect(Notification.webhooks.where.not(event_type: 'notify_move').pluck(:subscription_id, :event_type))
-        .to contain_exactly([subscription2.id, 'disregard_move'])
     end
   end
 

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -123,43 +123,5 @@ RSpec.describe GenericEvent::MoveRedirect do
         expect { generic_event.trigger }.to change { generic_event.eventable.move_type }.from('prison_transfer').to('court_appearance')
       end
     end
-
-    context 'when it becomes a cross-deck move' do
-      subject(:generic_event) { build(:event_move_redirect, details:, eventable:) }
-
-      let(:departing_supplier) { create(:supplier) }
-      let(:receiving_supplier) { create(:supplier) }
-      let(:from_location) { create(:location, :court, suppliers: [departing_supplier]) }
-      let(:old_to_location) { create(:location, :court, suppliers: [departing_supplier]) }
-      let(:new_to_location) { create(:location, :court, suppliers: [receiving_supplier]) }
-      let(:eventable) { build(:move, move_type: 'court_appearance', from_location:, to_location: old_to_location) }
-      let(:details) { { reason: 'other', to_location_id: new_to_location.id } }
-
-      before { allow(Notifier).to receive(:prepare_notifications) }
-
-      it 'sends a notify_move notification to the receiving supplier' do
-        generic_event.trigger
-        expect(Notifier).to have_received(:prepare_notifications).with(topic: eventable, action_name: 'notify')
-      end
-    end
-
-    context 'when it ceases to be a cross-deck move' do
-      subject(:generic_event) { build(:event_move_redirect, details:, eventable:) }
-
-      let(:departing_supplier) { create(:supplier) }
-      let(:receiving_supplier) { create(:supplier) }
-      let(:from_location) { create(:location, :court, suppliers: [departing_supplier]) }
-      let(:old_to_location) { create(:location, :court, suppliers: [receiving_supplier]) }
-      let(:new_to_location) { create(:location, :court, suppliers: [departing_supplier]) }
-      let(:eventable) { build(:move, move_type: 'court_appearance', from_location:, to_location: old_to_location) }
-      let(:details) { { reason: 'other', to_location_id: new_to_location.id } }
-
-      before { allow(Notifier).to receive(:prepare_notifications) }
-
-      it 'sends a disregard_move notification to the receiving supplier' do
-        generic_event.trigger
-        expect(Notifier).to have_received(:prepare_notifications).with(topic: eventable, action_name: 'disregard')
-      end
-    end
   end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -1049,20 +1049,4 @@ RSpec.describe Move do
       expect(journey3.date).to eq(Time.zone.today + 7)
     end
   end
-
-  describe '#cross_deck?' do
-    let(:move) { create(:move) }
-
-    it { expect(move.cross_deck?).to be false }
-
-    context 'when the origin and destination suppliers are different' do
-      let!(:supplier1) { create(:supplier) }
-      let!(:supplier2) { create(:supplier) }
-      let!(:from_location) { create(:location, suppliers: [supplier1]) }
-      let!(:to_location) { create(:location, :court, suppliers: [supplier2]) }
-      let(:move) { create(:move, from_location:, to_location:) }
-
-      it { expect(move.cross_deck?).to be true }
-    end
-  end
 end

--- a/spec/requests/api/allocations_controller_update_spec.rb
+++ b/spec/requests/api/allocations_controller_update_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Api::AllocationsController do
       it 'creates notifications for each move' do
         perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
           expect { patch_allocations }
-            .to change { subscription.notifications.count }
+            .to change { subscription.notifications.where(event_type: 'update_move').count }
             .by(2)
         end
       end

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -730,59 +730,6 @@ RSpec.describe Api::MovesController do
         before { do_post }
       end
     end
-
-    context 'when it is a cross-deck move' do
-      before do
-        create(:notification_type, :webhook)
-        allow(Faraday).to receive(:new).and_return(faraday_client)
-      end
-
-      let!(:receiving_supplier) { create(:supplier) }
-      let!(:subscription) { create(:subscription, :no_email_address, supplier: another_supplier) }
-      let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
-      let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
-
-      let(:faraday_client) do
-        class_double(
-          Faraday,
-          headers: {},
-          post: instance_double(Faraday::Response, success?: true, status: 202),
-        )
-      end
-
-      let(:expected_notification_attributes) do
-        {
-          'topic_id' => move.id,
-          'topic_type' => 'Move',
-          'delivery_attempts' => 1,
-          'delivery_attempted_at' => be_within(5.seconds).of(Time.zone.now),
-          'delivered_at' => be_within(5.seconds).of(Time.zone.now),
-          'discarded_at' => nil,
-          'response_id' => nil,
-          'notification_type_id' => 'webhook',
-        }
-      end
-
-      it 'notifies the initial supplier' do
-        perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
-          do_post
-        end
-
-        expect(subscription.notifications.last.attributes).to include_json(
-          expected_notification_attributes.merge({ 'event_type' => 'create_move' }),
-        )
-      end
-
-      it 'notifies the receiving supplier' do
-        perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
-          do_post
-        end
-
-        expect(subscription2.notifications.last.attributes).to include_json(
-          expected_notification_attributes.merge({ 'event_type' => 'notify_move' }),
-        )
-      end
-    end
   end
 
   def do_post


### PR DESCRIPTION
This reverts commit a08000838b2cd10aa3d99acde3d4a290ee5fe898.

GeoAmey have concerns about our implementation so we will roll back for now. Also the `disregard_move` notification doesn't seem to be firing.

[MAP-322]


[MAP-322]: https://dsdmoj.atlassian.net/browse/MAP-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ