### PR TITLE
MAP-1781 Cleanup Access Logs more than 3 months old

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -49,6 +49,9 @@ generic-service:
       REDIS_URL: url
 
 cronJobs:
+  - name: access-log-cleanup
+    schedule: "0 2 * * *"
+    command: ["bundle", "exec", "rake", "access_logs:cleanup"]
   - name: token-cleanup
     schedule: "0 1 * * 0"
     command: ["bundle", "exec", "rake", "doorkeeper:db:cleanup"]

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -77,6 +77,9 @@ sidekiq:
         GOVUK_NOTIFY_API_KEY: govuk_notify_api_key
 
 cronJobs:
+  - name: access-log-cleanup
+    schedule: "0 2 * * *"
+    command: ["bundle", "exec", "rake", "access_logs:cleanup"]
   - name: token-cleanup
     schedule: "0 1 * * 0"
     command: ["bundle", "exec", "rake", "doorkeeper:db:cleanup"]

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -63,6 +63,9 @@ sidekiq:
         GOVUK_NOTIFY_API_KEY: govuk_notify_api_key
 
 cronJobs:
+  - name: access-log-cleanup
+    schedule: "0 2 * * *"
+    command: ["bundle", "exec", "rake", "access_logs:cleanup"]
   - name: token-cleanup
     schedule: "0 1 * * 0"
     command: ["bundle", "exec", "rake", "doorkeeper:db:cleanup"]

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -55,6 +55,9 @@ sidekiq:
         GOVUK_NOTIFY_API_KEY: govuk_notify_api_key
 
 cronJobs:
+  - name: access-log-cleanup
+    schedule: "0 2 * * *"
+    command: ["bundle", "exec", "rake", "access_logs:cleanup"]
   - name: token-cleanup
     schedule: "0 1 * * 0"
     command: ["bundle", "exec", "rake", "doorkeeper:db:cleanup"]

--- a/lib/tasks/access_logs.rake
+++ b/lib/tasks/access_logs.rake
@@ -2,13 +2,13 @@ namespace :access_logs do
   desc 'Cleanup access_logs older than 3 months'
   task cleanup: [:environment] do
     cutoff_date = 3.months.ago
-    access_logs_count = AccessLog.where("timestamp < ?", cutoff_date).count
+    access_logs_count = AccessLog.where('timestamp < ?', cutoff_date).count
     number_of_iterations = (access_logs_count.to_f / 1000).ceil
 
     puts "Cleaning up #{access_logs_count} access_logs in #{number_of_iterations} iterations"
 
     1.upto(number_of_iterations).each do
-      AccessLog.where("timestamp < ?", cutoff_date).limit(1000).delete_all
+      AccessLog.where('timestamp < ?', cutoff_date).limit(1000).delete_all
     end
   end
 end

--- a/lib/tasks/access_logs.rake
+++ b/lib/tasks/access_logs.rake
@@ -1,0 +1,14 @@
+namespace :access_logs do
+  desc 'Cleanup access_logs older than 3 months'
+  task cleanup: [:environment] do
+    cutoff_date = 3.months.ago
+    access_logs_count = AccessLog.where("timestamp < ?", cutoff_date).count
+    number_of_iterations = (access_logs_count.to_f / 1000).ceil
+
+    puts "Cleaning up #{access_logs_count} access_logs in #{number_of_iterations} iterations"
+
+    1.upto(number_of_iterations).each do
+      AccessLog.where("timestamp < ?", cutoff_date).limit(1000).delete_all
+    end
+  end
+end

--- a/lib/tasks/access_logs.rake
+++ b/lib/tasks/access_logs.rake
@@ -1,7 +1,7 @@
 namespace :access_logs do
-  desc 'Cleanup access_logs older than 6 months'
+  desc 'Cleanup access_logs older than 1 year'
   task cleanup: [:environment] do
-    cutoff_date = 6.months.ago
+    cutoff_date = 1.year.ago
     access_logs_count = AccessLog.where('timestamp < ?', cutoff_date).count
     number_of_iterations = (access_logs_count.to_f / 1000).ceil
 

--- a/lib/tasks/access_logs.rake
+++ b/lib/tasks/access_logs.rake
@@ -1,7 +1,7 @@
 namespace :access_logs do
-  desc 'Cleanup access_logs older than 3 months'
+  desc 'Cleanup access_logs older than 6 months'
   task cleanup: [:environment] do
-    cutoff_date = 3.months.ago
+    cutoff_date = 6.months.ago
     access_logs_count = AccessLog.where('timestamp < ?', cutoff_date).count
     number_of_iterations = (access_logs_count.to_f / 1000).ceil
 

--- a/spec/factories/access_logs.rb
+++ b/spec/factories/access_logs.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :access_log do
-    id { '35cc6a19-0d88-453a-a0cb-970e161b5cbb' }
     request_id { 'b68c0883-540c-426a-a9a4-daf586eb5c78' }
     timestamp { Time.zone.now }
     whodunnit { 'AUSER01' }

--- a/spec/lib/tasks/access_logs_spec.rb
+++ b/spec/lib/tasks/access_logs_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Rake::Task['access_logs:cleanup'] do
+  before do
+    # 2 access_logs to retain
+    create(:access_log, timestamp: 1.month.ago)
+    create(:access_log, timestamp: 2.months.ago)
+
+    # 3 access_logs to delete
+    create(:access_log, timestamp: 7.months.ago)
+    create(:access_log, timestamp: 8.months.ago)
+    create(:access_log, timestamp: 9.months.ago)
+
+    allow($stdout).to receive(:puts)
+
+    described_class.invoke
+  end
+
+  it 'cleans up the access_logs and writes to stdout' do
+    expect(AccessLog.count).to eq(2)
+
+    expect($stdout)
+      .to have_received(:puts)
+      .with('Cleaning up 3 access_logs in 1 iterations')
+  end
+end

--- a/spec/lib/tasks/access_logs_spec.rb
+++ b/spec/lib/tasks/access_logs_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Rake::Task['access_logs:cleanup'] do
   before do
     # 2 access_logs to retain
     create(:access_log, timestamp: 1.month.ago)
-    create(:access_log, timestamp: 2.months.ago)
+    create(:access_log, timestamp: 7.months.ago)
 
     # 3 access_logs to delete
-    create(:access_log, timestamp: 7.months.ago)
-    create(:access_log, timestamp: 8.months.ago)
-    create(:access_log, timestamp: 9.months.ago)
+    create(:access_log, timestamp: 13.months.ago)
+    create(:access_log, timestamp: 14.months.ago)
+    create(:access_log, timestamp: 15.months.ago)
 
     allow($stdout).to receive(:puts)
 

--- a/spec/lib/tasks/access_logs_spec.rb
+++ b/spec/lib/tasks/access_logs_spec.rb
@@ -15,12 +15,15 @@ RSpec.describe Rake::Task['access_logs:cleanup'] do
 
     allow($stdout).to receive(:puts)
 
+    described_class.reenable
     described_class.invoke
   end
 
-  it 'cleans up the access_logs and writes to stdout' do
+  it 'cleans up the access_logs' do
     expect(AccessLog.count).to eq(2)
+  end
 
+  it 'writes to stdout' do
     expect($stdout)
       .to have_received(:puts)
       .with('Cleaning up 3 access_logs in 1 iterations')


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-1781

### What?

Adds a daily cronjob to delete stale Access Logs. 
DELETE can be a very expensive operation, so we do this in batches of 1000.

### Why?

200k Access Logs are created every day. 
We use them for debugging production issues, so it should be okay to remove anything older than three months. 