### PR TITLE
[MAP-972] Add vehicle_depot to Journey and JourneyStart & JourneyChangeVehicle events

### DIFF
--- a/app/controllers/api/journey_events_controller.rb
+++ b/app/controllers/api/journey_events_controller.rb
@@ -9,7 +9,8 @@ module Api
     around_action :idempotent_action
 
     COMMON_PARAMS = [:type, { attributes: %i[timestamp notes] }].freeze
-    START_COMPLETE_PARAMS = [:type, { attributes: %i[timestamp notes vehicle_reg] }].freeze
+    START_PARAMS = [:type, { attributes: %i[timestamp notes vehicle_reg vehicle_depot] }].freeze
+    COMPLETE_PARAMS = [:type, { attributes: %i[timestamp notes vehicle_reg] }].freeze
     LOCKOUT_PARAMS = [:type, { attributes: %i[timestamp notes], relationships: { from_location: {} } }].freeze
     LODGING_PARAMS = [:type, { attributes: %i[timestamp notes], relationships: { to_location: {} } }].freeze
 
@@ -20,8 +21,8 @@ module Api
     end
 
     def complete
-      JourneyEvents::ParamsValidator.new(start_complete_params).validate!
-      process_event(journey, GenericEvent::JourneyComplete, start_complete_params)
+      JourneyEvents::ParamsValidator.new(complete_params).validate!
+      process_event(journey, GenericEvent::JourneyComplete, complete_params)
       render status: :no_content
     end
 
@@ -44,8 +45,8 @@ module Api
     end
 
     def start
-      JourneyEvents::ParamsValidator.new(start_complete_params).validate!
-      process_event(journey, GenericEvent::JourneyStart, start_complete_params)
+      JourneyEvents::ParamsValidator.new(start_params).validate!
+      process_event(journey, GenericEvent::JourneyStart, start_params)
       render status: :no_content
     end
 
@@ -75,8 +76,12 @@ module Api
       @common_params ||= params.require(:data).permit(COMMON_PARAMS).to_h
     end
 
-    def start_complete_params
-      @start_complete_params ||= params.require(:data).permit(START_COMPLETE_PARAMS).to_h
+    def start_params
+      @start_params ||= params.require(:data).permit(START_PARAMS).to_h
+    end
+
+    def complete_params
+      @complete_params ||= params.require(:data).permit(COMPLETE_PARAMS).to_h
     end
 
     def journey

--- a/app/models/generic_event/journey_change_vehicle.rb
+++ b/app/models/generic_event/journey_change_vehicle.rb
@@ -1,6 +1,6 @@
 class GenericEvent
   class JourneyChangeVehicle < GenericEvent
-    details_attributes :vehicle_reg, :previous_vehicle_reg
+    details_attributes :vehicle_reg, :previous_vehicle_reg, :vehicle_depot
     eventable_types 'Journey'
 
     include VehicleRegValidations
@@ -9,6 +9,10 @@ class GenericEvent
 
     def trigger(*)
       eventable.vehicle_registration = vehicle_reg
+
+      if vehicle_depot.present?
+        eventable.vehicle_depot = vehicle_depot
+      end
     end
   end
 end

--- a/app/models/generic_event/journey_start.rb
+++ b/app/models/generic_event/journey_start.rb
@@ -1,6 +1,6 @@
 class GenericEvent
   class JourneyStart < GenericEvent
-    details_attributes :vehicle_reg
+    details_attributes :vehicle_reg, :vehicle_depot
     eventable_types 'Journey'
     validate_occurs_before 'GenericEvent::JourneyComplete'
     validate_occurs_after 'GenericEvent::MoveStart'
@@ -10,6 +10,10 @@ class GenericEvent
         eventable.vehicle_registration = vehicle_reg
       else
         Sentry.capture_message("#{self.class} created without vehicle_reg", level: 'warning', extra: { supplier: supplier&.key })
+      end
+
+      if vehicle_depot.present?
+        eventable.vehicle_depot = vehicle_depot
       end
 
       eventable.start

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -90,6 +90,14 @@ class Journey < VersionedModel
     (self.vehicle ||= {})['registration'] = reg
   end
 
+  def vehicle_depot
+    vehicle['depot'] if vehicle
+  end
+
+  def vehicle_depot=(reg)
+    (self.vehicle ||= {})['depot'] = reg
+  end
+
   def handle_event_run(dry_run: false)
     save! if changed? && valid? && !dry_run
   end

--- a/spec/models/generic_event/journey_change_vehicle_spec.rb
+++ b/spec/models/generic_event/journey_change_vehicle_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe GenericEvent::JourneyChangeVehicle do
   subject(:generic_event) { build(:event_journey_change_vehicle) }
 
-  it_behaves_like 'an event with details', :vehicle_reg, :previous_vehicle_reg
+  it_behaves_like 'an event with details', :vehicle_reg, :previous_vehicle_reg, :vehicle_depot
   it_behaves_like 'an event with eventable types', 'Journey'
   it_behaves_like 'an event that specifies a vehicle registration'
 
@@ -19,6 +19,29 @@ RSpec.describe GenericEvent::JourneyChangeVehicle do
       expect { generic_event.trigger }.to change { generic_event.eventable.vehicle_registration }
         .from(generic_event.eventable.vehicle_registration)
         .to(generic_event.vehicle_reg)
+    end
+
+    context 'when supplied a vehicle_depot' do
+      before do
+        generic_event.vehicle_depot = 'a vehicle depot'
+      end
+
+      it 'sets the vehicle_depot on the journey' do
+        generic_event.trigger
+        expect(generic_event.eventable.vehicle_depot).to eq(generic_event.vehicle_depot)
+      end
+    end
+
+    context 'when not supplied a vehicle_depot' do
+      before do
+        generic_event.eventable.vehicle_depot = 'Home Depot'
+        generic_event.vehicle_depot = nil
+      end
+
+      it 'does not set the vehicle_depot on the journey' do
+        generic_event.trigger
+        expect(generic_event.eventable.vehicle_depot).to eq('Home Depot')
+      end
     end
   end
 end

--- a/spec/models/generic_event/journey_start_spec.rb
+++ b/spec/models/generic_event/journey_start_spec.rb
@@ -28,6 +28,29 @@ RSpec.describe GenericEvent::JourneyStart do
     end
   end
 
+  context 'when supplied a vehicle_depot' do
+    before do
+      generic_event.vehicle_depot = 'a vehicle depot'
+    end
+
+    it 'sets the vehicle_depot on the journey' do
+      generic_event.trigger
+      expect(generic_event.eventable.vehicle_depot).to eq(generic_event.vehicle_depot)
+    end
+  end
+
+  context 'when not supplied a vehicle_depot' do
+    before do
+      generic_event.eventable.vehicle_depot = 'Home Depot'
+      generic_event.vehicle_depot = nil
+    end
+
+    it 'does not set the vehicle_depot on the journey' do
+      generic_event.trigger
+      expect(generic_event.eventable.vehicle_depot).to eq('Home Depot')
+    end
+  end
+
   it_behaves_like 'an event that must not occur after', 'GenericEvent::JourneyComplete'
   it_behaves_like 'an event that must not occur before', 'GenericEvent::MoveStart'
 end

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -238,6 +238,32 @@ RSpec.describe Journey, type: :model do
     end
   end
 
+  describe '#vehicle_depot=' do
+    subject(:journey) { build(:journey) }
+
+    let(:new_depot) { 'Depot 2' }
+
+    context 'when vehicle was already present' do
+      before do
+        journey.vehicle = { id: '12345678ABC', registration: 'AB12 CDE', depot: 'Depot 1' }
+      end
+
+      it 'assigns the new vehicle depot value' do
+        expect { journey.vehicle_depot = new_depot }.to change(journey, :vehicle_depot).from('Depot 1').to('Depot 2')
+      end
+    end
+
+    context 'when vehicle was not already present' do
+      before do
+        journey.vehicle = nil
+      end
+
+      it 'assigns the new depot' do
+        expect { journey.vehicle_depot = new_depot }.to change(journey, :vehicle_depot).from(nil).to('Depot 2')
+      end
+    end
+  end
+
   describe '#number' do
     let(:move) { create(:move) }
     let(:journey_1) { create(:journey, move:, client_timestamp: Date.new(2020, 1, 1)) }

--- a/spec/requests/api/journey_events_controller_start_spec.rb
+++ b/spec/requests/api/journey_events_controller_start_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe Api::JourneyEventsController do
             attributes: {
               timestamp: '2020-04-23T18:25:43.511Z',
               notes: 'something noteworthy',
+              vehicle_reg: 'B0RT',
+              vehicle_depot: 'Shelbyville',
             },
           },
         }
@@ -47,6 +49,18 @@ RSpec.describe Api::JourneyEventsController do
         do_post
         event = GenericEvent.last
         expect(event.created_by).to eq('TEST_USER')
+      end
+
+      it 'sets the correct vehicle_reg' do
+        do_post
+        event = GenericEvent.last
+        expect(event.vehicle_reg).to eq('B0RT')
+      end
+
+      it 'sets the correct vehicle_depot' do
+        do_post
+        event = GenericEvent.last
+        expect(event.vehicle_depot).to eq('Shelbyville')
       end
     end
 

--- a/swagger/v1/post_journey_start.yaml
+++ b/swagger/v1/post_journey_start.yaml
@@ -21,3 +21,7 @@ PostJourneyStart:
           $ref: notes_attribute.yaml#/Notes
         vehicle_reg:
           $ref: vehicle_reg_attribute.yaml#/Notes
+        vehicle_depot:
+          type: string
+          example: Leeds
+          description: The depot where the vehicle is based


### PR DESCRIPTION
### Jira link

[MAP-972]

### What?

I have added/removed/altered:

- Add vehicle_depot to Journey and JourneyStart & JourneyChangeVehicle events

### Why?

I am doing this because:

- We would like suppliers to send us info on the vehicle depot so that we can use this in reports

### Have you? (optional)

- [x] Updated API docs if necessary	

### Deployment risks (optional)

- Changes an api that is used in production



[MAP-972]: https://dsdmoj.atlassian.net/browse/MAP-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ