### PR TITLE
[MAP-322] Stop duplicating cross-deck notifications

### DIFF
--- a/app/controllers/api/generic_events_controller.rb
+++ b/app/controllers/api/generic_events_controller.rb
@@ -15,7 +15,7 @@ module Api
     def create
       GenericEvents::CommonParamsValidator.new(event_params, event_relationships).validate!
       event = event_type.constantize.create!(event_attributes)
-      was_cross_deck = cross_deck_move?(event.eventable)
+      was_cross_supplier = cross_supplier_move?(event.eventable)
 
       run_event_logs
 
@@ -23,11 +23,11 @@ module Api
         Notifier.prepare_notifications(topic: event, action_name: 'create_event')
       end
 
-      if !was_cross_deck && cross_deck_move?(event.eventable)
+      if !was_cross_supplier && cross_supplier_move?(event.eventable)
         Notifier.prepare_notifications(topic: event.eventable, action_name: 'cross_supplier_add')
       end
 
-      if was_cross_deck && !cross_deck_move?(event.eventable)
+      if was_cross_supplier && !cross_supplier_move?(event.eventable)
         Notifier.prepare_notifications(topic: event.eventable, action_name: 'cross_supplier_remove')
       end
 
@@ -40,8 +40,8 @@ module Api
 
   private
 
-    def cross_deck_move?(eventable)
-      eventable.reload.is_a?(Move) && eventable.cross_deck?
+    def cross_supplier_move?(eventable)
+      eventable.reload.is_a?(Move) && eventable.cross_supplier?
     end
 
     def render_event(event, status)

--- a/app/controllers/api/generic_events_controller.rb
+++ b/app/controllers/api/generic_events_controller.rb
@@ -15,10 +15,20 @@ module Api
     def create
       GenericEvents::CommonParamsValidator.new(event_params, event_relationships).validate!
       event = event_type.constantize.create!(event_attributes)
+      was_cross_deck = cross_deck_move?(event.eventable)
+
       run_event_logs
 
       unless doorkeeper_application_owner.is_a?(Supplier)
         Notifier.prepare_notifications(topic: event, action_name: 'create_event')
+      end
+
+      if !was_cross_deck && cross_deck_move?(event.eventable)
+        Notifier.prepare_notifications(topic: event.eventable, action_name: 'cross_supplier_add')
+      end
+
+      if was_cross_deck && !cross_deck_move?(event.eventable)
+        Notifier.prepare_notifications(topic: event.eventable, action_name: 'cross_supplier_remove')
       end
 
       render_event(event, :created)
@@ -29,6 +39,10 @@ module Api
     end
 
   private
+
+    def cross_deck_move?(eventable)
+      eventable.reload.is_a?(Move) && eventable.cross_deck?
+    end
 
     def render_event(event, status)
       render_json event, serializer: event.class.serializer, status:

--- a/app/controllers/api/move_events_controller.rb
+++ b/app/controllers/api/move_events_controller.rb
@@ -47,8 +47,19 @@ module Api
     end
 
     def redirects
+      was_cross_deck = move.cross_deck?
+
       MoveEvents::ParamsValidator.new(redirect_params).validate!
       process_event(move, GenericEvent::MoveRedirect, redirect_params)
+
+      if !was_cross_deck && move.cross_deck?
+        Notifier.prepare_notifications(topic: move, action_name: 'cross_supplier_add')
+      end
+
+      if was_cross_deck && !move.cross_deck?
+        Notifier.prepare_notifications(topic: move, action_name: 'cross_supplier_remove')
+      end
+
       render status: :no_content
     end
 

--- a/app/controllers/api/move_events_controller.rb
+++ b/app/controllers/api/move_events_controller.rb
@@ -47,16 +47,16 @@ module Api
     end
 
     def redirects
-      was_cross_deck = move.cross_deck?
+      was_cross_supplier = move.cross_supplier?
 
       MoveEvents::ParamsValidator.new(redirect_params).validate!
       process_event(move, GenericEvent::MoveRedirect, redirect_params)
 
-      if !was_cross_deck && move.cross_deck?
+      if !was_cross_supplier && move.cross_supplier?
         Notifier.prepare_notifications(topic: move, action_name: 'cross_supplier_add')
       end
 
-      if was_cross_deck && !move.cross_deck?
+      if was_cross_supplier && !move.cross_supplier?
         Notifier.prepare_notifications(topic: move, action_name: 'cross_supplier_remove')
       end
 

--- a/app/models/generic_event/move_redirect.rb
+++ b/app/models/generic_event/move_redirect.rb
@@ -25,18 +25,8 @@ class GenericEvent
     delegate :generic_events, to: :eventable
 
     def trigger(*)
-      was_cross_deck = eventable.cross_deck?
-
       eventable.to_location = to_location
       eventable.move_type = move_type if move_type.present?
-
-      if !was_cross_deck && eventable.cross_deck?
-        Notifier.prepare_notifications(topic: eventable, action_name: 'cross_supplier_add')
-      end
-
-      if was_cross_deck && !eventable.cross_deck?
-        Notifier.prepare_notifications(topic: eventable, action_name: 'cross_supplier_remove')
-      end
     end
   end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -382,7 +382,7 @@ class Move < VersionedModel
     generic_events.select { |event| event.type == 'GenericEvent::MoveNotifyPremisesOfExpectedCollectionTime' }.max_by(&:occurred_at)&.expected_at
   end
 
-  def cross_deck?
+  def cross_supplier?
     from_location&.suppliers != to_location&.suppliers
   end
 

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -19,7 +19,7 @@ generic-service:
     SENTRY_ENVIRONMENT: "staging"
     SERVER_FQDN: "hmpps-book-secure-move-api-staging.apps.cloud-platform.service.justice.gov.uk"
     WEB_CONCURRENCY: "3"
-    FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: "geoamey,serco"
+    FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: "geoamey,serco"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/spec/jobs/prepare_move_notifications_job_spec.rb
+++ b/spec/jobs/prepare_move_notifications_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
   let(:send_webhooks) { true }
   let(:send_emails) { true }
   let(:only_supplier_id) { nil }
-  let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
+  let(:envs) { { FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
 
   before do
     create(:notification_type, :webhook)
@@ -105,7 +105,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
       it_behaves_like 'it does not schedule NotifyWebhookJob'
     end
 
-    context 'when it is a cross-deck move' do
+    context 'when it is a cross-supplier move' do
       let!(:initial_supplier) { create(:supplier, :serco) }
       let!(:receiving_supplier) { create(:supplier, :geoamey) }
       let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
@@ -122,7 +122,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
       end
 
       context 'when the feature flag is not set' do
-        let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: '' } }
+        let(:envs) { { FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: '' } }
 
         it 'only sends the create_move notification to the initial supplier' do
           perform
@@ -162,7 +162,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
       it_behaves_like 'it does not schedule NotifyWebhookJob'
     end
 
-    context 'when it is updated to become a cross-deck move' do
+    context 'when it is updated to become a cross-supplier move' do
       let!(:initial_supplier) { create(:supplier, :serco) }
       let!(:receiving_supplier) { create(:supplier, :geoamey) }
       let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
@@ -179,7 +179,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
       end
 
       context 'when the feature flag is not set' do
-        let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: '' } }
+        let(:envs) { { FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: '' } }
 
         it 'only sends the update_move notification to the initial supplier' do
           perform
@@ -190,7 +190,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
       end
     end
 
-    context 'when it is a cross-deck move that has already been notified' do
+    context 'when it is a cross-supplier move that has already been notified' do
       let!(:initial_supplier) { create(:supplier, :serco) }
       let!(:receiving_supplier) { create(:supplier, :geoamey) }
       let!(:subscription) { create(:subscription, :no_email_address, supplier: initial_supplier) }
@@ -210,7 +210,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
       end
 
       context 'when the feature flag is not set' do
-        let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: '' } }
+        let(:envs) { { FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: '' } }
 
         it 'only sends the update_move notification to the initial supplier' do
           perform
@@ -284,7 +284,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
     end
   end
 
-  context 'when explicitly notifying a cross-deck move' do
+  context 'when explicitly notifying a cross-supplier move' do
     let(:action_name) { 'cross_supplier_add' }
     let!(:initial_supplier) { create(:supplier, :serco) }
     let!(:receiving_supplier) { create(:supplier, :geoamey) }
@@ -301,7 +301,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
     end
 
     context 'when the feature flag is not set' do
-      let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: '' } }
+      let(:envs) { { FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: '' } }
 
       it 'does not notify the receiving supplier' do
         perform
@@ -310,7 +310,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
     end
   end
 
-  context 'when explicitly notifying that a move is no longer cross-deck' do
+  context 'when explicitly notifying that a move is no longer cross-supplier' do
     let(:action_name) { 'cross_supplier_remove' }
     let!(:initial_supplier) { create(:supplier, :serco) }
     let!(:receiving_supplier) { create(:supplier, :geoamey) }
@@ -327,7 +327,7 @@ RSpec.describe PrepareMoveNotificationsJob, type: :job do
     end
 
     context 'when the feature flag is not set' do
-      let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: '' } }
+      let(:envs) { { FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: '' } }
 
       it 'does not notify the receiving supplier' do
         perform

--- a/spec/models/generic_event/move_redirect_spec.rb
+++ b/spec/models/generic_event/move_redirect_spec.rb
@@ -123,43 +123,5 @@ RSpec.describe GenericEvent::MoveRedirect do
         expect { generic_event.trigger }.to change { generic_event.eventable.move_type }.from('prison_transfer').to('court_appearance')
       end
     end
-
-    context 'when it becomes a cross-deck move' do
-      subject(:generic_event) { build(:event_move_redirect, details:, eventable:) }
-
-      let(:departing_supplier) { create(:supplier) }
-      let(:receiving_supplier) { create(:supplier) }
-      let(:from_location) { create(:location, :court, suppliers: [departing_supplier]) }
-      let(:old_to_location) { create(:location, :court, suppliers: [departing_supplier]) }
-      let(:new_to_location) { create(:location, :court, suppliers: [receiving_supplier]) }
-      let(:eventable) { build(:move, move_type: 'court_appearance', from_location:, to_location: old_to_location) }
-      let(:details) { { reason: 'other', to_location_id: new_to_location.id } }
-
-      before { allow(Notifier).to receive(:prepare_notifications) }
-
-      it 'sends a cross_supplier_move_add notification to the receiving supplier' do
-        generic_event.trigger
-        expect(Notifier).to have_received(:prepare_notifications).with(topic: eventable, action_name: 'cross_supplier_add')
-      end
-    end
-
-    context 'when it ceases to be a cross-deck move' do
-      subject(:generic_event) { build(:event_move_redirect, details:, eventable:) }
-
-      let(:departing_supplier) { create(:supplier) }
-      let(:receiving_supplier) { create(:supplier) }
-      let(:from_location) { create(:location, :court, suppliers: [departing_supplier]) }
-      let(:old_to_location) { create(:location, :court, suppliers: [receiving_supplier]) }
-      let(:new_to_location) { create(:location, :court, suppliers: [departing_supplier]) }
-      let(:eventable) { build(:move, move_type: 'court_appearance', from_location:, to_location: old_to_location) }
-      let(:details) { { reason: 'other', to_location_id: new_to_location.id } }
-
-      before { allow(Notifier).to receive(:prepare_notifications) }
-
-      it 'sends a cross_supplier_move_remove notification to the receiving supplier' do
-        generic_event.trigger
-        expect(Notifier).to have_received(:prepare_notifications).with(topic: eventable, action_name: 'cross_supplier_remove')
-      end
-    end
   end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -1050,10 +1050,10 @@ RSpec.describe Move do
     end
   end
 
-  describe '#cross_deck?' do
+  describe '#cross_supplier?' do
     let(:move) { create(:move) }
 
-    it { expect(move.cross_deck?).to be false }
+    it { expect(move.cross_supplier?).to be false }
 
     context 'when the origin and destination suppliers are different' do
       let!(:supplier1) { create(:supplier) }
@@ -1062,7 +1062,7 @@ RSpec.describe Move do
       let!(:to_location) { create(:location, :court, suppliers: [supplier2]) }
       let(:move) { create(:move, from_location:, to_location:) }
 
-      it { expect(move.cross_deck?).to be true }
+      it { expect(move.cross_supplier?).to be true }
     end
   end
 end

--- a/spec/requests/api/allocations_controller_update_spec.rb
+++ b/spec/requests/api/allocations_controller_update_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::AllocationsController do
     resource
   end
 
-  let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
+  let(:envs) { { FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
 
   around do |example|
     ClimateControl.modify(**envs) do

--- a/spec/requests/api/generic_events_controller_create_move_events_spec.rb
+++ b/spec/requests/api/generic_events_controller_create_move_events_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Api::GenericEventsController do
       }
     end
 
-    context 'when the move becomes cross-deck' do
+    context 'when the move becomes cross-supplier' do
       let(:initial_supplier) { create(:supplier, :serco) }
       let(:receiving_supplier) { create(:supplier, :geoamey) }
       let(:from_location) { create(:location, :court, suppliers: [initial_supplier]) }
@@ -218,7 +218,7 @@ RSpec.describe Api::GenericEventsController do
       end
     end
 
-    context 'when the move ceases to be cross-deck' do
+    context 'when the move ceases to be cross-supplier' do
       let(:initial_supplier) { create(:supplier, :serco) }
       let(:receiving_supplier) { create(:supplier, :geoamey) }
       let(:from_location) { create(:location, :court, suppliers: [initial_supplier]) }

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Api::MoveEventsController do
     end
     let(:before_post) { nil }
 
-    let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
+    let(:envs) { { FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
 
     around do |example|
       ClimateControl.modify(**envs) do
@@ -245,7 +245,7 @@ RSpec.describe Api::MoveEventsController do
         end
       end
 
-      context 'when it becomes a cross-deck move' do
+      context 'when it becomes a cross-supplier move' do
         let(:initial_supplier) { create(:supplier, :serco) }
         let(:receiving_supplier) { create(:supplier, :geoamey) }
         let(:from_location) { create(:location, :court, suppliers: [initial_supplier]) }
@@ -280,7 +280,7 @@ RSpec.describe Api::MoveEventsController do
         end
       end
 
-      context 'when it ceases to be a cross-deck move' do
+      context 'when it ceases to be a cross-supplier move' do
         let(:initial_supplier) { create(:supplier, :serco) }
         let(:receiving_supplier) { create(:supplier, :geoamey) }
         let(:from_location) { create(:location, :court, suppliers: [initial_supplier]) }

--- a/spec/requests/api/move_events_controller_redirect_spec.rb
+++ b/spec/requests/api/move_events_controller_redirect_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe Api::MoveEventsController do
     end
     let(:before_post) { nil }
 
+    let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
+
+    around do |example|
+      ClimateControl.modify(**envs) do
+        example.run
+      end
+    end
+
     before do
       allow(Notifier).to receive(:prepare_notifications)
       before_post
@@ -234,6 +242,76 @@ RSpec.describe Api::MoveEventsController do
               'detail' => 'To location id should be different to the from location',
             }]
           end
+        end
+      end
+
+      context 'when it becomes a cross-deck move' do
+        let(:initial_supplier) { create(:supplier, :serco) }
+        let(:receiving_supplier) { create(:supplier, :geoamey) }
+        let(:from_location) { create(:location, :court, suppliers: [initial_supplier]) }
+        let(:old_to_location) { create(:location, :court, suppliers: [initial_supplier]) }
+        let(:new_location) { create(:location, :court, suppliers: [receiving_supplier]) }
+        let(:move) { create(:move, :court_appearance, from_location:, to_location: old_to_location) }
+
+        let(:before_post) do
+          # Pre-existing events to make sure we don't send new notifications for all of them
+          create(
+            :event_move_redirect,
+            eventable: move,
+            occurred_at: '2019-01-01',
+            recorded_at: '2019-01-01',
+            details: {
+              to_location_id: new_location.id,
+            },
+          )
+          create(
+            :event_move_redirect,
+            eventable: move,
+            occurred_at: '2019-01-02',
+            recorded_at: '2019-01-02',
+            details: {
+              to_location_id: old_to_location.id,
+            },
+          )
+        end
+
+        it 'sends a cross_supplier_move_add notification to the receiving supplier' do
+          expect(Notifier).to have_received(:prepare_notifications).once.with(topic: move, action_name: 'cross_supplier_add')
+        end
+      end
+
+      context 'when it ceases to be a cross-deck move' do
+        let(:initial_supplier) { create(:supplier, :serco) }
+        let(:receiving_supplier) { create(:supplier, :geoamey) }
+        let(:from_location) { create(:location, :court, suppliers: [initial_supplier]) }
+        let(:old_to_location) { create(:location, :court, suppliers: [receiving_supplier]) }
+        let(:new_location) { create(:location, :court, suppliers: [initial_supplier]) }
+        let(:move) { create(:move, :court_appearance, from_location:, to_location: old_to_location) }
+
+        let(:before_post) do
+          # Pre-existing events to make sure we don't send new notifications for all of them
+          create(
+            :event_move_redirect,
+            eventable: move,
+            occurred_at: '2019-01-01',
+            recorded_at: '2019-01-01',
+            details: {
+              to_location_id: new_location.id,
+            },
+          )
+          create(
+            :event_move_redirect,
+            eventable: move,
+            occurred_at: '2019-01-02',
+            recorded_at: '2019-01-02',
+            details: {
+              to_location_id: old_to_location.id,
+            },
+          )
+        end
+
+        it 'sends a cross_supplier_move_remove notification to the receiving supplier' do
+          expect(Notifier).to have_received(:prepare_notifications).once.with(topic: move, action_name: 'cross_supplier_remove')
         end
       end
     end

--- a/spec/requests/api/moves_controller_create_v2_spec.rb
+++ b/spec/requests/api/moves_controller_create_v2_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::MovesController do
     }
   end
 
-  let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
+  let(:envs) { { FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
 
   around do |example|
     ClimateControl.modify(**envs) do
@@ -739,7 +739,7 @@ RSpec.describe Api::MovesController do
       end
     end
 
-    context 'when it is a cross-deck move' do
+    context 'when it is a cross-supplier move' do
       before do
         create(:notification_type, :webhook)
         allow(Faraday).to receive(:new).and_return(faraday_client)

--- a/spec/requests/api/moves_controller_update_v2_spec.rb
+++ b/spec/requests/api/moves_controller_update_v2_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::MovesController do
     }
   end
 
-  let(:envs) { { FEATURE_FLAG_CROSS_DECK_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
+  let(:envs) { { FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS: 'geoamey,serco' } }
 
   around do |example|
     ClimateControl.modify(**envs) do
@@ -348,7 +348,7 @@ RSpec.describe Api::MovesController do
       end
     end
 
-    context 'when it is a cross-deck move' do
+    context 'when it is a cross-supplier move' do
       let!(:receiving_supplier) { create(:supplier, :geoamey) }
       let!(:subscription) { create(:subscription, :no_email_address, supplier:) }
       let!(:subscription2) { create(:subscription, :no_email_address, supplier: receiving_supplier) }


### PR DESCRIPTION
### Jira link

[MAP-322]

### What?

I have added/removed/altered:

- Stop duplicating cross-deck notifications

### Why?

I am doing this because:

- The notifications were being sent when the even is triggered, but all of the events get triggered again and again for an eventable so it has to happen outside of the trigger so that it only happens once.




[MAP-322]: https://dsdmoj.atlassian.net/browse/MAP-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ