### PR TITLE
MAP-1917 Add a PerSuicideAndSelfHarm event

### DIFF
--- a/app/models/generic_event.rb
+++ b/app/models/generic_event.rb
@@ -87,6 +87,7 @@ class GenericEvent < ApplicationRecord
     PerPrisonerWelfare
     PerPropertyChange
     PerSelfHarm
+    PerSuicideAndSelfHarm
     PerUpdated
     PerViolentDangerous
     PerWeapons
@@ -110,6 +111,7 @@ class GenericEvent < ApplicationRecord
     incident: 'incident',
     medical: 'medical',
     notification: 'notification',
+    suicide_and_self_harm: 'suicide_and_self_harm',
   }
 
   belongs_to :eventable, polymorphic: true, touch: true

--- a/app/models/generic_event/per_suicide_and_self_harm.rb
+++ b/app/models/generic_event/per_suicide_and_self_harm.rb
@@ -1,0 +1,32 @@
+class GenericEvent
+  class PerSuicideAndSelfHarm < GenericEvent
+    LOCATION_ATTRIBUTE_KEY = :location_id
+
+    details_attributes :indication_of_self_harm_or_suicide,
+                       :nature_of_self_harm,
+                       :history_of_self_harm,
+                       :history_of_self_harm_recency,
+                       :history_of_self_harm_method,
+                       :history_of_self_harm_details,
+                       :actions_of_self_harm_undertaken,
+                       :observation_level,
+                       :comments,
+                       :reporting_officer,
+                       :reporting_officer_signed_at,
+                       :reception_officer,
+                       :reception_officer_signed_at,
+                       :supplier_personnel_number,
+                       :police_personnel_number
+
+    relationship_attributes location_id: :locations
+    eventable_types 'PersonEscortRecord'
+
+    include PersonnelNumberValidations
+    include LocationFeed
+    include LocationValidations
+
+    def event_classification
+      :suicide_and_self_harm
+    end
+  end
+end

--- a/spec/factories/generic_event.rb
+++ b/spec/factories/generic_event.rb
@@ -669,6 +669,16 @@ FactoryBot.define do
   factory :event_per_self_harm, parent: :per_incident, class: 'GenericEvent::PerSelfHarm' do
   end
 
+  factory :event_per_suicide_and_self_harm, parent: :generic_event, class: 'GenericEvent::PerSuicideAndSelfHarm' do
+    eventable { association(:person_escort_record) }
+    details do
+      {
+        location_id: create(:location).id,
+        supplier_personnel_number: SecureRandom.uuid,
+      }
+    end
+  end
+
   factory :event_per_violent_dangerous, parent: :per_incident, class: 'GenericEvent::PerViolentDangerous' do
   end
 

--- a/spec/models/generic_event/per_suicide_and_self_harm_spec.rb
+++ b/spec/models/generic_event/per_suicide_and_self_harm_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe GenericEvent::PerSuicideAndSelfHarm do
+  subject(:generic_event) { build(:event_per_suicide_and_self_harm) }
+
+  it_behaves_like 'an event with details', :indication_of_self_harm_or_suicide,
+                  :nature_of_self_harm,
+                  :history_of_self_harm,
+                  :history_of_self_harm_recency,
+                  :history_of_self_harm_method,
+                  :history_of_self_harm_details,
+                  :actions_of_self_harm_undertaken,
+                  :observation_level,
+                  :comments,
+                  :reporting_officer,
+                  :reporting_officer_signed_at,
+                  :reception_officer,
+                  :reception_officer_signed_at,
+                  :supplier_personnel_number,
+                  :police_personnel_number
+
+  it_behaves_like 'an event with relationships', location_id: :locations
+  it_behaves_like 'an event with eventable types', 'PersonEscortRecord'
+  it_behaves_like 'an event requiring a location', :location_id
+  it_behaves_like 'an event with a location in the feed', :location_id
+
+  it { is_expected.to validate_presence_of(:supplier_personnel_number) }
+
+  describe '#event_classification' do
+    subject(:event_classification) { generic_event.event_classification }
+
+    it { expect(event_classification).to eq(:suicide_and_self_harm) }
+  end
+end


### PR DESCRIPTION
### Jira link

[MAP-1917](https://dsdmoj.atlassian.net/browse/MAP-1917)

### What?

Add a new GenericEvent `PerSuicideAndSelfHarm` with classification `suicide_and_self_harm`

### Why?

Suppliers need to submit a PerSuicideAndSelfHarm via the API so it can be displayed as an important event in the move's timeline.

### Have you?

Documentation update: [wiki](https://github.com/ministryofjustice/hmpps-book-secure-move-api/wiki/Person-Escort-Record-Events#persuicideandselfharm)



[MAP-1917]: https://dsdmoj.atlassian.net/browse/MAP-1917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ