### PR TITLE
Update oauth2 gem to a version that supports Snaky Case

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'kaminari'
 gem 'net-http-persistent'
 gem 'nokogiri'
 gem 'notifications-ruby-client'
-gem 'oauth2', '2.0.9' # 2.0.10 introduces breaking changes. MAP-2438.
+gem 'oauth2'
 gem 'paper_trail'
 gem 'pg'
 gem 'prometheus-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
       bigdecimal (~> 3.1)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
-    jwt (2.10.1)
+    jwt (2.10.2)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -303,13 +303,14 @@ GEM
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
-    oauth2 (2.0.9)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
+    oauth2 (2.0.15)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0)
-      version_gem (~> 1.1)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.8)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -514,9 +515,9 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     slack-notifier (2.4.0)
-    snaky_hash (2.0.1)
-      hashie
-      version_gem (~> 1.1, >= 1.1.1)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     spring (4.4.0)
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
@@ -542,7 +543,7 @@ GEM
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
-    version_gem (1.1.8)
+    version_gem (1.1.9)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -586,7 +587,7 @@ DEPENDENCIES
   net-http-persistent
   nokogiri
   notifications-ruby-client
-  oauth2 (= 2.0.9)
+  oauth2
   ostruct
   paper_trail
   pg


### PR DESCRIPTION
### Jira link

https://dsdmoj.atlassian.net/browse/MAP-2438

### What?

Update oauth2 gem to the latest version

### Why?

The oauth2 gem was pinned to `2.0.9` due to a now-resolved issue 
with [SnakyHash](https://github.com/ruby-oauth/oauth2/issues/648)

Previous attempt to update this gem broke the response parser from the NOMIS API when
creating a PER
