### PR TITLE
MAP-2534 Fix ImportPeople to use Alerts API per-person calls

### DIFF
--- a/app/services/moves/import_people.rb
+++ b/app/services/moves/import_people.rb
@@ -16,21 +16,21 @@ module Moves
 
     def import_people
       people = NomisClient::People.get(prison_numbers).index_by { |p| p.fetch(:prison_number) }
-      alerts = AlertsApiClient::Alerts.get(prison_numbers).group_by { |p| p.fetch(:offender_no) }
       personal_care_needs = NomisClient::PersonalCareNeeds
                             .get(nomis_offender_numbers: prison_numbers)
                             .group_by { |p| p.fetch(:offender_no) }
 
       new_person_count = 0
       changed_profile_count = 0
-      people.each do |offender_no, person_data|
-        profile = People::BuildPersonAndProfileV1.new(person_data).call
 
+      people.each do |prison_number, person_data|
+        profile = People::BuildPersonAndProfileV1.new(person_data).call
         new_person_count += 1 if profile.new_record?
 
-        Alerts::Importer.new(profile:, alerts: alerts.fetch(offender_no, [])).call
+        alerts = AlertsApiClient::Alerts.get(prison_number)
+        Alerts::Importer.new(profile:, alerts:).call
 
-        PersonalCareNeeds::Importer.new(profile:, personal_care_needs: personal_care_needs.fetch(offender_no, [])).call
+        PersonalCareNeeds::Importer.new(profile:, personal_care_needs: personal_care_needs.fetch(prison_number, [])).call
 
         next unless profile.changed? || profile.person.changed?
 


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-2534

### What?

Changed `ImportPeople` service to make individual API calls to AlertsApiClient 
for each person instead of batching all prison numbers in a single request.

### Why?

The Alerts API expects per-person calls rather than batch operations. 
The previous batch approach was incompatible with the API's design.

There is no evidence that anyone is using this particular endpoint (create move v1)
as the code wouldn't have worked in the current state, but as part of the overall
refactor to move away from NOMIS, we should ensure everything is working.
