### PR TITLE
MAP-2387 Add prisoner location to moves api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ NOMIS_SITE_FOR_AUTH='https://nomis-api.example.com/auth'
 NOMIS_PRISON_API_PATH_PREFIX='/api'
 ALERTS_API_BASE_URL=https://alerts-api-dev.hmpps.service.justice.gov.uk/
 MANAGE_USERS_API_BASE_URL=https://manage-users-api-dev.hmpps.service.justice.gov.uk/
+PRISONER_SEARCH_API_BASE_URL=https://prisoner-search-dev.prison.service.justice.gov.uk/
 SENTRY_DSN='https://sentry.example.com/'
 
 ENCRYPTOR_SALT="\x97\x19\xBF\xF6\xC2\x9DZ\x92D\xFFq\xFC\x9B\x1C\xC4\t\x95\xBA\xBF\xF7q<\xC9\xFC\x81\xBD;\xDEtH\xA4\xB2"

--- a/app/lib/prisoner_search_api_client/base.rb
+++ b/app/lib/prisoner_search_api_client/base.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PrisonerSearchApiClient
+  class Base < HmppsApiClient
+    class << self
+    protected
+
+      def site_for_api
+        ENV['PRISONER_SEARCH_API_BASE_URL']
+      end
+
+      def token_request_path_prefix
+        ''
+      end
+    end
+  end
+end

--- a/app/lib/prisoner_search_api_client/location_description.rb
+++ b/app/lib/prisoner_search_api_client/location_description.rb
@@ -1,0 +1,15 @@
+module PrisonerSearchApiClient
+  class LocationDescription < PrisonerSearchApiClient::Base
+    class << self
+      def get(prison_number)
+        JSON.parse(fetch_response(prison_number).body)['locationDescription']
+      rescue OAuth2::Error
+        nil
+      end
+
+      def fetch_response(prison_number)
+        PrisonerSearchApiClient::Base.get("/prisoner/#{prison_number}")
+      end
+    end
+  end
+end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -394,6 +394,10 @@ class Move < VersionedModel
     journeys.select(&:billable?).any?
   end
 
+  def prisoner_location_description
+    PrisonerSearchApiClient::LocationDescription.get(person.prison_number) if person
+  end
+
 private
 
   def date_to_after_date_from

--- a/app/serializers/move_serializer.rb
+++ b/app/serializers/move_serializer.rb
@@ -20,7 +20,8 @@ class MoveSerializer
              :move_agreed,
              :move_agreed_by,
              :date_from,
-             :date_to
+             :date_to,
+             :prisoner_location_description
 
   has_one :person
   belongs_to :profile

--- a/app/serializers/v2/move_serializer.rb
+++ b/app/serializers/v2/move_serializer.rb
@@ -23,7 +23,8 @@ module V2
                :time_due,
                :updated_at,
                :is_lockout,
-               :recall_date
+               :recall_date,
+               :prisoner_location_description
 
     belongs_to :from_location,          serializer: LocationSerializer
     belongs_to :prison_transfer_reason, serializer: PrisonTransferReasonSerializer

--- a/app/serializers/v2/moves_serializer.rb
+++ b/app/serializers/v2/moves_serializer.rb
@@ -21,7 +21,8 @@ module V2
                 :time_due,
                 :updated_at,
                 :is_lockout,
-                :recall_date
+                :recall_date,
+                :prisoner_location_description
 
     set_type :moves
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -35,6 +35,7 @@ generic-service:
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       ALERTS_API_BASE_URL: alerts_api_base_url_key
       MANAGE_USERS_API_BASE_URL: manage_users_api_base_url_key
+      PRISONER_SEARCH_API_BASE_URL: prisoner_search_api_base_url_key
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key
       ENCRYPTOR_SALT: encryptor_salt

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -42,6 +42,7 @@ generic-service:
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       ALERTS_API_BASE_URL: alerts_api_base_url_key
       MANAGE_USERS_API_BASE_URL: manage_users_api_base_url_key
+      PRISONER_SEARCH_API_BASE_URL: prisoner_search_api_base_url_key
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key
       PER_QUALITY_REPORT_RECIPIENTS: per_quality_report_recipients

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -37,6 +37,7 @@ generic-service:
       NOMIS_PRISON_API_PATH_PREFIX: nomis_prison_api_path_prefix_key
       ALERTS_API_BASE_URL: alerts_api_base_url_key
       MANAGE_USERS_API_BASE_URL: manage_users_api_base_url_key
+      PRISONER_SEARCH_API_BASE_URL: prisoner_search_api_base_url_key
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -36,6 +36,7 @@ generic-service:
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       ALERTS_API_BASE_URL: alerts_api_base_url_key
       MANAGE_USERS_API_BASE_URL: manage_users_api_base_url_key
+      PRISONER_SEARCH_API_BASE_URL: prisoner_search_api_base_url_key
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key
       ENCRYPTOR_SALT: encryptor_salt

--- a/spec/fixtures/files/prisoner_search_api/get_prisoner_200.json
+++ b/spec/fixtures/files/prisoner_search_api/get_prisoner_200.json
@@ -1,0 +1,169 @@
+{
+  "prisonerNumber": "A1234AA",
+  "pncNumber": "12/394773H",
+  "pncNumberCanonicalShort": "12/394773H",
+  "pncNumberCanonicalLong": "2012/394773H",
+  "croNumber": "29906/12J",
+  "bookingId": "0001200924",
+  "bookNumber": "38412A",
+  "title": "Ms",
+  "firstName": "Robert",
+  "middleNames": "John James",
+  "lastName": "Larsen",
+  "dateOfBirth": "1975-04-02",
+  "gender": "Female",
+  "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+  "raceCode": "W1",
+  "youthOffender": true,
+  "maritalStatus": "Widowed",
+  "religion": "Church of England (Anglican)",
+  "nationality": "Egyptian",
+  "status": "ACTIVE IN",
+  "lastMovementTypeCode": "CRT",
+  "lastMovementReasonCode": "CA",
+  "inOutStatus": "IN",
+  "prisonId": "MDI",
+  "lastPrisonId": "MDI",
+  "prisonName": "HMP Leeds",
+  "cellLocation": "A-1-002",
+  "aliases": [
+    {
+      "title": "Ms",
+      "firstName": "Robert",
+      "middleNames": "Trevor",
+      "lastName": "Lorsen",
+      "dateOfBirth": "1975-04-02",
+      "gender": "Male",
+      "ethnicity": "White : Irish",
+      "raceCode": "W1"
+    }
+  ],
+  "alerts": [
+    {
+      "alertType": "H",
+      "alertCode": "HA",
+      "active": true,
+      "expired": true
+    }
+  ],
+  "csra": "HIGH",
+  "category": "C",
+  "complexityOfNeedLevel": "low",
+  "legalStatus": "SENTENCED",
+  "imprisonmentStatus": "LIFE",
+  "imprisonmentStatusDescription": "Serving Life Imprisonment",
+  "convictedStatus": "Convicted",
+  "mostSeriousOffence": "Robbery",
+  "recall": false,
+  "indeterminateSentence": true,
+  "sentenceStartDate": "2020-04-03",
+  "releaseDate": "2023-05-02",
+  "confirmedReleaseDate": "2023-05-01",
+  "sentenceExpiryDate": "2023-05-01",
+  "licenceExpiryDate": "2023-05-01",
+  "homeDetentionCurfewEligibilityDate": "2023-05-01",
+  "homeDetentionCurfewActualDate": "2023-05-01",
+  "homeDetentionCurfewEndDate": "2023-05-02",
+  "topupSupervisionStartDate": "2023-04-29",
+  "topupSupervisionExpiryDate": "2023-05-01",
+  "additionalDaysAwarded": 10,
+  "nonDtoReleaseDate": "2023-05-01",
+  "nonDtoReleaseDateType": "ARD",
+  "receptionDate": "2023-05-01",
+  "lastAdmissionDate": "2023-05-01",
+  "paroleEligibilityDate": "2023-05-01",
+  "automaticReleaseDate": "2023-05-01",
+  "postRecallReleaseDate": "2023-05-01",
+  "conditionalReleaseDate": "2023-05-01",
+  "actualParoleDate": "2023-05-01",
+  "tariffDate": "2023-05-01",
+  "releaseOnTemporaryLicenceDate": "2023-05-01",
+  "locationDescription": "Outside - released from Leeds",
+  "restrictedPatient": true,
+  "supportingPrisonId": "LEI",
+  "dischargedHospitalId": "HAZLWD",
+  "dischargedHospitalDescription": "Hazelwood House",
+  "dischargeDate": "2020-05-01",
+  "dischargeDetails": "Psychiatric Hospital Discharge to Hazelwood House",
+  "currentIncentive": {
+    "level": {
+      "code": "STD",
+      "description": "Standard"
+    },
+    "dateTime": "2022-11-10T15:47:24",
+    "nextReviewDate": "2022-11-10"
+  },
+  "heightCentimetres": 200,
+  "weightKilograms": 102,
+  "hairColour": "Blonde",
+  "rightEyeColour": "Green",
+  "leftEyeColour": "Hazel",
+  "facialHair": "Clean Shaven",
+  "shapeOfFace": "Round",
+  "build": "Muscular",
+  "shoeSize": 10,
+  "tattoos": [
+    {
+      "bodyPart": "Head",
+      "comment": "Skull and crossbones covering chest"
+    }
+  ],
+  "scars": [
+    {
+      "bodyPart": "Head",
+      "comment": "Skull and crossbones covering chest"
+    }
+  ],
+  "marks": [
+    {
+      "bodyPart": "Head",
+      "comment": "Skull and crossbones covering chest"
+    }
+  ],
+  "addresses": [
+    {
+      "fullAddress": "1",
+      "postalCode": "S10 1BP",
+      "startDate": "2020-07-17",
+      "primaryAddress": true,
+      "noFixedAddress": true,
+      "phoneNumbers": [
+        {
+          "type": "HOME, MOB",
+          "number": "01141234567"
+        }
+      ]
+    }
+  ],
+  "emailAddresses": [
+    {
+      "email": "john.smith@gmail.com"
+    }
+  ],
+  "phoneNumbers": [
+    {
+      "type": "HOME, MOB",
+      "number": "01141234567"
+    }
+  ],
+  "identifiers": [
+    {
+      "type": "PNC, CRO, DL, NINO",
+      "value": "12/394773H",
+      "issuedDate": "2020-07-17",
+      "issuedAuthorityText": "string",
+      "createdDateTime": "2020-07-17T12:34:56.833Z"
+    }
+  ],
+  "allConvictedOffences": [
+    {
+      "statuteCode": "TH68",
+      "offenceCode": "TH68010",
+      "offenceDescription": "Theft from a shop",
+      "offenceDate": "2024-05-23",
+      "latestBooking": true,
+      "sentenceStartDate": "2018-03-10",
+      "primarySentence": true
+    }
+  ]
+}

--- a/spec/fixtures/files/prisoner_search_api/get_prisoner_404.json
+++ b/spec/fixtures/files/prisoner_search_api/get_prisoner_404.json
@@ -1,0 +1,4 @@
+{
+    "status": 404,
+    "developerMessage": "UN_KNOWN not found"
+}

--- a/spec/lib/prisoner_search_api_client/location_description_spec.rb
+++ b/spec/lib/prisoner_search_api_client/location_description_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PrisonerSearchApiClient::LocationDescription, :with_hmpps_authentication do
+  describe '.get' do
+    let(:response) { described_class.get('A1234AA') }
+
+    let(:response_body) { file_fixture('prisoner_search_api/get_prisoner_200.json').read }
+
+    let(:response_status) { 200 }
+
+    it 'returns the expected locationDescription' do
+      expect(response).to eq('Outside - released from Leeds')
+    end
+  end
+
+  describe '.get with errors' do
+    let(:response) { described_class.get('UN_KNOWN') }
+
+    let(:response_body) { file_fixture('prisoner_search_api/get_prisoner_404.json').read }
+
+    let(:response_status) { 404 }
+
+    it 'returns nil' do
+      expect(response).to be_nil
+    end
+  end
+end

--- a/spec/lib/prisoner_search_api_client/location_description_spec.rb
+++ b/spec/lib/prisoner_search_api_client/location_description_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PrisonerSearchApiClient::LocationDescription, :with_hmpps_authentication do
+RSpec.describe PrisonerSearchApiClient::LocationDescription, :with_hmpps_authentication, :with_location_description_api do
   describe '.get' do
     let(:response) { described_class.get('A1234AA') }
 

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -1105,4 +1105,33 @@ RSpec.describe Move do
       end
     end
   end
+
+  describe '#prisoner_location_description' do
+    let(:prison_number) { 'A1234BC' }
+    let(:person) { create(:person, prison_number: prison_number) }
+    let(:profile) { create(:profile, person: person) }
+    let(:move) { create(:move, profile: profile) }
+
+    context 'when the API returns a location description' do
+      let(:location_description) { 'HMP Leeds' }
+
+      before do
+        allow(PrisonerSearchApiClient::LocationDescription).to receive(:get).with(prison_number).and_return(location_description)
+      end
+
+      it 'returns the location description from the API' do
+        expect(move.prisoner_location_description).to eq(location_description)
+      end
+    end
+
+    context 'when the API returns nil' do
+      before do
+        allow(PrisonerSearchApiClient::LocationDescription).to receive(:get).with(prison_number).and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(move.prisoner_location_description).to be_nil
+      end
+    end
+  end
 end

--- a/spec/serializers/move_serializer_spec.rb
+++ b/spec/serializers/move_serializer_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe MoveSerializer do
     it 'contains an additional_information attribute' do
       expect(attributes[:additional_information]).to eql move.additional_information
     end
+
+    it 'contains a prisoner_location_description attribute' do
+      expect(attributes[:prisoner_location_description]).to eql move.prisoner_location_description
+    end
   end
 
   context 'with main options' do

--- a/spec/serializers/v2/move_serializer_spec.rb
+++ b/spec/serializers/v2/move_serializer_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe V2::MoveSerializer do
             updated_at: move.updated_at.iso8601,
             is_lockout: false,
             recall_date: move.recall_date.iso8601,
+            prisoner_location_description: move.prisoner_location_description,
           },
           relationships: {
             profile: { data: { id: move.profile.id, type: 'profiles' } },

--- a/spec/serializers/v2/moves_serializer_spec.rb
+++ b/spec/serializers/v2/moves_serializer_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe V2::MovesSerializer do
             updated_at: move.updated_at.iso8601,
             is_lockout: false,
             recall_date: move.recall_date.iso8601,
+            prisoner_location_description: move.prisoner_location_description,
           },
           relationships: {
             profile: { data: { id: move.profile_id, type: 'profiles' } },

--- a/spec/support/with_hmpps_auth_context.rb
+++ b/spec/support/with_hmpps_auth_context.rb
@@ -37,6 +37,8 @@ RSpec.shared_context 'with HmppsAuthClient', shared_context: :metadata do
     ManageUsersApiClient::Base.instance_variable_set(:@token, nil)
     NomisClient::Base.instance_variable_set(:@client, nil)
     NomisClient::Base.instance_variable_set(:@token, nil)
+    PrisonerSearchApiClient::Base.instance_variable_set(:@client, nil)
+    PrisonerSearchApiClient::Base.instance_variable_set(:@token, nil)
 
     allow(OAuth2::Client).to receive(:new).and_return(oauth2_client)
   end
@@ -50,6 +52,8 @@ RSpec.shared_context 'with HmppsAuthClient', shared_context: :metadata do
     ManageUsersApiClient::Base.instance_variable_set(:@token, nil)
     NomisClient::Base.instance_variable_set(:@client, nil)
     NomisClient::Base.instance_variable_set(:@token, nil)
+    PrisonerSearchApiClient::Base.instance_variable_set(:@client, nil)
+    PrisonerSearchApiClient::Base.instance_variable_set(:@token, nil)
   end
 end
 

--- a/swagger/v1/move_include_parameter.yaml
+++ b/swagger/v1/move_include_parameter.yaml
@@ -39,4 +39,5 @@ MoveIncludeParameter:
       - profile.youth_risk_assessment.responses.nomis_mappings
       - profile.youth_risk_assessment.responses.question
       - profile.youth_risk_assessment.responses.question.descendants.\*\*
+      - prisoner_location_description
   example: from_location

--- a/swagger/v2/move_include_parameter.yaml
+++ b/swagger/v2/move_include_parameter.yaml
@@ -39,4 +39,5 @@ MoveIncludeParameter:
       - timeline_events
       - timeline_events.eventable
       - lodgings
+      - prisoner_location_description
   example: from_location

--- a/swagger/v2/moves_include_parameter.yaml
+++ b/swagger/v2/moves_include_parameter.yaml
@@ -19,4 +19,5 @@ MovesIncludeParameter:
       - to_location
       - important_events
       - timeline_events
+      - prisoner_location_description
   example: from_location


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-2387

### What?

Enables suppliers to checked prisoners are at establishment prior to pick up  

- introduced a Prisoner Search API client to retrieve a locationDescription
- added `prisoner_location_description` to the Move/Moves serializers eg:
 ```
prisonerLocationDescription: 'Winchester (HMP)` (prisoner is in this prison)
prisonerLocationDescription: 'Outside - released from Winchester (HMP)` (prisoner is not in this prison)
```

### Why?

Sometimes after a move is booked in advance, the prisoner being moved is temporarily out of the prison on the day of the move. If the move isn’t changed or cancelled, the supplier still arrives to collect which results in wasted journey which we’re still charged for.

### Have you?  

- [x] Updated API docs 	
- [x] Added new environment variables to the [Helm chart](https://github.com/ministryofjustice/hmpps-book-secure-move-api/tree/main/helm_deploy)
- [x] PRISONER_SEARCH_API_BASE_URL is in the staging env
- [x] PRISONER_SEARCH_API_BASE_URL is in the uat env
- [x] PRISONER_SEARCH_API_BASE_URL is in the preprod env
- [x] PRISONER_SEARCH_API_BASE_URL is in the production env

### Deployment risks 
- Requires environment variable: `PRISONER_SEARCH_API_BASE_URL` in all environments


