### PR TITLE
Select DISTINCT to remove duplicates from report

### DIFF
--- a/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-cancelled-moves/01-weekly-cancelled-moves-config.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-cancelled-moves/01-weekly-cancelled-moves-config.yaml
@@ -13,7 +13,7 @@ data:
   retention: "1 week"
   confirm_email: "true"
   report_sql: |-
-      select m.status,
+      select DISTINCT m.status,
       m.reference,
       m.move_type,
       m.date,


### PR DESCRIPTION
### Jira link

[MAP-1812](https://dsdmoj.atlassian.net/browse/MAP-1812)

### What?

Added `SELECT DISTINCT` to remove duplicate rows from report.

Tested locally and produced a sample report with 3398 rows. With duplicates removed, that became 2200.
For a large dataset, DISTINCT is not very efficient, but with a sample size of a few thousand rows that is run as an async task, it should be fine.

### Why?

Duplicates are making it difficult for PECS and prisons to trust the data in the report
 

[MAP-1812]: https://dsdmoj.atlassian.net/browse/MAP-1812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ