### PR TITLE
Extend eager loading to improve CSV download performance

### DIFF
--- a/app/services/moves/exporter.rb
+++ b/app/services/moves/exporter.rb
@@ -73,7 +73,17 @@ module Moves
         headings = STATIC_HEADINGS
         headings += flags_by_section
         csv << headings
-        moves.includes(:cancellation_events, :person_escort_record, :youth_risk_assessment).find_each do |move|
+        moves.includes(
+          :cancellation_events,
+          :journeys,
+          :from_location,
+          :to_location,
+          :profile,
+          :supplier,
+          person: %i[ethnicity gender],
+          person_escort_record: :framework_flags,
+          youth_risk_assessment: :framework_flags,
+        ).find_each do |move|
           csv << attributes_row(move)
         end
         file.flush


### PR DESCRIPTION
### Jira link

[MAP-1971](https://dsdmoj.atlassian.net/browse/MAP-1971)

### What?

Added eager loading to improve CSV download performance

 Benchmark for 4000 moves (in seconds)
`Benchmark.measure {  Moves::Exporter.new(Move.where.not(date: nil).limit(4000)).call }.total`

Before enabling framework_flags:
10.715672

After enabling framework_flags:
11.017437

After enabling framework_flags and eager loading refactor: 
4.828155


### Why?

CSV download performance is impaired and the download times out after 30 seconds



[MAP-1971]: https://dsdmoj.atlassian.net/browse/MAP-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ