### PR TITLE
Map 1363 move basm api to use new roll count

### DIFF
--- a/app/lib/nomis_client/rollcount.rb
+++ b/app/lib/nomis_client/rollcount.rb
@@ -3,8 +3,8 @@
 module NomisClient
   class Rollcount
     class << self
-      def get(agency_id:, unassigned:)
-        NomisClient::Base.get("/movements/rollcount/#{agency_id}?unassigned=#{unassigned}").parsed
+      def get(agency_id:)
+        NomisClient::Base.get("/prison/roll-count/#{agency_id}").parsed
       end
     end
   end

--- a/app/services/populations/defaults_from_nomis.rb
+++ b/app/services/populations/defaults_from_nomis.rb
@@ -4,15 +4,13 @@ module Populations
   class DefaultsFromNomis
     def self.call(location, date)
       nomis_agency_id = location.nomis_agency_id
-      assigned_cells = NomisClient::Rollcount.get(agency_id: nomis_agency_id, unassigned: false)
-      unassigned_cells = NomisClient::Rollcount.get(agency_id: nomis_agency_id, unassigned: true)
+      all_cells = NomisClient::Rollcount.get(agency_id: nomis_agency_id)
       movements = NomisClient::Movements.get(agency_id: nomis_agency_id, date:)
       discharges = NomisClient::Discharges.get(agency_id: nomis_agency_id, date:)
 
-      return {} unless assigned_cells.present? && unassigned_cells.present? && movements.present?
+      return {} unless all_cells.present? && movements.present?
 
-      all_cells = [assigned_cells, unassigned_cells].flatten
-      cell_total = all_cells.compact.sum { |cell| cell['currentlyInCell'].to_i }
+      cell_total = all_cells.totals.currentlyInCell
       arrivals = movements['in'].to_i
       discharges = discharges.length
 

--- a/app/services/populations/defaults_from_nomis.rb
+++ b/app/services/populations/defaults_from_nomis.rb
@@ -10,7 +10,7 @@ module Populations
 
       return {} unless all_cells.present? && movements.present?
 
-      cell_total = all_cells.totals.currentlyInCell
+      cell_total = all_cells['totals']['currentlyInCell']
       arrivals = movements['in'].to_i
       discharges = discharges.length
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: postgres
@@ -27,7 +25,7 @@ services:
   web:
     build: .
     env_file:
-      - ./.env
+      - ./.env.example
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db/hmpps-book-secure-move-api
       - SECRET_KEY_BASE=h463472fhaa91f4a277002e9652f86f330e636358e2090d86ab4a4f06845ege1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   web:
     build: .
     env_file:
-      - ./.env.example
+      - ./.env
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db/hmpps-book-secure-move-api
       - SECRET_KEY_BASE=h463472fhaa91f4a277002e9652f86f330e636358e2090d86ab4a4f06845ege1

--- a/spec/fixtures/files/nomis/get_rollcount_200.json
+++ b/spec/fixtures/files/nomis/get_rollcount_200.json
@@ -1,7 +1,18 @@
-[
-  {"livingUnitId":8839, "livingUnitDesc":"COURT", "bedsInUse":33, "currentlyInCell":2, "currentlyOut":31, "maximumCapacity":400, "availablePhysical":367, "outOfOrder":0},
-  {"livingUnitId":180030, "livingUnitDesc":"CSWAP", "bedsInUse":0, "currentlyInCell":0, "currentlyOut":0, "maximumCapacity":50, "availablePhysical":50, "outOfOrder":0},
-  {"livingUnitId":185744, "livingUnitDesc":"REC/OUT", "bedsInUse":1, "currentlyInCell":0, "currentlyOut":1, "maximumCapacity":100, "availablePhysical":99, "outOfOrder":0},
-  {"livingUnitId":4021, "livingUnitDesc":"RECP", "bedsInUse":7, "currentlyInCell":7, "currentlyOut":0, "maximumCapacity":100, "availablePhysical":93, "outOfOrder":0},
-  {"livingUnitId":8838, "livingUnitDesc":"TAP", "bedsInUse":12, "currentlyInCell":0, "currentlyOut":12, "maximumCapacity":50, "availablePhysical":38, "outOfOrder":0}
-]
+{
+  "prisonId": "PRI",
+  "numUnlockRollToday": 0,
+  "numCurrentPopulation": 97,
+  "numArrivedToday": 0,
+  "numInReception": 0,
+  "numStillToArrive": 0,
+  "numOutToday": 0,
+  "numNoCellAllocated": 0,
+  "totals": {
+    "bedsInUse": 53,
+    "currentlyInCell": 7,
+    "currentlyOut": 44,
+    "workingCapacity": 0,
+    "netVacancies": 0,
+    "outOfOrder": 0
+  }
+}

--- a/spec/lib/nomis_client/rollcount_spec.rb
+++ b/spec/lib/nomis_client/rollcount_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe NomisClient::Rollcount, with_nomis_client_authentication: true do
       let(:response_status) { 200 }
       let(:response_body) { file_fixture('nomis/get_rollcount_200.json').read }
 
-
       it 'returns the correct data' do
         expect(response.totals.symbolize_keys).to eq({
           bedsInUse: 53,

--- a/spec/lib/nomis_client/rollcount_spec.rb
+++ b/spec/lib/nomis_client/rollcount_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe NomisClient::Rollcount, with_nomis_client_authentication: true do
       let(:response_body) { file_fixture('nomis/get_rollcount_200.json').read }
 
       it 'returns the correct data' do
-        expect(response.totals.symbolize_keys).to eq({
+        expect(response.symbolize_keys.totals).to eq({
           bedsInUse: 53,
           currentlyInCell: 7,
           currentlyOut: 44,

--- a/spec/lib/nomis_client/rollcount_spec.rb
+++ b/spec/lib/nomis_client/rollcount_spec.rb
@@ -12,13 +12,23 @@ RSpec.describe NomisClient::Rollcount, with_nomis_client_authentication: true do
       let(:response_body) { file_fixture('nomis/get_rollcount_200.json').read }
 
       it 'returns the correct data' do
-        expect(response.symbolize_keys.totals).to eq({
-          bedsInUse: 53,
-          currentlyInCell: 7,
-          currentlyOut: 44,
-          workingCapacity: 0,
-          netVacancies: 0,
-          outOfOrder: 0,
+        expect(response.symbolize_keys).to eq({
+          prisonId: 'PRI',
+          numUnlockRollToday: 0,
+          numCurrentPopulation: 97,
+          numArrivedToday: 0,
+          numInReception: 0,
+          numStillToArrive: 0,
+          numOutToday: 0,
+          numNoCellAllocated: 0,
+          totals: {
+            bedsInUse: 53,
+            currentlyInCell: 7,
+            currentlyOut: 44,
+            workingCapacity: 0,
+            netVacancies: 0,
+            outOfOrder: 0,
+          }
         })
       end
     end

--- a/spec/lib/nomis_client/rollcount_spec.rb
+++ b/spec/lib/nomis_client/rollcount_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe NomisClient::Rollcount, with_nomis_client_authentication: true do
           numOutToday: 0,
           numNoCellAllocated: 0,
           totals: {
-            "bedsInUse" => 53,
-            "currentlyInCell" => 7,
-            "currentlyOut" => 44,
-            "workingCapacity" => 0,
-            "netVacancies" => 0,
-            "outOfOrder" => 0,
+            'bedsInUse' => 53,
+            'currentlyInCell' => 7,
+            'currentlyOut' => 44,
+            'workingCapacity' => 0,
+            'netVacancies' => 0,
+            'outOfOrder' => 0,
           },
         })
       end

--- a/spec/lib/nomis_client/rollcount_spec.rb
+++ b/spec/lib/nomis_client/rollcount_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe NomisClient::Rollcount, with_nomis_client_authentication: true do
             workingCapacity: 0,
             netVacancies: 0,
             outOfOrder: 0,
-          }
+          },
         })
       end
     end

--- a/spec/lib/nomis_client/rollcount_spec.rb
+++ b/spec/lib/nomis_client/rollcount_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe NomisClient::Rollcount, with_nomis_client_authentication: true do
           numOutToday: 0,
           numNoCellAllocated: 0,
           totals: {
-            bedsInUse: 53,
-            currentlyInCell: 7,
-            currentlyOut: 44,
-            workingCapacity: 0,
-            netVacancies: 0,
-            outOfOrder: 0,
+            "bedsInUse" => 53,
+            "currentlyInCell" => 7,
+            "currentlyOut" => 44,
+            "workingCapacity" => 0,
+            "netVacancies" => 0,
+            "outOfOrder" => 0,
           },
         })
       end

--- a/spec/lib/nomis_client/rollcount_spec.rb
+++ b/spec/lib/nomis_client/rollcount_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe NomisClient::Rollcount, with_nomis_client_authentication: true do
 
       it 'returns the correct data' do
         expect(response.totals.symbolize_keys).to eq({
-         "bedsInUse": 53,
-         "currentlyInCell": 7,
-         "currentlyOut": 44,
-         "workingCapacity": 0,
-         "netVacancies": 0,
-         "outOfOrder": 0
-       })
+          bedsInUse: 53,
+          currentlyInCell: 7,
+          currentlyOut: 44,
+          workingCapacity: 0,
+          netVacancies: 0,
+          outOfOrder: 0,
+        })
       end
     end
   end

--- a/spec/lib/nomis_client/rollcount_spec.rb
+++ b/spec/lib/nomis_client/rollcount_spec.rb
@@ -4,29 +4,23 @@ require 'rails_helper'
 
 RSpec.describe NomisClient::Rollcount, with_nomis_client_authentication: true do
   describe '.get' do
-    let(:response) { described_class.get(agency_id:, unassigned:) }
+    let(:response) { described_class.get(agency_id:) }
     let(:agency_id) { 'PRI' }
-    let(:unassigned) { true }
 
     context 'when a resource is found' do
       let(:response_status) { 200 }
       let(:response_body) { file_fixture('nomis/get_rollcount_200.json').read }
 
-      it 'has the correct number of results' do
-        expect(response.count).to be 5
-      end
 
       it 'returns the correct data' do
-        expect(response.first.symbolize_keys).to eq({
-          availablePhysical: 367,
-          bedsInUse: 33,
-          currentlyInCell: 2,
-          currentlyOut: 31,
-          livingUnitDesc: 'COURT',
-          livingUnitId: 8839,
-          maximumCapacity: 400,
-          outOfOrder: 0,
-        })
+        expect(response.totals.symbolize_keys).to eq({
+         "bedsInUse": 53,
+         "currentlyInCell": 7,
+         "currentlyOut": 44,
+         "workingCapacity": 0,
+         "netVacancies": 0,
+         "outOfOrder": 0
+       })
       end
     end
   end

--- a/spec/services/populations/defaults_from_nomis_spec.rb
+++ b/spec/services/populations/defaults_from_nomis_spec.rb
@@ -9,16 +9,12 @@ RSpec.describe Populations::DefaultsFromNomis, with_nomis_client_authentication:
   let(:location) { create(:location, :prison, nomis_agency_id: agency_id) }
   let(:date) { Time.zone.today }
 
-  let(:assigned_cells) do
-    [
-      { 'currentlyInCell' => 3 },
-      { 'currentlyInCell' => 4 },
-    ]
-  end
-  let(:unassigned_cells) do
-    [
-      { 'currentlyInCell' => 1 },
-    ]
+  let(:all_cells) do
+    {
+      'totals': {
+        'currentlyInCell': 8,
+      }
+    }
   end
   let(:movements) { { 'in' => 10, 'out' => 5 } }
   let(:discharges) do
@@ -29,8 +25,7 @@ RSpec.describe Populations::DefaultsFromNomis, with_nomis_client_authentication:
   end
 
   before do
-    allow(NomisClient::Rollcount).to receive(:get).with(agency_id:, unassigned: false).and_return(assigned_cells)
-    allow(NomisClient::Rollcount).to receive(:get).with(agency_id:, unassigned: true).and_return(unassigned_cells)
+    allow(NomisClient::Rollcount).to receive(:get).with(agency_id:).and_return(all_cells)
     allow(NomisClient::Movements).to receive(:get).with(agency_id:, date:).and_return(movements)
     allow(NomisClient::Discharges).to receive(:get).with(agency_id:, date:).and_return(discharges)
   end
@@ -60,8 +55,7 @@ RSpec.describe Populations::DefaultsFromNomis, with_nomis_client_authentication:
   end
 
   context 'with missing rollcount details from Nomis' do
-    let(:assigned_cells) { nil }
-    let(:unassigned_cells) { nil }
+    let(:all_cells) { nil }
 
     it 'returns empty hash' do
       expect(defaults).to be_empty
@@ -77,8 +71,7 @@ RSpec.describe Populations::DefaultsFromNomis, with_nomis_client_authentication:
   end
 
   context 'with missing rollcount and movement details from Nomis' do
-    let(:assigned_cells) { nil }
-    let(:unassigned_cells) { nil }
+    let(:all_cells) { nil }
     let(:movements) { nil }
     let(:discharges) { nil }
 

--- a/spec/services/populations/defaults_from_nomis_spec.rb
+++ b/spec/services/populations/defaults_from_nomis_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Populations::DefaultsFromNomis, with_nomis_client_authentication:
   end
 
   context 'with blank rollcount details from Nomis' do
-    let(:unassigned_cells) do
+    let(:all_cells) do
       [
         nil,
       ]
@@ -46,7 +46,7 @@ RSpec.describe Populations::DefaultsFromNomis, with_nomis_client_authentication:
 
     it 'returns correct unlock and discharges' do
       expect(defaults).to eq({
-        unlock: 3 + 4 - 10 + 2,
+        unlock: 10 + 2,
         discharges: 2,
       })
     end

--- a/spec/services/populations/defaults_from_nomis_spec.rb
+++ b/spec/services/populations/defaults_from_nomis_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Populations::DefaultsFromNomis, with_nomis_client_authentication:
 
   let(:all_cells) do
     {
-      'totals': { 'currentlyInCell' => 8 },
+      'totals' => { 'currentlyInCell' => 8 },
     }
   end
   let(:movements) { { 'in' => 10, 'out' => 5 } }

--- a/spec/services/populations/defaults_from_nomis_spec.rb
+++ b/spec/services/populations/defaults_from_nomis_spec.rb
@@ -37,21 +37,6 @@ RSpec.describe Populations::DefaultsFromNomis, with_nomis_client_authentication:
     end
   end
 
-  context 'with blank rollcount details from Nomis' do
-    let(:all_cells) do
-      {
-        'totals' => { 'currentlyInCell' => nil },
-      }
-    end
-
-    it 'returns correct unlock and discharges' do
-      expect(defaults).to eq({
-        unlock: 10 + 2,
-        discharges: 2,
-      })
-    end
-  end
-
   context 'with missing rollcount details from Nomis' do
     let(:all_cells) { nil }
 

--- a/spec/services/populations/defaults_from_nomis_spec.rb
+++ b/spec/services/populations/defaults_from_nomis_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe Populations::DefaultsFromNomis, with_nomis_client_authentication:
 
   context 'with blank rollcount details from Nomis' do
     let(:all_cells) do
-      [
-        nil,
-      ]
+      {
+        'totals' => { 'currentlyInCell' => nil },
+      }
     end
 
     it 'returns correct unlock and discharges' do

--- a/spec/services/populations/defaults_from_nomis_spec.rb
+++ b/spec/services/populations/defaults_from_nomis_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe Populations::DefaultsFromNomis, with_nomis_client_authentication:
 
   let(:all_cells) do
     {
-      'totals': {
-        'currentlyInCell': 8,
-      }
+      'totals': { 'currentlyInCell' => 8 },
     }
   end
   let(:movements) { { 'in' => 10, 'out' => 5 } }


### PR DESCRIPTION
### Jira link

MAP-1363

### What?

I have altered:

- [ ] Changed the call the prison-api /movement/rollcount to the new /prison/roll-count endpoint which summaries the in cell values

### Why?

I am doing this because:

- The old endpoint is deprecated and will shortly be removed.


### Deployment risks (optional)

- Changes where we get roll count data from, regression testing required

