### PR TITLE
Revert "Save the X-Client-IP to access_logs#client_ip (#2525)"

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -365,7 +365,6 @@ private
       timestamp: Time.zone.now,
       whodunnit: created_by,
       client: current_user&.name,
-      client_ip: request.headers['X-Client-IP'],
       verb: request.method,
       controller_name:,
       path: request.path,

--- a/db/migrate/20250325111637_add_client_ip_to_access_logs.rb
+++ b/db/migrate/20250325111637_add_client_ip_to_access_logs.rb
@@ -1,6 +1,0 @@
-class AddClientIpToAccessLogs < ActiveRecord::Migration[8.0]
-  def change
-    add_column :access_logs, :client_ip, :string
-    add_index :access_logs, :client_ip
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_25_111637) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_09_102311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -28,9 +28,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_25_111637) do
     t.string "path"
     t.string "params"
     t.text "body"
-    t.string "client_ip"
     t.index ["client"], name: "index_access_logs_on_client"
-    t.index ["client_ip"], name: "index_access_logs_on_client_ip"
     t.index ["controller_name"], name: "index_access_logs_on_controller_name"
     t.index ["timestamp"], name: "index_access_logs_on_timestamp"
   end


### PR DESCRIPTION
This reverts commit d51ca2f600e3a65ecbbde40eac5d6318b60c762b.

Disable the long-running indexing of the `access_logs` table