### PR TITLE
Remove unused logstash gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,8 +59,6 @@ gem 'ostruct'
 # Augments Rails logging to output JSON for Fluentd/Kibana
 # on Cloud Platform
 gem 'lograge'
-gem 'logstash-event'
-gem 'logstash-logger'
 
 group :development, :test do
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,9 +264,6 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    logstash-event (1.2.02)
-    logstash-logger (0.26.1)
-      logstash-event (~> 1.2)
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -580,8 +577,6 @@ DEPENDENCIES
   kaminari
   listen
   lograge
-  logstash-event
-  logstash-logger
   net-http-persistent
   nokogiri
   notifications-ruby-client


### PR DESCRIPTION
### Jira link

N/A

### What?

Removed gems: `logstash-event` and `logstash-logger`

### Why?
Dependabot flagged a security vulnerability: https://github.com/ministryofjustice/hmpps-book-secure-move-api/security/dependabot/102

There is no indication that we actually use logstash, so removing it.
