### PR TITLE
MAP-1565 Add Civil disorder to the list of assessment questions

### DIFF
--- a/app/services/assessment_questions/importer.rb
+++ b/app/services/assessment_questions/importer.rb
@@ -5,6 +5,7 @@ module AssessmentQuestions
     ASSESSMENT_QUESTIONS = [
       { key: :violent, category: :risk, title: 'Violent' },
       { key: :escape, category: :risk, title: 'Escape' },
+      { key: :civil_disorder, category: :risk, title: 'Civil disorder' },
       { key: :hold_separately, category: :risk, title: 'Must be held separately' },
       { key: :self_harm, category: :risk, title: 'Self harm' },
       { key: :concealed_items, category: :risk, title: 'Concealed items' },

--- a/spec/services/assessment_questions/importer_spec.rb
+++ b/spec/services/assessment_questions/importer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AssessmentQuestions::Importer do
 
   context 'with no existing records' do
     it 'creates all the input items' do
-      expect { importer.call }.to change(AssessmentQuestion, :count).by(17)
+      expect { importer.call }.to change(AssessmentQuestion, :count).by(18)
     end
 
     it 'creates `Violent`' do
@@ -34,7 +34,7 @@ RSpec.describe AssessmentQuestions::Importer do
     end
 
     it 'creates only the missing item' do
-      expect { importer.call }.to change(AssessmentQuestion, :count).by(16)
+      expect { importer.call }.to change(AssessmentQuestion, :count).by(17)
     end
   end
 


### PR DESCRIPTION
### Jira link

[MAP-1565](https://dsdmoj.atlassian.net/browse/MAP-1565)

### What?

Here we add a new assessment question: 
`Civil disorder offender`

See [Frontend PR for screenshots](https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/2353)

### Why?

To support the latest BaSM Framework [v2.5.1](https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks/releases/tag/v2.5.1)

### Deployment risks  

- The following rake task **must** be run when the deployment is complete. [Docs](https://dsdmoj.atlassian.net/wiki/spaces/MAP/pages/4107239526/Process+for+making+a+frameworks+change)
`bundle exec rake frameworks:populate_data`
 


[MAP-1565]: https://dsdmoj.atlassian.net/browse/MAP-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ