### PR TITLE
Avoid migrating audit-trail data to pre-prod

### DIFF
--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -123,7 +123,7 @@ scripts:
       schedule: "0 */4 * * *"
       dataSince: "6 hours ago"
     versions:
-      enabled: true
+      enabled: false # disabled: there is no need to migrate audit-trail data to pre-prod
       schedule: "15 7 * * *"
       dataSince: "26 hours ago"
   reports:


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-1975

### What?

Currently, there are 165 million records in the versions table and the migrate script is not working.

### Why?

Rather than debugging the script, it makes more sense to disable it as there is no use case for Papertail version history on pre-prod.
