### PR TITLE
MAP-1987 - Remove some fields from SAR Locations export

### DIFF
--- a/app/services/subject_access_request.rb
+++ b/app/services/subject_access_request.rb
@@ -92,8 +92,8 @@ private
 
   def serialize_location(location)
     LocationSerializer.new(location).serializable_hash.tap do |data|
-      [:disabled_at, :can_upload_documents, :extradition_capable].each do |k|
-        data[:data][:attributes].delete(k)
+      %i[disabled_at can_upload_documents extradition_capable].each do |k|
+        data.dig(:data, :attributes).delete(k)
       end
     end
   end

--- a/app/services/subject_access_request.rb
+++ b/app/services/subject_access_request.rb
@@ -91,7 +91,11 @@ private
   end
 
   def serialize_location(location)
-    LocationSerializer.new(location).serializable_hash.except(:disabled_at, :can_upload_documents, :extradition_capable)
+    LocationSerializer.new(location).serializable_hash.tap do |data|
+      [:disabled_at, :can_upload_documents, :extradition_capable].each do |k|
+        data[:data][:attributes].delete(k)
+      end
+    end
   end
 
   def serialize_ptr(ptr)


### PR DESCRIPTION
The fields were slightly more buried than originally thought