### PR TITLE
MAP-1380 Made changes to include a 'cancelled_at' column to the download showing the time when the move had been cancelled

### DIFF
--- a/app/services/moves/exporter.rb
+++ b/app/services/moves/exporter.rb
@@ -18,6 +18,7 @@ module Moves
       'To location code',
       'Additional information',
       'Date of travel',
+      'Cancelled at',
       'PNC number',
       'Prison number',
       'Last name',
@@ -100,6 +101,7 @@ module Moves
         move.to_location&.nomis_agency_id, # To location code
         move.additional_information, # Additional information
         move.date&.strftime('%Y-%m-%d'), # Date of travel
+        move.generic_events.find_by(type: 'GenericEvent::MoveCancel')&.occurred_at, # Cancelled at
         person&.police_national_computer, # PNC number
         person&.prison_number, # Prison number
         person&.last_name, # Last name

--- a/spec/services/moves/exporter_spec.rb
+++ b/spec/services/moves/exporter_spec.rb
@@ -16,17 +16,18 @@ RSpec.describe Moves::Exporter do
   let(:person) { create(:person) }
   let!(:move) { create(:move, from_location:, to_location:, person:) }
   let(:moves) { Move.where(id: move.id) }
+  let!(:cancel_event) { create(:event_move_cancel, eventable: move) }
 
   it 'includes correct header names' do
     expect(header).to eq(described_class::STATIC_HEADINGS)
   end
 
   it 'has correct number of header columns' do
-    expect(header.count).to eq(54)
+    expect(header.count).to eq(55)
   end
 
   it 'has correct number of body columns' do
-    expect(row.count).to eq(54)
+    expect(row.count).to eq(55)
   end
 
   it 'includes move details' do
@@ -35,6 +36,10 @@ RSpec.describe Moves::Exporter do
 
   it 'includes move timestamps and date' do
     expect(row).to include(move.created_at.iso8601, move.updated_at.iso8601, move.date.strftime('%Y-%m-%d'))
+  end
+
+  it 'includes move cancelled at' do
+    expect(row).to include(cancel_event.occurred_at.iso8601)
   end
 
   it 'includes from location details' do
@@ -130,11 +135,11 @@ RSpec.describe Moves::Exporter do
       end
 
       it 'has correct number of header columns' do
-        expect(header.count).to eq(56)
+        expect(header.count).to eq(57)
       end
 
       it 'has correct number of body columns' do
-        expect(row.count).to eq(56)
+        expect(row.count).to eq(57)
       end
 
       it 'has the correct rows' do
@@ -154,11 +159,11 @@ RSpec.describe Moves::Exporter do
       end
 
       it 'has correct number of header columns' do
-        expect(header.count).to eq(54)
+        expect(header.count).to eq(55)
       end
 
       it 'has correct number of body columns' do
-        expect(row.count).to eq(54)
+        expect(row.count).to eq(55)
       end
     end
   end


### PR DESCRIPTION
### Jira link

MAP-1380

### What?

I have added/removed/altered:

- [ ] Added a "cancelled at" column to the csv download.

### Why?

I am doing this because:

- Users want to be able to see when a move had been cancelled.