### PR TITLE
MAP-1976: Remove old live-1 URLs

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,7 +10,6 @@ generic-service:
     annotations:
       external-dns.alpha.kubernetes.io/set-identifier: hmpps-book-secure-move-api-v1-2-hmpps-book-secure-move-api-preprod-green
     hosts:
-      - hmpps-book-secure-move-api-preprod.apps.live-1.cloud-platform.service.justice.gov.uk
       - hmpps-book-secure-move-api-preprod.apps.cloud-platform.service.justice.gov.uk
 
   env:

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -11,7 +11,6 @@ generic-service:
       external-dns.alpha.kubernetes.io/set-identifier: hmpps-book-secure-move-api-v1-2-hmpps-book-secure-move-api-production-green
     hosts:
       - api.bookasecuremove.service.justice.gov.uk
-      - hmpps-book-secure-move-api-production.apps.live-1.cloud-platform.service.justice.gov.uk
       - hmpps-book-secure-move-api-production.apps.cloud-platform.service.justice.gov.uk
     tlsSecretName: hmpps-book-secure-move-api-production-cert
 

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -10,7 +10,6 @@ generic-service:
     annotations:
       external-dns.alpha.kubernetes.io/set-identifier: hmpps-book-secure-move-api-v1-2-hmpps-book-secure-move-api-staging-green
     hosts:
-      - hmpps-book-secure-move-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
       - hmpps-book-secure-move-api-staging.apps.cloud-platform.service.justice.gov.uk
 
   env:

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -11,7 +11,6 @@ generic-service:
       external-dns.alpha.kubernetes.io/set-identifier: hmpps-book-secure-move-api-v1-2-hmpps-book-secure-move-api-uat-green
       nginx.ingress.kubernetes.io/server-snippet: add_header X-Robots-Tag "noindex, nofollow";
     hosts:
-      - hmpps-book-secure-move-api-uat.apps.live-1.cloud-platform.service.justice.gov.uk
       - hmpps-book-secure-move-api-uat.apps.cloud-platform.service.justice.gov.uk
 
   env:


### PR DESCRIPTION
These are unused

MAP-1976

