### PR TITLE
Remove erroneous full-stop that is already in the Notify template

### DIFF
--- a/app/mailers/move_reject_mailer.rb
+++ b/app/mailers/move_reject_mailer.rb
@@ -25,7 +25,7 @@ private
     when 'no_transport_available'
       'no transport is available for this move'
     when 'no_space_at_receiving_prison'
-      "there are no spaces at #{move.to_location.title} on the dates you requested."
+      "there are no spaces at #{move.to_location.title} on the dates you requested"
     end
   end
 end

--- a/spec/mailer/move_reject_mailer_spec.rb
+++ b/spec/mailer/move_reject_mailer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe MoveRejectMailer, type: :mailer do
     context 'when rejection reason is no_space_at_receiving_prison' do
       let(:rejection_reason) { 'no_space_at_receiving_prison' }
 
-      it { is_expected.to include('rejection-reason': "there are no spaces at #{move.to_location.title} on the dates you requested.") }
+      it { is_expected.to include('rejection-reason': "there are no spaces at #{move.to_location.title} on the dates you requested") }
     end
 
     context 'when rejection reason is no_transport_available' do


### PR DESCRIPTION
### Jira link

[MAP-2128](https://dsdmoj.atlassian.net/browse/MAP-2128)

### What?

Remove erroneous full-stop from Notify personalisation

### Why?

It is already in the Notify template

[MAP-2128]: https://dsdmoj.atlassian.net/browse/MAP-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ