### PR TITLE
MAPB-207 persist csra to profile and add to serializer attributes

### DIFF
--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -27,6 +27,7 @@ module Api
       :type,
       { attributes: [
           :requires_youth_risk_assessment,
+          :csra,
           { assessment_answers: [
             %i[
               key

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -5,7 +5,7 @@ class ProfileSerializer
 
   set_type :profiles
 
-  attributes :requires_youth_risk_assessment, :assessment_answers
+  attributes :requires_youth_risk_assessment, :assessment_answers, :csra
 
   belongs_to :person
   has_many :documents

--- a/spec/requests/api/profiles_controller_create_spec.rb
+++ b/spec/requests/api/profiles_controller_create_spec.rb
@@ -203,5 +203,23 @@ RSpec.describe Api::ProfilesController do
 
       it_behaves_like 'an endpoint that responds with error 404'
     end
+
+    context 'with CSRA from NOMIS' do
+      let(:latest_nomis_booking_id) { 123 }
+      let(:person) { create(:person_without_profiles, prison_number: nil, latest_nomis_booking_id:) }
+
+      before do
+        allow(NomisClient::BookingDetails).to receive(:get).with(latest_nomis_booking_id).and_return({ csra: 'Standard' })
+        post "/api/v1/people/#{person.id}/profiles", params: profile_params, headers:, as: :json
+      end
+
+      it 'persists the CSRA value to the profile' do
+        expect(person.profiles.last.csra).to eq('Standard')
+      end
+
+      it 'includes CSRA in the response' do
+        expect(response_json['data']['attributes']['csra']).to eq('Standard')
+      end
+    end
   end
 end

--- a/spec/requests/api/profiles_controller_update_spec.rb
+++ b/spec/requests/api/profiles_controller_update_spec.rb
@@ -296,5 +296,26 @@ RSpec.describe Api::ProfilesController do
 
       it_behaves_like 'an endpoint that responds with error 404'
     end
+
+    context 'with CSRA from NOMIS' do
+      let(:profile) { create(:profile, csra: nil, documents: before_documents) }
+      let(:before_documents) { create_list(:document, 2) }
+      let(:latest_nomis_booking_id) { 123 }
+
+      before do
+        profile.person.update!(latest_nomis_booking_id:)
+        allow(NomisClient::BookingDetails).to receive(:get).with(latest_nomis_booking_id).and_return({ csra: 'High' })
+        allow(Notifier).to receive(:prepare_notifications)
+        patch "/api/v1/people/#{profile.person.id}/profiles/#{profile.id}", params: profile_params, headers:, as: :json
+      end
+
+      it 'persists the updated CSRA value to the profile' do
+        expect(profile.reload.csra).to eq('High')
+      end
+
+      it 'includes CSRA in the response' do
+        expect(response_json['data']['attributes']['csra']).to eq('High')
+      end
+    end
   end
 end

--- a/spec/serializers/profile_serializer_spec.rb
+++ b/spec/serializers/profile_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProfileSerializer do
       data: {
         id: profile.id,
         type: 'profiles',
-        attributes: { assessment_answers: [], requires_youth_risk_assessment: nil },
+        attributes: { assessment_answers: [], requires_youth_risk_assessment: nil, csra: nil },
         relationships: {
           person: {
             data: { id: profile.person.id, type: 'people' },
@@ -75,7 +75,7 @@ RSpec.describe ProfileSerializer do
         data: {
           id: profile.id,
           type: 'profiles',
-          attributes: { assessment_answers: [] },
+          attributes: { assessment_answers: [], csra: nil },
           relationships: {
             person: {
               data: { id: profile.person.id, type: 'people' },


### PR DESCRIPTION
### Jira link

MAPB-207

### What?

The CSRA value was being fetched from the NOMIS API (BookingDetails endpoint) but was not being persisted to the profiles table.

I have added/removed/altered:

PROFILE_ATTRIBUTES = [
:type,
{ attributes: [
:requires_youth_risk_assessment,
:csra, # ← ADDED THIS LINE
{ assessment_answers: [
# ...rest of attributes
] },
],
relationships: {} },
].freeze

### Why?

I am doing this because:

csra not being persisted

### Have you? (optional)

- [ ] Updated API docs if necessary	
- [ ] Added any new environment variables to the [Helm chart](https://github.com/ministryofjustice/hmpps-book-secure-move-api/tree/main/helm_deploy)

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical offender data
- Changes an api that is used in production

