### PR TITLE
Add gcompat to fix pg gem libresolv.so.2 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ EXPOSE $PUMA_PORT
 RUN addgroup -g $APPUID -S appgroup && \
     adduser -u $APPUID -S appuser -G appgroup -h /app
 
-RUN apk add --update --no-cache git tzdata postgresql-dev shared-mime-info yaml-dev libffi-dev
+RUN apk add --update --no-cache git tzdata postgresql-dev shared-mime-info yaml-dev libffi-dev gcompat
 
 WORKDIR /app
 COPY --chown=appuser:appgroup --from=build-stage /usr/local/bundle /usr/local/bundle


### PR DESCRIPTION
### Jira link

N/A

### What?

Add gcompat to Docker manifest

### Why?
Fixes pg gem libresolv.so.2 error that broke the deployment pipeline