### PR TITLE
MAP-1645: Send van depots to the analytical platform

### DIFF
--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -81,6 +81,7 @@ class Journey < VersionedModel
       .merge(to_location.for_feed(prefix: :to))
       .merge(supplier.for_feed)
       .merge(vehicle_registration:)
+      .merge(vehicle_depot:)
   end
 
   def vehicle_registration

--- a/spec/factories/journeys.rb
+++ b/spec/factories/journeys.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     association(:from_location, factory: :location)
     association(:to_location, :court, factory: :location)
     client_timestamp { Time.zone.now.utc + rand(-60..60).seconds } # NB: the client_timestamp will never be perfectly in sync with system clock
-    vehicle { { id: '12345678ABC', registration: 'AB12 CDE' } }
+    vehicle { { id: '12345678ABC', registration: 'AB12 CDE', depot: 'Depot 1' } }
     date { Time.zone.today }
 
     # NB we need to initialize_state because FactoryBot fires the after_initialize callback before the attributes are initialised!

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -160,6 +160,7 @@ RSpec.describe Journey, type: :model do
         'date': be_a(Date),
         'state': 'proposed',
         'vehicle_registration': 'AB12 CDE',
+        'vehicle_depot': 'Depot 1',
         'client_timestamp': be_a(Time),
         'created_at': be_a(Time),
         'updated_at': be_a(Time),

--- a/spec/requests/api/journeys_controller_update_spec.rb
+++ b/spec/requests/api/journeys_controller_update_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Api::JourneysController do
 
         it 'does not update the underlying journey vehicle' do
           do_patch
-          expect(journey.vehicle).to eql('id' => '12345678ABC', 'registration' => 'AB12 CDE')
+          expect(journey.vehicle).to eql('id' => '12345678ABC', 'registration' => 'AB12 CDE', 'depot' => 'Depot 1')
         end
       end
 
@@ -218,7 +218,7 @@ RSpec.describe Api::JourneysController do
 
         it 'does not update the underlying journey vehicle' do
           do_patch
-          expect(journey.vehicle).to eql('id' => '12345678ABC', 'registration' => 'AB12 CDE')
+          expect(journey.vehicle).to eql('id' => '12345678ABC', 'registration' => 'AB12 CDE', 'depot' => 'Depot 1')
         end
       end
 

--- a/spec/serializers/journey_serializer_spec.rb
+++ b/spec/serializers/journey_serializer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe JourneySerializer do
   end
 
   it 'contains vehicle attributes' do
-    expect(result[:data][:attributes][:vehicle]).to eql(id: '12345678ABC', registration: 'AB12 CDE')
+    expect(result[:data][:attributes][:vehicle]).to eql(id: '12345678ABC', registration: 'AB12 CDE', depot: 'Depot 1')
   end
 
   it 'contains a `from_location` relationship' do

--- a/spec/serializers/journeys_serializer_spec.rb
+++ b/spec/serializers/journeys_serializer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe JourneysSerializer do
   end
 
   it 'contains vehicle attributes' do
-    expect(result[:data][:attributes][:vehicle]).to eql(id: '12345678ABC', registration: 'AB12 CDE')
+    expect(result[:data][:attributes][:vehicle]).to eql(id: '12345678ABC', registration: 'AB12 CDE', depot: 'Depot 1')
   end
 
   it 'contains a `from_location` relationship' do


### PR DESCRIPTION
### Jira link

[MAP-1645](https://dsdmoj.atlassian.net/browse/MAP-1645)

### What?

I have added `vehicle_depot` to the Journey analytics feed (`#for_feed`)

### Why?

So that `depot` will be available on the analytics platform





[MAP-1645]: https://dsdmoj.atlassian.net/browse/MAP-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ