### PR TITLE
MAP-676 Add cron job to run nomis location sync

### DIFF
--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -106,6 +106,9 @@ cronJobs:
   - name: per-report-job
     schedule: "0 7 1 1,4,7,10 *"
     command: ["bundle", "exec", "rake", "reports:person_escort_record_quality"]
+  - name: nomis-location-sync-job
+    schedule: "0 * * * *"
+    command: ["bundle", "exec", "rails", "reference_data:create_locations" ]
 
 dashboards:
   enabled: true


### PR DESCRIPTION
### Jira link

MAP-676

### What?

I have added/removed/altered:

- [x] Added a cron job to automatically run the nomis location sync

### Why?

I am doing this because:

- We don't have to rely on manually running the job after locations are updated in NOMIS



