### PR TITLE
MAP-2301 Add date_changed_reason to Allocations

### DIFF
--- a/app/controllers/api/allocations_controller.rb
+++ b/app/controllers/api/allocations_controller.rb
@@ -47,7 +47,7 @@ module Api
       { attributes: %i[date estate estate_comment prisoner_category sentence_length sentence_length_comment moves_count complete_in_full other_criteria requested_by],
         relationships: {} },
     ].freeze
-    PERMITTED_UPDATE_ALLOCATION_PARAMS = [:type, { attributes: %i[date] }].freeze
+    PERMITTED_UPDATE_ALLOCATION_PARAMS = [:type, { attributes: %i[date date_changed_reason] }].freeze
 
     PERMITTED_COMPLEX_CASE_PARAMS = %i[key title answer allocation_complex_case_id].freeze
 

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -59,6 +59,7 @@ class Allocation < VersionedModel
   validates :cancellation_reason, absence: true, unless: :cancelled?
 
   attribute :complex_cases, Types::Jsonb.new(Allocation::ComplexCaseAnswers)
+  attribute :date_changed_reason, :string
 
   has_state_machine AllocationStateMachine, on: :status
 

--- a/app/services/allocations/updater.rb
+++ b/app/services/allocations/updater.rb
@@ -31,12 +31,13 @@ module Allocations
     def update_move_dates
       allocation.moves.each do |move|
         move.date = allocation.date
+        move.date_changed_reason = allocation.date_changed_reason
         move.save!(context: :update_allocation)
 
         create_automatic_event!(
           eventable: move,
           event_class: GenericEvent::MoveDateChanged,
-          details: { date: move.date.iso8601 },
+          details: { date: move.date.iso8601, date_changed_reason: move.date_changed_reason },
         )
 
         Notifier.prepare_notifications(topic: move, action_name: 'update')

--- a/app/services/allocations/updater.rb
+++ b/app/services/allocations/updater.rb
@@ -17,7 +17,7 @@ module Allocations
       self.allocation = Allocation.find(allocation_id)
       existing_date = allocation.date
 
-      allocation.assign_attributes(allocation_params[:attributes])
+      allocation.assign_attributes(allocation_params[:attributes] || {})
       allocation.validate!
 
       allocation.transaction do

--- a/spec/swagger/swagger_doc_v1.yaml
+++ b/spec/swagger/swagger_doc_v1.yaml
@@ -338,7 +338,10 @@
         - name: body
           in: body
           required: true
-          description: The allocation object to be modified. Only the date will be updated.
+          description: |
+            The allocation object to be modified.
+            The date will be updated.
+            The date_changed_reason will be propogated to the associated moves.
           schema:
             "$ref": "../v1/allocation.yaml#/Allocation"
         - "$ref": "../v1/allocation_include_parameter.yaml#/AllocationIncludeParameter"

--- a/swagger/v1/allocation.yaml
+++ b/swagger/v1/allocation.yaml
@@ -130,6 +130,11 @@ Allocation:
           format: date
           example: '2020-05-17'
           description: Date on which the allocation is scheduled
+        date_changed_reason:
+          type: string
+          format: date
+          example: 'operational_issues'
+          description: Reason the allocation has been changed
         other_criteria:
           oneOf:
           - type: string

--- a/swagger/v2/move.yaml
+++ b/swagger/v2/move.yaml
@@ -76,6 +76,13 @@ Move:
           description:
             Date on which the move is scheduled (mandatory unless status
             is proposed)
+        date_changed_reason:
+          oneOf:
+            - type: string
+            - type: "null"
+          example: "operational_issues"
+          description:
+            Reason for the date change
         date_from:
           oneOf:
             - type: string

--- a/swagger/v2/patch_move.yaml
+++ b/swagger/v2/patch_move.yaml
@@ -69,6 +69,13 @@ Move:
           description:
             Date on which the move is scheduled (mandatory unless status
             is proposed)
+        date_changed_reason:
+          oneOf:
+            - type: string
+            - type: "null"
+          example: "operational_issues"
+          description:
+            Reason for the date change
         date_from:
           oneOf:
             - type: string


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-2301

### What?

When allocation dates change,  propagate `date_changed_reason` to associated moves.

- Update allocation API to accept date_changed_reason parameter
- When allocation date changes, propagate the reason to all associated moves
- Include date_changed_reason in GenericEvent::MoveDateChanged events for moves

### Why?

When allocation dates are updated (which cascades to all associated moves), we need to capture and maintain the reason consistently across the allocation and all its moves.

### Have you? (optional)

- [ ] Updated API docs if necessary	

