### PR TITLE
MAP-2530 Avoid invalid calls to the Prisoner API

### DIFF
--- a/app/lib/prisoner_search_api_client/location_description.rb
+++ b/app/lib/prisoner_search_api_client/location_description.rb
@@ -2,6 +2,8 @@ module PrisonerSearchApiClient
   class LocationDescription < PrisonerSearchApiClient::Base
     class << self
       def get(prison_number)
+        return nil unless prison_number
+
         JSON.parse(fetch_response(prison_number).body)['locationDescription']
       rescue OAuth2::Error
         nil

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -386,7 +386,7 @@ class Move < VersionedModel
   end
 
   def prisoner_location_description
-    PrisonerSearchApiClient::LocationDescription.get(person.prison_number) if person
+    PrisonerSearchApiClient::LocationDescription.get(person.prison_number) if person&.prison_number
   end
 
 private

--- a/spec/lib/prisoner_search_api_client/location_description_spec.rb
+++ b/spec/lib/prisoner_search_api_client/location_description_spec.rb
@@ -26,4 +26,12 @@ RSpec.describe PrisonerSearchApiClient::LocationDescription, :with_hmpps_authent
       expect(response).to be_nil
     end
   end
+
+  describe '.get without a prison_number' do
+    let(:response) { described_class.get(nil) }
+
+    it 'returns nil' do
+      expect(response).to be_nil
+    end
+  end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -1155,5 +1155,13 @@ RSpec.describe Move do
         expect(move.prisoner_location_description).to be_nil
       end
     end
+
+    context 'when the prison_number is nil' do
+      let(:prison_number) { nil }
+
+      it 'returns nil' do
+        expect(move.prisoner_location_description).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-2530

### What?

Prevents API calls when prison_number is nil/blank.

### Why?

This was causing 404 "No static resource prisoner" errors in BaSM logs.
