### PR TITLE
Rollback oauth2 gem from 2.0.10 to 2.0.9 to restore SnakyHash 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'kaminari'
 gem 'net-http-persistent'
 gem 'nokogiri'
 gem 'notifications-ruby-client'
-gem 'oauth2'
+gem 'oauth2', '2.0.9' # 2.0.10 introduces breaking changes. MAP-2438.
 gem 'paper_trail'
 gem 'pg'
 gem 'prometheus-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,14 +301,13 @@ GEM
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
-    oauth2 (2.0.10)
-      faraday (>= 0.17.3, < 4.0)
-      jwt (>= 1.0, < 4.0)
-      logger (~> 1.2)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
-      version_gem (>= 1.1.8, < 3)
+      version_gem (~> 1.1)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -582,7 +581,7 @@ DEPENDENCIES
   net-http-persistent
   nokogiri
   notifications-ruby-client
-  oauth2
+  oauth2 (= 2.0.9)
   ostruct
   paper_trail
   pg


### PR DESCRIPTION
### Jira link

MAP-2348

### What?

In `oauth2 v2.0.10`, API responses are parsed into regular Ruby Hash objects, whereas in `oauth2 v2.0.9` they are parsed into SnakyHash::StringKeyed objects.

- 2.0.9 (working): `response['reasonableAdjustments'`] would work even if the actual key was `reasonable_adjustments` thanks to SnakyHash::StringKeyed

- 2.0.10 (broken): `response['reasonableAdjustments']` returns nil when the key is `reasonable_adjustments` because it's a regular Hash

### Why?

The tests didn't pick this up so we are rolling back the oauth2 upgrade until we can figure out the possible impact.
 