### PR TITLE
MAP-1485 - Add PER/YRA id to move/profile feeds

### DIFF
--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -316,6 +316,9 @@ class Move < VersionedModel
     feed_attributes.merge!(to_location.for_feed(prefix: :to)) if to_location
     feed_attributes.merge!(supplier.for_feed) if supplier
 
+    feed_attributes['person_escort_record_id'] = person_escort_record_id if person_escort_record_id.present?
+    feed_attributes['youth_risk_assessment_id'] = youth_risk_assessment_id if youth_risk_assessment_id.present?
+
     feed_attributes
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -62,7 +62,12 @@ class Profile < VersionedModel
   end
 
   def for_feed
-    attributes.slice(*FEED_ATTRIBUTES)
+    feed_attributes = attributes.slice(*FEED_ATTRIBUTES)
+
+    feed_attributes['person_escort_record_id'] = person_escort_record_id if person_escort_record_id.present?
+    feed_attributes['youth_risk_assessment_id'] = youth_risk_assessment_id if youth_risk_assessment_id.present?
+
+    feed_attributes
   end
 
 private

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -678,7 +678,7 @@ RSpec.describe Move do
   end
 
   describe '#for_feed' do
-    subject(:move) { create(:move) }
+    subject(:move) { create(:move, :with_person_escort_record) }
 
     let(:expected_json) do
       {
@@ -706,6 +706,7 @@ RSpec.describe Move do
         'to_location_type' => 'court',
         'updated_at' => be_a(Time),
         'supplier' => move.supplier.key,
+        'person_escort_record_id' => move.person_escort_record_id,
       }
     end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Profile, type: :model do
   end
 
   describe '#for_feed' do
-    subject(:profile) { create(:profile) }
+    subject(:profile) { create(:profile, :with_person_escort_record) }
 
     let(:expected_json) do
       {
@@ -189,6 +189,7 @@ RSpec.describe Profile, type: :model do
         'created_at' => be_a(Time),
         'updated_at' => be_a(Time),
         'assessment_answers' => [],
+        'person_escort_record_id' => profile.person_escort_record_id,
       }
     end
 


### PR DESCRIPTION
### Jira link

MAP-1485

### What?

I have added/removed/altered:

- [x] Added person_escort_record_id and youth_risk_assessment_id to move and profile feeds

### Why?

I am doing this because:

- Analytical platform have requested it

