### PR TITLE
MAP-1975: Shorten name for preprod refresh versions script

### DIFF
--- a/helm_deploy/hmpps-book-secure-move-api/templates/preprod-refresh/07-preprod-refresh-versions-script.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/preprod-refresh/07-preprod-refresh-versions-script.yaml
@@ -1,4 +1,4 @@
-{{- $fullName := printf "%s-%s" (include "generic-service.fullname" $) "preprod-refresh-versions-script" | trunc 52 }}
+{{- $fullName := printf "%s-%s" (include "generic-service.fullname" $) "preprod-refresh-vers-scrp" | trunc 52 }}
 {{- if .Values.scripts.preprodRefresh.versions.enabled }}
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
When truncated it ended with a hyphen which made k8s have a right moan

MAP-1975
