### PR TITLE
Revert "Prevent prisons access to preprod (#2474)"

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -11,12 +11,7 @@ generic-service:
       external-dns.alpha.kubernetes.io/set-identifier: hmpps-book-secure-move-api-v1-2-hmpps-book-secure-move-api-preprod-green
     hosts:
       - hmpps-book-secure-move-api-preprod.apps.cloud-platform.service.justice.gov.uk
-      
-  allowlist: 
-    groups:
-      - circleci
-      - internal
-      
+
   env:
     SENTRY_ENVIRONMENT: "preprod"
     SERVE_API_DOCS: "false"


### PR DESCRIPTION
This reverts commit 5a548ed561772a211c4877c0c749fe727fa0d5ae which prevented access to:
https://hmpps-book-secure-move-api-preprod.apps.cloud-platform.service.justice.gov.uk/health

https://dsdmoj.atlassian.net/browse/MAP-2076
 