### PR TITLE
MAP-1975: Enable preprod refresh script via Helm chart

### DIFF
--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -119,7 +119,7 @@ dashboards:
 
 scripts:
   preprodRefresh:
-    enabled: false
+    enabled: true
     schedule: "15 6 * * *"
   reports:
     enabled: true


### PR DESCRIPTION
We added this to the helm chart but never enabled it, so it is actually still using the original manually-deployed preprod refresh script

MAP-1975
