### PR TITLE
Restore framework flags to CSV downloads

### DIFF
--- a/db/migrate/20250109102311_add_index_title_to_framework_flags.rb
+++ b/db/migrate/20250109102311_add_index_title_to_framework_flags.rb
@@ -1,0 +1,5 @@
+class AddIndexTitleToFrameworkFlags < ActiveRecord::Migration[8.0]
+  def change
+    add_index :framework_flags, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_25_114943) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_09_102311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -161,6 +161,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_25_114943) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["framework_question_id"], name: "index_framework_flags_on_framework_question_id"
+    t.index ["title"], name: "index_framework_flags_on_title"
   end
 
   create_table "framework_flags_responses", id: false, force: :cascade do |t|

--- a/spec/services/moves/exporter_spec.rb
+++ b/spec/services/moves/exporter_spec.rb
@@ -109,7 +109,8 @@ RSpec.describe Moves::Exporter do
     expect(row).to include("Yikes!\n\nBam!")
   end
 
-  context 'with PER' do
+  context 'with PER and YRA' do
+    let(:from_location) { create(:location, :stc) }
     let(:framework_questions) do
       [
         create(:framework_question, section: 'risk-information'),
@@ -125,55 +126,36 @@ RSpec.describe Moves::Exporter do
       person_escort_record = create(:person_escort_record)
       create(:string_response, framework_question: framework_questions.first, responded: true, assessmentable: person_escort_record)
       create(:string_response, framework_question: framework_questions.second, responded: true, framework_flags: [flag], assessmentable: person_escort_record)
-      create(:string_response, framework_question: framework_questions.third, responded: true, framework_flags: [flag2], assessmentable: person_escort_record)
 
       person_escort_record
     end
 
-    before { move.person_escort_record = person_escort_record }
+    let(:youth_risk_assessment) do
+      youth_risk_assessment = create(:youth_risk_assessment)
+      create(:string_response, framework_question: framework_questions.third, responded: true, framework_flags: [flag2], assessmentable: youth_risk_assessment)
 
-    context 'when feature flag enabled' do
-      around do |example|
-        ClimateControl.modify(FEATURE_FLAG_CSV_ALERT_COLUMNS: 'true') do
-          example.run
-        end
-      end
-
-      it 'includes correct header names' do
-        expect(header).to eq(described_class::STATIC_HEADINGS + ['Flag 2', 'Flag 1'])
-      end
-
-      it 'has correct number of header columns' do
-        expect(header.count).to eq(56)
-      end
-
-      it 'has correct number of body columns' do
-        expect(row.count).to eq(56)
-      end
-
-      it 'has the correct rows' do
-        expect(row.last(2)).to eq(%w[TRUE TRUE])
-      end
+      youth_risk_assessment
     end
 
-    context 'when feature flag disabled' do
-      around do |example|
-        ClimateControl.modify(FEATURE_FLAG_CSV_ALERT_COLUMNS: 'false') do
-          example.run
-        end
-      end
+    before do
+      move.person_escort_record = person_escort_record
+      move.youth_risk_assessment = youth_risk_assessment
+    end
 
-      it 'includes correct header names' do
-        expect(header).to eq(described_class::STATIC_HEADINGS)
-      end
+    it 'includes correct header names' do
+      expect(header).to eq(described_class::STATIC_HEADINGS + ['Flag 2', 'Flag 1'])
+    end
 
-      it 'has correct number of header columns' do
-        expect(header.count).to eq(54)
-      end
+    it 'has correct number of header columns' do
+      expect(header.count).to eq(56)
+    end
 
-      it 'has correct number of body columns' do
-        expect(row.count).to eq(54)
-      end
+    it 'has correct number of body columns' do
+      expect(row.count).to eq(56)
+    end
+
+    it 'has the correct rows' do
+      expect(row.last(2)).to eq(%w[TRUE TRUE])
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-1971

### What?

Here we 
- restore the framework flags to the CSV downloads  
- add support for flags generated by the `Youth Risk Assessment`
- index the `framework_flags#title` to support `SELECT DISTINCT ON`


### Why?

The ticket is to add 4 individual framework flags to the CSV download but, having looked at the code, there was a prior requirement to display all the framework flags. Due to performance issues, this was hidden behind a feature flag. It seems like a good opportunity to restore the original behaviour and resolve the performance issues.

- [original ticket to add the framework flags](https://dsdmoj.atlassian.net/browse/MAP-346)
- [ticket to disable the framework flags](https://dsdmoj.atlassian.net/browse/MAP-511)

