### PR TITLE
MAP-1975: Use unique name for preprod versions job

### DIFF
--- a/helm_deploy/hmpps-book-secure-move-api/templates/preprod-refresh/08-refresh-versions-cronjob.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/preprod-refresh/08-refresh-versions-cronjob.yaml
@@ -1,12 +1,12 @@
 {{- $genericService := index .Values "generic-service" -}}
-{{- $fullName := printf "%s-%s" (include "generic-service.fullname" $) "preprod-refresh" | trunc 52 }}
+{{- $fullName := printf "%s-%s" (include "generic-service.fullname" $) "preprod-refresh-versions" | trunc 52 }}
 {{- $script1 := printf "%s-%s" (include "generic-service.fullname" $) "preprod-refresh-versions-script" | trunc 52 }}
 {{- if .Values.scripts.preprodRefresh.versions.enabled }}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: preprod-refresh-versions-job
+  name: {{ $fullName }}
 spec:
   schedule: {{ .Values.scripts.preprodRefresh.versions.schedule }}
   concurrencyPolicy: "Forbid"


### PR DESCRIPTION
So that the name doesn't clash with the manually deployed one, or with any parallel Helm deployment if one should exist

MAP-1975