### PR TITLE
Add weekly prison recall report

### DIFF
--- a/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-prison-recalls/01-weekly-prison-recalls-config.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-prison-recalls/01-weekly-prison-recalls-config.yaml
@@ -1,0 +1,53 @@
+{{- $fullName := printf "%s-%s" (include "generic-service.fullname" $) "weekly-prison-recall-config" | trunc 52 }}
+{{- if .Values.scripts.reports.weeklyPrisonRecalls.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}
+data:
+  from-date: "7 days ago"
+  to-date: "1 day ago"
+  subject: "BaSM Prison Recall Report [TODAY_DATE]"
+  body: "BaSM Prison Recall report for last week ([FROM_DATE_FULL] to [TO_DATE_FULL]) is available at the link below."
+  filename: "basm-prison-recall-report-[TODAY_DATE]"
+  retention: "1 week"
+  confirm_email: "true"
+  report_sql: |-
+    SELECT
+        moves.status AS "Status",
+        moves.move_type AS "Move type",
+        from_location.title AS "From location name",
+        from_location.nomis_agency_id AS "From location code",
+        to_location.title AS "To location name",
+        to_location.nomis_agency_id AS "To location code",
+        moves.additional_information AS "Additional information",
+        TO_CHAR(moves.date, 'YYYY-MM-DD') AS "Date of travel",
+        people.prison_number AS "Prison number",
+        people.last_name AS "Last name",
+        people.first_names AS "First name",
+        TO_CHAR(people.date_of_birth, 'YYYY-MM-DD') AS "Date of birth",
+        genders.title AS "Gender",
+        CASE WHEN EXISTS (
+            SELECT 1 FROM journeys
+            WHERE journeys.move_id = moves.id
+            AND journeys.billable = true
+        ) THEN true ELSE false END AS "Journey billable",
+        suppliers.name AS "Supplier"
+    FROM
+        moves
+    LEFT JOIN
+        locations AS from_location ON moves.from_location_id = from_location.id
+    LEFT JOIN
+        locations AS to_location ON moves.to_location_id = to_location.id
+    LEFT JOIN
+        profiles ON moves.profile_id = profiles.id
+    LEFT JOIN
+        people ON profiles.person_id = people.id
+    LEFT JOIN
+        genders ON people.gender_id = genders.id
+    LEFT JOIN
+        suppliers ON moves.supplier_id = suppliers.id
+    WHERE moves.move_type = 'prison_recall'
+        AND moves.date BETWEEN '[FROM]' AND '[TO]'
+    ORDER BY moves.date, people.last_name, people.prison_number
+{{- end }}

--- a/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-prison-recalls/02-weekly-prison-recalls-cronjob.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/templates/reports/weekly-prison-recalls/02-weekly-prison-recalls-cronjob.yaml
@@ -1,0 +1,107 @@
+{{- $fullName := printf "%s-%s" (include "generic-service.fullname" $) "weekly-prison-recall-report" | trunc 52 }}
+{{- $script := printf "%s-%s" (include "generic-service.fullname" $) "automated-reports-scripts" | trunc 52 }}
+{{- $config := printf "%s-%s" (include "generic-service.fullname" $) "weekly-prison-recall-config" | trunc 52 }}
+{{- if .Values.scripts.reports.weeklyPrisonRecalls.enabled }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $fullName }}
+spec:
+  schedule: {{ .Values.scripts.reports.weeklyPrisonRecalls.schedule }}
+  concurrencyPolicy: "Forbid"
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 345600
+      backoffLimit: 0
+      activeDeadlineSeconds: 7200
+      template:
+        spec:
+          serviceAccountName: "book-a-secure-move-api"
+          containers:
+            - name: weekly-prison-recall
+              image: "ghcr.io/ministryofjustice/hmpps-devops-tools:latest"
+              command: ["bash", "/scripts/run-report.sh"]
+              volumeMounts:
+                - name: report-scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: report-sql
+                  mountPath: /report
+                  readOnly: false
+              env:
+                - name: DB_INSTANCE
+                  valueFrom:
+                    secretKeyRef:
+                      name: read-rds-instance-hmpps-book-secure-move-api-production
+                      key: url
+                - name: NOTIFY_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-book-secure-move-api-secrets-production
+                      key: govuk_notify_api_key
+                - name: REPORT_START
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ $config }}
+                      key: from-date
+                - name: REPORT_END
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ $config }}
+                      key: to-date
+                - name: EMAIL_SUBJECT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ $config }}
+                      key: subject
+                - name: EMAIL_BODY
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ $config }}
+                      key: body
+                - name: FILENAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ $config }}
+                      key: filename
+                - name: RETENTION_PERIOD
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ $config }}
+                      key: retention
+                - name: EMAIL_ADDRESSEES
+                  valueFrom:
+                    secretKeyRef:
+                      name: automated-report-recipients
+                      key: weekly-recalls
+                - name: CONFIRM_EMAIL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ $config }}
+                      key: confirm_email
+                - name: AWS_DEFAULT_REGION
+                  value: "eu-west-2"
+          restartPolicy: "Never"
+          volumes:
+            - name: report-scripts
+              configMap:
+                name: {{ $script }}
+                defaultMode: 0755
+                items:
+                  - key: "notify-token.sh"
+                    path: "notify-token.sh"
+                  - key: "run-report.sh"
+                    path: "run-report.sh"
+                  - key: "placeholders"
+                    path: "placeholders.sh"
+            - name: report-sql
+              configMap:
+                name: {{ $config }}
+                defaultMode: 0755
+                items:
+                  - key: "report_sql"
+                    path: "report.sql"
+{{- end }}

--- a/helm_deploy/hmpps-book-secure-move-api/values.yaml
+++ b/helm_deploy/hmpps-book-secure-move-api/values.yaml
@@ -85,3 +85,6 @@ scripts:
     weeklyCanCourtMoves:
       enabled: false
       # schedule: "30 6 * * 1"
+    weeklyPrisonRecalls:
+      enabled: false
+      # schedule: "30 7 * * 1"

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -142,3 +142,6 @@ scripts:
     weeklyCanCourtMoves:
       enabled: true
       schedule: "30 6 * * 1"
+    weeklyPrisonRecalls:
+      enabled: true
+      schedule: "30 7 * * 1"


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-2458

### What?
New weekly prison recall report
- Runs every Monday at 7:30 AM covering previous week
- Emails CSV report via GovNotify
- Includes all prison recall moves with person and location details

Depends on email recipients defined in:
- automated-report-recipients / weekly-recalls

https://dsdmoj.atlassian.net/browse/MAP-2458
