### PR TITLE
[MAP-322] Send cross_supplier_move_* notification to cross-deck supplier

### DIFF
--- a/app/jobs/prepare_base_notifications_job.rb
+++ b/app/jobs/prepare_base_notifications_job.rb
@@ -7,15 +7,13 @@ class PrepareBaseNotificationsJob < ApplicationJob
     topic = find_topic(topic_id)
     move = associated_move(topic)
 
-    subscriptions(move, only_supplier_id:).find_each do |subscription|
+    subscriptions(move, action_name:, only_supplier_id:).find_each do |subscription|
       if send_webhooks && subscription.callback_url.present? && should_webhook?(subscription, move, action_name)
-        notification = build_notification(subscription, NotificationType::WEBHOOK, topic, action_name)
-        NotifyWebhookJob.perform_later(notification_id: notification.id, queue_as:)
+        build_and_send_notifications(subscription, NotificationType::WEBHOOK, topic, action_name, queue_as)
       end
 
       if send_emails && subscription.email_address.present? && should_email?(move)
-        notification = build_notification(subscription, NotificationType::EMAIL, topic, action_name)
-        NotifyEmailJob.perform_later(notification_id: notification.id, queue_as:)
+        build_and_send_notifications(subscription, NotificationType::EMAIL, topic, action_name, queue_as)
       end
     end
   end
@@ -30,20 +28,36 @@ private
     raise NotImplementedError
   end
 
-  def subscriptions(move, only_supplier_id: nil)
-    suppliers = [move.supplier || move.suppliers].flatten.filter do |supplier|
+  def subscriptions(move, action_name:, only_supplier_id: nil)
+    # only cross-deck suppliers get `cross_supplier_add` or `cross_supplier_remove` notifications
+    case action_name
+    when 'cross_supplier_add'
+      return Subscription.kept.enabled.where(supplier: move.to_location&.suppliers || [])
+    when 'cross_supplier_remove'
+      notified_sub_ids = Notification.where(topic: move, event_type: 'cross_supplier_move_add').pluck(:subscription_id)
+      return Subscription.kept.enabled.where(id: notified_sub_ids)
+    end
+
+    suppliers = [move.supplier || move.suppliers].flatten
+
+    if move.cross_deck?
+      suppliers += move.to_location&.suppliers || []
+    end
+
+    suppliers = suppliers.uniq.filter do |supplier|
       only_supplier_id.nil? || only_supplier_id == supplier.id
     end
 
     Subscription.kept.enabled.where(supplier: suppliers)
   end
 
-  def build_notification(subscription, type_id, topic, action_name)
-    subscription.notifications.create!(
+  def build_and_send_notifications(subscription, type_id, topic, action_name, queue_as)
+    notification = subscription.notifications.create!(
       notification_type_id: type_id,
       topic:,
-      event_type: event_type(action_name, topic, type_id),
+      event_type: event_type(action_name, topic, type_id, subscription),
     )
+    notify_job(type_id).perform_later(notification_id: notification.id, queue_as:)
   end
 
   def should_webhook?(subscription, move, action_name)
@@ -62,17 +76,45 @@ private
     move.current? && VALID_EMAIL_STATUSES.include?(move.status)
   end
 
-  def event_type(action_name, topic, type_id)
+  CROSS_SUPPLIER_EQUIVALENT = {
+    'update_move' => 'cross_supplier_move_update',
+    'update_move_status' => 'cross_supplier_move_update_status',
+  }.freeze
+
+  def event_type(action_name, topic, type_id, subscription)
     action = {
       'create' => 'create_move',
       'update' => 'update_move',
       'update_status' => 'update_move_status',
       'destroy' => 'destroy_move',
+      'cross_supplier_add' => 'cross_supplier_move_add',
+      'cross_supplier_remove' => 'cross_supplier_move_remove',
     }.fetch(action_name, action_name)
 
-    return action unless action == 'update_move_status'
+    # make sure we send a create_move notification if we haven't sent one yet
+    if action == 'update_move_status'
+      create_notification = topic.notifications.find_by(event_type: 'create_move', notification_type_id: type_id)
+      action = 'create_move' if create_notification.nil? && !topic.cancelled?
+    end
 
-    create_notification = topic.notifications.find_by(event_type: 'create_move', notification_type_id: type_id)
-    create_notification.nil? && !topic.cancelled? ? 'create_move' : 'update_move_status'
+    # send create notification as `cross_supplier_move_add` if we are notifying a cross-deck supplier
+    if action == 'create_move' && !topic.from_location.suppliers.include?(subscription.supplier)
+      action = 'cross_supplier_move_add'
+    end
+
+    # make sure we send a cross_supplier_move_add notification if we haven't sent one yet for a cross-deck supplier
+    if %w[update_move update_move_status].include?(action) && !topic.from_location.suppliers.include?(subscription.supplier)
+      add_notification = topic.notifications.find_by(event_type: 'cross_supplier_move_add', notification_type_id: type_id)
+      action = add_notification.nil? ? 'cross_supplier_move_add' : CROSS_SUPPLIER_EQUIVALENT[action]
+    end
+
+    action
+  end
+
+  def notify_job(type_id)
+    {
+      NotificationType::WEBHOOK => NotifyWebhookJob,
+      NotificationType::EMAIL => NotifyEmailJob,
+    }[type_id]
   end
 end

--- a/app/jobs/prepare_lodging_notifications_job.rb
+++ b/app/jobs/prepare_lodging_notifications_job.rb
@@ -11,7 +11,7 @@ private
     topic.move
   end
 
-  def event_type(action_name, topic, _)
+  def event_type(action_name, topic, _, _)
     "#{action_name}_#{topic.class.name&.underscore}"
   end
 end

--- a/app/models/generic_event/move_redirect.rb
+++ b/app/models/generic_event/move_redirect.rb
@@ -25,8 +25,18 @@ class GenericEvent
     delegate :generic_events, to: :eventable
 
     def trigger(*)
+      was_cross_deck = eventable.cross_deck?
+
       eventable.to_location = to_location
       eventable.move_type = move_type if move_type.present?
+
+      if !was_cross_deck && eventable.cross_deck?
+        Notifier.prepare_notifications(topic: eventable, action_name: 'cross_supplier_add')
+      end
+
+      if was_cross_deck && !eventable.cross_deck?
+        Notifier.prepare_notifications(topic: eventable, action_name: 'cross_supplier_remove')
+      end
     end
   end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -382,6 +382,10 @@ class Move < VersionedModel
     generic_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime' }.max_by(&:occurred_at)&.expected_at
   end
 
+  def cross_deck?
+    from_location&.suppliers != to_location&.suppliers
+  end
+
 private
 
   def date_to_after_date_from

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -123,5 +123,43 @@ RSpec.describe GenericEvent::MoveRedirect do
         expect { generic_event.trigger }.to change { generic_event.eventable.move_type }.from('prison_transfer').to('court_appearance')
       end
     end
+
+    context 'when it becomes a cross-deck move' do
+      subject(:generic_event) { build(:event_move_redirect, details:, eventable:) }
+
+      let(:departing_supplier) { create(:supplier) }
+      let(:receiving_supplier) { create(:supplier) }
+      let(:from_location) { create(:location, :court, suppliers: [departing_supplier]) }
+      let(:old_to_location) { create(:location, :court, suppliers: [departing_supplier]) }
+      let(:new_to_location) { create(:location, :court, suppliers: [receiving_supplier]) }
+      let(:eventable) { build(:move, move_type: 'court_appearance', from_location:, to_location: old_to_location) }
+      let(:details) { { reason: 'other', to_location_id: new_to_location.id } }
+
+      before { allow(Notifier).to receive(:prepare_notifications) }
+
+      it 'sends a cross_supplier_move_add notification to the receiving supplier' do
+        generic_event.trigger
+        expect(Notifier).to have_received(:prepare_notifications).with(topic: eventable, action_name: 'cross_supplier_add')
+      end
+    end
+
+    context 'when it ceases to be a cross-deck move' do
+      subject(:generic_event) { build(:event_move_redirect, details:, eventable:) }
+
+      let(:departing_supplier) { create(:supplier) }
+      let(:receiving_supplier) { create(:supplier) }
+      let(:from_location) { create(:location, :court, suppliers: [departing_supplier]) }
+      let(:old_to_location) { create(:location, :court, suppliers: [receiving_supplier]) }
+      let(:new_to_location) { create(:location, :court, suppliers: [departing_supplier]) }
+      let(:eventable) { build(:move, move_type: 'court_appearance', from_location:, to_location: old_to_location) }
+      let(:details) { { reason: 'other', to_location_id: new_to_location.id } }
+
+      before { allow(Notifier).to receive(:prepare_notifications) }
+
+      it 'sends a cross_supplier_move_remove notification to the receiving supplier' do
+        generic_event.trigger
+        expect(Notifier).to have_received(:prepare_notifications).with(topic: eventable, action_name: 'cross_supplier_remove')
+      end
+    end
   end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -1049,4 +1049,20 @@ RSpec.describe Move do
       expect(journey3.date).to eq(Time.zone.today + 7)
     end
   end
+
+  describe '#cross_deck?' do
+    let(:move) { create(:move) }
+
+    it { expect(move.cross_deck?).to be false }
+
+    context 'when the origin and destination suppliers are different' do
+      let!(:supplier1) { create(:supplier) }
+      let!(:supplier2) { create(:supplier) }
+      let!(:from_location) { create(:location, suppliers: [supplier1]) }
+      let!(:to_location) { create(:location, :court, suppliers: [supplier2]) }
+      let(:move) { create(:move, from_location:, to_location:) }
+
+      it { expect(move.cross_deck?).to be true }
+    end
+  end
 end

--- a/spec/requests/api/allocations_controller_update_spec.rb
+++ b/spec/requests/api/allocations_controller_update_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Api::AllocationsController do
       it 'creates notifications for each move' do
         perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
           expect { patch_allocations }
-            .to change { subscription.notifications.where(event_type: 'update_move').count }
+            .to change { subscription.notifications.count }
             .by(2)
         end
       end

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -730,6 +730,59 @@ RSpec.describe Api::MovesController do
         before { do_post }
       end
     end
+
+    context 'when it is a cross-deck move' do
+      before do
+        create(:notification_type, :webhook)
+        allow(Faraday).to receive(:new).and_return(faraday_client)
+      end
+
+      let!(:receiving_supplier) { create(:supplier) }
+      let!(:subscription) { create(:subscription, :no_email_address, supplier: another_supplier) }
+      let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }
+      let(:to_location) { create :location, :court, suppliers: [receiving_supplier] }
+
+      let(:faraday_client) do
+        class_double(
+          Faraday,
+          headers: {},
+          post: instance_double(Faraday::Response, success?: true, status: 202),
+        )
+      end
+
+      let(:expected_notification_attributes) do
+        {
+          'topic_id' => move.id,
+          'topic_type' => 'Move',
+          'delivery_attempts' => 1,
+          'delivery_attempted_at' => be_within(5.seconds).of(Time.zone.now),
+          'delivered_at' => be_within(5.seconds).of(Time.zone.now),
+          'discarded_at' => nil,
+          'response_id' => nil,
+          'notification_type_id' => 'webhook',
+        }
+      end
+
+      it 'notifies the initial supplier' do
+        perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
+          do_post
+        end
+
+        expect(subscription.notifications.last.attributes).to include_json(
+          expected_notification_attributes.merge({ 'event_type' => 'create_move' }),
+        )
+      end
+
+      it 'notifies the receiving supplier' do
+        perform_enqueued_jobs(only: [PrepareMoveNotificationsJob, NotifyWebhookJob]) do
+          do_post
+        end
+
+        expect(subscription2.notifications.last.attributes).to include_json(
+          expected_notification_attributes.merge({ 'event_type' => 'cross_supplier_move_add' }),
+        )
+      end
+    end
   end
 
   def do_post


### PR DESCRIPTION
### Jira link

[MAP-322]

### What?

Where the receiving location is operated by another supplier, we now send them a `cross_supplier_move_add` notification at the same time as we send the initial supplier a `create_move` notification. This means that they can add it to their systems to be ready for when they take over.

When a MoveRedirect causes a move to no longer be cross-deck, we send a `cross_supplier_move_remove` notification to any supplier that previously received a `cross_supplier_move_add` notification, to let them know that they no longer need to be aware of this move.

While a move is cross-deck, update and update status notifications will be sent to the receiving supplier as `cross_supplier_move_update` and `cross_supplier_move_update_status` respectively.

### Why?

I am doing this because:

So that the receiving supplier can add it to their systems to be ready for when they take over the move




[MAP-322]: https://dsdmoj.atlassian.net/browse/MAP-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ