### PR TITLE
Upgrade to Trivy Scan v1

### DIFF
--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   security-kotlin-trivy-check:
     name: Project security trivy dependency check
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_trivy.yml@v0.5 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_trivy.yml@v1 # WORKFLOW_VERSION
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit


### PR DESCRIPTION
### Jira link

[MAP-1757](https://dsdmoj.atlassian.net/browse/MAP-1757)

### What?

I have upgraded to Trivy scan v1

### Why?

Failing on v0.5 [Security trivy dependency check · ministryofjustice/hmpps-book-secure-move-api@43cdb35](https://github.com/ministryofjustice/hmpps-book-secure-move-api/actions/runs/11548024715)

Working on v1 https://github.com/ministryofjustice/hmpps-book-secure-move-api/actions/runs/11551365189

[MAP-1757]: https://dsdmoj.atlassian.net/browse/MAP-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ