### PR TITLE
MAP-530 Add cancellation fields to CSV Download

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -9,7 +9,7 @@ module Api
     before_action :validate_idempotency_key, only: %i[create update]
     around_action :idempotent_action, only: %i[create update]
 
-    CSV_INCLUDES = [:from_location, :to_location, { profile: :documents }, { person: %i[gender ethnicity] }].freeze
+    CSV_INCLUDES = [:from_location, :to_location, :journeys, :profile, :supplier, { person: %i[gender ethnicity] }].freeze
 
     def index
       index_and_render

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -98,6 +98,7 @@ class Move < VersionedModel
   has_many :generic_events, as: :eventable, dependent: :destroy
   has_many :incident_events, -> { where classification: :incident }, as: :eventable, class_name: 'GenericEvent'
   has_many :notification_events, -> { where classification: :notification }, as: :eventable, class_name: 'GenericEvent'
+  has_many :cancellation_events, as: :eventable, class_name: 'GenericEvent::MoveCancel'
 
   validates :from_location, presence: true
   validates :to_location, presence: true, unless: -> { prison_recall? || video_remand? }
@@ -387,6 +388,10 @@ class Move < VersionedModel
 
   def cross_supplier?
     from_location&.suppliers != to_location&.suppliers
+  end
+
+  def billable?
+    journeys.select(&:billable?).any?
   end
 
 private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,7 @@ Rails.application.configure do
     Bullet.enable        = true
     Bullet.bullet_logger = true
     Bullet.add_footer    = true
+    Bullet.rails_logger = true
   end
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/db/migrate/20241125114943_add_index_to_generic_events_type.rb
+++ b/db/migrate/20241125114943_add_index_to_generic_events_type.rb
@@ -1,0 +1,5 @@
+class AddIndexToGenericEventsType < ActiveRecord::Migration[8.0]
+  def change
+    add_index :generic_events, :type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_18_095830) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_25_114943) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -284,6 +284,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_18_095830) do
     t.index ["occurred_at"], name: "index_generic_events_on_occurred_at"
     t.index ["recorded_at"], name: "index_generic_events_on_recorded_at"
     t.index ["supplier_id"], name: "index_generic_events_on_supplier_id"
+    t.index ["type"], name: "index_generic_events_on_type"
     t.index ["updated_at"], name: "index_generic_events_on_updated_at"
   end
 

--- a/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-cancelled-court-moves/01-weekly-cancelled-court-moves-config.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-cancelled-court-moves/01-weekly-cancelled-court-moves-config.yaml
@@ -13,34 +13,38 @@ data:
   retention: "1 week"
   confirm_email: "true"
   report_sql: |-
-      select m.status, 
-        m.reference, 
-        m.move_type, 
-        m.date, 
-        f.title as from_loc, 
-        t.title as to_loc, 
-        COALESCE(person.nomis_prison_number, person.prison_number) as prison_number,
+    SELECT m.status,
+      m.reference,
+      m.move_type,
+      m.date,
+      f.title AS FROM_loc,
+      t.title AS to_loc,
+      COALESCE(person.nomis_prison_number, person.prison_number) AS prison_number,
+      COALESCE(person.last_name, '(Allocation)') AS last_name,
+      m.created_at,
+      m.updated_at,
+      m.cancellation_reason,
+      m.cancellation_reason_comment,
+      e.created_at AS cancelled_at, e.created_by AS cancelled_by,
+      (SELECT EXISTS
+        (select * FROM journeys where move_id = m.id AND billable = true limit 1)::boolean)
+          AS journey_billable,
+      beforeafter((m.date::timestamp + interval '6 hours') - e.created_at) AS difference,
+      s.name AS journey_supplier
 
-        COALESCE(person.last_name, '(Allocation)') as last_name,
-        m.created_at,
-        m.updated_at,
-        m.cancellation_reason,
-        m.cancellation_reason_comment,
-        e.created_at as cancelled_at, e.created_by as cancelled_by,
-        j.billable as journey_billable,
-        beforeafter((m.date::timestamp +  interval '6 hours') - e.created_at) as difference,
-        s.name as journey_supplier
-        from moves m 
-          left join profiles pro on m.profile_id = pro.id
-        left join person_escort_records per on pro.id = per.profile_id
-        left join people person on  pro.person_id = person.id
-        left join locations f on  m.from_location_id = f.id
-        left join locations t on  m.to_location_id = t.id
-        left join generic_events e on e.eventable_type = 'Move' and e.eventable_id = m.id and type = 'GenericEvent::MoveCancel'
-        left join journeys j on j.move_id = m.id 
-        left join suppliers s on j.supplier_id = s.id 
-      where m.date between '[FROM]' and '[TO]' 
-      and m.status = 'cancelled' 
-      and m.move_type = 'court_appearance'
-      order by date, last_name, prison_number
+    FROM moves m
+      LEFT JOIN profiles pro ON m.profile_id = pro.id
+      LEFT JOIN person_escort_records per ON pro.id = per.profile_id
+      LEFT JOIN people person ON  pro.person_id = person.id
+      LEFT JOIN locations f ON  m.FROM_location_id = f.id
+      LEFT JOIN locations t ON  m.to_location_id = t.id
+      LEFT JOIN generic_events e ON e.eventable_type = 'Move'
+        AND e.eventable_id = m.id AND type = 'GenericEvent::MoveCancel'
+      LEFT JOIN suppliers s ON m.supplier_id = s.id
+
+    WHERE m.date between '[FROM]' and '[TO]'
+      AND m.status = 'cancelled'
+      AND m.move_type = 'court_appearance'
+
+    ORDER BY date, last_name, prison_number
 {{- end }}

--- a/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-cancelled-moves/01-weekly-cancelled-moves-config.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-cancelled-moves/01-weekly-cancelled-moves-config.yaml
@@ -13,33 +13,37 @@ data:
   retention: "1 week"
   confirm_email: "true"
   report_sql: |-
-      select m.status,
+    SELECT m.status,
       m.reference,
       m.move_type,
       m.date,
-      f.title as from_loc,
-      t.title as to_loc,
-      COALESCE(person.nomis_prison_number, person.prison_number) as prison_number,
-
-      COALESCE(person.last_name, '(Allocation)') as last_name,
+      f.title AS FROM_loc,
+      t.title AS to_loc,
+      COALESCE(person.nomis_prison_number, person.prison_number) AS prison_number,
+      COALESCE(person.last_name, '(Allocation)') AS last_name,
       m.created_at,
       m.updated_at,
       m.cancellation_reason,
       m.cancellation_reason_comment,
-      e.created_at as cancelled_at, e.created_by as cancelled_by,
-      j.billable as journey_billable,
-      beforeafter((m.date::timestamp -  interval '9 hours') - e.created_at) as difference,
-      s.name as journey_supplier
-      from moves m
-      left join profiles pro on m.profile_id = pro.id
-      left join person_escort_records per on pro.id = per.profile_id
-      left join people person on  pro.person_id = person.id
-      left join journeys j on j.move_id = m.id
-      left join locations f on  j.from_location_id = f.id
-      left join locations t on  j.to_location_id = t.id
-      left join generic_events e on e.eventable_type = 'Move' and e.eventable_id = m.id and type = 'GenericEvent::MoveCancel'
-      left join suppliers s on j.supplier_id = s.id
-      where m.date between '[FROM]' and '[TO]'
-      and m.status = 'cancelled'
-      order by date, last_name, prison_number
+      e.created_at AS cancelled_at, e.created_by AS cancelled_by,
+      (SELECT EXISTS
+        (select * FROM journeys where move_id = m.id AND billable = true limit 1)::boolean)
+          AS journey_billable,
+      beforeafter((m.date::timestamp + interval '6 hours') - e.created_at) AS difference,
+      s.name AS journey_supplier
+
+    FROM moves m
+      LEFT JOIN profiles pro ON m.profile_id = pro.id
+      LEFT JOIN person_escort_records per ON pro.id = per.profile_id
+      LEFT JOIN people person ON  pro.person_id = person.id
+      LEFT JOIN locations f ON  m.FROM_location_id = f.id
+      LEFT JOIN locations t ON  m.to_location_id = t.id
+      LEFT JOIN generic_events e ON e.eventable_type = 'Move'
+        AND e.eventable_id = m.id AND type = 'GenericEvent::MoveCancel'
+      LEFT JOIN suppliers s ON m.supplier_id = s.id
+
+    WHERE m.date BETWEEN '[FROM]' AND '[TO]'
+      AND m.status = 'cancelled'
+
+    ORDER BY date, last_name, prison_number
 {{- end }}

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -1066,4 +1066,20 @@ RSpec.describe Move do
       it { expect(move.cross_supplier?).to be true }
     end
   end
+
+  describe '#billable?' do
+    let!(:move) { create(:move, :with_journey) }
+
+    it 'is not billable' do
+      expect(move).not_to be_billable
+    end
+
+    context 'with a billable journey' do
+      before { create(:journey, move: move, billable: true) }
+
+      it 'is not billable' do
+        expect(move).to be_billable
+      end
+    end
+  end
 end

--- a/spec/requests/api/moves_controller_csv_spec.rb
+++ b/spec/requests/api/moves_controller_csv_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Api::MovesController do
           filter_params: { from_location_id: },
           ability:,
           order_params: {},
-          active_record_relationships: [:from_location, :to_location, { profile: :documents }, { person: %i[gender ethnicity] }],
+          active_record_relationships: [:from_location, :to_location, :journeys, :profile, :supplier, { person: %i[gender ethnicity] }],
         )
       end
     end

--- a/spec/services/moves/exporter_spec.rb
+++ b/spec/services/moves/exporter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Moves::Exporter do
   let(:from_location) { create(:location, title: 'From Location', nomis_agency_id: 'FROM1') }
   let(:to_location) { create(:location, title: 'To Location', nomis_agency_id: 'TO1') }
   let(:person) { create(:person) }
-  let!(:move) { create(:move, from_location:, to_location:, person:) }
+  let!(:move) { create(:move, :cancelled, from_location:, to_location:, person:) }
   let(:moves) { Move.where(id: move.id) }
   let!(:cancel_event) { create(:event_move_cancel, eventable: move) }
 
@@ -23,11 +23,11 @@ RSpec.describe Moves::Exporter do
   end
 
   it 'has correct number of header columns' do
-    expect(header.count).to eq(48)
+    expect(header.count).to eq(54)
   end
 
   it 'has correct number of body columns' do
-    expect(row.count).to eq(48)
+    expect(row.count).to eq(54)
   end
 
   it 'includes move details' do
@@ -68,6 +68,25 @@ RSpec.describe Moves::Exporter do
 
   it 'includes FALSE flag and empty comments when no alerts are present' do
     expect(row).to include('false', '')
+  end
+
+  context 'with a cancelled event that occurred_at a a specific time' do
+    before do
+      move.cancel!(cancellation_reason: 'cancelled_by_pmu', cancellation_reason_comment: 'cancelled early')
+      cancel_event.update!(occurred_at: move.date.to_time.advance(hours: -24.5))
+    end
+
+    it 'includes the cancellation_reason' do
+      expect(row).to include('cancelled_by_pmu')
+    end
+
+    it 'includes the cancellation_reason_comment' do
+      expect(row).to include('cancelled early')
+    end
+
+    it 'includes the `difference` between cancellation date and 9am cutoff on the day of the move' do
+      expect(row).to include('Before cutoff (1d 06h 30m)')
+    end
   end
 
   %w[violent escape hold_separately self_harm concealed_items other_risks health_issue medication wheelchair pregnant other_health interpreter not_to_be_released special_vehicle].each do |alert_type|
@@ -125,11 +144,11 @@ RSpec.describe Moves::Exporter do
       end
 
       it 'has correct number of header columns' do
-        expect(header.count).to eq(50)
+        expect(header.count).to eq(56)
       end
 
       it 'has correct number of body columns' do
-        expect(row.count).to eq(50)
+        expect(row.count).to eq(56)
       end
 
       it 'has the correct rows' do
@@ -149,11 +168,11 @@ RSpec.describe Moves::Exporter do
       end
 
       it 'has correct number of header columns' do
-        expect(header.count).to eq(48)
+        expect(header.count).to eq(54)
       end
 
       it 'has correct number of body columns' do
-        expect(row.count).to eq(48)
+        expect(row.count).to eq(54)
       end
     end
   end


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-530

### What?

Here, we

- Add 'Group 1, cancellation fields' to the CSV Download (weekly moves summary)
- Bring the Weekly Cancellation Reports (Monday morning cron job) inline with the CSV Download
- Add an index to `generic_events#type` to improve performance
- Enable bullet logging in the development console to help resolve n+1 queries

### Why?

- Users have reported that results from CSV Downloads and Weekly Cancellation Reports don't match up.
- The cutoff `difference` (time between the move date and cancellation of the move) is now calculated from 6am on the day of the move in all reports
- A move is now `billable` if any of the journeys are `billable`
- The acceptance criteria for Group 2 needs clarification (how to map column names to journey events) and will be revisited in another ticket 

