### PR TITLE
Fix Rack deprecation warnings by overriding Rails' 422 status mappings

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -45,6 +45,8 @@ class ApiController < ApplicationController
     'Faraday::ConnectionFailed' => :service_unavailable,
     'Faraday::TimeoutError' => :gateway_timeout,
     'OAuth2::Error' => :bad_gateway,
+    'ActiveRecord::RecordInvalid' => :unprocessable_content,
+    'ActiveRecord::RecordNotSaved' => :unprocessable_content,
   }.freeze
 
   def current_user


### PR DESCRIPTION
### Jira link

N/A

### What?

Override Rails' default exception mappings for RecordInvalid and 
RecordNotSaved to use :unprocessable_content instead of deprecated 
:unprocessable_entity status code.

### Why?

To suppress deprecation warnings:
`./home/circleci/project/app/controllers****_controller.rb:358: warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.`