### PR TITLE
MAPI-1682 Revert doorkeeper upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'bootsnap', require: false
 gem 'cancancan'
 gem 'csv'
 gem 'discard'
-gem 'doorkeeper', '5.7.1'
+gem 'doorkeeper', '5.5.4'
 gem 'faraday'
 gem 'faraday-net_http_persistent'
 gem 'faraday-retry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     discard (1.3.0)
       activerecord (>= 4.2, < 8)
     docile (1.4.0)
-    doorkeeper (5.7.1)
+    doorkeeper (5.5.4)
       railties (>= 5)
     dotenv (3.1.4)
     dotenv-rails (3.1.4)
@@ -539,7 +539,7 @@ DEPENDENCIES
   csv
   database_cleaner-active_record
   discard
-  doorkeeper (= 5.7.1)
+  doorkeeper (= 5.5.4)
   dotenv
   dotenv-rails
   factory_bot_rails


### PR DESCRIPTION
### Jira link

[MAP-1682](https://dsdmoj.atlassian.net/browse/MAP-1682)

### What?

Revert the [commit to upgrade the doorkeeper gem](https://github.com/ministryofjustice/hmpps-book-secure-move-api/commit/40666eb342f26b1c84e87a3c6cff510db9686525)

### Why?

Authentication on staging is broken. User logs in and random pages raise a 401. No obvious solution

[MAP-1682]: https://dsdmoj.atlassian.net/browse/MAP-1682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ