### PR TITLE
MAP-2482 Replace csv download with an email version

### DIFF
--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -10,6 +10,7 @@ module Api
     around_action :idempotent_action, only: %i[create update]
 
     CSV_INCLUDES = [:from_location, :to_location, :journeys, :profile, :supplier, { person: %i[gender ethnicity] }].freeze
+    STREAM_CSV_MOVES_THRESHOLD = 5000
 
     def index
       index_and_render
@@ -17,6 +18,21 @@ module Api
 
     def csv
       csv_moves = find_moves(active_record_relationships: CSV_INCLUDES)
+      if (params[:async] == 'allow') && csv_moves.size > STREAM_CSV_MOVES_THRESHOLD
+
+        recipient_email = ManageUsersApiClient::UserEmail.get(created_by)
+        if recipient_email
+          MovesExportEmailWorker.perform_async(
+            recipient_email,
+            csv_moves.pluck(:id),
+          )
+          render json: {
+            success: true,
+            message: 'Your CSV export is being prepared and will be emailed to you shortly',
+          }, status: :accepted and return
+        end
+      end
+
       send_file(Moves::Exporter.new(csv_moves).call, type: 'text/csv', disposition: :inline)
     end
 

--- a/app/controllers/api/moves_controller.rb
+++ b/app/controllers/api/moves_controller.rb
@@ -10,7 +10,7 @@ module Api
     around_action :idempotent_action, only: %i[create update]
 
     CSV_INCLUDES = [:from_location, :to_location, :journeys, :profile, :supplier, { person: %i[gender ethnicity] }].freeze
-    STREAM_CSV_MOVES_THRESHOLD = 5000
+    STREAM_CSV_MOVES_THRESHOLD = ENV.fetch('MOVES_CSV_ASYNC_THRESHOLD', 5000).to_i
 
     def index
       index_and_render

--- a/app/lib/manage_users_api_client/user_email.rb
+++ b/app/lib/manage_users_api_client/user_email.rb
@@ -4,6 +4,9 @@ module ManageUsersApiClient
   class UserEmail < ManageUsersApiClient::Base
     class << self
       def get(username)
+        return nil if username.blank?
+        return username if username =~ URI::MailTo::EMAIL_REGEXP
+
         JSON.parse(fetch_response(username).body)['email']
       rescue OAuth2::Error
         nil

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -25,4 +25,40 @@ class ReportMailer < ApplicationMailer
 
     mail
   end
+
+  def moves_export
+    recipient_email = params[:recipient_email]
+    moves = params[:moves]
+
+    @recipients = [recipient_email]
+
+    timestamp = Time.current.strftime('%Y-%m-%d_%H-%M')
+    filename = "moves_export_#{timestamp}.csv"
+
+    csv_tempfile = nil
+
+    begin
+      csv_tempfile = Moves::Exporter.new(moves).call
+      csv_tempfile.rewind
+      csv_content = csv_tempfile.read
+      csv_string_io = StringIO.new(csv_content)
+
+      set_personalisation(
+        'report-title': 'Moves Export',
+        'report-description': "CSV export generated on #{Time.current.strftime('%d/%m/%Y at %H:%M')}",
+        'report-file': Notifications.prepare_upload(csv_string_io, filename: filename),
+      )
+
+      mail
+    ensure
+      if csv_tempfile
+        begin
+          csv_tempfile.close unless csv_tempfile.closed?
+          File.unlink(csv_tempfile.path) if File.exist?(csv_tempfile.path)
+        rescue StandardError => e
+          Rails.logger.warn "Failed to clean up tempfile #{csv_tempfile.path}: #{e.message}"
+        end
+      end
+    end
+  end
 end

--- a/app/models/generic_event/move_reject.rb
+++ b/app/models/generic_event/move_reject.rb
@@ -37,15 +37,7 @@ class GenericEvent
     end
 
     def move_proposed_by_email
-      @move_proposed_by_email ||=
-
-        if move_proposed_by =~ URI::MailTo::EMAIL_REGEXP
-          # If move_proposed_by is an email address,
-          # there is no need to perform a lookup
-          move_proposed_by
-        elsif move_proposed_by
-          ManageUsersApiClient::UserEmail.get(move_proposed_by)
-        end
+      @move_proposed_by_email ||= ManageUsersApiClient::UserEmail.get(move_proposed_by)
     end
   end
 end

--- a/app/workers/moves_export_email_worker.rb
+++ b/app/workers/moves_export_email_worker.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class MovesExportEmailWorker
+  include Sidekiq::Worker
+
+  def perform(recipient_email, move_ids)
+    moves = Move.includes(CSV_INCLUDES).where(id: move_ids)
+
+    ReportMailer.with(
+      recipient_email: recipient_email,
+      moves: moves,
+    ).moves_export.deliver_now
+  rescue StandardError => e
+    Rails.logger.error "MovesExportEmailWorker failed for email #{recipient_email}: #{e.message}"
+  end
+
+  CSV_INCLUDES = [:from_location, :to_location, :journeys, :profile, :supplier, { person: %i[gender ethnicity] }].freeze
+end

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -35,6 +35,7 @@ generic-service:
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       ALERTS_API_BASE_URL: alerts_api_base_url_key
       MANAGE_USERS_API_BASE_URL: manage_users_api_base_url_key
+      MOVES_CSV_ASYNC_THRESHOLD: moves_csv_async_threshold_key
       PRISONER_SEARCH_API_BASE_URL: prisoner_search_api_base_url_key
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -42,6 +42,7 @@ generic-service:
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       ALERTS_API_BASE_URL: alerts_api_base_url_key
       MANAGE_USERS_API_BASE_URL: manage_users_api_base_url_key
+      MOVES_CSV_ASYNC_THRESHOLD: moves_csv_async_threshold_key
       PRISONER_SEARCH_API_BASE_URL: prisoner_search_api_base_url_key
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -37,6 +37,7 @@ generic-service:
       NOMIS_PRISON_API_PATH_PREFIX: nomis_prison_api_path_prefix_key
       ALERTS_API_BASE_URL: alerts_api_base_url_key
       MANAGE_USERS_API_BASE_URL: manage_users_api_base_url_key
+      MOVES_CSV_ASYNC_THRESHOLD: moves_csv_async_threshold_key
       PRISONER_SEARCH_API_BASE_URL: prisoner_search_api_base_url_key
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       SENTRY_DSN: sentry_dsn_key

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -36,6 +36,7 @@ generic-service:
       NOMIS_AUTH_PATH_PREFIX: nomis_auth_path_prefix_key
       ALERTS_API_BASE_URL: alerts_api_base_url_key
       MANAGE_USERS_API_BASE_URL: manage_users_api_base_url_key
+      MOVES_CSV_ASYNC_THRESHOLD: moves_csv_async_threshold_key
       PRISONER_SEARCH_API_BASE_URL: prisoner_search_api_base_url_key
       SENTRY_DSN: sentry_dsn_key
       CORS_ALLOWED_ORIGINS: cors_allowed_origins_key

--- a/spec/mailer/report_mailer_spec.rb
+++ b/spec/mailer/report_mailer_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe ReportMailer, type: :mailer do
     let(:start_date) { Date.new(2020, 1, 1) }
     let(:end_date) { nil }
     let(:filename) { 'per_quality_report_2020-01-01.csv' }
-
     let(:file_params) do
       {
         confirm_email_before_download: nil,
@@ -62,6 +61,55 @@ RSpec.describe ReportMailer, type: :mailer do
         it { is_expected.to include('report-title': 'Person Escort Record Quality') }
         it { is_expected.to include('report-description': '2020-01-01 - 2021-01-01') }
         it { is_expected.to include('report-file': file_params) }
+      end
+    end
+  end
+
+  describe '#moves_export' do
+    subject(:mail) do
+      described_class.with(
+        recipient_email: 'user@example.com',
+        moves: instance_double(ActiveRecord::Relation),
+      ).moves_export
+    end
+
+    let(:csv_tempfile) { instance_double(Tempfile, path: '/tmp/test.csv', closed?: false) }
+
+    before do
+      moves_exporter = instance_double(Moves::Exporter, call: csv_tempfile)
+      allow(Moves::Exporter).to receive(:new).and_return(moves_exporter)
+      allow(csv_tempfile).to receive(:rewind)
+      allow(csv_tempfile).to receive(:read).and_return('csv_content')
+      allow(csv_tempfile).to receive(:close)
+      allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:unlink)
+      allow(Notifications).to receive(:prepare_upload)
+    end
+
+    describe 'to' do
+      it { expect(mail.to).to eq(['user@example.com']) }
+    end
+
+    describe 'govuk_notify_template' do
+      it { expect(mail.govuk_notify_template).to eq('abc') }
+    end
+
+    describe 'govuk_notify_personalisation' do
+      subject(:govuk_notify_personalisation) { mail.govuk_notify_personalisation }
+
+      before do
+        allow(Time).to receive(:current).and_return(Time.zone.parse('2025-06-12 14:30:00'))
+      end
+
+      it { is_expected.to include('report-title': 'Moves Export') }
+      it { is_expected.to include('report-description': 'CSV export generated on 12/06/2025 at 14:30') }
+    end
+
+    describe 'tempfile cleanup' do
+      it 'closes and unlinks the tempfile' do
+        mail.to # Force the mail to be built
+        expect(csv_tempfile).to have_received(:close)
+        expect(File).to have_received(:unlink).with('/tmp/test.csv')
       end
     end
   end

--- a/spec/models/generic_event/move_reject_spec.rb
+++ b/spec/models/generic_event/move_reject_spec.rb
@@ -90,19 +90,6 @@ RSpec.describe GenericEvent::MoveReject do
         expect(mailer_double).to receive(:deliver_later)
         move_reject
       end
-
-      context 'and that username is an email address' do
-        let(:username) { 'alice@example.com' }
-
-        before do
-          allow(MoveRejectMailer).to receive(:notify).with('alice@example.com', move, an_instance_of(described_class)).and_return(mailer_double)
-        end
-
-        it 'sends a notification email to the username' do
-          expect(mailer_double).to receive(:deliver_later)
-          move_reject
-        end
-      end
     end
 
     context 'when there is no email address for that username' do

--- a/spec/requests/api/moves_controller_csv_spec.rb
+++ b/spec/requests/api/moves_controller_csv_spec.rb
@@ -14,12 +14,9 @@ RSpec.describe Api::MovesController do
       'Authorization' => "Bearer #{access_token}",
     }
   end
-
   let(:params) { {} }
 
-  describe 'POST /moves/csv' do
-    let!(:moves) { create_list :move, 2 }
-
+  shared_examples 'streams CSV file' do
     it 'returns a success code' do
       post_moves_csv
       expect(response).to have_http_status(:ok)
@@ -33,6 +30,79 @@ RSpec.describe Api::MovesController do
     it 'sets the correct content type header' do
       post_moves_csv
       expect(response.headers['Content-Type']).to eq('text/csv')
+    end
+  end
+
+  describe 'POST /moves/csv' do
+    let!(:moves) { create_list :move, 2 }
+
+    before do
+      stub_const('Api::MovesController::STREAM_CSV_MOVES_THRESHOLD', 2)
+    end
+
+    context 'when async is requested' do
+      let(:params) { { async: 'allow' } }
+
+      context 'with low number of moves' do
+        let!(:moves) { create_list :move, 1 } # Below threshold of 2
+
+        it_behaves_like 'streams CSV file'
+      end
+
+      context 'with no email for user' do
+        let!(:moves) { create_list :move, 3 } # Above threshold of 2
+
+        before do
+          allow(ManageUsersApiClient::UserEmail).to receive(:get).and_return(nil)
+        end
+
+        it_behaves_like 'streams CSV file'
+      end
+
+      context 'with high move count and user has email' do
+        let!(:moves) { create_list :move, 3 } # Above threshold of 2
+
+        before do
+          allow(ManageUsersApiClient::UserEmail).to receive(:get).and_return('user@example.com')
+          allow(MovesExportEmailWorker).to receive(:perform_async)
+        end
+
+        it 'returns accepted status' do
+          post_moves_csv
+          expect(response).to have_http_status(:accepted)
+        end
+
+        it 'returns JSON response with success message' do
+          post_moves_csv
+          json_response = JSON.parse(response.body)
+          expect(json_response['success']).to be true
+          expect(json_response['message']).to include('emailed')
+        end
+
+        it 'queues the worker with correct parameters' do
+          post_moves_csv
+          expect(MovesExportEmailWorker).to have_received(:perform_async).with(
+            'user@example.com',
+            match_array(moves.pluck(:id)),
+          )
+        end
+
+        it 'does not stream the file' do
+          post_moves_csv
+          expect(response.headers['Content-Disposition']).not_to match('inline')
+        end
+      end
+    end
+
+    context 'when async is not requested (default behavior)' do
+      it_behaves_like 'streams CSV file'
+
+      it 'delegates the CSV generation to Moves::Exporter with the correct moves' do
+        moves_exporter = instance_double(Moves::Exporter, call: Tempfile.new)
+        allow(Moves::Exporter).to receive(:new).and_return(moves_exporter)
+        post_moves_csv
+        expect(Moves::Exporter).to have_received(:new).with(ActiveRecord::Relation)
+      end
     end
 
     describe 'filtering results' do
@@ -62,15 +132,6 @@ RSpec.describe Api::MovesController do
           active_record_relationships: [:from_location, :to_location, :journeys, :profile, :supplier, { person: %i[gender ethnicity] }],
         )
       end
-    end
-
-    it 'delegates the CSV generation to Moves::Exporter with the correct moves' do
-      moves_exporter = instance_double(Moves::Exporter, call: Tempfile.new)
-      allow(Moves::Exporter).to receive(:new).and_return(moves_exporter)
-
-      post_moves_csv
-
-      expect(Moves::Exporter).to have_received(:new).with(ActiveRecord::Relation)
     end
   end
 end

--- a/spec/workers/moves_export_email_worker_spec.rb
+++ b/spec/workers/moves_export_email_worker_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MovesExportEmailWorker do
+  describe '#perform' do
+    subject(:worker) { described_class.new }
+
+    let(:recipient_email) { 'user@example.com' }
+    let(:move_ids) { [1, 2, 3] }
+    let(:moves) { instance_double(ActiveRecord::Relation) }
+    let(:report_mailer) { instance_double(ReportMailer) }
+    let(:mail_delivery) { instance_double(ActionMailer::MessageDelivery) }
+
+    before do
+      allow(Move).to receive(:includes).and_return(Move)
+      allow(Move).to receive(:where).with(id: move_ids).and_return(moves)
+      allow(ReportMailer).to receive(:with).and_return(report_mailer)
+      allow(report_mailer).to receive(:moves_export).and_return(mail_delivery)
+      allow(mail_delivery).to receive(:deliver_now)
+    end
+
+    it 'processes the export workflow correctly' do
+      worker.perform(recipient_email, move_ids)
+
+      expect(Move).to have_received(:includes).with(described_class::CSV_INCLUDES)
+      expect(Move).to have_received(:where).with(id: move_ids)
+      expect(ReportMailer).to have_received(:with).with(
+        recipient_email: recipient_email,
+        moves: moves,
+      )
+      expect(report_mailer).to have_received(:moves_export)
+      expect(mail_delivery).to have_received(:deliver_now)
+    end
+
+    context 'when an error occurs' do
+      before do
+        allow(Move).to receive(:includes).and_raise(StandardError.new('Something went wrong'))
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'logs the error without re-raising' do
+        expect {
+          worker.perform(recipient_email, move_ids)
+        }.not_to raise_error
+
+        expect(Rails.logger).to have_received(:error).with(
+          "MovesExportEmailWorker failed for email #{recipient_email}: Something went wrong",
+        )
+      end
+    end
+
+    context 'with empty move_ids array' do
+      let(:move_ids) { [] }
+
+      it 'handles empty move_ids gracefully' do
+        worker.perform(recipient_email, move_ids)
+
+        expect(Move).to have_received(:includes).with(described_class::CSV_INCLUDES)
+        expect(Move).to have_received(:where).with(id: [])
+        expect(ReportMailer).to have_received(:with).with(
+          recipient_email: recipient_email,
+          moves: moves,
+        )
+      end
+    end
+
+    context 'with single move_id' do
+      let(:move_ids) { [42] }
+
+      it 'handles single move ID correctly' do
+        worker.perform(recipient_email, move_ids)
+
+        expect(Move).to have_received(:where).with(id: [42])
+      end
+    end
+
+    context 'when moves query returns empty result' do
+      let(:empty_moves) { Move.none }
+
+      before do
+        allow(Move).to receive(:where).with(id: move_ids).and_return(empty_moves)
+      end
+
+      it 'still sends the email with empty moves collection' do
+        worker.perform(recipient_email, move_ids)
+
+        expect(ReportMailer).to have_received(:with).with(
+          recipient_email: recipient_email,
+          moves: empty_moves,
+        )
+        expect(mail_delivery).to have_received(:deliver_now)
+      end
+    end
+  end
+
+  it 'includes Sidekiq::Worker' do
+    expect(described_class.included_modules).to include(Sidekiq::Worker)
+  end
+
+  describe 'CSV_INCLUDES constant' do
+    it 'defines the correct includes for CSV export' do
+      expected_includes = [:from_location, :to_location, :journeys, :profile, :supplier, { person: %i[gender ethnicity] }]
+      expect(described_class::CSV_INCLUDES).to eq(expected_includes)
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-2482

### What?

Currently, the BaSM front end has a "Download moves (.csv)" link that opens up a csv file.  This ticket is to update the code to deliver the CSV via email.

- Added async CSV export for large datasets (5000+ moves) with async=allow parameter
- Moves are only sent by email if the POST request is made with `async=allow`. 
- Added MovesExportEmailWorker background job
- Added moves_export mailer method
- Refactored UserEmail.get to handle emails directly 

### Why?

- Large CSV downloads were timing out
- The async=allow parameter ensures existing clients continue working with CSV downloads by default

### Dependencies:
- [x] Add `moves_csv_async_threshold_key` to staging (set to '3')
- [x] Add `moves_csv_async_threshold_key` to uat (set to '5000')
- [x] Add `moves_csv_async_threshold_key` to preprod (set to '5000')
- [x] Add `moves_csv_async_threshold_key` to production (set to '5000')


