### PR TITLE
Ensure Helm Chart uses correct GOVUK_NOTIFY_MOVE_REJECT_TEMPLATE_ID

### DIFF
--- a/helm_deploy/hmpps-book-secure-move-api/values.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/values.yaml
@@ -46,7 +46,7 @@ generic-service:
 
   poddisruptionbudget:
     minAvailable: 50%
-  
+
 sidekiq:
   replicaCount: 2
   overrideValues:
@@ -54,7 +54,7 @@ sidekiq:
       AWS_DEFAULT_REGION: "eu-west-2"
       GOVUK_NOTIFY_ENABLED: "TRUE"
       GOVUK_NOTIFY_MOVE_TEMPLATE_ID: "8f2e5473-15f2-4db8-a2de-153f26a0524c"
-      GOVUK_NOTIFY_MOVE_REJECTED_TEMPLATE_ID: "e728365d-5b0c-41ee-8c76-aca57f59c843"
+      GOVUK_NOTIFY_MOVE_REJECT_TEMPLATE_ID: "e728365d-5b0c-41ee-8c76-aca57f59c843"
       GOVUK_NOTIFY_PER_TEMPLATE_ID: "e2aa6021-d0a7-475f-afce-68b49ec9c2c6"
       GOVUK_NOTIFY_REPORT_TEMPLATE_ID: "aa5fbe87-e530-495e-8135-fcd237893be9"
 


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-2128

### What?

Sets the correct `GOVUK_NOTIFY_MOVE_REJECT_TEMPLATE_ID`

### Why?

It was incorrectly set as `GOVUK_NOTIFY_MOVE_REJECTED_TEMPLATE_ID`