### PR TITLE
MAP-304 Eager load location#suppliers to improve performance

### DIFF
--- a/app/services/locations/finder.rb
+++ b/app/services/locations/finder.rb
@@ -58,6 +58,8 @@ module Locations
     end
 
     def apply_supplier_filters(scope)
+      scope = scope.includes(:suppliers)
+
       return scope unless filter_params.key?(:supplier_id)
 
       scope = scope.includes(:suppliers).where(suppliers: { id: split_params(:supplier_id) })


### PR DESCRIPTION
### Jira link

[MAP-304](https://dsdmoj.atlassian.net/browse/MAP-304)

### What?

Eager load location#suppliers to improve performance


### Why?

The above ticket is about performance issues when loading Location reference data. I noticed an n+1 query when the list is not filtered by supplier_id. This wasn't very serious because Locations are cached in Redis by the frontend and not loaded multiple times.
 

[MAP-304]: https://dsdmoj.atlassian.net/browse/MAP-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ