### PR TITLE
MAP-1662 Remove veracode policy scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,18 +473,3 @@ workflows:
             - basm-api-production
           requires:
             - hold_production
-
-  security:
-    triggers:
-      - schedule:
-          cron: "0 7 * * 1-5"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - hmpps/veracode_policy_scan:
-          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-          context:
-            - veracode-credentials
-            - hmpps-common-vars


### PR DESCRIPTION
### Jira link

[MAP-1662](https://dsdmoj.atlassian.net/browse/MAP-1662)

### What?

Remove veracode policy scan

### Why?

It's unclear when this last run successfully and the team are confident that we have other tools in place to do the job

[MAP-1662]: https://dsdmoj.atlassian.net/browse/MAP-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ