### PR TITLE
Ensure MoveRejectMailer uses the Sidekiq worker

### DIFF
--- a/app/models/generic_event/move_reject.rb
+++ b/app/models/generic_event/move_reject.rb
@@ -26,7 +26,7 @@ class GenericEvent
       return if move.cancelled?
 
       if move_proposed_by_email
-        MoveRejectMailer.notify(move_proposed_by_email, move, self).deliver_now!
+        MoveRejectMailer.notify(move_proposed_by_email, move, self).deliver_later
       end
     end
 

--- a/spec/models/generic_event/move_reject_spec.rb
+++ b/spec/models/generic_event/move_reject_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe GenericEvent::MoveReject do
       end
 
       it 'sends a notification email' do
-        expect(mailer_double).to receive(:deliver_now!)
+        expect(mailer_double).to receive(:deliver_later)
         move_reject
       end
 
@@ -99,7 +99,7 @@ RSpec.describe GenericEvent::MoveReject do
         end
 
         it 'sends a notification email to the username' do
-          expect(mailer_double).to receive(:deliver_now!)
+          expect(mailer_double).to receive(:deliver_later)
           move_reject
         end
       end


### PR DESCRIPTION

### Jira link

https://dsdmoj.atlassian.net/browse/MAP-2128

### What?

Invoke the MoveRejectMailer with `deliver_later` 

### Why?

Only the Sidekiq instance has access to the NOTIFY env vars, 
so we can't `deliver_now!`
 