### PR TITLE
Fix Prometheus metrics duplicate registration in development

### DIFF
--- a/app/lib/prometheus_metrics.rb
+++ b/app/lib/prometheus_metrics.rb
@@ -24,11 +24,15 @@ private
   end
 
   def move_count_gauge
-    @move_count_gauge ||= registry.gauge(
-      :app_move_count_total,
-      docstring: 'The total count of the number of moves.',
-      labels: %i[status],
-      store_settings: { aggregation: :max },
-    )
+    @move_count_gauge ||= if registry.exist?(:app_move_count_total)
+                            registry.get(:app_move_count_total)
+                          else
+                            registry.gauge(
+                              :app_move_count_total,
+                              docstring: 'The total count of the number of moves.',
+                              labels: %i[status],
+                              store_settings: { aggregation: :max },
+                            )
+                          end
   end
 end


### PR DESCRIPTION
This was causing problems in development:

```
Prometheus::Client::Registry::AlreadyRegisteredError (app_move_count_total has already been registered):
app/lib/prometheus_metrics.rb:27:in move_count_gauge'
app/lib/prometheus_metrics.rb:16:in block in record_move_count'
app/lib/prometheus_metrics.rb:15:in each'
app/lib/prometheus_metrics.rb:15:in record_move_count'
```

We now looking for an existing `app_move_count_total` before generating a new one:

```
f registry.exist?(:app_move_count_total)...
```

