### PR TITLE
Move supplier always gets create_move notification

### DIFF
--- a/app/jobs/prepare_base_notifications_job.rb
+++ b/app/jobs/prepare_base_notifications_job.rb
@@ -55,6 +55,9 @@ private
     type = event_type(action_name, topic, type_id, subscription)
 
     if type.starts_with?('cross_supplier_')
+      # Move's assigned supplier should never get cross-supplier notifications
+      return if subscription.supplier == topic.supplier
+
       enabled_suppliers = ENV.fetch('FEATURE_FLAG_CROSS_SUPPLIER_NOTIFICATIONS_SUPPLIERS', '').split(',')
       return unless enabled_suppliers.include?(subscription.supplier.key)
     end


### PR DESCRIPTION
### Jira link

[MAP-2746](https://dsdmoj.atlassian.net/browse/MAP-2746)

### What?

When a supplier creates a move, they now always get a `create_move` webhook notification and are blocked from receiving any cross-supplier notifications, regardless of location or feature flags.


### Why?

Suppliers were creating moves for other supplier locations and not receiving webhook notifications



[MAP-2746]: https://dsdmoj.atlassian.net/browse/MAP-2746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ