### PR TITLE
MAP-1672 Rails 8 PR comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby File.read('.ruby-version')
 
-gem 'rails', '~> 8.0'
+gem 'rails', '~> 8.0.0'
 
 gem 'activerecord-import'
 gem 'auto_strip_attributes'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,7 +578,7 @@ DEPENDENCIES
   puma
   rack-cors
   rack-test
-  rails (~> 8.0)
+  rails (~> 8.0.0)
   rails-erd
   redis
   routing-filter!

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ Bundler.require(*Rails.groups)
 module BookASecureMoveApi
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 8.0
+    config.load_defaults 7.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
### Jira link

[MAP-1672](https://dsdmoj.atlassian.net/browse/MAP-1672)

### What?

Pin Rails to 8.0.0 to prevent auto-upgrade to 8.1

Revert to 7.1 defaults until production has proven to be stable

### Why?

[Issues raised on PR](https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/2409)
 

[MAP-1672]: https://dsdmoj.atlassian.net/browse/MAP-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ