### PR TITLE
MAP-1917 Add `source` to the PerSuicideAndSelfHarm attributes

### DIFF
--- a/app/models/generic_event/per_suicide_and_self_harm.rb
+++ b/app/models/generic_event/per_suicide_and_self_harm.rb
@@ -10,6 +10,7 @@ class GenericEvent
                        :history_of_self_harm_details,
                        :actions_of_self_harm_undertaken,
                        :observation_level,
+                       :source,
                        :comments,
                        :reporting_officer,
                        :reporting_officer_signed_at,

--- a/spec/models/generic_event/per_suicide_and_self_harm_spec.rb
+++ b/spec/models/generic_event/per_suicide_and_self_harm_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe GenericEvent::PerSuicideAndSelfHarm do
                   :actions_of_self_harm_undertaken,
                   :observation_level,
                   :comments,
+                  :source,
                   :reporting_officer,
                   :reporting_officer_signed_at,
                   :reception_officer,


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-1917

### What?

Adds `source` to the PerSuicideAndSelfHarm attributes

### Why?

To add `details.source` to the event and enable frontend display

### Usage 

"source": {
  "option": "Third Party",
  "details": "PC Plod at Nuneaton"
  "comments": "Lorem ipsum",
  "observations": "Lorem ipsum"
}
