### PR TITLE
MAP-1809 PerMedical attributes can be optional

### DIFF
--- a/app/models/generic_event/medical.rb
+++ b/app/models/generic_event/medical.rb
@@ -15,8 +15,7 @@ class GenericEvent
       child.include LocationFeed
       child.include LocationValidations
 
-      child.validates :advised_at, presence: true, iso_date_time: true
-      child.validates :advised_by, presence: true
+      child.validates :advised_at, allow_nil: true, iso_date_time: true
       child.validates :treated_at, allow_nil: true, iso_date_time: true
 
       super

--- a/spec/support/an_event_about_a_medical.rb
+++ b/spec/support/an_event_about_a_medical.rb
@@ -5,9 +5,6 @@ RSpec.shared_examples 'an event about a medical' do
   it_behaves_like 'an event with a supplier personnel number'
   it_behaves_like 'an event with a location in the feed', :location_id
 
-  it { is_expected.to validate_presence_of(:advised_at) }
-  it { is_expected.to validate_presence_of(:advised_by) }
-
   it { is_expected.to validate_inclusion_of(:eventable_type).in_array(%w[PersonEscortRecord]) }
 
   it { is_expected.to validate_presence_of(:supplier_personnel_number) }
@@ -28,10 +25,12 @@ RSpec.shared_examples 'an event about a medical' do
     it { is_expected.not_to be_valid }
   end
 
-  context 'when the treated_at and treated_by are nil' do
+  context 'when the advised_at, advised_by, treated_at and treated_by are nil' do
     before do
-      generic_event.treated_by = nil
+      generic_event.advised_at = nil
+      generic_event.advised_by = nil
       generic_event.treated_at = nil
+      generic_event.treated_by = nil
     end
 
     it { is_expected.to be_valid }


### PR DESCRIPTION
### Jira link

[MAP-1809](https://dsdmoj.atlassian.net/browse/MAP-1809)

### What?

Makes the following PerMedical attributes optional.
- details#advised_at
- details#advised_by

### Why?

Request from Geoamey to support their PER change process
