### PR TITLE
chore: Hide cross-deck notifications behind feature flag

### DIFF
--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -19,7 +19,7 @@ generic-service:
     SENTRY_ENVIRONMENT: "staging"
     SERVER_FQDN: "hmpps-book-secure-move-api-staging.apps.cloud-platform.service.justice.gov.uk"
     WEB_CONCURRENCY: "3"
-
+    FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: "geoamey,serco"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -18,7 +18,6 @@ generic-service:
     SENTRY_ENVIRONMENT: "uat"
     SERVER_FQDN: "hmpps-book-secure-move-api-uat.apps.cloud-platform.service.justice.gov.uk"
 
-
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
   #   [name of kubernetes secret]:

--- a/spec/requests/api/allocations_controller_update_spec.rb
+++ b/spec/requests/api/allocations_controller_update_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Api::AllocationsController do
     resource
   end
 
+  let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
+
+  around do |example|
+    ClimateControl.modify(**envs) do
+      example.run
+    end
+  end
+
   describe 'PATCH /allocations' do
     subject(:patch_allocations) do
       patch "/api/allocations/#{allocation.id}", params: { data: }, headers:, as: :json
@@ -25,7 +33,7 @@ RSpec.describe Api::AllocationsController do
     let(:headers) { { 'Authorization' => "Bearer #{access_token}", 'CONTENT_TYPE': content_type } }
     let(:existing_date) { Date.new(2023, 1, 1) }
     let(:new_date) { existing_date.tomorrow }
-    let(:supplier) { create(:supplier) }
+    let(:supplier) { create(:supplier, :serco) }
     let!(:allocation) { create(:allocation, date: existing_date, moves_count:) }
     let!(:moves) { create_list(:move, moves_count, allocation:, date: existing_date, person: create(:person), supplier:) }
 


### PR DESCRIPTION
### Jira link

[MAP-322]

### What?

I have added/removed/altered:

- Added FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS environment variable. It should be set to a comma-separated list, e.g. "geoamey,serco".

### Why?

I am doing this because:

- The suppliers aren't ready for this yet. We need to at least wait for them to ignore these notifications before we release it.

### Have you? (optional)

- [x] Added any new environment variables to the [Helm chart](https://github.com/ministryofjustice/hmpps-book-secure-move-api/tree/main/helm_deploy)



[MAP-322]: https://dsdmoj.atlassian.net/browse/MAP-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ